### PR TITLE
dev → main: クエスト機能の本気実装 (structural detection + ログ画面)

### DIFF
--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useState } from 'react';
 import { NavLink, Outlet, useLocation } from 'react-router-dom';
-import { BellIcon, BrusukonIcon, HomeIcon, PersonIcon, SearchIcon, SettingsIcon } from './icons';
+import { BellIcon, BrusukonIcon, HomeIcon, PersonIcon, ScrollIcon, SearchIcon, SettingsIcon } from './icons';
 import { useSession } from '@/lib/session';
 import { getUnreadNotificationCount } from '@/lib/atproto';
 
 const nav = [
   { to: '/', label: 'ホーム', icon: HomeIcon, end: true, key: 'home' as const },
   { to: '/me', label: '自分', icon: PersonIcon, key: 'me' as const },
+  { to: '/quests', label: 'クエスト', icon: ScrollIcon, key: 'quests' as const },
   { to: '/notifications', label: '通知', icon: BellIcon, key: 'notifications' as const },
   { to: '/spirit', label: 'ブルスコン', icon: BrusukonIcon, key: 'spirit' as const },
   { to: '/search', label: '検索', icon: SearchIcon, key: 'search' as const },

--- a/apps/web/src/components/compose-modal.tsx
+++ b/apps/web/src/components/compose-modal.tsx
@@ -241,9 +241,21 @@ function ComposeDialog({
       // バックグラウンドで進める。結果は UI 側 (ホーム / /spirit) が
       // useOnPosted で再フェッチするし、LV アップ通知も届いたら表示される。
       if (did && body) {
+        // 投稿の構造的特徴 (返信か / 引用か / 自分のスレッドか / 文字数) を post-processor に
+        // 渡して、テキスト分類だけでは取れない quote_with_*, thread_continue,
+        // calm_debate_reply 等を確定的にカウントできるようにする。
+        const isReply = !!replyTo;
+        const isReplyToSelf = !!replyTo && replyTo.author === did;
+        // 画像添付の card 共有や引用ポストはここでは true 化しない (引用リッチ化は将来対応)。
+        const structure = {
+          isReply,
+          isReplyToSelf,
+          isQuote: false,
+          textLength: body.length,
+        };
         void (async () => {
           try {
-            const result = await processSelfPost(agent, did, body);
+            const result = await processSelfPost(agent, did, body, structure);
             if (result.jobLeveledUp && result.jobLevel) {
               notifyLevelUp({
                 kind: 'job',

--- a/apps/web/src/components/icons.tsx
+++ b/apps/web/src/components/icons.tsx
@@ -130,6 +130,15 @@ export function PersonAddIcon(props: IconProps) {
   );
 }
 
+export function ScrollIcon(props: IconProps) {
+  // Material Icons "assignment" — クリップボード型のチェックリスト。クエスト用。
+  return (
+    <svg viewBox="0 0 24 24" style={base(props)} aria-hidden>
+      <path d="M19 3h-4.18C14.4 1.84 13.3 1 12 1s-2.4.84-2.82 2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 0c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zm2 14H7v-2h7v2zm3-4H7v-2h10v2zm0-4H7V7h10v2z" />
+    </svg>
+  );
+}
+
 export function ShareIcon(props: IconProps) {
   // Material Icons "share"
   return (

--- a/apps/web/src/lib/oauth.ts
+++ b/apps/web/src/lib/oauth.ts
@@ -31,25 +31,16 @@ export function onSessionDeleted(listener: SessionDeletedListener): () => void {
   };
 }
 
-/** OAuth client に渡す共通の hook 群。session 寿命を console に残し、削除は listener にも通知する。 */
+/** OAuth client に渡す共通の hook 群。
+ *  onDelete は **同タブのローカル削除** と **別タブからの cross-tab broadcast** の
+ *  両方で呼ばれる。ここでは listener に流すだけで、log は session.ts 側
+ *  (実際に自分の sub に該当するもののみ) で出すようにしてノイズを抑える。 */
 function buildHooks() {
   return {
     onDelete: async (sub: string, cause: unknown) => {
-      const causes: unknown[] = [];
-      let cur: unknown = (cause as { cause?: unknown })?.cause;
-      for (let i = 0; i < 5 && cur; i++) {
-        causes.push(cur);
-        cur = (cur as { cause?: unknown })?.cause;
-      }
-      console.error('[oauth/onDelete] session removed from store', {
-        sub,
-        cause,
-        name: (cause as Error)?.name,
-        message: (cause as Error)?.message,
-        stack: (cause as Error)?.stack,
-        causes,
-        timestamp: new Date().toISOString(),
-      });
+      // 詳細 log は session.ts の listener が「自分の sub に該当する」ときだけ出す。
+      // ここでは listener へ素通しするだけ (cross-tab broadcast でも全 listener が
+      // 確実に呼ばれる必要があるため早期 return しない)。
       for (const l of sessionDeletedListeners) {
         try {
           l(sub, cause);

--- a/apps/web/src/lib/post-processor.ts
+++ b/apps/web/src/lib/post-processor.ts
@@ -34,6 +34,7 @@ import { classifyCognitiveFromVec } from './cognitive-classifier';
 import { getCognitiveOnnxClassifier } from './cognitive-onnx';
 import { getEmbedder } from './embedder';
 import { getRecord, putRecord } from './atproto';
+import { deriveActionTypes, type PostStructure } from './structural-action';
 
 export interface QuestLogEntry {
   id: string;
@@ -52,8 +53,11 @@ export interface ActivityEntry {
   at: string;
   /** 投稿本文の先頭 (最大 60 字)。プライバシー配慮で全文は記録しない。 */
   preview: string;
-  /** 分類された行動タイプ。分類不能なら null。 */
+  /** 分類された主行動タイプ (text classifier 由来)。分類不能なら null。 */
   action: string | null;
+  /** この投稿に該当した全 ActionType (テキスト分類 + 構造判定の合成)。
+   *  例: ['opinion_post', 'quote_with_opinion'] のように複数つく場合がある。 */
+  actionTypes?: string[];
   /** この投稿で +1 された quest の templateId 一覧。 */
   incremented: string[];
 }
@@ -104,6 +108,7 @@ export async function processSelfPost(
   agent: Agent,
   did: string,
   text: string,
+  structure?: PostStructure,
 ): Promise<ProcessResult> {
   const trimmed = text.trim();
   const empty: ProcessResult = { action: null, incremented: [], completed: [], xpGained: 0 };
@@ -129,6 +134,15 @@ export async function processSelfPost(
 
   const action = actResult.action;
   const actionType = action ? (action as ActionType) : null;
+  // テキスト分類 + 構造から該当 ActionType 集合を合成。
+  // structure が無いケース (旧 API) でも textLength は trimmed から導出する。
+  const fallbackStructure: PostStructure = structure ?? {
+    isReply: false,
+    isReplyToSelf: false,
+    isQuote: false,
+    textLength: trimmed.length,
+  };
+  const actionTypes = deriveActionTypes(action, fallbackStructure);
 
   // 3) questLog の更新 (常に記録: 分類されなかった投稿も activity に残すことで「なぜ進まないか」が分かる)
   const incremented: string[] = [];
@@ -144,19 +158,23 @@ export async function processSelfPost(
       totalXpGained: 0,
       updatedAt: new Date().toISOString(),
     };
-    if (actionType) {
+    // actionTypes 集合のいずれかが quest の expectedActionTypes / forbiddenActionTypes に
+    // 含まれれば match。complex 行動 (引用 + 意見表明など) は両方カウント可。
+    if (actionTypes.size > 0) {
       for (const q of log.quests) {
         if (q.completed) continue;
         const tmpl = templateById(q.templateId);
         if (!tmpl) continue;
         if (tmpl.type === 'restraint') {
-          if (tmpl.forbiddenActionTypes?.includes(actionType)) {
+          const violated = tmpl.forbiddenActionTypes?.some((t) => actionTypes.has(t)) ?? false;
+          if (violated) {
             q.completed = false;
             q.xpAwarded = 0;
           }
           continue;
         }
-        if (tmpl.expectedActionTypes?.includes(actionType)) {
+        const matched = tmpl.expectedActionTypes?.some((t) => actionTypes.has(t)) ?? false;
+        if (matched) {
           q.currentCount = q.currentCount + 1;
           incremented.push(q.templateId);
           if (q.currentCount >= q.requiredCount && q.requiredCount > 0) {
@@ -174,6 +192,7 @@ export async function processSelfPost(
       at: new Date().toISOString(),
       preview,
       action: actionType,
+      actionTypes: [...actionTypes],
       incremented,
     };
     const prev = log.activity ?? [];

--- a/apps/web/src/lib/session.ts
+++ b/apps/web/src/lib/session.ts
@@ -37,11 +37,30 @@ export function useSessionLoader(): SessionState {
     //    無駄な re-render を避ける
     // 2. 削除された sub が自分の did と一致しない (= 別タブ・別アカウントの
     //    削除 broadcast) → 自分のセッションは生きているので維持
-    const unsubscribe = onSessionDeleted((deletedSub) => {
+    const unsubscribe = onSessionDeleted((deletedSub, cause) => {
       if (cancelled) return;
       setState((curr) => {
         if (curr.status !== 'signed-in') return curr; // 1.
         if (curr.did && deletedSub && curr.did !== deletedSub) return curr; // 2.
+        // 自分の現セッションが消されたケース。ここで初めて log を出す
+        // (oauth.ts は cross-tab broadcast も含めて全 onDelete を捉えるが、
+        // signed-out に倒す決定はこの listener 内で sub マッチを見て出すため、
+        // 観測すべきイベントもこのタイミングで出す)。
+        const causes: unknown[] = [];
+        let cur: unknown = (cause as { cause?: unknown })?.cause;
+        for (let i = 0; i < 5 && cur; i++) {
+          causes.push(cur);
+          cur = (cur as { cause?: unknown })?.cause;
+        }
+        console.error('[session] my session was deleted; signing out', {
+          sub: deletedSub,
+          cause,
+          name: (cause as Error)?.name,
+          message: (cause as Error)?.message,
+          stack: (cause as Error)?.stack,
+          causes,
+          timestamp: new Date().toISOString(),
+        });
         return { status: 'signed-out' };
       });
     });

--- a/apps/web/src/lib/session.ts
+++ b/apps/web/src/lib/session.ts
@@ -28,12 +28,22 @@ export function useSessionLoader(): SessionState {
 
   useEffect(() => {
     let cancelled = false;
-    // 何らかの理由 (concurrent refresh の race / 手動 IDB 削除 等) で
-    // SessionStore から session が消えた瞬間に signed-out へ flip する。
-    // boot 時の warmup 経路でも runtime の cascade 経路でもここを通る。
-    const unsubscribe = onSessionDeleted(() => {
+    // 何らかの理由 (concurrent refresh の race / 手動 IDB 削除 / 別タブからの
+    // cross-tab broadcast 等) で SessionStore から session が消えた瞬間に
+    // signed-out へ flip する。
+    //
+    // ただし以下の場合は flip しない:
+    // 1. 既に signed-out (= 別タブの broadcast を受けただけで自分は無関係) →
+    //    無駄な re-render を避ける
+    // 2. 削除された sub が自分の did と一致しない (= 別タブ・別アカウントの
+    //    削除 broadcast) → 自分のセッションは生きているので維持
+    const unsubscribe = onSessionDeleted((deletedSub) => {
       if (cancelled) return;
-      setState({ status: 'signed-out' });
+      setState((curr) => {
+        if (curr.status !== 'signed-in') return curr; // 1.
+        if (curr.did && deletedSub && curr.did !== deletedSub) return curr; // 2.
+        return { status: 'signed-out' };
+      });
     });
     (async () => {
       try {

--- a/apps/web/src/lib/structural-action.ts
+++ b/apps/web/src/lib/structural-action.ts
@@ -1,0 +1,67 @@
+/**
+ * 投稿の「構造的特徴」から確定的に判定できる action タイプ。
+ *
+ * `action-classifier.ts` のテキスト分類 (5 カテゴリ) は内容ベースで曖昧 (margin が
+ * 小さいと null)、かつ ActionType の半分しか出せない。一方で post の record 構造
+ * (返信か / 引用か / 文字数 / 親が誰か) は決定的に取れるので、これを併用すれば
+ * `quote_with_opinion` `quote_with_analysis` `thread_continue` `calm_debate_reply`
+ * などが「テキスト分類 + 構造」の合成で確定的にカウントできる。
+ *
+ * ※ `quick_reply` は親 post の indexedAt 取得が要るのでここでは未対応 (返信か否か
+ *   までは取る)。`streak_maintain` `repost_only` `like_underseen` は別 pipeline。
+ */
+
+import type { ActionType } from '@aozoraquest/core';
+import type { ActionCategory } from './action-classifier';
+
+export interface PostStructure {
+  /** 返信か (record.reply が存在) */
+  isReply: boolean;
+  /** 自分自身の post への返信か (= スレッド継続)。isReply 必須。 */
+  isReplyToSelf: boolean;
+  /** 引用ポスト (embed.record があるか) */
+  isQuote: boolean;
+  /** 投稿テキストの文字数 (preprocess 前の生 text) */
+  textLength: number;
+}
+
+/**
+ * テキスト分類結果 + 構造 → 当該 post に該当する ActionType の集合。
+ *
+ * - text 分類が出した action はそのまま採用 (5 カテゴリ)
+ * - quote × textAction → quote_with_*
+ * - reply 自分自身 → thread_continue
+ * - reply × analysis → calm_debate_reply (議論への落ち着いた返答の proxy)
+ * - 文字数 ≥200 → analysis_post (テキスト分類が外しても拾う)
+ * - 文字数 ≤80 で且つ analysis_post でない → short_burst を補助的に追加
+ */
+export function deriveActionTypes(
+  textAction: ActionCategory | null,
+  s: PostStructure,
+): Set<ActionType> {
+  const out = new Set<ActionType>();
+  if (textAction && textAction !== 'neutral') {
+    out.add(textAction as ActionType);
+  }
+
+  // 長文は textAction によらず analysis_post 扱い
+  if (s.textLength >= 200) out.add('analysis_post');
+  // 短文 (80 字以下) かつ analysis でないなら short_burst 補助
+  if (s.textLength > 0 && s.textLength <= 80 && !out.has('analysis_post')) {
+    out.add('short_burst');
+  }
+
+  // 引用 + 内容 → 合成 action
+  if (s.isQuote) {
+    if (out.has('opinion_post')) out.add('quote_with_opinion');
+    if (out.has('analysis_post')) out.add('quote_with_analysis');
+  }
+
+  // 自分への返信 = スレッド継続
+  if (s.isReplyToSelf) out.add('thread_continue');
+
+  // 返信 + 分析調 = 落ち着いた議論への参戦の proxy
+  if (s.isReply && out.has('analysis_post')) out.add('calm_debate_reply');
+
+  return out;
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -8,6 +8,7 @@ import { Friends } from '@/routes/friends';
 import { Card } from '@/routes/card';
 import { PostDetail } from '@/routes/post-detail';
 import { Notifications } from '@/routes/notifications';
+import { Quests } from '@/routes/quests';
 import { Search } from '@/routes/search';
 import { Settings } from '@/routes/settings';
 import { Spirit } from '@/routes/spirit';
@@ -34,6 +35,7 @@ const router = createBrowserRouter([
       { path: 'me/card', element: <Card /> },
       { path: 'profile/:handle/post/:rkey', element: <PostDetail /> },
       { path: 'notifications', element: <Notifications /> },
+      { path: 'quests', element: <Quests /> },
       { path: 'search', element: <Search /> },
       { path: 'settings', element: <Settings /> },
       { path: 'spirit', element: <Spirit /> },

--- a/apps/web/src/routes/quests.tsx
+++ b/apps/web/src/routes/quests.tsx
@@ -1,0 +1,465 @@
+/**
+ * クエスト履歴画面 (/quests)
+ *
+ * 今日のクエストとログ、それと過去 14 日分のサマリ + 詳細展開を表示する。
+ * 履歴は PDS の `app.aozoraquest.questLog` collection から listRecords で
+ * 取得 (rkey = YYYY-MM-DD, sorted desc が default)。
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import type { Agent } from '@atproto/api';
+import type { DiagnosisResult, Quest, StatVector } from '@aozoraquest/core';
+import {
+  ARCHETYPES,
+  DEFAULT_QUEST_TEMPLATES,
+  JOBS_BY_ID,
+  actionLabel,
+  generateDailyQuests,
+  jobDisplayName,
+  statArrayToVector,
+} from '@aozoraquest/core';
+import { useSession } from '@/lib/session';
+import { COL } from '@/lib/collections';
+import { getRecord } from '@/lib/atproto';
+import { ensureTodayQuestLog, type ActivityEntry, type QuestLogEntry, type QuestLogRecord } from '@/lib/post-processor';
+import { useOnPosted } from '@/components/compose-modal';
+
+interface ProfileRecord {
+  targetJob?: string;
+}
+
+const HISTORY_LIMIT = 14; // 過去何日分を取るか
+
+function todayDateString(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+function isQuestDone(q: Pick<QuestLogEntry, 'requiredCount' | 'currentCount'>): boolean {
+  return q.requiredCount > 0 && q.currentCount >= q.requiredCount;
+}
+
+function templateById(id: string) {
+  return DEFAULT_QUEST_TEMPLATES.find((t) => t.id === id);
+}
+
+/** stored QuestLogEntry を表示用 Quest に戻す (description が PDS 側に無いので template から再構築)。 */
+function entryToQuest(e: QuestLogEntry, today: Quest[]): Quest {
+  const tmpl = templateById(e.templateId);
+  const todayMatch = today.find((t) => t.id === e.id);
+  const description =
+    todayMatch?.description ??
+    tmpl?.descriptionTemplate.replace('{N}', String(e.requiredCount)) ??
+    e.templateId;
+  return {
+    id: e.id,
+    templateId: e.templateId,
+    type: e.type,
+    targetStat: e.targetStat,
+    description,
+    requiredCount: e.requiredCount,
+    currentCount: e.currentCount,
+    xpReward: tmpl?.xpRewardFn(e.currentCount) ?? 0,
+    issuedDate: todayMatch?.issuedDate ?? '',
+  };
+}
+
+export function Quests() {
+  const session = useSession();
+  const agent = session.agent;
+  const did = session.did;
+
+  const [selfDiag, setSelfDiag] = useState<DiagnosisResult | null>(null);
+  const [targetJobId, setTargetJobId] = useState<string | null>(null);
+  const [history, setHistory] = useState<QuestLogRecord[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const targetStats: StatVector | null = useMemo(() => {
+    if (!targetJobId) return null;
+    if (!(targetJobId in JOBS_BY_ID)) return null;
+    return statArrayToVector(JOBS_BY_ID[targetJobId as keyof typeof JOBS_BY_ID].stats);
+  }, [targetJobId]);
+
+  // 今日のクエストを (まだ無ければ) 生成 + ログ初期化
+  const generatedToday: Quest[] = useMemo(() => {
+    if (!selfDiag || !targetStats || !did) return [];
+    return generateDailyQuests({
+      userDid: did,
+      dateStr: todayDateString(),
+      level: 1,
+      currentStats: selfDiag.rpgStats,
+      targetStats,
+      recentTemplateIds: [],
+    });
+  }, [selfDiag, targetStats, did]);
+
+  // 自分の analysis + profile (target job) ロード
+  useEffect(() => {
+    if (!agent || !did) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const [diag, prof] = await Promise.all([
+          getRecord<DiagnosisResult>(agent, did, COL.analysis, 'self').catch(() => null),
+          getRecord<ProfileRecord>(agent, did, COL.profile, 'self').catch(() => null),
+        ]);
+        if (cancelled) return;
+        if (diag) setSelfDiag(diag);
+        const tj = prof?.targetJob;
+        if (tj && (ARCHETYPES as readonly string[]).includes(tj)) setTargetJobId(tj);
+      } catch (e) {
+        if (!cancelled) setErr(String((e as Error)?.message ?? e));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [agent, did]);
+
+  // 履歴ロード (今日含む直近 14 日分)
+  useEffect(() => {
+    if (!agent || !did) return;
+    let cancelled = false;
+    setLoading(true);
+    setErr(null);
+    (async () => {
+      try {
+        const res = await agent.com.atproto.repo.listRecords({
+          repo: did,
+          collection: COL.questLog,
+          limit: HISTORY_LIMIT,
+        });
+        if (cancelled) return;
+        const records = res.data.records
+          .map((r) => r.value as unknown as QuestLogRecord)
+          .filter((v): v is QuestLogRecord => !!v && typeof v.date === 'string')
+          .sort((a, b) => (a.date < b.date ? 1 : -1)); // 新しい順
+        setHistory(records);
+      } catch (e) {
+        if (!cancelled) setErr(String((e as Error)?.message ?? e));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [agent, did]);
+
+  // 今日のクエストを log に初期化 (ホーム経由でも初期化されるが、この画面から開いたときも保証)
+  useEffect(() => {
+    if (!agent || !did || generatedToday.length === 0) return;
+    let cancelled = false;
+    (async () => {
+      const rec = await ensureTodayQuestLog(agent, did, generatedToday);
+      if (cancelled) return;
+      // 履歴にも反映 (今日分が無ければ先頭に追加 / 既にあれば差し替え)
+      setHistory((prev) => {
+        const today = todayDateString();
+        const without = prev.filter((r) => r.date !== today);
+        return [rec, ...without];
+      });
+    })().catch((e) => console.warn('ensure questLog failed', e));
+    return () => {
+      cancelled = true;
+    };
+  }, [agent, did, generatedToday]);
+
+  // 投稿後に今日分を再フェッチ
+  useOnPosted(() => {
+    if (!agent || !did) return;
+    setTimeout(() => {
+      const today = todayDateString();
+      getRecord<QuestLogRecord>(agent, did, COL.questLog, today)
+        .then((rec) => {
+          if (!rec) return;
+          setHistory((prev) => {
+            const without = prev.filter((r) => r.date !== today);
+            return [rec, ...without];
+          });
+        })
+        .catch(() => {});
+    }, 400);
+  });
+
+  if (session.status === 'loading') return <p>準備しています...</p>;
+  if (session.status === 'signed-out') {
+    return (
+      <div>
+        <h2>クエスト</h2>
+        <p style={{ color: 'var(--color-muted)' }}>
+          ログインすると、毎日のクエストとログを見られます。
+        </p>
+        <Link to="/onboarding">
+          <button style={{ marginTop: '1em' }}>ログインして始める</button>
+        </Link>
+      </div>
+    );
+  }
+
+  if (!selfDiag) {
+    return (
+      <div>
+        <h2>クエスト</h2>
+        <p>
+          まだあなたの気質を調べていません。
+          <Link to="/me" style={{ marginLeft: '0.4em' }}>
+            自分のページ
+          </Link>{' '}
+          から調べると、ここに毎日のクエストが出ます。
+        </p>
+      </div>
+    );
+  }
+  if (!targetStats) {
+    return (
+      <div>
+        <h2>クエスト</h2>
+        <p>
+          <Link to="/settings">目指す姿</Link> を選ぶと、そこへ近づくための毎日のクエストが出ます。
+        </p>
+      </div>
+    );
+  }
+
+  const todayStr = todayDateString();
+
+  return (
+    <div>
+      <h2>クエスト</h2>
+      <p style={{ fontSize: '0.85em', color: 'var(--color-muted)', marginTop: 0 }}>
+        目指す:{' '}
+        {targetJobId
+          ? jobDisplayName(targetJobId as keyof typeof JOBS_BY_ID, 'default')
+          : '—'}{' '}
+        / 累計 {history.length} 日分の記録
+      </p>
+
+      {err && <p style={{ color: 'var(--color-danger)' }}>うまく読み込めませんでした: {err}</p>}
+      {loading && history.length === 0 && <p style={{ color: 'var(--color-muted)' }}>読み込み中...</p>}
+
+      <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: '0.6em' }}>
+        {history.map((rec) => (
+          <li key={rec.date}>
+            <DayCard rec={rec} today={generatedToday} isToday={rec.date === todayStr} />
+          </li>
+        ))}
+      </ul>
+      {!loading && history.length === 0 && !err && (
+        <p style={{ color: 'var(--color-muted)' }}>
+          まだクエストの記録がありません。投稿するとここに溜まっていきます。
+        </p>
+      )}
+    </div>
+  );
+}
+
+function DayCard({ rec, today, isToday }: { rec: QuestLogRecord; today: Quest[]; isToday: boolean }) {
+  // 今日は最初から開く、過去日は折りたたみ
+  const [open, setOpen] = useState(isToday);
+
+  const quests = rec.quests.map((e) => entryToQuest(e, today));
+  const doneCount = quests.filter(isQuestDone).length;
+  const total = quests.length;
+  const xp = rec.totalXpGained ?? 0;
+  const activityCount = rec.activity?.length ?? 0;
+
+  return (
+    <section
+      className="dq-window"
+      style={{
+        padding: '0.6em 0.8em',
+        ...(isToday ? { outline: '2px solid var(--color-accent)', outlineOffset: -2 } : {}),
+      }}
+    >
+      <button
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        style={{
+          width: '100%',
+          background: 'transparent',
+          border: 'none',
+          padding: '0.2em 0',
+          color: 'var(--color-fg)',
+          font: 'inherit',
+          textAlign: 'left',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.6em',
+          cursor: 'pointer',
+          boxShadow: 'none',
+          flexWrap: 'wrap',
+        }}
+      >
+        <span style={{ fontWeight: 700, fontFamily: 'ui-monospace, monospace' }}>{rec.date}</span>
+        {isToday && (
+          <span
+            style={{
+              fontSize: '0.7em',
+              padding: '0.05em 0.4em',
+              background: 'var(--color-accent)',
+              color: '#0a1528',
+              borderRadius: 2,
+              fontWeight: 700,
+            }}
+          >
+            今日
+          </span>
+        )}
+        <span style={{ fontSize: '0.85em', color: 'var(--color-muted)' }}>
+          達成 {doneCount}/{total}
+        </span>
+        {xp > 0 && (
+          <span style={{ fontSize: '0.85em', color: 'var(--color-accent)', fontFamily: 'ui-monospace, monospace' }}>
+            +{xp} XP
+          </span>
+        )}
+        {activityCount > 0 && (
+          <span style={{ fontSize: '0.75em', color: 'var(--color-muted)' }}>
+            行動 {activityCount}
+          </span>
+        )}
+        <span style={{ marginLeft: 'auto', color: 'var(--color-muted)' }}>{open ? '▾' : '▸'}</span>
+      </button>
+
+      {open && (
+        <>
+          <ul style={{ listStyle: 'none', padding: 0, margin: '0.5em 0 0', display: 'flex', flexDirection: 'column', gap: '0.4em' }}>
+            {quests.map((q) => (
+              <li key={q.id}>
+                <QuestRow quest={q} />
+              </li>
+            ))}
+          </ul>
+          {rec.activity && rec.activity.length > 0 && (
+            <details style={{ marginTop: '0.6em' }}>
+              <summary style={{ fontSize: '0.8em', color: 'var(--color-muted)', cursor: 'pointer' }}>
+                行動ログ ({rec.activity.length})
+              </summary>
+              <ul style={{ listStyle: 'none', padding: 0, margin: '0.4em 0 0', display: 'flex', flexDirection: 'column', gap: '0.3em' }}>
+                {[...rec.activity].reverse().map((e, i) => (
+                  <li key={i}>
+                    <ActivityRow entry={e} />
+                  </li>
+                ))}
+              </ul>
+            </details>
+          )}
+        </>
+      )}
+    </section>
+  );
+}
+
+function QuestRow({ quest }: { quest: Quest }) {
+  const progress = quest.requiredCount > 0 ? Math.min(1, quest.currentCount / quest.requiredCount) : 0;
+  const done = isQuestDone(quest);
+  const typeBadge = { growth: '成長', maintenance: '維持', restraint: '節制' }[quest.type];
+  const typeColor = {
+    growth: 'var(--color-accent)',
+    maintenance: 'var(--color-muted)',
+    restraint: 'var(--color-agi)',
+  }[quest.type];
+
+  return (
+    <div
+      style={{
+        background: 'rgba(0,0,0,0.25)',
+        border: '1px solid rgba(255,255,255,0.1)',
+        borderRadius: 4,
+        padding: '0.4em 0.5em',
+        ...(done ? { opacity: 0.55 } : {}),
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: '0.5em', flexWrap: 'wrap' }}>
+        <span
+          style={{
+            fontSize: '0.7em',
+            padding: '0.05em 0.4em',
+            border: `1px solid ${typeColor}`,
+            color: typeColor,
+            borderRadius: 2,
+          }}
+        >
+          {typeBadge}
+        </span>
+        {done && (
+          <span
+            style={{
+              fontSize: '0.7em',
+              padding: '0.05em 0.4em',
+              background: 'var(--color-accent)',
+              color: '#0a1528',
+              borderRadius: 2,
+              fontWeight: 700,
+            }}
+          >
+            達成!
+          </span>
+        )}
+        <span style={{ fontSize: '0.9em', ...(done ? { textDecoration: 'line-through' } : {}) }}>
+          {quest.description}
+        </span>
+      </div>
+      {quest.requiredCount > 0 && (
+        <div style={{ marginTop: '0.4em', display: 'flex', alignItems: 'center', gap: '0.5em' }}>
+          <div style={{ flex: 1, height: 4, background: 'rgba(28,43,68,0.3)', borderRadius: 2, overflow: 'hidden' }}>
+            <div style={{ width: `${progress * 100}%`, height: '100%', background: typeColor }} />
+          </div>
+          <span style={{ fontSize: '0.75em', color: '#869', minWidth: '2.5em', textAlign: 'right', fontFamily: 'ui-monospace, monospace' }}>
+            {quest.currentCount}/{quest.requiredCount}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ActivityRow({ entry }: { entry: ActivityEntry }) {
+  const time = (() => {
+    try {
+      return new Date(entry.at).toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' });
+    } catch {
+      return '';
+    }
+  })();
+  const actionText = actionLabel(entry.action);
+  const types = entry.actionTypes ?? (entry.action ? [entry.action] : []);
+  return (
+    <div
+      style={{
+        background: 'rgba(0,0,0,0.4)',
+        border: '1px solid rgba(255,255,255,0.08)',
+        borderRadius: 4,
+        padding: '0.35em 0.5em',
+        fontSize: '0.78em',
+        lineHeight: 1.4,
+      }}
+    >
+      <div style={{ display: 'flex', gap: '0.5em', color: 'var(--color-muted)', fontSize: '0.9em', flexWrap: 'wrap' }}>
+        <span style={{ fontFamily: 'ui-monospace, monospace' }}>{time}</span>
+        <span>→</span>
+        <span style={{ color: entry.action ? 'var(--color-accent)' : 'var(--color-muted)' }}>{actionText}</span>
+        {types.length > 1 && (
+          <span style={{ color: 'var(--color-muted)', fontSize: '0.85em' }}>
+            ({types.join(' / ')})
+          </span>
+        )}
+      </div>
+      <div style={{ marginTop: '0.2em', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        「{entry.preview}」
+      </div>
+      {entry.incremented.length > 0 ? (
+        <div style={{ marginTop: '0.2em', color: 'var(--color-muted)' }}>
+          +1: {entry.incremented.join(' / ')}
+        </div>
+      ) : (
+        <div style={{ marginTop: '0.2em', color: 'var(--color-muted)' }}>
+          {entry.action ? '該当クエスト無し' : '分類できず'}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/core/src/__tests__/quest.test.ts
+++ b/packages/core/src/__tests__/quest.test.ts
@@ -3,8 +3,11 @@ import { DEFAULT_QUEST_TEMPLATES, JOB_XP_CURVE, PLAYER_XP_CURVE, generateDailyQu
 import type { StatVector } from '../types.js';
 
 describe('DEFAULT_QUEST_TEMPLATES', () => {
-  test('45 件ある', () => {
-    expect(DEFAULT_QUEST_TEMPLATES.length).toBe(45);
+  test('39 件ある', () => {
+    // pipeline で確定的にトラッキングできる action のみに絞った結果。
+    // 旧 45 件から repost_only / like_underseen / streak_maintain / quick_reply
+    // 系の untrackable 6 件を削除した。
+    expect(DEFAULT_QUEST_TEMPLATES.length).toBe(39);
   });
 
   test('全 ID がユニーク', () => {
@@ -12,10 +15,10 @@ describe('DEFAULT_QUEST_TEMPLATES', () => {
     expect(new Set(ids).size).toBe(ids.length);
   });
 
-  test('growth が 30, maintenance 5, restraint 10', () => {
+  test('growth が 27, maintenance 5, restraint 7', () => {
     const counts = { growth: 0, maintenance: 0, restraint: 0 };
     for (const t of DEFAULT_QUEST_TEMPLATES) counts[t.type]++;
-    expect(counts).toEqual({ growth: 30, maintenance: 5, restraint: 10 });
+    expect(counts).toEqual({ growth: 27, maintenance: 5, restraint: 7 });
   });
 
   test('restraint は必ず forbiddenActionTypes を持つ', () => {
@@ -26,10 +29,10 @@ describe('DEFAULT_QUEST_TEMPLATES', () => {
     }
   });
 
-  test('5 軸それぞれに growth テンプレがある', () => {
+  test('5 軸それぞれに growth テンプレが 3 件以上', () => {
     for (const s of ['atk', 'def', 'agi', 'int', 'luk'] as const) {
       const count = DEFAULT_QUEST_TEMPLATES.filter((t) => t.type === 'growth' && t.targetStat === s).length;
-      expect(count).toBeGreaterThanOrEqual(5);
+      expect(count).toBeGreaterThanOrEqual(3);
     }
   });
 
@@ -39,6 +42,22 @@ describe('DEFAULT_QUEST_TEMPLATES', () => {
       const at50 = t.requiredCountFn(50);
       expect(at1).toBeGreaterThanOrEqual(0);
       expect(at50).toBeGreaterThanOrEqual(at1);
+    }
+  });
+
+  test('全テンプレが pipeline でトラッキング可能な ActionType しか参照しない', () => {
+    // post-processor + structural-action が出せる ActionType の集合。
+    // これ以外 (streak_maintain / repost_only / like_underseen / quick_reply /
+    // like_regular) を要求するテンプレは pipeline で永遠に進まないので除外する。
+    const trackable = new Set<string>([
+      'opinion_post', 'analysis_post', 'short_burst', 'humor_post', 'empathy_reply',
+      'quote_with_opinion', 'quote_with_analysis', 'thread_continue', 'calm_debate_reply',
+    ]);
+    for (const t of DEFAULT_QUEST_TEMPLATES) {
+      const types = [...(t.expectedActionTypes ?? []), ...(t.forbiddenActionTypes ?? [])];
+      for (const at of types) {
+        expect(trackable.has(at)).toBe(true);
+      }
     }
   });
 });

--- a/packages/core/src/quest.ts
+++ b/packages/core/src/quest.ts
@@ -19,8 +19,13 @@ export interface QuestTemplate {
 }
 
 /**
- * クエストテンプレートプール (45 件)。
- * 5 軸 × growth 6 + maintenance 5 + restraint 10。
+ * クエストテンプレートプール。
+ * 5 軸 × growth + maintenance + restraint。
+ *
+ * action-classifier (5 カテゴリ) + structural detection (引用 / 返信 / 文字数 /
+ * 自スレ継続) の合成で確定的にカウントできるテンプレのみに絞っている。
+ * `streak_maintain` `repost_only` `like_underseen` `quick_reply` (parent timestamp 必要)
+ * は現在 pipeline に入っていないため、それらに依存する templates は除外した。
  *
  * requiredCountFn は LV 補正を緩めに (1 LV ごと +10%)。restraint は 0 回、maintenance は 1 回。
  */
@@ -36,20 +41,20 @@ export const DEFAULT_QUEST_TEMPLATES: QuestTemplate[] = [
   { id: 'atk_solo_thread',   type: 'growth', targetStat: 'atk', descriptionTemplate: '一つのテーマで連続投稿を {N} 本書け',   requiredCountFn: scaleLv(2), xpRewardFn: n => 70 + n * 15, expectedActionTypes: ['opinion_post', 'analysis_post'] },
 
   // ─── DEF 成長 (6) ───
-  { id: 'def_thread',         type: 'growth', targetStat: 'def', descriptionTemplate: 'スレッドを {N} 段続けよ',              requiredCountFn: () => 3,     xpRewardFn: n => 50 + n * 10, expectedActionTypes: ['analysis_post', 'thread_continue'] },
-  { id: 'def_streak',         type: 'growth', targetStat: 'def', descriptionTemplate: '{N} 日連続で投稿せよ',                  requiredCountFn: () => 3,     xpRewardFn: n => 50 + n * 10, expectedActionTypes: ['streak_maintain', 'short_burst', 'analysis_post'] },
-  { id: 'def_calm_debate',    type: 'growth', targetStat: 'def', descriptionTemplate: '荒れた会話に落ち着いて返答を {N} 回', requiredCountFn: scaleLv(2), xpRewardFn: n => 65 + n * 13, expectedActionTypes: ['calm_debate_reply', 'analysis_post'] },
-  { id: 'def_deep_reply',     type: 'growth', targetStat: 'def', descriptionTemplate: '同じ相手に {N} 往復、会話を深めよ',   requiredCountFn: scaleLv(2), xpRewardFn: n => 60 + n * 12, expectedActionTypes: ['analysis_post', 'calm_debate_reply'] },
-  { id: 'def_anchored_series',type: 'growth', targetStat: 'def', descriptionTemplate: 'テーマを固定して {N} 日投稿せよ',     requiredCountFn: () => 3,     xpRewardFn: n => 70 + n * 15, expectedActionTypes: ['analysis_post'] },
+  { id: 'def_thread',         type: 'growth', targetStat: 'def', descriptionTemplate: '自分のスレッドに {N} 件、自分で返信を重ねよ', requiredCountFn: () => 3,     xpRewardFn: n => 50 + n * 10, expectedActionTypes: ['thread_continue', 'analysis_post'] },
+  { id: 'def_steady_post',    type: 'growth', targetStat: 'def', descriptionTemplate: '今日のうちに {N} 投稿、地に足をつけよ', requiredCountFn: () => 3,     xpRewardFn: n => 50 + n * 10, expectedActionTypes: ['short_burst', 'analysis_post', 'opinion_post'] },
+  { id: 'def_calm_debate',    type: 'growth', targetStat: 'def', descriptionTemplate: '会話に {N} 回、落ち着いて長めに返答せよ', requiredCountFn: scaleLv(2), xpRewardFn: n => 65 + n * 13, expectedActionTypes: ['calm_debate_reply', 'analysis_post'] },
+  { id: 'def_deep_reply',     type: 'growth', targetStat: 'def', descriptionTemplate: '会話を {N} 回、深めるように返せ',     requiredCountFn: scaleLv(2), xpRewardFn: n => 60 + n * 12, expectedActionTypes: ['analysis_post', 'calm_debate_reply'] },
+  { id: 'def_anchored_series',type: 'growth', targetStat: 'def', descriptionTemplate: 'じっくり考えた投稿を {N} 件書け',     requiredCountFn: () => 3,     xpRewardFn: n => 70 + n * 15, expectedActionTypes: ['analysis_post'] },
   { id: 'def_supporter_reply',type: 'growth', targetStat: 'def', descriptionTemplate: '困っている投稿に {N} 件、静かに寄り添え', requiredCountFn: scaleLv(2), xpRewardFn: n => 60 + n * 12, expectedActionTypes: ['empathy_reply'] },
 
-  // ─── AGI 成長 (6) ───
+  // ─── AGI 成長 (5) ───
+  // ※ 旧 agi_fast_repost (repost_only 必要) は pipeline 未対応のため削除
   { id: 'agi_short_post',    type: 'growth', targetStat: 'agi', descriptionTemplate: '軽やかに短文を {N} 個連投せよ',        requiredCountFn: scaleLv(3), xpRewardFn: n => 50 + n * 10, expectedActionTypes: ['short_burst'] },
-  { id: 'agi_quick_reply',   type: 'growth', targetStat: 'agi', descriptionTemplate: '{N} 件のポストに 5 分以内に反応せよ',  requiredCountFn: () => 3,     xpRewardFn: n => 50 + n * 10, expectedActionTypes: ['quick_reply', 'short_burst'] },
-  { id: 'agi_rhythm_chain',  type: 'growth', targetStat: 'agi', descriptionTemplate: '30 分以内に {N} 投稿、リズムを保て',   requiredCountFn: scaleLv(3), xpRewardFn: n => 55 + n * 10, expectedActionTypes: ['short_burst'] },
-  { id: 'agi_pulse_burst',   type: 'growth', targetStat: 'agi', descriptionTemplate: '今日の瞬間を {N} 回切り取って投稿',   requiredCountFn: scaleLv(3), xpRewardFn: n => 50 + n * 10, expectedActionTypes: ['short_burst'] },
-  { id: 'agi_skim_reply',    type: 'growth', targetStat: 'agi', descriptionTemplate: 'TL を流し読み、気になった {N} 件に即反応', requiredCountFn: scaleLv(4), xpRewardFn: n => 50 + n * 10, expectedActionTypes: ['short_burst', 'quick_reply'] },
-  { id: 'agi_fast_repost',   type: 'growth', targetStat: 'agi', descriptionTemplate: '{N} 回、1 分以内にリポスト判断せよ',   requiredCountFn: scaleLv(3), xpRewardFn: n => 45 + n * 10, expectedActionTypes: ['repost_only'] },
+  { id: 'agi_quick_reply',   type: 'growth', targetStat: 'agi', descriptionTemplate: '短い返信を {N} 件、テンポよく送れ',     requiredCountFn: () => 3,     xpRewardFn: n => 50 + n * 10, expectedActionTypes: ['short_burst'] },
+  { id: 'agi_rhythm_chain',  type: 'growth', targetStat: 'agi', descriptionTemplate: '今日の瞬間を {N} 投稿、リズムを保て', requiredCountFn: scaleLv(3), xpRewardFn: n => 55 + n * 10, expectedActionTypes: ['short_burst'] },
+  { id: 'agi_pulse_burst',   type: 'growth', targetStat: 'agi', descriptionTemplate: '思いつきを {N} 回切り取って投稿',     requiredCountFn: scaleLv(3), xpRewardFn: n => 50 + n * 10, expectedActionTypes: ['short_burst'] },
+  { id: 'agi_skim_reply',    type: 'growth', targetStat: 'agi', descriptionTemplate: '気になった投稿に {N} 件、軽く反応',   requiredCountFn: scaleLv(4), xpRewardFn: n => 50 + n * 10, expectedActionTypes: ['short_burst'] },
 
   // ─── INT 成長 (6) ───
   { id: 'int_long_post',      type: 'growth', targetStat: 'int', descriptionTemplate: '200 字以上の分析を {N} 件書け',        requiredCountFn: () => 2,     xpRewardFn: n => 70 + n * 15, expectedActionTypes: ['analysis_post'] },
@@ -59,11 +64,11 @@ export const DEFAULT_QUEST_TEMPLATES: QuestTemplate[] = [
   { id: 'int_critical_read',  type: 'growth', targetStat: 'int', descriptionTemplate: '読んだ記事に批判的コメントを {N} 回付けよ', requiredCountFn: scaleLv(2), xpRewardFn: n => 70 + n * 14, expectedActionTypes: ['analysis_post', 'opinion_post'] },
   { id: 'int_research_reply', type: 'growth', targetStat: 'int', descriptionTemplate: '質問に調べた情報を添えて {N} 回返せ',   requiredCountFn: scaleLv(2), xpRewardFn: n => 65 + n * 13, expectedActionTypes: ['analysis_post'] },
 
-  // ─── LUK 成長 (6) ───
+  // ─── LUK 成長 (4) ───
+  // ※ 旧 luk_underseen (like_underseen) と luk_boost_fresh (repost_only) は
+  //   pipeline 未対応のため削除
   { id: 'luk_empathy',       type: 'growth', targetStat: 'luk', descriptionTemplate: '{N} 人に共感を贈れ',                   requiredCountFn: scaleLv(5), xpRewardFn: n => 50 + n * 10, expectedActionTypes: ['empathy_reply'] },
-  { id: 'luk_underseen',     type: 'growth', targetStat: 'luk', descriptionTemplate: '埋もれた投稿に {N} いいね',            requiredCountFn: () => 5,     xpRewardFn: n => 60 + n * 10, expectedActionTypes: ['like_underseen'] },
-  { id: 'luk_boost_fresh',   type: 'growth', targetStat: 'luk', descriptionTemplate: '投稿数の少ない人を {N} 回リポストせよ', requiredCountFn: scaleLv(3), xpRewardFn: n => 60 + n * 12, expectedActionTypes: ['repost_only'] },
-  { id: 'luk_warm_welcome',  type: 'growth', targetStat: 'luk', descriptionTemplate: '新しく出会った人に {N} 回声をかけよ',  requiredCountFn: scaleLv(2), xpRewardFn: n => 60 + n * 12, expectedActionTypes: ['empathy_reply'] },
+  { id: 'luk_warm_welcome',  type: 'growth', targetStat: 'luk', descriptionTemplate: '誰かに {N} 回、優しい声をかけよ',      requiredCountFn: scaleLv(2), xpRewardFn: n => 60 + n * 12, expectedActionTypes: ['empathy_reply'] },
   { id: 'luk_thank_reply',   type: 'growth', targetStat: 'luk', descriptionTemplate: '感謝の返信を {N} 件送れ',               requiredCountFn: scaleLv(3), xpRewardFn: n => 50 + n * 10, expectedActionTypes: ['empathy_reply'] },
   { id: 'luk_humor_post',    type: 'growth', targetStat: 'luk', descriptionTemplate: '空気を和ませる投稿を {N} 件書け',       requiredCountFn: scaleLv(2), xpRewardFn: n => 55 + n * 12, expectedActionTypes: ['humor_post'] },
 
@@ -74,17 +79,16 @@ export const DEFAULT_QUEST_TEMPLATES: QuestTemplate[] = [
   { id: 'maintenance_read_silent',  type: 'maintenance', targetStat: 'int', descriptionTemplate: '読むだけの時間を作り、考えを言葉にしない日', requiredCountFn: () => 0, xpRewardFn: () => 20 },
   { id: 'maintenance_thanks_round', type: 'maintenance', targetStat: 'luk', descriptionTemplate: '誰か一人に静かに「ありがとう」を送れ',   requiredCountFn: () => 1, xpRewardFn: () => 20, expectedActionTypes: ['empathy_reply'] },
 
-  // ─── 節制 (10) ───
+  // ─── 節制 (7) ───
+  // ※ 旧 restraint_quick_reply (quick_reply) / restraint_streak (streak_maintain) /
+  //   restraint_repost (repost_only) は pipeline 未対応のため削除
   { id: 'restraint_opinion',        type: 'restraint', targetStat: 'atk', descriptionTemplate: '今日は意見投稿を控えよ',       requiredCountFn: () => 0, xpRewardFn: () => 80, forbiddenActionTypes: ['opinion_post', 'quote_with_opinion'] },
   { id: 'restraint_hot_take',       type: 'restraint', targetStat: 'atk', descriptionTemplate: '衝動的な発信を一日休め',       requiredCountFn: () => 0, xpRewardFn: () => 80, forbiddenActionTypes: ['opinion_post'] },
   { id: 'restraint_long_analysis',  type: 'restraint', targetStat: 'int', descriptionTemplate: '今日は長文分析を控えよ',       requiredCountFn: () => 0, xpRewardFn: () => 80, forbiddenActionTypes: ['analysis_post', 'quote_with_analysis'] },
   { id: 'restraint_quote_analysis', type: 'restraint', targetStat: 'int', descriptionTemplate: '引用考察を一日置いておけ',     requiredCountFn: () => 0, xpRewardFn: () => 80, forbiddenActionTypes: ['quote_with_analysis'] },
   { id: 'restraint_short_burst',    type: 'restraint', targetStat: 'agi', descriptionTemplate: '今日は短文連投を控えよ',       requiredCountFn: () => 0, xpRewardFn: () => 80, forbiddenActionTypes: ['short_burst'] },
-  { id: 'restraint_quick_reply',    type: 'restraint', targetStat: 'agi', descriptionTemplate: '即レスを一日休め、一息置け',   requiredCountFn: () => 0, xpRewardFn: () => 80, forbiddenActionTypes: ['quick_reply'] },
   { id: 'restraint_thread',         type: 'restraint', targetStat: 'def', descriptionTemplate: '連続スレッドは一日休め',       requiredCountFn: () => 0, xpRewardFn: () => 80, forbiddenActionTypes: ['thread_continue'] },
-  { id: 'restraint_streak',         type: 'restraint', targetStat: 'def', descriptionTemplate: '継続にこだわらず、書かない日を作れ', requiredCountFn: () => 0, xpRewardFn: () => 80, forbiddenActionTypes: ['streak_maintain'] },
   { id: 'restraint_empathy',        type: 'restraint', targetStat: 'luk', descriptionTemplate: '共感返信は今日だけ休め',       requiredCountFn: () => 0, xpRewardFn: () => 80, forbiddenActionTypes: ['empathy_reply'] },
-  { id: 'restraint_repost',         type: 'restraint', targetStat: 'luk', descriptionTemplate: 'リポストだけの発信を一日控えよ', requiredCountFn: () => 0, xpRewardFn: () => 80, forbiddenActionTypes: ['repost_only'] },
 ];
 
 /**


### PR DESCRIPTION
## Summary

dev に溜まっている 4 commits を main に反映する PR。クエスト機能の本気実装 + cross-tab race の対症対応。

### `ecb3d23` structural detection + 追跡不能テンプレ除去
- text classifier だけだと拾えない ActionType を post 構造から確定的に判定する `structural-action.ts` を追加 (引用 / 自スレ返信 / 文字数 ≥200 / 文字数 ≤80)
- `processSelfPost` が text + structural を union した Set\<ActionType\> で quest matching するように
- pipeline で永遠に拾えない (streak_maintain / repost_only / like_underseen) を要求するテンプレ 6 件を削除 (45 → 39)
- test に「全テンプレが trackable な ActionType しか参照しない」assertion を追加 (CI でガード)

### `56dae48` /quests タブ + 履歴画面
- フッタナビに「クエスト」タブ追加 (新規 ScrollIcon)
- `/quests` ルート: PDS の questLog から直近 14 日を listRecords で取得 → 日付ごとに折りたたみカード
  - 今日のカードは強調枠 + 既定で開く
  - 各カードに「達成 N/M」「+XP」「行動 N」のサマリ
  - 開くと当日のクエスト 3 件 (進捗バー / 達成バッジ) + 行動ログ (actionTypes 全種表示)
- 投稿後に今日分だけ再フェッチして履歴更新

### `3e58854` onSessionDeleted listener が無関係な broadcast で flip しないように
- 別タブで onDelete が発火すると BroadcastChannel 経由で全タブに伝搬される (browser-oauth-client.js の syncChannel)。これまでは sub に関わらず無条件で signed-out へ flip していた
- listener を 2 段階で絞る: (1) 既に signed-out なら no-op (2) 削除された sub が現在 did と一致しないなら維持
- 別タブで他アカウントを使っているとき、その削除 event でこちらの session を切らない

### `9e1a2ff` onDelete ログを「自分の sub に実際にマッチした時」だけに絞る
- oauth.ts onDelete: ログを削除し listener へ素通し
- session.ts listener: マッチ判定 (signed-in × 自分の did === deletedSub) を通った瞬間だけ詳細ログ
- アイドル signed-out 画面で 30 秒ごとに `[oauth/onDelete]` が鳴り続ける現象が止まる

## 効果

- **クエスト trackable 率**: 全 39 テンプレが少なくとも 1 つの確定可能な action signal を持つ (CI assertion 済)
- **可視性**: フッタタブ + 履歴ページで「いつ何を達成したか」が一覧できる
- **session ノイズ**: cross-tab broadcast による誤 sign-out / 余計な log が止まる

## 残課題 (別タスク)

- 単一タブでも数十秒ごとに session 削除イベントが届く根本原因の調査 (この PR は対症)
- `app.bsky.feed.like` / `app.bsky.feed.repost` を pipeline 化 → `like_underseen` / `repost_only` 系を復活
- 過去 N 日の post 履歴を見る cross-day 判定 → `streak_maintain` / `quick_reply` の真の実装
- compose-modal に引用 UI を追加 (今は isQuote=false 固定)

## Test plan
- [ ] CI 緑 (core test に新 assertion 含む)
- [ ] dev.aozoraquest.app で動作確認
  - [ ] フッタに「クエスト」タブが出る
  - [ ] /quests で今日 + 過去日のクエスト記録が見える
  - [ ] 自分のスレに返信 → `def_thread` (thread_continue) が +1
  - [ ] 200字 以上の投稿 → `int_long_post` (analysis_post) が +1
  - [ ] signed-out 画面アイドル中に `[oauth/onDelete]` ログが鳴らない

🤖 Generated with [Claude Code](https://claude.com/claude-code)