### PR TITLE
feat: 通知集約 + プロフィール/OG カードの翻訳 + リポスト非表示トグル

### DIFF
--- a/apps/web/src/components/notification-item.tsx
+++ b/apps/web/src/components/notification-item.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import type { AppBskyFeedDefs } from '@atproto/api';
 import { Avatar } from './avatar';
@@ -55,12 +56,15 @@ export function NotificationItem({
   postCache: Map<string, AppBskyFeedDefs.PostView>;
 }) {
   const navigate = useNavigate();
+  const [expanded, setExpanded] = useState(false);
   const Icon = iconFor(group.reason);
   const label = labelForReason(group.reason);
   const previewUri = previewUriForGroup(group);
   const post = previewUri ? postCache.get(previewUri) : undefined;
   const primary = group.authors[0];
   if (!primary) return null;
+  // 2 人以上集約されている時だけ accordion を出す (1 人なら展開しても情報増えない)。
+  const expandable = group.authors.length > 1;
 
   const onCardClick = (e: React.MouseEvent) => {
     // 子の Link / button が onClick stopPropagation しているのでここに来たら navigate
@@ -103,11 +107,37 @@ export function NotificationItem({
         <span style={{ marginLeft: 'auto', fontFamily: 'ui-monospace, monospace' }}>
           {formatDateTime(group.latestAt)}
         </span>
+        {expandable && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              setExpanded((v) => !v);
+            }}
+            aria-expanded={expanded}
+            aria-label={expanded ? '反応した人の一覧を閉じる' : '反応した人の一覧を開く'}
+            title={expanded ? '閉じる' : `反応した ${group.authors.length} 人を表示`}
+            style={{
+              background: 'transparent',
+              border: 'none',
+              padding: '0 0.3em',
+              cursor: 'pointer',
+              color: 'var(--color-muted)',
+              fontSize: '0.85em',
+              lineHeight: 1,
+            }}
+          >
+            {expanded ? '▲' : '▼'}
+          </button>
+        )}
       </div>
-      {headerText && (
+      {headerText && !expanded && (
         <p style={{ marginTop: '0.4em', fontSize: '0.85em', color: 'var(--color-muted)' }}>
           {headerText}
         </p>
+      )}
+      {expanded && (
+        <ExpandedAuthorList authors={group.authors} />
       )}
       {group.reason === 'follow' ? (
         <FollowPreview author={primary} />
@@ -150,6 +180,34 @@ function AuthorStack({ authors }: { authors: NotifGroup['authors'] }) {
         <span style={{ marginLeft: 6, fontSize: '0.85em' }}>他 {extra} 人</span>
       )}
     </span>
+  );
+}
+
+/** accordion 展開時の全 author 縦リスト。 */
+function ExpandedAuthorList({ authors }: { authors: NotifGroup['authors'] }) {
+  return (
+    <ul style={{ listStyle: 'none', padding: 0, margin: '0.5em 0 0 0', display: 'flex', flexDirection: 'column', gap: '0.4em' }}>
+      {authors.map((a) => (
+        <li key={a.did}>
+          <Link
+            to={`/profile/${a.handle}`}
+            onClick={(e) => e.stopPropagation()}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.5em',
+              fontSize: '0.85em',
+              color: 'inherit',
+              textDecoration: 'none',
+            }}
+          >
+            <Avatar src={a.avatar} size={24} archetype={null} />
+            <span style={{ fontWeight: 600 }}>{a.displayName || a.handle}</span>
+            <span style={{ color: 'var(--color-muted)' }}>@{a.handle}</span>
+          </Link>
+        </li>
+      ))}
+    </ul>
   );
 }
 

