### PR TITLE
fix(spirit): ブルスコンの発話を 2 文・60 字以内に強制する

### DIFF
--- a/apps/web/src/lib/generator.ts
+++ b/apps/web/src/lib/generator.ts
@@ -140,7 +140,7 @@ export class Generator {
 
   async generate(
     messages: ChatMessage[],
-    opts: { onToken?: (t: string) => void; temperature?: number } = {},
+    opts: { onToken?: (t: string) => void; temperature?: number; maxNewTokens?: number } = {},
   ): Promise<string> {
     if (!this.worker) await this.load();
     await this.ready;
@@ -149,10 +149,11 @@ export class Generator {
       const pending: Pending = { resolve, reject, acc: '' };
       if (opts.onToken) pending.onToken = opts.onToken;
       this.pending.set(id, pending);
-      const msg: { type: 'generate'; id: string; messages: ChatMessage[]; temperature?: number } = {
+      const msg: { type: 'generate'; id: string; messages: ChatMessage[]; temperature?: number; maxNewTokens?: number } = {
         type: 'generate', id, messages,
       };
       if (opts.temperature !== undefined) msg.temperature = opts.temperature;
+      if (opts.maxNewTokens !== undefined) msg.maxNewTokens = opts.maxNewTokens;
       this.worker!.postMessage(msg);
     });
   }

--- a/apps/web/src/lib/generator.worker.ts
+++ b/apps/web/src/lib/generator.worker.ts
@@ -30,7 +30,7 @@ interface ChatMessage {
 
 type IncomingMessage =
   | { type: 'load'; spec?: GenerationModelSpec }
-  | { type: 'generate'; id: string; messages: ChatMessage[]; temperature?: number };
+  | { type: 'generate'; id: string; messages: ChatMessage[]; temperature?: number; maxNewTokens?: number };
 
 type Backend = 'webgpu' | 'wasm';
 
@@ -102,8 +102,9 @@ self.addEventListener('message', async (event: MessageEvent<IncomingMessage>) =>
       });
 
       const temp = msg.temperature ?? GENERATION_TEMPERATURE;
+      const maxTok = msg.maxNewTokens ?? GENERATION_MAX_NEW_TOKENS;
       const output = await generator(msg.messages, {
-        max_new_tokens: GENERATION_MAX_NEW_TOKENS,
+        max_new_tokens: maxTok,
         temperature: temp,
         repetition_penalty: GENERATION_REPETITION_PENALTY,
         // temperature=0 はサンプリング不要 (greedy) なので do_sample を切る

--- a/apps/web/src/routes/spirit.tsx
+++ b/apps/web/src/routes/spirit.tsx
@@ -35,11 +35,14 @@ const HISTORY_TURNS = SPIRIT_CHAT_HISTORY_TURNS;
 const DEFAULT_SYSTEM_PROMPT = `あなたは「あおぞらくえすと」の精霊、ブルスコン。
 青空の化身で、穏やかで詩的、押し付けがましくない。
 応答ルール:
-- 2 文以内で返す
+- **必ず 1〜2 文、合計 60 字以内で**簡潔に返す。長文・列挙・前置きは禁止
 - 一人称は使わない
 - 古風な語尾 (じゃ、ぞ、など) は使わない
 - 断定予言や強い助言はしない
 - 相手の名前が分かれば自然に添える`;
+
+/** 精霊応答の最大トークン数。日本語 1 token ≒ 0.5-1 字なので 60 字 ≒ 100 token 強で打ち切り。 */
+const SPIRIT_MAX_NEW_TOKENS = 100;
 
 interface HistoryItem {
   uri?: string;
@@ -207,6 +210,7 @@ export function Spirit() {
     let full = '';
     try {
       full = await g.generate(messages, {
+        maxNewTokens: SPIRIT_MAX_NEW_TOKENS,
         onToken: (chunk: string) => {
           if (streamingRef.current !== streamKey) return;
           setHistory((h) => h.map((x) => (x.uri === streamKey ? { ...x, text: x.text + chunk } : x)));
@@ -493,11 +497,25 @@ async function loadChatHistory(agent: Agent, did: string): Promise<HistoryItem[]
   }
 }
 
+/** 精霊の応答を整える。
+ *  1) 特殊トークン / role prefix を除去
+ *  2) **2 文 (「。！？!?」) で打ち切る** — system prompt で指示しても LLM が
+ *     伸びる場合があるので、出力側でも強制
+ *  3) ハードキャップ 120 字 (極端に長い 1 文への保険)
+ */
 function cleanGenerated(s: string): string {
-  return s
+  const stripped = s
     .replace(/^<\|.*?\|>/g, '')
     .replace(/<\|.*?\|>$/g, '')
     .replace(/^(assistant|system):\s*/i, '')
-    .trim()
-    .slice(0, 400);
+    .trim();
+  // 文末記号で 2 文目までを採用。デリミタは前文末に残す。
+  const SENTENCE_END = /[。！？!?]/g;
+  const ends: number[] = [];
+  for (const m of stripped.matchAll(SENTENCE_END)) {
+    if (m.index !== undefined) ends.push(m.index + m[0].length);
+    if (ends.length >= 2) break;
+  }
+  const cut = ends.length >= 2 ? stripped.slice(0, ends[1]!) : stripped;
+  return cut.slice(0, 120);
 }


### PR DESCRIPTION
## Summary

精霊の返事が長すぎる体感への対処を 3 段階で:

1. **system prompt 強化**: 「**必ず 1〜2 文、合計 60 字以内**」「長文・列挙・前置きは禁止」と明示
2. **生成側 max_new_tokens を 200 → 100 (Spirit 専用)**: `generator.ts` の `generate()` に optional `maxNewTokens` を追加し、`spirit.tsx` だけが 100 を渡す。翻訳等 default 200 の利用は不変
3. **出力側 `cleanGenerated` を強化**: 「。！？!?」で **2 文目までで打ち切り**。ハードキャップ 120 字。LLM が prompt を無視して伸びても確実に切る

これで発話は 1〜2 文で揃い、言い切りが弱い間延びした応答も自動的に短くなる。

## Test plan
- [ ] CI 緑
- [ ] dev.aozoraquest.app /spirit で動作確認
  - [ ] 短い応答 (1〜2 文) が安定して返る
  - [ ] 翻訳機能 (compose-modal の自動翻訳 / 再翻訳) は変わらず動く

🤖 Generated with [Claude Code](https://claude.com/claude-code)