--- a/apps/web/src/components/notification-item.tsx
+++ b/apps/web/src/components/notification-item.tsx
@@ -61,10 +61,14 @@ export function NotificationItem({
   const label = labelForReason(group.reason);
   const previewUri = previewUriForGroup(group);
   const post = previewUri ? postCache.get(previewUri) : undefined;
-  const primary = group.authors[0];
+  // 同一 author が連投したケース (subscribed-post で 1 人が 20 件連投など) は
+  // 1 人 1 行に集約。group.authors は notification 1 件ごとに重複し得るので
+  // did で dedupe してから UI に渡す。出現順は最古発見順 = notification DESC。
+  const uniqueAuthors = dedupeAuthorsByDid(group.authors);
+  const primary = uniqueAuthors[0];
   if (!primary) return null;
   // 2 人以上集約されている時だけ accordion を出す (1 人なら展開しても情報増えない)。
-  const expandable = group.authors.length > 1;
+  const expandable = uniqueAuthors.length > 1;
 
   const onCardClick = (e: React.MouseEvent) => {
     // 子の Link / button が onClick stopPropagation しているのでここに来たら navigate
@@ -78,7 +82,7 @@ export function NotificationItem({
     }
   };
 
-  const headerText = buildHeaderText(group);
+  const headerText = buildHeaderText(uniqueAuthors);
 
   return (
     <article
@@ -100,7 +104,7 @@ export function NotificationItem({
         }}
       >
         <Icon size={18} style={{ color: 'var(--color-accent)' }} />
-        <AuthorStack authors={group.authors} />
+        <AuthorStack authors={uniqueAuthors} />
         <span>
           が<strong style={{ color: 'var(--color-fg)' }}>{label}</strong>しました
         </span>
@@ -116,7 +120,7 @@ export function NotificationItem({
             }}
             aria-expanded={expanded}
             aria-label={expanded ? '反応した人の一覧を閉じる' : '反応した人の一覧を開く'}
-            title={expanded ? '閉じる' : `反応した ${group.authors.length} 人を表示`}
+            title={expanded ? '閉じる' : `反応した ${uniqueAuthors.length} 人を表示`}
             style={{
               background: 'transparent',
               border: 'none',
@@ -137,7 +141,7 @@ export function NotificationItem({
         </p>
       )}
       {expanded && (
-        <ExpandedAuthorList authors={group.authors} />
+        <ExpandedAuthorList authors={uniqueAuthors} />
       )}
       {group.reason === 'follow' ? (
         <FollowPreview author={primary} />
@@ -211,16 +215,27 @@ function ExpandedAuthorList({ authors }: { authors: NotifGroup['authors'] }) {
   );
 }
 
-function buildHeaderText(g: NotifGroup): string | null {
-  const first = g.authors[0];
+function dedupeAuthorsByDid(authors: NotifGroup['authors']): NotifGroup['authors'] {
+  const seen = new Set<string>();
+  const out: NotifGroup['authors'] = [];
+  for (const a of authors) {
+    if (seen.has(a.did)) continue;
+    seen.add(a.did);
+    out.push(a);
+  }
+  return out;
+}
+
+function buildHeaderText(authors: NotifGroup['authors']): string | null {
+  const first = authors[0];
   if (!first) return null;
   const firstName = first.displayName || first.handle;
-  if (g.authors.length === 1) return firstName;
-  const second = g.authors[1];
+  if (authors.length === 1) return firstName;
+  const second = authors[1];
   if (!second) return firstName;
   const secondName = second.displayName || second.handle;
-  if (g.authors.length === 2) return `${firstName}、${secondName}`;
-  return `${firstName}、${secondName} 他 ${g.authors.length - 2} 人`;
+  if (authors.length === 2) return `${firstName}、${secondName}`;
+  return `${firstName}、${secondName} 他 ${authors.length - 2} 人`;
 }
 
 function FollowPreview({ author }: { author: NotifGroup['authors'][number] }) {

--- a/apps/web/src/components/notification-item.tsx
+++ b/apps/web/src/components/notification-item.tsx
@@ -4,6 +4,7 @@ import { Avatar } from './avatar';
 import { PostArticle } from './post-article';
 import {
   AtIcon,
+  BellIcon,
   HeartIcon,
   PersonAddIcon,
   QuoteIcon,
@@ -39,6 +40,8 @@ function iconFor(reason: string) {
       return AtIcon;
     case 'quote':
       return QuoteIcon;
+    case 'subscribed-post':
+      return BellIcon;
     default:
       return HeartIcon;
   }

--- a/apps/web/src/components/post-body.tsx
+++ b/apps/web/src/components/post-body.tsx
@@ -86,7 +86,7 @@ export function PostBody({ text, facets, images, external, video, postUri, langs
   );
 }
 
-function TranslationControls({
+export function TranslationControls({
   state,
   hasTranslation,
   showOriginal,

--- a/apps/web/src/components/post-external.tsx
+++ b/apps/web/src/components/post-external.tsx
@@ -1,5 +1,7 @@
+import { useState } from 'react';
 import type { PostExternal } from '@/lib/post-embed';
 import { useTranslation } from '@/lib/translate';
+import { TranslationControls } from './post-body';
 
 /**
  * 外部リンクカード (app.bsky.embed.external#view)。
@@ -24,96 +26,123 @@ export function PostExternalCard({ external }: { external: PostExternal }) {
     descHasText ? `og-desc:${external.uri}` : undefined,
     external.description ?? '',
   );
-  const titleDisplay = titleTr.translated ?? external.title;
-  const descDisplay = descTr.translated ?? external.description;
-  const anyTranslated = !!titleTr.translated || !!descTr.translated;
+  const [showOriginal, setShowOriginal] = useState(false);
+  const titleDisplay = !showOriginal && titleTr.translated ? titleTr.translated : external.title;
+  const descDisplay = !showOriginal && descTr.translated ? descTr.translated : external.description;
+  const hasTranslation = !!titleTr.translated || !!descTr.translated;
+  // 2 つの翻訳 state を 1 つに統合 (UI 表示の優先順位)
+  const combinedState: ReturnType<typeof useTranslation>['state'] =
+    titleTr.state === 'loading' || descTr.state === 'loading' ? 'loading'
+    : hasTranslation ? 'done'
+    : titleTr.state === 'error' || descTr.state === 'error' ? 'error'
+    : 'idle';
+  const combinedError = titleTr.error ?? descTr.error;
+  // どちらかでも翻訳対象なら controls を出す
+  const showControls = titleTr.isNonJapanese || descTr.isNonJapanese;
+  const onTriggerTranslate = () => {
+    titleTr.triggerTranslate();
+    descTr.triggerTranslate();
+  };
+  const onRetranslate = () => {
+    setShowOriginal(false);
+    titleTr.retranslate();
+    descTr.retranslate();
+  };
   return (
-    <a
-      href={external.uri}
-      target="_blank"
-      rel="noopener noreferrer"
-      onClick={(e) => e.stopPropagation()}
+    <div
       style={{
-        display: 'flex',
-        gap: 8,
-        alignItems: 'center',
         marginTop: '0.5em',
         padding: 8,
         border: '1px solid var(--color-border)',
         borderRadius: 6,
-        textDecoration: 'none',
-        color: 'inherit',
         background: 'rgba(255, 255, 255, 0.03)',
       }}
+      onClick={(e) => e.stopPropagation()}
     >
-      {external.thumb && (
-        <img
-          src={external.thumb}
-          alt=""
-          loading="lazy"
-          decoding="async"
-          style={{
-            width: 72,
-            height: 72,
-            borderRadius: 4,
-            objectFit: 'cover',
-            flexShrink: 0,
-            background: '#000',
-          }}
-        />
-      )}
-      <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 2 }}>
-        {host && (
-          <div
+      <a
+        href={external.uri}
+        target="_blank"
+        rel="noopener noreferrer"
+        style={{
+          display: 'flex',
+          gap: 8,
+          alignItems: 'center',
+          textDecoration: 'none',
+          color: 'inherit',
+        }}
+      >
+        {external.thumb && (
+          <img
+            src={external.thumb}
+            alt=""
+            loading="lazy"
+            decoding="async"
             style={{
-              fontSize: '0.75em',
-              color: 'var(--color-muted)',
-              whiteSpace: 'nowrap',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              display: 'flex',
-              alignItems: 'center',
-              gap: 4,
+              width: 72,
+              height: 72,
+              borderRadius: 4,
+              objectFit: 'cover',
+              flexShrink: 0,
+              background: '#000',
             }}
-          >
-            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{host}</span>
-            {anyTranslated && (
-              <span title="日本語に翻訳済み" aria-label="日本語に翻訳済み" style={{ flexShrink: 0 }}>
-                🌐
-              </span>
-            )}
-          </div>
+          />
         )}
-        <div
-          style={{
-            fontWeight: 700,
-            fontSize: '0.95em',
-            lineHeight: 1.3,
-            display: '-webkit-box',
-            WebkitLineClamp: 2,
-            WebkitBoxOrient: 'vertical',
-            overflow: 'hidden',
-          }}
-        >
-          {titleDisplay || external.uri}
-        </div>
-        {descDisplay && (
+        <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 2 }}>
+          {host && (
+            <div
+              style={{
+                fontSize: '0.75em',
+                color: 'var(--color-muted)',
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+              }}
+            >
+              {host}
+            </div>
+          )}
           <div
             style={{
-              fontSize: '0.85em',
-              color: 'var(--color-muted)',
-              lineHeight: 1.4,
+              fontWeight: 700,
+              fontSize: '0.95em',
+              lineHeight: 1.3,
               display: '-webkit-box',
               WebkitLineClamp: 2,
               WebkitBoxOrient: 'vertical',
               overflow: 'hidden',
             }}
           >
-            {descDisplay}
+            {titleDisplay || external.uri}
           </div>
-        )}
-      </div>
-    </a>
+          {descDisplay && (
+            <div
+              style={{
+                fontSize: '0.85em',
+                color: 'var(--color-muted)',
+                lineHeight: 1.4,
+                display: '-webkit-box',
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: 'vertical',
+                overflow: 'hidden',
+              }}
+            >
+              {descDisplay}
+            </div>
+          )}
+        </div>
+      </a>
+      {showControls && (
+        <TranslationControls
+          state={combinedState}
+          hasTranslation={hasTranslation}
+          showOriginal={showOriginal}
+          error={combinedError}
+          onToggleOriginal={() => setShowOriginal((v) => !v)}
+          onTranslate={onTriggerTranslate}
+          onRetranslate={onRetranslate}
+        />
+      )}
+    </div>
   );
 }
 

--- a/apps/web/src/components/post-external.tsx
+++ b/apps/web/src/components/post-external.tsx
@@ -1,12 +1,32 @@
 import type { PostExternal } from '@/lib/post-embed';
+import { useTranslation } from '@/lib/translate';
 
 /**
  * 外部リンクカード (app.bsky.embed.external#view)。
  * Bluesky 本家の Open Graph プレビューに相当。サムネイル (あれば) + タイトル +
  * ドメイン + 説明を横並びで表示し、カード全体を外部リンクにする。
+ *
+ * title / description は **投稿本文と同じ翻訳経路**で日本語化する (非日本語
+ * 判定時、自動翻訳設定 ON ならカード mount 時に発火)。キャッシュキーは
+ * `og-title:<url>` / `og-desc:<url>` で実 post URI と衝突しない。
  */
 export function PostExternalCard({ external }: { external: PostExternal }) {
   const host = safeHost(external.uri);
+  // useTranslation は uri=undefined or text=空 / 短い時は no-op (= isNonJapanese=false)
+  // なので、title/desc が無い OG カードでも安全に呼べる。
+  const titleHasText = !!external.title && external.title.length > 0;
+  const descHasText = !!external.description && external.description.length > 0;
+  const titleTr = useTranslation(
+    titleHasText ? `og-title:${external.uri}` : undefined,
+    external.title ?? '',
+  );
+  const descTr = useTranslation(
+    descHasText ? `og-desc:${external.uri}` : undefined,
+    external.description ?? '',
+  );
+  const titleDisplay = titleTr.translated ?? external.title;
+  const descDisplay = descTr.translated ?? external.description;
+  const anyTranslated = !!titleTr.translated || !!descTr.translated;
   return (
     <a
       href={external.uri}
@@ -51,9 +71,17 @@ export function PostExternalCard({ external }: { external: PostExternal }) {
               whiteSpace: 'nowrap',
               overflow: 'hidden',
               textOverflow: 'ellipsis',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 4,
             }}
           >
-            {host}
+            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{host}</span>
+            {anyTranslated && (
+              <span title="日本語に翻訳済み" aria-label="日本語に翻訳済み" style={{ flexShrink: 0 }}>
+                🌐
+              </span>
+            )}
           </div>
         )}
         <div
@@ -67,9 +95,9 @@ export function PostExternalCard({ external }: { external: PostExternal }) {
             overflow: 'hidden',
           }}
         >
-          {external.title || external.uri}
+          {titleDisplay || external.uri}
         </div>
-        {external.description && (
+        {descDisplay && (
           <div
             style={{
               fontSize: '0.85em',
@@ -81,7 +109,7 @@ export function PostExternalCard({ external }: { external: PostExternal }) {
               overflow: 'hidden',
             }}
           >
-            {external.description}
+            {descDisplay}
           </div>
         )}
       </div>

--- a/apps/web/src/lib/notifications.ts
+++ b/apps/web/src/lib/notifications.ts
@@ -28,6 +28,9 @@ const GROUPABLE = new Set<string>([
   'follow',
   'like-via-repost',
   'repost-via-repost',
+  // 購読中ユーザーの新着投稿。各 notification は別 post を指すが、グループ化
+  // しないと連投で通知欄が埋まる。subjectKey 無し (= 全部マージ) で扱う。
+  'subscribed-post',
 ]);
 
 function subjectKey(n: Notification): string | undefined {
@@ -90,8 +93,11 @@ export function previewUriForGroup(g: NotifGroup): string | undefined {
       g.reason === 'like-via-repost' || g.reason === 'repost-via-repost')) {
     return g.subjectUri;
   }
-  // reply / mention / quote: 相手の投稿 (notification.uri が record URI)
-  if (g.reason === 'reply' || g.reason === 'mention' || g.reason === 'quote') {
+  // reply / mention / quote / subscribed-post: 相手の投稿
+  // (notification.uri が新規 record の URI)。グループ内 notifications は
+  // DESC 順なので [0] が最新 = preview として最も妥当。
+  if (g.reason === 'reply' || g.reason === 'mention' || g.reason === 'quote'
+      || g.reason === 'subscribed-post') {
     return g.notifications[0]?.uri;
   }
   return undefined;
@@ -115,6 +121,8 @@ export function labelForReason(reason: string): string {
       return '引用';
     case 'starterpack-joined':
       return 'スターターパック参加';
+    case 'subscribed-post':
+      return '新しい投稿';
     default:
       return reason;
   }

--- a/apps/web/src/lib/prefs.ts
+++ b/apps/web/src/lib/prefs.ts
@@ -39,3 +39,22 @@ export function setAnalyzePosts(v: boolean): void {
     /* no-op */
   }
 }
+
+const KEY_HIDE_REPOSTS = 'aozoraquest:hideReposts';
+
+/** タイムラインからリポストを除外するか。デフォルト OFF (= リポストも表示)。 */
+export function getHideReposts(): boolean {
+  try {
+    return localStorage.getItem(KEY_HIDE_REPOSTS) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+export function setHideReposts(v: boolean): void {
+  try {
+    localStorage.setItem(KEY_HIDE_REPOSTS, String(v));
+  } catch {
+    /* no-op */
+  }
+}

--- a/apps/web/src/routes/home.tsx
+++ b/apps/web/src/routes/home.tsx
@@ -15,6 +15,7 @@ import { HomeSummary } from '@/components/home-summary';
 import { PostArticle } from '@/components/post-article';
 import { useCompose, useOnPosted } from '@/components/compose-modal';
 import { seedArchetype, useArchetypes } from '@/lib/archetype-cache';
+import { getHideReposts } from '@/lib/prefs';
 
 type Tab = 'following' | 'resonance';
 
@@ -92,10 +93,25 @@ export function Home() {
       : {}),
   });
 
+  // 設定でリポスト非表示 ON の場合、reasonRepost 付きの item を除外する。
+  // 元の本人の投稿 (reason 無し) はそのまま流れる。設定は localStorage 直読みなので
+  // mount 時に決まる (頻繁に切り替えない想定)。切り替え後はリロードで反映。
+  const hideReposts = getHideReposts();
+  const followingItems = useMemo(
+    () =>
+      hideReposts
+        ? followingFeed.items.filter(
+            (it) =>
+              (it.reason as { $type?: string } | undefined)?.$type !== 'app.bsky.feed.defs#reasonRepost',
+          )
+        : followingFeed.items,
+    [followingFeed.items, hideReposts],
+  );
+
   // フォロー TL の著者 archetype 解決
   const followingAuthorDids = useMemo(
-    () => followingFeed.items.map((it) => it.post.author.did),
-    [followingFeed.items],
+    () => followingItems.map((it) => it.post.author.did),
+    [followingItems],
   );
   const followingArchetypes = useArchetypes(agent ?? null, followingAuthorDids);
 
@@ -156,11 +172,11 @@ export function Home() {
       {tab === 'following' && (
         <section style={{ marginTop: '1em' }}>
           {followingFeed.err && <p style={{ color: 'var(--color-danger)' }}>うまく読み込めませんでした: {followingFeed.err}</p>}
-          {!followingFeed.loading && followingFeed.items.length === 0 && !followingFeed.err && (
+          {!followingFeed.loading && followingItems.length === 0 && !followingFeed.err && (
             <p style={{ color: 'var(--color-muted)' }}>タイムラインが空です。</p>
           )}
           <VirtualFeed
-            items={followingFeed.items}
+            items={followingItems}
             keyOf={(x) => x.post.uri}
             renderItem={(item) => (
               <PostCard item={item} archetype={followingArchetypes.get(item.post.author.did) ?? null} />
@@ -169,7 +185,7 @@ export function Home() {
             footer={
               <>
                 {followingFeed.loading && <p style={{ textAlign: 'center' }}>読み込み中...</p>}
-                {followingFeed.done && followingFeed.items.length > 0 && (
+                {followingFeed.done && followingItems.length > 0 && (
                   <p style={{ textAlign: 'center', fontSize: '0.8em', color: 'var(--color-muted)' }}>
                     これ以上はありません。
                   </p>

--- a/apps/web/src/routes/profile.tsx
+++ b/apps/web/src/routes/profile.tsx
@@ -11,8 +11,10 @@ import { Avatar } from '@/components/avatar';
 import { RadarChart } from '@/components/radar-chart';
 import { PostArticle } from '@/components/post-article';
 import { PostText } from '@/components/post-text';
+import { TranslationControls } from '@/components/post-body';
 import { VirtualFeed } from '@/components/virtual-feed';
 import { useInfiniteFeed } from '@/lib/use-infinite-feed';
+import { useTranslation } from '@/lib/translate';
 
 interface LoadState {
   kind: 'loading' | 'not-found' | 'ok' | 'error';
@@ -115,7 +117,7 @@ export function Profile() {
           )}
         </div>
         {profile.description && (
-          <PostText text={profile.description} style={{ marginTop: '0.6em', fontSize: '0.9em' }} />
+          <ProfileBio did={profile.did} description={profile.description} />
         )}
         <div style={{ marginTop: '0.6em', fontSize: '0.8em', color: 'var(--color-muted)' }}>
           フォロー {profile.followsCount ?? 0} · フォロワー {profile.followersCount ?? 0} · 投稿 {profile.postsCount ?? 0}
@@ -164,6 +166,35 @@ export function Profile() {
       <div style={{ marginTop: '1em' }}>
         <RecentPosts agent={session.agent} did={profile.did} />
       </div>
+    </div>
+  );
+}
+
+/** プロフィール bio の翻訳対応ラッパー。本文と同じ TinySwallow/Nano 経路を
+ *  使うが、URI が無いので合成キー `profile-bio:<did>` を翻訳キャッシュ key に。 */
+function ProfileBio({ did, description }: { did: string; description: string }) {
+  const cacheKey = `profile-bio:${did}`;
+  const { state, translated, error, triggerTranslate, retranslate, isNonJapanese } =
+    useTranslation(cacheKey, description);
+  const [showOriginal, setShowOriginal] = useState(false);
+  const displayText = !showOriginal && translated ? translated : undefined;
+  return (
+    <div style={{ marginTop: '0.6em', fontSize: '0.9em' }}>
+      <PostText text={description} override={displayText} />
+      {isNonJapanese && (
+        <TranslationControls
+          state={state}
+          hasTranslation={!!translated}
+          showOriginal={showOriginal}
+          error={error}
+          onToggleOriginal={() => setShowOriginal((v) => !v)}
+          onTranslate={triggerTranslate}
+          onRetranslate={() => {
+            setShowOriginal(false);
+            retranslate();
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -7,7 +7,7 @@ import { useSession } from '@/lib/session';
 import { signOut } from '@/lib/oauth';
 import { createTaggedPost, getRecord, putRecord } from '@/lib/atproto';
 import { COL } from '@/lib/collections';
-import { getAutoTranslate, setAutoTranslate, getAnalyzePosts, setAnalyzePosts } from '@/lib/prefs';
+import { getAutoTranslate, setAutoTranslate, getAnalyzePosts, setAnalyzePosts, getHideReposts, setHideReposts } from '@/lib/prefs';
 import { TextField } from '@/components/text-field';
 import { RadarChart } from '@/components/radar-chart';
 import { Avatar } from '@/components/avatar';
@@ -307,6 +307,7 @@ export function Settings() {
         <h3 style={{ fontSize: '0.95em' }}>表示設定</h3>
         <AutoTranslateToggle />
         <AnalyzePostsToggle />
+        <HideRepostsToggle />
       </section>
 
       <section style={{ marginTop: '2em' }}>
@@ -340,6 +341,29 @@ function AutoTranslateToggle() {
       </label>
       <p style={{ fontSize: '0.75em', color: 'var(--color-muted)', marginTop: '0.3em', marginLeft: '1.5em' }}>
         ブラウザ内で TinySwallow が動くので外部に送信されません。OFF にした場合も各投稿下の「🌐 翻訳する」ボタンから個別に翻訳できます。
+      </p>
+    </div>
+  );
+}
+
+function HideRepostsToggle() {
+  const [enabled, setEnabled] = useState<boolean>(() => getHideReposts());
+  function handleChange(v: boolean) {
+    setHideReposts(v);
+    setEnabled(v);
+  }
+  return (
+    <div style={{ marginTop: '1em' }}>
+      <label style={{ display: 'flex', alignItems: 'center', gap: '0.5em', fontSize: '0.9em', cursor: 'pointer' }}>
+        <input
+          type="checkbox"
+          checked={enabled}
+          onChange={(e) => handleChange(e.target.checked)}
+        />
+        <span>タイムラインのリポストを非表示にする</span>
+      </label>
+      <p style={{ fontSize: '0.75em', color: 'var(--color-muted)', marginTop: '0.3em', marginLeft: '1.5em' }}>
+        フォロー中のタイムラインで、他人がリポストした投稿を流さないようにします。フォローしている本人の投稿はそのまま表示されます。
       </p>
     </div>
   );


### PR DESCRIPTION
## Summary

主に「TL 周りの情報密度改善」と「翻訳カバー範囲拡大」のまとめ。LocalLLM 抽象 (前 PR) の上に乗っかって、翻訳経路を 2 箇所追加 + 通知の集約改善 + リポスト非表示オプション。

## 主要 commit

### 翻訳カバー範囲拡大
- `9a1b8f5` プロフィール bio (description) を翻訳対象に。合成キー `profile-bio:<did>` で IDB キャッシュ
- `7db0154` OG カード (外部リンクプレビュー) の title / description を翻訳対象に。`og-title:<url>` / `og-desc:<url>` のキー
- `ef89f9c` OG カードに原文 toggle / 再翻訳 / エラー再試行を追加。投稿本文と同じ `TranslationControls` を流用

### 通知 (subscribed-post 対応 + accordion)
- `1339dad` subscribed-post を `GROUPABLE` に追加、プレビューに最新投稿本文を表示。本家風の情報密度に
- `ce69f7b` グループ author 一覧を ▼ で展開可能 (本家 Bluesky 通知と同等)
- `8842642` 同一 author の連投を dedupe (matsuu が 20 件 → 1 行 + 「他 N 人」が正確な人数)

### リポスト非表示
- `92ab48e` 設定 → 表示設定に「タイムラインのリポストを非表示にする」追加。デフォルト OFF、Following TL の `reasonRepost` 付き item を除外

## 設計上の決定

- **翻訳キャッシュキーは合成 URI**: 実 post URI と衝突しない接頭辞 (`profile-bio:` / `og-title:` / `og-desc:`) で同じ translation-idb に同居
- **OG カード 2 系統の翻訳 state を combine**: loading > done > error > idle の優先順位で UI に一本化
- **通知の dedupe は did で**: `group.notifications` の生件数は保持しつつ表示用に `uniqueAuthors` を導出
- **DOM 構造**: OG カードは `<a>` 内に `<button>` を置くと invalid HTML なので、外側 `<div>` + 内側 `<a>` + 兄弟の controls に再構成

## Test plan

- [ ] CI 緑
- [ ] dev.aozoraquest.app で:
  - [ ] 英語 bio の profile が翻訳されて表示される
  - [ ] 英語 OG カードの title / description が翻訳される、「原文を見る」/「再翻訳」ボタンが動く
  - [ ] 通知タブで subscribed-post が複数まとまり、最新投稿の本文プレビューが見える
  - [ ] ▼ で展開すると authors 縦リスト、同一人物の連投は 1 行
  - [ ] 設定でリポスト非表示 ON にしてリロード → Following TL からリポストが消える
- [ ] Firefox/Safari/モバイル等 LLM 利用不可な環境で通知 / OG カードが UI 崩壊しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)