### PR TITLE
feat(card+quest): レアリティ差別化 + 抽選演出 + 相互フォロー + クエスト整理

### DIFF
--- a/apps/web/src/components/card-draw-overlay.tsx
+++ b/apps/web/src/components/card-draw-overlay.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useRef, useState, type CSSProperties } from 'react';
+import { RARITY_LABEL, type Rarity } from '@aozoraquest/core';
+
+/**
+ * カード抽選演出のフルスクリーンオーバーレイ。
+ *
+ * 3 段階で展開:
+ *   drawing  - 暗闇に光るカード裏面が回転。汎用 (rarity 不明 or 初期)
+ *   sensing  - rarity が判明したら色付きのオーラ・粒子・(上位レアは) 光線/
+ *              shockwave/虹色 conic がフェードイン。シェイク (SSR/UR のみ)
+ *   reveal   - LLM が完了 + 最低 PRE_REVEAL_MS 経過したらフィナーレ。
+ *              フラッシュ + カードが消える → onComplete で呼び出し側が state を
+ *              コミットしオーバーレイを閉じる
+ *
+ * 演出の役割: LLM 生成の待ち時間 (1-5 秒) を「カードを引いている儀式の時間」
+ * に見立てて隠す。レアリティが演出の途中で変わるので、上位レアを引いた瞬間に
+ * 感情的なピークが来る。
+ */
+export interface CardDrawOverlayProps {
+  /** 抽選結果のレアリティ。drawing 中も即セット (sensing で色出すため)。 */
+  rarity: Rarity;
+  /** LLM 生成が終わったか。true になったら reveal へ移行できる。 */
+  llmDone: boolean;
+  /** reveal アニメーションが終わって閉じてよくなった時点で呼ぶ。 */
+  onComplete: () => void;
+}
+
+type Stage = 'drawing' | 'sensing' | 'reveal';
+
+/** drawing → sensing への切替 (rarity の色が出るタイミング)。 */
+const DRAWING_MS = 900;
+/** click 〜 reveal までの最低時間 (LLM が早く終わっても演出を見せる)。 */
+const PRE_REVEAL_MS = 2400;
+/** reveal アニメーションが完了して onComplete を呼ぶまで。 */
+const REVEAL_MS = 1300;
+
+export function CardDrawOverlay({ rarity, llmDone, onComplete }: CardDrawOverlayProps) {
+  const [stage, setStage] = useState<Stage>('drawing');
+  const startedAtRef = useRef<number>(performance.now());
+
+  // drawing → sensing
+  useEffect(() => {
+    if (stage !== 'drawing') return;
+    const elapsed = performance.now() - startedAtRef.current;
+    const wait = Math.max(0, DRAWING_MS - elapsed);
+    const t = setTimeout(() => setStage('sensing'), wait);
+    return () => clearTimeout(t);
+  }, [stage]);
+
+  // sensing → reveal (LLM 完了 AND 最低時間経過)
+  useEffect(() => {
+    if (stage !== 'sensing' || !llmDone) return;
+    const elapsed = performance.now() - startedAtRef.current;
+    const wait = Math.max(0, PRE_REVEAL_MS - elapsed);
+    const t = setTimeout(() => setStage('reveal'), wait);
+    return () => clearTimeout(t);
+  }, [stage, llmDone]);
+
+  // reveal → onComplete
+  useEffect(() => {
+    if (stage !== 'reveal') return;
+    const t = setTimeout(onComplete, REVEAL_MS);
+    return () => clearTimeout(t);
+  }, [stage, onComplete]);
+
+  return (
+    <div
+      className="cd-overlay"
+      data-stage={stage}
+      data-rarity={rarity}
+      aria-live="polite"
+      aria-label="カードを抽選中"
+    >
+      <div className="cd-aura" />
+      <div className="cd-stage">
+        <div className="cd-rays">
+          {RAY_ANGLES.map((a) => (
+            <span key={a} style={{ ['--a' as string]: a } as CSSProperties} />
+          ))}
+        </div>
+        <div className="cd-rings">
+          <span /><span /><span />
+        </div>
+        <div className="cd-particles">
+          {Array.from({ length: 13 }).map((_, i) => (
+            <span key={i} style={{ ['--i' as string]: i } as CSSProperties} />
+          ))}
+        </div>
+        <div className="cd-card-wrap">
+          <div className="cd-card" />
+        </div>
+        <div className="cd-big-sparkles">
+          {BIG_SPARKLE_POS.map((p, i) => (
+            <span
+              key={i}
+              style={{
+                ['--x' as string]: p.x,
+                ['--y' as string]: p.y,
+                ['--d' as string]: `${p.delay}s`,
+              } as CSSProperties}
+            />
+          ))}
+        </div>
+        <div className="cd-rarity-label">{RARITY_LABEL[rarity]}</div>
+      </div>
+      <div className="cd-flash" />
+    </div>
+  );
+}
+
+const RAY_ANGLES = [0, 30, 60, 90, 120, 150, 180, 210, 240, 270, 300, 330];
+
+const BIG_SPARKLE_POS: Array<{ x: string; y: string; delay: number }> = [
+  { x: '12%',  y: '20%', delay: 0.0  },
+  { x: '78%',  y: '12%', delay: 0.25 },
+  { x: '85%',  y: '60%', delay: 0.5  },
+  { x: '8%',   y: '70%', delay: 0.75 },
+  { x: '50%',  y: '8%',  delay: 0.35 },
+  { x: '50%',  y: '88%', delay: 0.6  },
+  { x: '22%',  y: '45%', delay: 0.9  },
+  { x: '72%',  y: '35%', delay: 0.15 },
+];

--- a/apps/web/src/components/job-card.tsx
+++ b/apps/web/src/components/job-card.tsx
@@ -54,6 +54,33 @@ const PANEL_STROKE = '#4a3416';
 const FRAME_OUTER = '#0e0600';    // カード最外周の縁 (純黒に近い深い焦げ茶)
 const ACCENT = '#7a5220';         // 金寄り
 
+/**
+ * rarity 別の枠スタイル。
+ * - bodyGradId: 枠の主色 (multi-stop メタリック)
+ * - shimmer: 上に重ねるシマー層 (複数可、UR/SSR は 2 重で深みを出す)
+ * - trimId: 外側ダブルラインの色 (silver / gold / rainbow)
+ * - sparkleCount: 枠帯にちりばめる星の数 (上位レアほど多い)
+ * - bigSparkles: 大粒の + 字型スパークルを混ぜるか (SSR/UR のみ)
+ */
+type RarityFrameStyle = {
+  bodyGradId: string;
+  shimmer: Array<{ id: string; opacity: number }>;
+  trimId: 'silverTrim' | 'goldTrim' | 'rainbowTrim';
+  sparkleCount: number;
+  bigSparkles: boolean;
+};
+
+const FRAME_STYLES: Record<Rarity, RarityFrameStyle> = {
+  common:   { bodyGradId: 'commonGrad',   shimmer: [],                                              trimId: 'silverTrim', sparkleCount: 0,  bigSparkles: false },
+  uncommon: { bodyGradId: 'uncommonGrad', shimmer: [],                                              trimId: 'silverTrim', sparkleCount: 0,  bigSparkles: false },
+  rare:     { bodyGradId: 'rareGrad',     shimmer: [{ id: 'rareShimmer',  opacity: 0.22 }],         trimId: 'goldTrim',   sparkleCount: 0,  bigSparkles: false },
+  srare:    { bodyGradId: 'srareGrad',    shimmer: [{ id: 'srareShimmer', opacity: 0.32 }],         trimId: 'goldTrim',   sparkleCount: 8,  bigSparkles: false },
+  ssr:      { bodyGradId: 'ssrGrad',      shimmer: [{ id: 'ssrShimmer',   opacity: 0.45 },
+                                                    { id: 'ssrShimmer2',  opacity: 0.30 }],         trimId: 'goldTrim',   sparkleCount: 20, bigSparkles: true  },
+  ur:       { bodyGradId: 'urGrad',       shimmer: [{ id: 'urShimmer',    opacity: 0.55 },
+                                                    { id: 'urShimmer2',   opacity: 0.40 }],         trimId: 'rainbowTrim', sparkleCount: 36, bigSparkles: true  },
+};
+
 
 export interface JobCardProps {
   result: DiagnosisResult;
@@ -86,6 +113,7 @@ export const JobCard = forwardRef<SVGSVGElement, JobCardProps>(function JobCard(
   const { result, effectName, effectCost, effectDescription, flavorText, flavorAttribution, rarity, displayName, handle, artSrc, avatarSrc, className, style } = props;
   const rarityColor = RARITY_COLOR[rarity];
   const rarityLabel = RARITY_LABEL[rarity];
+  const frameStyle = FRAME_STYLES[rarity];
   const job = JOBS_BY_ID[result.archetype];
   const jobName = jobDisplayName(result.archetype, 'default');
   const lv = result.playerLevel ? playerLevelFromXp(result.playerLevel.xp) : 1;
@@ -105,34 +133,117 @@ export const JobCard = forwardRef<SVGSVGElement, JobCardProps>(function JobCard(
       style={style}
     >
       <defs>
-        {/* === Card frame (新規 / 旧 AI 枠画像の置き換え) ===
-            rarity 色を frame の主役にして、上に金縁 + 角飾りを乗せる。
+        {/* === Card frame の defs ===
+            - bodyGrad-*: rarity 別の枠主色 (multi-stop メタリック)
+            - shimmer-*: rarity 別のシマー層 (光沢の色味と方向を変える)
+            - silverTrim/goldTrim/rainbowTrim: 外側ダブルラインの色
             - frameLight: 上から光が当たって下が落ちる擬似 3D
-            - goldTrim: メタリック金 (上ハイライト→下シャドウのリニア)
-            - urShimmer: UR/SSR 用、虹色っぽいシマー
         */}
         <linearGradient id="frameLight" x1="0" y1="0" x2="0" y2="1">
           <stop offset="0%" stopColor="rgba(255,255,255,0.22)" />
           <stop offset="35%" stopColor="rgba(255,255,255,0)" />
           <stop offset="100%" stopColor="rgba(0,0,0,0.4)" />
         </linearGradient>
+
+        {/* ─── 枠主色 (rarity 別 multi-stop) ─── */}
+        <linearGradient id="commonGrad" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="#9a8e80" />
+          <stop offset="50%" stopColor="#7a7066" />
+          <stop offset="100%" stopColor="#3a3028" />
+        </linearGradient>
+        <linearGradient id="uncommonGrad" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="#7aaa88" />
+          <stop offset="50%" stopColor="#4c7a5a" />
+          <stop offset="100%" stopColor="#1c3024" />
+        </linearGradient>
+        <linearGradient id="rareGrad" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="#7ea2d4" />
+          <stop offset="50%" stopColor="#5c7aa8" />
+          <stop offset="100%" stopColor="#1e3a64" />
+        </linearGradient>
+        <linearGradient id="srareGrad" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="#c388e4" />
+          <stop offset="50%" stopColor="#9e60c0" />
+          <stop offset="100%" stopColor="#4a1a70" />
+        </linearGradient>
+        <linearGradient id="ssrGrad" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="#f9d670" />
+          <stop offset="40%" stopColor="#c49833" />
+          <stop offset="100%" stopColor="#5a3a08" />
+        </linearGradient>
+        <linearGradient id="urGrad" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="#ff96b6" />
+          <stop offset="40%" stopColor="#c93c6a" />
+          <stop offset="100%" stopColor="#4a0818" />
+        </linearGradient>
+
+        {/* ─── シマー層 (上に重ねる光沢) ─── */}
+        <linearGradient id="rareShimmer" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0%" stopColor="#a8d4ff" />
+          <stop offset="50%" stopColor="#ffffff" />
+          <stop offset="100%" stopColor="#7eb5e8" />
+        </linearGradient>
+        <linearGradient id="srareShimmer" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0%" stopColor="#ffa8e8" />
+          <stop offset="50%" stopColor="#ffe0ff" />
+          <stop offset="100%" stopColor="#a880ff" />
+        </linearGradient>
+        {/* SSR: 金スイープ (水平、中央に強い白ハイライト) */}
+        <linearGradient id="ssrShimmer" x1="0" y1="0" x2="1" y2="0.3">
+          <stop offset="0%" stopColor="#fff8d0" stopOpacity="0" />
+          <stop offset="35%" stopColor="#fff8d0" stopOpacity="0.55" />
+          <stop offset="50%" stopColor="#ffffff" stopOpacity="0.95" />
+          <stop offset="65%" stopColor="#fff8d0" stopOpacity="0.55" />
+          <stop offset="100%" stopColor="#fff8d0" stopOpacity="0" />
+        </linearGradient>
+        {/* SSR 第 2 層: 縦方向の暖色グロー */}
+        <linearGradient id="ssrShimmer2" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="#ffd87a" stopOpacity="0.5" />
+          <stop offset="50%" stopColor="#ffa854" stopOpacity="0.1" />
+          <stop offset="100%" stopColor="#a86510" stopOpacity="0.4" />
+        </linearGradient>
+        {/* UR: 完全プリズム虹 (対角) */}
+        <linearGradient id="urShimmer" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0%"   stopColor="#ff80c0" />
+          <stop offset="20%"  stopColor="#ffd57a" />
+          <stop offset="40%"  stopColor="#a5ff8a" />
+          <stop offset="60%"  stopColor="#80e8ff" />
+          <stop offset="80%"  stopColor="#c080ff" />
+          <stop offset="100%" stopColor="#ff80c0" />
+        </linearGradient>
+        {/* UR 第 2 層: 反対方向の白ハイライト (ホログラフィック干渉) */}
+        <linearGradient id="urShimmer2" x1="1" y1="0" x2="0" y2="1">
+          <stop offset="0%"   stopColor="#ffffff" stopOpacity="0.7" />
+          <stop offset="35%"  stopColor="#ffffff" stopOpacity="0.05" />
+          <stop offset="65%"  stopColor="#ffffff" stopOpacity="0.05" />
+          <stop offset="100%" stopColor="#ffffff" stopOpacity="0.7" />
+        </linearGradient>
+
+        {/* ─── トリム (外側ダブルライン用) ─── */}
+        <linearGradient id="silverTrim" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%"   stopColor="#f4f6fa" />
+          <stop offset="40%"  stopColor="#c0c4ca" />
+          <stop offset="70%"  stopColor="#7a7e84" />
+          <stop offset="100%" stopColor="#3a3e44" />
+        </linearGradient>
         <linearGradient id="goldTrim" x1="0" y1="0" x2="0" y2="1">
-          <stop offset="0%" stopColor="#f8e493" />
-          <stop offset="40%" stopColor="#e1b04a" />
-          <stop offset="70%" stopColor="#a87420" />
+          <stop offset="0%"   stopColor="#f8e493" />
+          <stop offset="40%"  stopColor="#e1b04a" />
+          <stop offset="70%"  stopColor="#a87420" />
           <stop offset="100%" stopColor="#6a4310" />
         </linearGradient>
         <linearGradient id="goldTrimHoriz" x1="0" y1="0" x2="1" y2="0">
-          <stop offset="0%" stopColor="#a87420" />
-          <stop offset="50%" stopColor="#f8e493" />
+          <stop offset="0%"   stopColor="#a87420" />
+          <stop offset="50%"  stopColor="#f8e493" />
           <stop offset="100%" stopColor="#a87420" />
         </linearGradient>
-        <linearGradient id="urShimmer" x1="0" y1="0" x2="1" y2="1">
-          <stop offset="0%" stopColor="#f9e0a0" />
-          <stop offset="25%" stopColor="#ffb6e0" />
-          <stop offset="50%" stopColor="#b4d8ff" />
-          <stop offset="75%" stopColor="#cfffe0" />
-          <stop offset="100%" stopColor="#f9e0a0" />
+        <linearGradient id="rainbowTrim" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0%"   stopColor="#ff6aa8" />
+          <stop offset="20%"  stopColor="#ffd54f" />
+          <stop offset="40%"  stopColor="#85ff7e" />
+          <stop offset="60%"  stopColor="#7eebff" />
+          <stop offset="80%"  stopColor="#c47eff" />
+          <stop offset="100%" stopColor="#ff6aa8" />
         </linearGradient>
         <clipPath id="artClip">
           <rect x={PADX + 14} y={ART_Y} width={W - 2 * (PADX + 14)} height={ART_H} rx="4" />
@@ -180,32 +291,37 @@ export const JobCard = forwardRef<SVGSVGElement, JobCardProps>(function JobCard(
       {/* === カード背景 (プログラマティック frame) ===
           層構成 (下→上):
           1. 最外周の濃焦げ茶リム (silhouette を決める)
-          2. rarity 色 (このカードの「色」=希少度を一目で識別)
-          3. UR/SSR は光らせる虹シマー帯を重ねる
+          2. rarity 別の枠主色 multi-stop メタリック
+          3. シマー層 (rarity 別、UR/SSR は 2 重で深みを出す)
           4. frameLight (上ハイライト→下シャドウで 3D 感)
-          5. 金縁ダブルライン (内側に細線、外側に太線)
-          6. 4 隅の装飾オーナメント
+          5. スパークル (srare 以上で枠帯に星をちりばめる、UR は最多)
+          6. トリム ダブルライン (silver / gold / rainbow を rarity で切替)
+          7. 4 隅オーナメント + 上下中央装飾
       */}
       <rect x="0" y="0" width={W} height={H} fill={FRAME_OUTER} rx="18" />
-      <rect x="6" y="6" width={W - 12} height={H - 12} fill={rarityColor} rx="14" />
-      {(rarity === 'ssr' || rarity === 'ur') && (
-        <rect x="6" y="6" width={W - 12} height={H - 12}
-              fill="url(#urShimmer)" opacity={rarity === 'ur' ? 0.45 : 0.22} rx="14" />
-      )}
+      <rect x="6" y="6" width={W - 12} height={H - 12} fill={`url(#${frameStyle.bodyGradId})`} rx="14" />
+      {frameStyle.shimmer.map((sh) => (
+        <rect key={sh.id} x="6" y="6" width={W - 12} height={H - 12}
+              fill={`url(#${sh.id})`} opacity={sh.opacity} rx="14" />
+      ))}
       <rect x="6" y="6" width={W - 12} height={H - 12} fill="url(#frameLight)" rx="14" />
-      {/* 金縁ダブルライン */}
+      {/* トリム ダブルライン (silver/gold/rainbow) */}
       <rect x="13" y="13" width={W - 26} height={H - 26} fill="none"
-            stroke="url(#goldTrim)" strokeWidth="2.2" rx="11" />
+            stroke={`url(#${frameStyle.trimId})`} strokeWidth="2.2" rx="11" />
       <rect x="18" y="18" width={W - 36} height={H - 36} fill="none"
             stroke="rgba(0,0,0,0.55)" strokeWidth="0.7" rx="9" />
       {/* 4 隅のオーナメント */}
-      <CornerOrnament cx={18} cy={18} rotation={0} />
-      <CornerOrnament cx={W - 18} cy={18} rotation={90} />
-      <CornerOrnament cx={W - 18} cy={H - 18} rotation={180} />
-      <CornerOrnament cx={18} cy={H - 18} rotation={270} />
+      <CornerOrnament cx={18} cy={18} rotation={0} trimId={frameStyle.trimId} />
+      <CornerOrnament cx={W - 18} cy={18} rotation={90} trimId={frameStyle.trimId} />
+      <CornerOrnament cx={W - 18} cy={H - 18} rotation={180} trimId={frameStyle.trimId} />
+      <CornerOrnament cx={18} cy={H - 18} rotation={270} trimId={frameStyle.trimId} />
       {/* 上下中央の装飾 (沈黙の baroque な仕切り) */}
-      <CenterFlourish cx={W / 2} cy={14} />
-      <CenterFlourish cx={W / 2} cy={H - 14} rotation={180} />
+      <CenterFlourish cx={W / 2} cy={14} trimId={frameStyle.trimId} />
+      <CenterFlourish cx={W / 2} cy={H - 14} rotation={180} trimId={frameStyle.trimId} />
+      {/* スパークル (枠帯のみ、パネル上には載せない / トリムと装飾の上に光らせる) */}
+      {frameStyle.sparkleCount > 0 && (
+        <SparkleField count={frameStyle.sparkleCount} seed={hashRarity(rarity)} bigSparkles={frameStyle.bigSparkles} />
+      )}
 
       {/* === 1. Title bar === */}
       <g>
@@ -516,46 +632,143 @@ function wrapJa(text: string, perLine: number, maxLines: number): string[] {
 }
 
 /**
- * 4 隅の金細工オーナメント。L 字の二重線 + コーナーの宝石風ダイヤ + 沿線のドット。
- * cx,cy は L の内角 (= 内側ゴールド trim の角)。rotation で 4 隅に向きを合わせる。
+ * 4 隅のオーナメント。L 字の二重線 + コーナーの宝石風ダイヤ + 沿線のドット。
+ * cx,cy は L の内角 (= 内側トリムの角)。rotation で 4 隅に向きを合わせる。
+ * trimId は silver/gold/rainbow から選び、宝石とダイヤの色味が rarity と合う。
  */
-function CornerOrnament({ cx, cy, rotation }: { cx: number; cy: number; rotation: number }) {
+function CornerOrnament({ cx, cy, rotation, trimId }: { cx: number; cy: number; rotation: number; trimId: string }) {
+  const stroke = `url(#${trimId})`;
   return (
     <g transform={`translate(${cx},${cy}) rotate(${rotation})`}>
-      {/* 内側細線 L (黒で陰影) */}
       <path d="M 4 38 L 4 4 L 38 4" fill="none"
             stroke="rgba(0,0,0,0.55)" strokeWidth="0.6" />
-      {/* 主役: 金 L */}
       <path d="M 0 40 L 0 0 L 40 0" fill="none"
-            stroke="url(#goldTrim)" strokeWidth="1.8" strokeLinecap="round" />
-      {/* コーナーの菱形宝石 */}
+            stroke={stroke} strokeWidth="1.8" strokeLinecap="round" />
       <path d="M 0 0 L 9 -9 L 18 0 L 9 9 Z"
-            fill="url(#goldTrim)" stroke="#3a2408" strokeWidth="0.7" />
+            fill={stroke} stroke="#1a0e02" strokeWidth="0.7" />
       <path d="M 9 -5.5 L 14 0 L 9 5.5 L 4 0 Z"
-            fill="rgba(255,240,180,0.7)" />
-      {/* 沿線のドット (2 つずつ) */}
-      <circle cx="24" cy="0" r="1.8" fill="url(#goldTrim)" />
-      <circle cx="32" cy="0" r="1.2" fill="url(#goldTrim)" opacity="0.7" />
-      <circle cx="0" cy="24" r="1.8" fill="url(#goldTrim)" />
-      <circle cx="0" cy="32" r="1.2" fill="url(#goldTrim)" opacity="0.7" />
+            fill="rgba(255,255,255,0.7)" />
+      <circle cx="24" cy="0" r="1.8" fill={stroke} />
+      <circle cx="32" cy="0" r="1.2" fill={stroke} opacity="0.7" />
+      <circle cx="0" cy="24" r="1.8" fill={stroke} />
+      <circle cx="0" cy="32" r="1.2" fill={stroke} opacity="0.7" />
     </g>
   );
 }
 
 /**
  * 上下中央の小さな baroque 装飾。シンメトリな菱形 + 横線。
- * cx,cy は装飾の中心点。
+ * trimId は CornerOrnament と同じ色味系を共有させる。
  */
-function CenterFlourish({ cx, cy, rotation = 0 }: { cx: number; cy: number; rotation?: number }) {
+function CenterFlourish({ cx, cy, rotation = 0, trimId }: { cx: number; cy: number; rotation?: number; trimId: string }) {
+  const stroke = `url(#${trimId})`;
   return (
     <g transform={`translate(${cx},${cy}) rotate(${rotation})`}>
-      <path d="M -28 0 L -8 0" stroke="url(#goldTrimHoriz)" strokeWidth="1.4" />
-      <path d="M 28 0 L 8 0" stroke="url(#goldTrimHoriz)" strokeWidth="1.4" />
+      <path d="M -28 0 L -8 0" stroke={stroke} strokeWidth="1.4" />
+      <path d="M 28 0 L 8 0" stroke={stroke} strokeWidth="1.4" />
       <path d="M -8 0 L 0 -5 L 8 0 L 0 5 Z"
-            fill="url(#goldTrim)" stroke="#3a2408" strokeWidth="0.5" />
-      <circle cx="-32" cy="0" r="1.4" fill="url(#goldTrim)" />
-      <circle cx="32" cy="0" r="1.4" fill="url(#goldTrim)" />
+            fill={stroke} stroke="#1a0e02" strokeWidth="0.5" />
+      <circle cx="-32" cy="0" r="1.4" fill={stroke} />
+      <circle cx="32" cy="0" r="1.4" fill={stroke} />
     </g>
   );
+}
+
+/**
+ * 枠帯にちりばめるスパークル星。
+ *
+ * 配置はパネル外 (x < PADX, x > W - PADX, y < PADY, y > H - PADY) の枠帯のみ。
+ * 角オーナメント / 中央装飾 と被らないようにバッファを取って rejection sampling。
+ * seed (rarity から導出) で決定的に位置決め → 同じ rarity は毎回同じ模様。
+ *
+ * bigSparkles=true なら 1/4 を + 字型の大粒に置き換える (SSR/UR で輝きを強める)。
+ */
+function SparkleField({ count, seed, bigSparkles }: { count: number; seed: number; bigSparkles: boolean }) {
+  const stars = generateSparkles(seed, count);
+  return (
+    <g>
+      {stars.map((s, i) => {
+        if (bigSparkles && i % 4 === 0) {
+          // + 字型の大粒 (4-point star)
+          const r = s.r * 1.4;
+          const inner = r * 0.28;
+          return (
+            <path
+              key={i}
+              transform={`translate(${s.x},${s.y})`}
+              d={`M 0 ${-r} L ${inner} ${-inner} L ${r} 0 L ${inner} ${inner} L 0 ${r} L ${-inner} ${inner} L ${-r} 0 L ${-inner} ${-inner} Z`}
+              fill="#fffce8"
+              opacity={s.op}
+            />
+          );
+        }
+        return (
+          <circle key={i} cx={s.x} cy={s.y} r={s.r} fill="#fffce8" opacity={s.op} />
+        );
+      })}
+    </g>
+  );
+}
+
+/** rarity 文字列を deterministic な seed に潰す (FNV-1a 簡易版)。 */
+function hashRarity(r: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < r.length; i++) {
+    h ^= r.charCodeAt(i);
+    h = (h * 0x01000193) >>> 0;
+  }
+  return h;
+}
+
+/**
+ * 枠帯 (パネルの外側) にスパークル星の座標を count 個生成。
+ * - 上下のストリップ: y < 32 / y > H - 32
+ * - 左右のストリップ: x < 32 / x > W - 32
+ * - 角オーナメント (±50px) と中央装飾 (±36px) を避ける rejection sampling
+ */
+function generateSparkles(seed: number, count: number): Array<{ x: number; y: number; r: number; op: number }> {
+  const stars: Array<{ x: number; y: number; r: number; op: number }> = [];
+  let h = seed >>> 0;
+  const rand = () => {
+    h = (h * 1664525 + 1013904223) >>> 0;
+    return h / 0x100000000;
+  };
+  const corners: Array<[number, number]> = [[18, 18], [W - 18, 18], [W - 18, H - 18], [18, H - 18]];
+  const flourishes: Array<[number, number]> = [[W / 2, 14], [W / 2, H - 14]];
+  let attempts = 0;
+  while (stars.length < count && attempts < count * 12) {
+    attempts++;
+    const side = Math.floor(rand() * 4);
+    let x: number;
+    let y: number;
+    if (side === 0) {        // top strip
+      x = 30 + rand() * (W - 60);
+      y = 3 + rand() * 28;
+    } else if (side === 1) { // bottom strip
+      x = 30 + rand() * (W - 60);
+      y = H - 31 + rand() * 28;
+    } else if (side === 2) { // left strip
+      x = 3 + rand() * 28;
+      y = 50 + rand() * (H - 100);
+    } else {                 // right strip
+      x = W - 31 + rand() * 28;
+      y = 50 + rand() * (H - 100);
+    }
+    // reject if too close to corner ornaments or center flourishes
+    let bad = false;
+    for (const [cx, cy] of corners) {
+      if (Math.hypot(x - cx, y - cy) < 50) { bad = true; break; }
+    }
+    if (!bad) {
+      for (const [cx, cy] of flourishes) {
+        if (Math.hypot(x - cx, y - cy) < 36) { bad = true; break; }
+      }
+    }
+    if (bad) continue;
+    const r = 1.5 + rand() * 2.2;
+    const op = 0.55 + rand() * 0.4;
+    stars.push({ x, y, r, op });
+  }
+  return stars;
 }
 

--- a/apps/web/src/lib/atproto.ts
+++ b/apps/web/src/lib/atproto.ts
@@ -87,6 +87,9 @@ export interface FollowProfile {
   handle: string;
   displayName?: string;
   avatar?: string;
+  /** 相互フォロー (相手も viewer をフォロー返ししているか)。
+   *  ※ actor が viewer 自身の場合のみ意味を持つ (viewer.followedBy 由来)。 */
+  isMutual?: boolean;
 }
 
 /**
@@ -103,6 +106,7 @@ export async function fetchFirstPageFollows(agent: Agent, actor: string): Promis
     handle: f.handle,
     ...(f.displayName ? { displayName: f.displayName } : {}),
     ...(f.avatar ? { avatar: f.avatar } : {}),
+    ...(f.viewer?.followedBy ? { isMutual: true } : {}),
   }));
   firstPageFollowsCache.set(actor, out);
   return out;
@@ -127,6 +131,7 @@ export async function fetchFollows(agent: Agent, actor: string): Promise<FollowP
         handle: f.handle,
         ...(f.displayName ? { displayName: f.displayName } : {}),
         ...(f.avatar ? { avatar: f.avatar } : {}),
+        ...(f.viewer?.followedBy ? { isMutual: true } : {}),
       });
     }
     cursor = res.data.cursor;

--- a/apps/web/src/routes/card.tsx
+++ b/apps/web/src/routes/card.tsx
@@ -12,6 +12,7 @@ import { recordCardDraw } from '@/lib/card-power';
 import { generateCardText, getFallbackCardText, stripMarkdown, CardTextError, type CardText } from '@/lib/flavor-text';
 import { cardToPngBlob, cardToShareBlob, downloadBlob } from '@/lib/card-export';
 import { JobCard } from '@/components/job-card';
+import { CardDrawOverlay } from '@/components/card-draw-overlay';
 import { CasinoIcon, DownloadIcon, ShareIcon } from '@/components/icons';
 import { useCompose, useOnPosted } from '@/components/compose-modal';
 import { Spinner } from '@/components/spinner';
@@ -44,6 +45,15 @@ export function Card() {
   const [shareErr, setShareErr] = useState<string | null>(null);
   const [genError, setGenError] = useState<{ stage: string; message: string; raw?: string } | null>(null);
   const [flavorAttribution, setFlavorAttribution] = useState<string | null>(null);
+  // 引き直し演出: 抽選結果のレアリティをオーバーレイ表示中に保持。
+  // llmDone が true になったらオーバーレイは reveal フェーズへ進む。
+  // pending は LLM 完了後の結果バッファ。オーバーレイの onComplete で実 state に commit。
+  const [drawing, setDrawing] = useState<{ rarity: Rarity; llmDone: boolean } | null>(null);
+  const [pending, setPending] = useState<{
+    card: CardText;
+    attribution: string | null;
+    variant: 1 | 2;
+  } | null>(null);
   const svgRef = useRef<SVGSVGElement>(null);
 
   // 初回: session 確認 → 診断 + points ロード
@@ -181,49 +191,35 @@ export function Card() {
 
     setFlavorBusy(true);
     setGenError(null);
-    try {
-      // レアリティと枠 variant を抽選
-      const nextRarity = rollRarity();
-      const nextVariant: 1 | 2 = Math.random() < 0.5 ? 1 : 2;
-      // フォロイーからフレーバー発言者をランダムに選ぶ (失敗しても致命ではない)。
-      let attribution: string | null = null;
-      if (session.did) {
-        try {
-          const follows = await fetchFirstPageFollows(agent, session.did);
-          if (follows.length > 0) {
-            const pick = follows[Math.floor(Math.random() * follows.length)]!;
-            attribution = pick.displayName?.trim() || pick.handle;
-          }
-        } catch (e) {
-          console.warn('[card] fetch follows for attribution failed', e);
-        }
-      }
-      // LLM 先に走らせてから state を一括更新 (背景だけ先に変わる現象を防ぐ)
-      const r = await generateCardText(load.result, nextRarity, { seed: Date.now() });
-      setRarity(nextRarity);
-      setFrameVariant(nextVariant);
-      setCard(r);
-      setFlavorAttribution(attribution);
-      // PDS に一式保存 (effect 3 要素 + flavor + rarity + frameVariant + attribution)
+
+    // レアリティと枠 variant を抽選 (同期、即決定するので演出開始前に決められる)
+    const nextRarity = rollRarity();
+    const nextVariant: 1 | 2 = Math.random() < 0.5 ? 1 : 2;
+    // 明示的な引き直しのみ演出を出す。初回 (PDS にカードが無い時の自動生成) は無音で。
+    const showOverlay = !opts.initial;
+    if (showOverlay) {
+      setDrawing({ rarity: nextRarity, llmDone: false });
+    }
+
+    // 相互フォローの中からフレーバー発言者を選ぶ (失敗しても致命ではない)
+    let attribution: string | null = null;
+    if (session.did) {
       try {
-        const now = new Date().toISOString();
-        await putRecord(agent, COL.analysis, 'self', {
-          ...load.result,
-          cardEffectName: r.effect.name,
-          cardEffectCost: r.effect.cost,
-          cardEffectDescription: r.effect.description,
-          // 後方互換: 旧 cardEffect フィールドには "名前 ― 説明" を入れる
-          cardEffect: `${r.effect.name} ― ${r.effect.description}`,
-          flavorText: r.flavor,
-          ...(attribution ? { flavorAttribution: attribution } : {}),
-          cardRarity: nextRarity,
-          cardFrameVariant: nextVariant,
-          cardDrawnAt: now,
-          flavorGeneratedAt: now,
-        });
+        const follows = await fetchFirstPageFollows(agent, session.did);
+        const mutuals = follows.filter((f) => f.isMutual);
+        if (mutuals.length > 0) {
+          const pick = mutuals[Math.floor(Math.random() * mutuals.length)]!;
+          attribution = pick.displayName?.trim() || pick.handle;
+        }
       } catch (e) {
-        console.warn('[card] save card to PDS failed', e);
+        console.warn('[card] fetch follows for attribution failed', e);
       }
+    }
+
+    // LLM 生成 (失敗時は fallback テキストにフォールバック、演出は最後まで流す)
+    let generated: CardText;
+    try {
+      generated = await generateCardText(load.result, nextRarity, { seed: Date.now() });
     } catch (e) {
       console.error('[card] regenerate card failed', e);
       if (e instanceof CardTextError) {
@@ -235,11 +231,57 @@ export function Card() {
       } else {
         setGenError({ stage: 'unknown', message: String((e as Error)?.message ?? e) });
       }
-    } finally {
-      setFlavorBusy(false);
+      generated = getFallbackCardText(load.result.archetype, Date.now(), nextRarity);
+    }
+
+    // PDS に一式保存 (effect 3 要素 + flavor + rarity + frameVariant + attribution)
+    try {
+      const now = new Date().toISOString();
+      await putRecord(agent, COL.analysis, 'self', {
+        ...load.result,
+        cardEffectName: generated.effect.name,
+        cardEffectCost: generated.effect.cost,
+        cardEffectDescription: generated.effect.description,
+        cardEffect: `${generated.effect.name} ― ${generated.effect.description}`,
+        flavorText: generated.flavor,
+        ...(attribution ? { flavorAttribution: attribution } : {}),
+        cardRarity: nextRarity,
+        cardFrameVariant: nextVariant,
+        cardDrawnAt: now,
+        flavorGeneratedAt: now,
+      });
+    } catch (e) {
+      console.warn('[card] save card to PDS failed', e);
+    }
+
+    setFlavorBusy(false);
+
+    if (showOverlay) {
+      // 演出を出してる間は state を温存して、onDrawComplete で一括コミット。
+      // これでオーバーレイ下の旧カードが先に変わって "ネタバレ" するのを防ぐ。
+      setPending({ card: generated, attribution, variant: nextVariant });
+      setDrawing((d) => (d ? { ...d, llmDone: true } : null));
+    } else {
+      // initial 経路 (PDS から復元できなかった初回生成): 即時コミット
+      setRarity(nextRarity);
+      setFrameVariant(nextVariant);
+      setCard(generated);
+      setFlavorAttribution(attribution);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [load.status, session.status, session.agent, power]);
+
+  /** カード抽選演出が reveal を終えた瞬間に pending を実 state にコミット。 */
+  const onDrawComplete = useCallback(() => {
+    if (drawing && pending) {
+      setRarity(drawing.rarity);
+      setFrameVariant(pending.variant);
+      setCard(pending.card);
+      setFlavorAttribution(pending.attribution);
+    }
+    setDrawing(null);
+    setPending(null);
+  }, [drawing, pending]);
 
   const onDownload = useCallback(async () => {
     if (!svgRef.current || !result) return;
@@ -379,12 +421,12 @@ export function Card() {
 
       <div style={{ display: 'flex', gap: '0.6em', justifyContent: 'center', flexWrap: 'wrap', marginTop: '1em' }}>
         <button
-          disabled={flavorBusy || !power || power.balance < 1}
+          disabled={flavorBusy || !!drawing || !power || power.balance < 1}
           onClick={() => void regenerateCard({ initial: false })}
         >
           <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.35em' }}>
             <CasinoIcon size={16} />
-            {flavorBusy ? '詩を探している…' : (power && power.balance < 1) ? '引き直せない' : '引き直す (−1)'}
+            {drawing ? '抽選中…' : flavorBusy ? '詩を探している…' : (power && power.balance < 1) ? '引き直せない' : '引き直す (−1)'}
           </span>
         </button>
         <button disabled={shareBusy !== 'idle' || !card} onClick={() => void onDownload()}>
@@ -445,6 +487,14 @@ export function Card() {
       <div style={{ marginTop: '2em' }}>
         <Link to="/me">← 自分の気質に戻る</Link>
       </div>
+
+      {drawing && (
+        <CardDrawOverlay
+          rarity={drawing.rarity}
+          llmDone={drawing.llmDone}
+          onComplete={onDrawComplete}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -508,3 +508,349 @@ p { margin: 0.4em 0; }
   animation: ritual-burst-fly 1800ms ease-out forwards;
   pointer-events: none;
 }
+
+/* ─── カード抽選演出 ─────────────────── */
+/* 3 段階: drawing (汎用) → sensing (rarity 判明) → reveal (フィナーレ) */
+
+.cd-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 250;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: auto;
+  overflow: hidden;
+  /* rarity 色は data-rarity でセット (下で個別定義) */
+  --rar: #cccccc;
+  --intensity: 1;
+  background: radial-gradient(ellipse at center,
+    rgba(20, 10, 30, 0.65) 0%,
+    rgba(5, 5, 15, 0.96) 60%,
+    rgba(0, 0, 0, 1) 100%);
+  animation: cd-fade-in 350ms ease forwards;
+}
+.cd-overlay[data-stage="reveal"] {
+  animation: cd-fade-out 600ms ease 700ms forwards;
+}
+
+@keyframes cd-fade-in  { from { opacity: 0 } to { opacity: 1 } }
+@keyframes cd-fade-out { from { opacity: 1 } to { opacity: 0 } }
+
+/* rarity 色変数 */
+.cd-overlay[data-rarity="common"]   { --rar: #b0a89c; --intensity: 0.6; }
+.cd-overlay[data-rarity="uncommon"] { --rar: #6acc8a; --intensity: 0.8; }
+.cd-overlay[data-rarity="rare"]     { --rar: #5c9fff; --intensity: 1.1; }
+.cd-overlay[data-rarity="srare"]    { --rar: #c47eff; --intensity: 1.4; }
+.cd-overlay[data-rarity="ssr"]      { --rar: #ffce5e; --intensity: 1.8; }
+.cd-overlay[data-rarity="ur"]       { --rar: #ff7eb0; --intensity: 2.4; }
+
+.cd-stage {
+  position: relative;
+  width: min(360px, 80vw);
+  height: min(520px, 80vh);
+  perspective: 900px;
+}
+
+/* オーラ (rarity 色の柔らかい発光) */
+.cd-aura {
+  position: absolute;
+  inset: -40%;
+  background: radial-gradient(circle at center,
+    color-mix(in srgb, var(--rar) 80%, transparent) 0%,
+    color-mix(in srgb, var(--rar) 30%, transparent) 35%,
+    transparent 70%);
+  filter: blur(28px);
+  opacity: 0;
+  animation: cd-aura-breathe 1.6s ease-in-out infinite;
+  transition: opacity 600ms ease;
+  pointer-events: none;
+}
+.cd-overlay[data-stage="sensing"] .cd-aura,
+.cd-overlay[data-stage="reveal"] .cd-aura {
+  opacity: calc(0.45 * var(--intensity));
+}
+
+@keyframes cd-aura-breathe {
+  0%, 100% { transform: scale(1);    filter: blur(28px); }
+  50%      { transform: scale(1.08); filter: blur(22px); }
+}
+
+/* UR 用: 虹色 conic を重ねる */
+.cd-overlay[data-rarity="ur"] .cd-aura {
+  background:
+    conic-gradient(from 0deg,
+      #ff80c0, #ffd57a, #a5ff8a, #80e8ff, #c080ff, #ff80c0);
+  filter: blur(36px);
+  animation: cd-aura-breathe 1.6s ease-in-out infinite,
+             cd-conic-rotate 5s linear infinite;
+}
+@keyframes cd-conic-rotate {
+  to { transform: rotate(360deg); }
+}
+
+/* 中央のカード裏面 (Y 軸回転で「めくる」感を出す) */
+.cd-card-wrap {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transform-style: preserve-3d;
+}
+.cd-card {
+  width: 56%;
+  aspect-ratio: 768 / 1100;
+  border-radius: 14px;
+  background:
+    radial-gradient(circle at 50% 35%, rgba(255, 255, 255, 0.18), transparent 55%),
+    linear-gradient(160deg, #1a1028 0%, #0a0418 100%);
+  border: 2px solid color-mix(in srgb, var(--rar) 60%, #2a1a08);
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.08) inset,
+    0 0 calc(36px * var(--intensity)) color-mix(in srgb, var(--rar) 80%, transparent),
+    0 12px 28px rgba(0, 0, 0, 0.7);
+  transform-style: preserve-3d;
+  animation: cd-card-spin 2.2s cubic-bezier(0.4, 0.0, 0.6, 1) infinite;
+}
+.cd-overlay[data-stage="reveal"] .cd-card {
+  animation: cd-card-final-flip 900ms cubic-bezier(0.2, 0.7, 0.3, 1) forwards;
+}
+
+/* 中央に小さな菱形 (カード裏紋章) */
+.cd-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 12px;
+  background:
+    linear-gradient(45deg, transparent 47%, color-mix(in srgb, var(--rar) 50%, transparent) 50%, transparent 53%),
+    linear-gradient(-45deg, transparent 47%, color-mix(in srgb, var(--rar) 50%, transparent) 50%, transparent 53%);
+  background-size: 28px 28px;
+  opacity: 0.35;
+}
+.cd-card::after {
+  content: '';
+  position: absolute;
+  top: 50%; left: 50%;
+  width: 32%; aspect-ratio: 1;
+  margin: -16% 0 0 -16%;
+  background: radial-gradient(circle, var(--rar) 0%, transparent 70%);
+  border-radius: 50%;
+  filter: blur(8px);
+  opacity: calc(0.6 * var(--intensity));
+}
+
+@keyframes cd-card-spin {
+  0%   { transform: rotateY(0deg)   rotateZ(-2deg); }
+  50%  { transform: rotateY(180deg) rotateZ(2deg);  }
+  100% { transform: rotateY(360deg) rotateZ(-2deg); }
+}
+@keyframes cd-card-final-flip {
+  0%   { transform: rotateY(0deg)    scale(1); }
+  60%  { transform: rotateY(720deg)  scale(1.25); }
+  100% { transform: rotateY(720deg)  scale(0); opacity: 0; }
+}
+
+/* 光線 (srare 以上で出る、中央から放射) */
+.cd-rays {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 500ms ease;
+}
+.cd-overlay[data-stage="sensing"][data-rarity="srare"] .cd-rays,
+.cd-overlay[data-stage="sensing"][data-rarity="ssr"] .cd-rays,
+.cd-overlay[data-stage="sensing"][data-rarity="ur"] .cd-rays,
+.cd-overlay[data-stage="reveal"] .cd-rays {
+  opacity: calc(0.5 * var(--intensity));
+}
+.cd-rays span {
+  position: absolute;
+  width: 4px;
+  height: 200%;
+  background: linear-gradient(to bottom,
+    transparent 0%,
+    color-mix(in srgb, var(--rar) 90%, white) 45%,
+    color-mix(in srgb, var(--rar) 90%, white) 55%,
+    transparent 100%);
+  transform-origin: center center;
+  transform: rotate(calc(var(--a, 0) * 1deg));
+  animation: cd-ray-rotate 6s linear infinite;
+  filter: blur(1px);
+}
+@keyframes cd-ray-rotate {
+  from { transform: rotate(calc(var(--a, 0) * 1deg)); }
+  to   { transform: rotate(calc((var(--a, 0) + 360) * 1deg)); }
+}
+
+/* 衝撃波リング (ssr 以上) */
+.cd-rings {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+.cd-rings span {
+  position: absolute;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 2px solid color-mix(in srgb, var(--rar) 90%, white);
+  opacity: 0;
+}
+.cd-overlay[data-stage="sensing"][data-rarity="ssr"] .cd-rings span,
+.cd-overlay[data-stage="sensing"][data-rarity="ur"] .cd-rings span,
+.cd-overlay[data-stage="reveal"] .cd-rings span {
+  animation: cd-ring-pulse 1.6s ease-out infinite;
+}
+.cd-rings span:nth-child(2) { animation-delay: 0.5s; }
+.cd-rings span:nth-child(3) { animation-delay: 1s; }
+
+@keyframes cd-ring-pulse {
+  0%   { transform: scale(0.4); opacity: 0;    border-width: 4px; }
+  20%  {                         opacity: 0.7; }
+  100% { transform: scale(8);   opacity: 0;    border-width: 1px; }
+}
+
+/* 粒子 (rarity 色の小さな星が落ちる) */
+.cd-particles {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+.cd-particles span {
+  position: absolute;
+  width: 4px;
+  height: 4px;
+  top: -10%;
+  left: calc(var(--i, 0) * 7.6%);
+  background: color-mix(in srgb, var(--rar) 85%, white);
+  border-radius: 50%;
+  box-shadow: 0 0 8px color-mix(in srgb, var(--rar) 80%, transparent);
+  opacity: 0;
+  animation: cd-particle-fall 3s ease-in infinite;
+  animation-delay: calc(var(--i, 0) * 0.13s);
+}
+.cd-overlay[data-stage="drawing"] .cd-particles span {
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 0 6px rgba(255, 255, 255, 0.6);
+}
+@keyframes cd-particle-fall {
+  0%   { transform: translateY(0)     scale(0.4); opacity: 0; }
+  15%  {                                          opacity: 1; }
+  100% { transform: translateY(120vh) scale(1.2); opacity: 0; }
+}
+
+/* 大粒スパークル (ur のみ、ランダム位置でキラっと光る + 字星) */
+.cd-big-sparkles {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0;
+}
+.cd-overlay[data-rarity="ur"][data-stage="sensing"] .cd-big-sparkles,
+.cd-overlay[data-rarity="ur"][data-stage="reveal"] .cd-big-sparkles,
+.cd-overlay[data-rarity="ssr"][data-stage="sensing"] .cd-big-sparkles,
+.cd-overlay[data-rarity="ssr"][data-stage="reveal"] .cd-big-sparkles {
+  opacity: 1;
+}
+.cd-big-sparkles span {
+  position: absolute;
+  width: 22px;
+  height: 22px;
+  top: var(--y);
+  left: var(--x);
+  background:
+    linear-gradient(0deg,    transparent 45%, white 50%, transparent 55%),
+    linear-gradient(90deg,   transparent 45%, white 50%, transparent 55%),
+    linear-gradient(45deg,   transparent 47%, white 50%, transparent 53%),
+    linear-gradient(135deg,  transparent 47%, white 50%, transparent 53%);
+  filter: drop-shadow(0 0 6px color-mix(in srgb, var(--rar) 80%, white));
+  animation: cd-big-sparkle 1.4s ease-out infinite;
+  animation-delay: var(--d, 0s);
+  opacity: 0;
+}
+@keyframes cd-big-sparkle {
+  0%   { transform: scale(0)   rotate(0deg);   opacity: 0; }
+  30%  { transform: scale(1.4) rotate(45deg);  opacity: 1; }
+  100% { transform: scale(0.7) rotate(90deg);  opacity: 0; }
+}
+
+/* レアリティ判明テキスト (sensing で fade-in) */
+.cd-rarity-label {
+  position: absolute;
+  top: 14%;
+  left: 0; right: 0;
+  text-align: center;
+  font-family: 'Hiragino Mincho ProN', 'Yu Mincho', serif;
+  font-size: clamp(20px, 5vw, 32px);
+  font-weight: 800;
+  letter-spacing: 0.15em;
+  color: color-mix(in srgb, var(--rar) 80%, white);
+  text-shadow:
+    0 0 calc(20px * var(--intensity)) var(--rar),
+    0 0 4px rgba(0, 0, 0, 0.6);
+  opacity: 0;
+  transform: translateY(8px) scale(0.95);
+  transition: opacity 400ms ease, transform 400ms ease;
+}
+.cd-overlay[data-stage="sensing"] .cd-rarity-label,
+.cd-overlay[data-stage="reveal"] .cd-rarity-label {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  animation: cd-rarity-pulse 1.4s ease-in-out infinite;
+}
+@keyframes cd-rarity-pulse {
+  0%, 100% { letter-spacing: 0.15em; }
+  50%      { letter-spacing: 0.22em; }
+}
+
+/* シェイク (ssr/ur で sensing 中に画面が震える) */
+.cd-overlay[data-stage="sensing"][data-rarity="ssr"] .cd-stage,
+.cd-overlay[data-stage="sensing"][data-rarity="ur"] .cd-stage,
+.cd-overlay[data-stage="reveal"][data-rarity="ssr"] .cd-stage,
+.cd-overlay[data-stage="reveal"][data-rarity="ur"] .cd-stage {
+  animation: cd-shake 0.18s ease-in-out infinite;
+}
+@keyframes cd-shake {
+  0%, 100% { transform: translate(0, 0); }
+  25%      { transform: translate(-2px, 1px); }
+  50%      { transform: translate(1px, -2px); }
+  75%      { transform: translate(-1px, -1px); }
+}
+
+/* reveal 時のフラッシュ */
+.cd-flash {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at center,
+    rgba(255, 255, 255, 0.95) 0%,
+    color-mix(in srgb, var(--rar) 70%, white) 30%,
+    transparent 70%);
+  pointer-events: none;
+  opacity: 0;
+}
+.cd-overlay[data-stage="reveal"] .cd-flash {
+  animation: cd-flash 750ms ease-out forwards;
+}
+@keyframes cd-flash {
+  0%   { opacity: 0; transform: scale(0.6); }
+  30%  { opacity: 1; transform: scale(1.1); }
+  100% { opacity: 0; transform: scale(2); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  /* モーション削減: 演出のループだけ止めて、フェード in/out は最小限残す */
+  .cd-card, .cd-rays span, .cd-rings span, .cd-particles span,
+  .cd-big-sparkles span, .cd-aura, .cd-rarity-label, .cd-stage {
+    animation: none !important;
+  }
+  .cd-overlay { background: rgba(0, 0, 0, 0.92); }
+}

--- a/packages/core/src/__tests__/quest.test.ts
+++ b/packages/core/src/__tests__/quest.test.ts
@@ -3,11 +3,8 @@ import { DEFAULT_QUEST_TEMPLATES, JOB_XP_CURVE, PLAYER_XP_CURVE, generateDailyQu
 import type { StatVector } from '../types.js';
 
 describe('DEFAULT_QUEST_TEMPLATES', () => {
-  test('39 件ある', () => {
-    // pipeline で確定的にトラッキングできる action のみに絞った結果。
-    // 旧 45 件から repost_only / like_underseen / streak_maintain / quick_reply
-    // 系の untrackable 6 件を削除した。
-    expect(DEFAULT_QUEST_TEMPLATES.length).toBe(39);
+  test('34 件ある', () => {
+    expect(DEFAULT_QUEST_TEMPLATES.length).toBe(34);
   });
 
   test('全 ID がユニーク', () => {
@@ -15,10 +12,10 @@ describe('DEFAULT_QUEST_TEMPLATES', () => {
     expect(new Set(ids).size).toBe(ids.length);
   });
 
-  test('growth が 27, maintenance 5, restraint 7', () => {
+  test('growth が 22, maintenance 5, restraint 7', () => {
     const counts = { growth: 0, maintenance: 0, restraint: 0 };
     for (const t of DEFAULT_QUEST_TEMPLATES) counts[t.type]++;
-    expect(counts).toEqual({ growth: 27, maintenance: 5, restraint: 7 });
+    expect(counts).toEqual({ growth: 22, maintenance: 5, restraint: 7 });
   });
 
   test('restraint は必ず forbiddenActionTypes を持つ', () => {
@@ -46,9 +43,6 @@ describe('DEFAULT_QUEST_TEMPLATES', () => {
   });
 
   test('全テンプレが pipeline でトラッキング可能な ActionType しか参照しない', () => {
-    // post-processor + structural-action が出せる ActionType の集合。
-    // これ以外 (streak_maintain / repost_only / like_underseen / quick_reply /
-    // like_regular) を要求するテンプレは pipeline で永遠に進まないので除外する。
     const trackable = new Set<string>([
       'opinion_post', 'analysis_post', 'short_burst', 'humor_post', 'empathy_reply',
       'quote_with_opinion', 'quote_with_analysis', 'thread_continue', 'calm_debate_reply',
@@ -58,6 +52,33 @@ describe('DEFAULT_QUEST_TEMPLATES', () => {
       for (const at of types) {
         expect(trackable.has(at)).toBe(true);
       }
+    }
+  });
+
+  test('description が pipeline で判定不能な語を含まない', () => {
+    // 過去に description と実装の乖離を起こしていた語のリスト。
+    // 出典 URL / 異論判定 / スレッド深さ / 困窮判定 / テーマ統一 / 連投構造 は
+    // いずれも現状の pipeline では判定できないので、これらが文言に含まれていると
+    // ユーザーの努力方向と達成判定が乖離する。
+    const banned = ['出典', '異論', '複数段', '困っている', 'テーマで連続', '連投'];
+    for (const t of DEFAULT_QUEST_TEMPLATES) {
+      for (const word of banned) {
+        expect(t.descriptionTemplate, `${t.id}: "${t.descriptionTemplate}" は禁止語 "${word}" を含む`).not.toContain(word);
+      }
+    }
+  });
+
+  test('返信構造を示唆する文言を含む場合は thread_continue or calm_debate_reply を expect する', () => {
+    // 「返信」「返せ」「返答」を description に含むなら、実装側も返信構造を判定
+    // できる ActionType (thread_continue / calm_debate_reply) を expect していないと
+    // 受動的なクエスト (相手の投稿待ち) になってしまう。
+    const replyIndicators = /(返信|返せ|返答)/;
+    const replyAware = new Set(['thread_continue', 'calm_debate_reply']);
+    for (const t of DEFAULT_QUEST_TEMPLATES) {
+      if (!replyIndicators.test(t.descriptionTemplate)) continue;
+      const types = t.expectedActionTypes ?? [];
+      const hasReplyAware = types.some((at) => replyAware.has(at));
+      expect(hasReplyAware, `${t.id}: "${t.descriptionTemplate}" は返信語を含むが返信判定 ActionType を expect していない`).toBe(true);
     }
   });
 });
@@ -92,6 +113,31 @@ describe('generateDailyQuests', () => {
     const a = generateDailyQuests(input);
     const b = generateDailyQuests(input);
     expect(a.map((q) => q.templateId)).toEqual(b.map((q) => q.templateId));
+  });
+
+  test('遊び人志望で int 過剰 → restraint は int 系 (regression: 相対ギャップ)', () => {
+    // バグ再現シナリオ: 遊び人 target (atk=20, def=12, agi=30, int=10, luk=28) に
+    // 対して current (atk=23, def=14, agi=33, int=13, luk=18) のとき、
+    // 絶対 |gap| は atk/agi/int=3 で同点、絶対値ソートのタイブレークで atk が
+    // 拾われて「衝動的な発信を一日休め」が出ていた。
+    // 相対ギャップ (|gap|/target) では int=30% が最大の負ギャップなので、
+    // restraint は int 系 (restraint_long_analysis or restraint_quote_analysis) が
+    // 選ばれるはず。
+    const quests = generateDailyQuests({
+      userDid: 'did:plc:performer-seeker',
+      dateStr: '2026-05-17',
+      level: 3,
+      currentStats: stats(23, 14, 33, 13, 18),
+      targetStats: stats(20, 12, 30, 10, 28), // 遊び人
+      recentTemplateIds: [],
+    });
+    const restraint = quests.find((q) => q.type === 'restraint');
+    expect(restraint).toBeDefined();
+    expect(restraint!.targetStat).toBe('int');
+    expect(['restraint_long_analysis', 'restraint_quote_analysis']).toContain(restraint!.templateId);
+    // growth は luk (共感) で変わらず
+    const growthLuk = quests.find((q) => q.type === 'growth' && q.targetStat === 'luk');
+    expect(growthLuk).toBeDefined();
   });
 
   test('目標ジョブを切り替えると育成軸が変わる', () => {

--- a/packages/core/src/__tests__/stats.test.ts
+++ b/packages/core/src/__tests__/stats.test.ts
@@ -8,7 +8,7 @@ import {
   currentStatsRaw,
   normalizeStats,
   scaleStats,
-  sortStatsByAbsGap,
+  sortStatsByRelativeGap,
   statGap,
   zeroStats,
 } from '../stats.js';
@@ -110,10 +110,31 @@ describe('computeStats end-to-end', () => {
 });
 
 describe('statGap and sort', () => {
-  test('sortStatsByAbsGap orders by |gap|', () => {
+  test('sortStatsByRelativeGap orders by |gap| / target', () => {
+    // target ベースの正規化が効くケース: 絶対値が同じでも target が小さい方が上に来る。
     const gap = { atk: 5, def: -20, agi: 0, int: 10, luk: -3 };
-    const sorted = sortStatsByAbsGap(gap);
+    const target = { atk: 25, def: 25, agi: 25, int: 25, luk: 25 };
+    const sorted = sortStatsByRelativeGap(gap, target);
+    // 同じ target なら abs ベースと同じ順序になる
     expect(sorted[0]).toBe('def');
     expect(sorted[1]).toBe('int');
+  });
+
+  test('sortStatsByRelativeGap は target レンジ差を吸収する (遊び人シナリオ)', () => {
+    // 遊び人 target: atk=20, def=12, agi=30, int=10, luk=28
+    // current:      atk=23, def=14, agi=33, int=13, luk=18
+    // 絶対 |gap|:    3,      2,      3,      3,     10
+    // 相対 |gap|/tgt 0.150,  0.167,  0.100,  0.300, 0.357
+    // 絶対値ソートでは atk/agi/int が同点 3 でタイブレーク不定だが、
+    // 相対ソートでは int (0.300) が atk/agi より明確に上位に来る。
+    const target = { atk: 20, def: 12, agi: 30, int: 10, luk: 28 };
+    const current = { atk: 23, def: 14, agi: 33, int: 13, luk: 18 };
+    const gap = statGap(current, target);
+    const sorted = sortStatsByRelativeGap(gap, target);
+    expect(sorted[0]).toBe('luk'); // 最大の正ギャップ
+    expect(sorted[1]).toBe('int'); // 最大の負ギャップ (絶対 |gap|=3 だが相対 30%)
+    // atk, agi (相対 15% / 10%) は int より後
+    expect(sorted.indexOf('int')).toBeLessThan(sorted.indexOf('atk'));
+    expect(sorted.indexOf('int')).toBeLessThan(sorted.indexOf('agi'));
   });
 });

--- a/packages/core/src/quest.ts
+++ b/packages/core/src/quest.ts
@@ -1,4 +1,4 @@
-import { statGap, sortStatsByAbsGap } from './stats.js';
+import { statGap, sortStatsByRelativeGap } from './stats.js';
 import { JOB_LEVEL_TUNING, PLAYER_LEVEL_TUNING, XP_REWARDS } from './tuning.js';
 import type { ActionType, Quest, Stat, StatVector } from './types.js';
 
@@ -32,63 +32,53 @@ export interface QuestTemplate {
 const scaleLv = (base: number) => (lv: number) => Math.max(base, Math.floor(base * (1 + (lv - 1) * 0.1)));
 
 export const DEFAULT_QUEST_TEMPLATES: QuestTemplate[] = [
-  // ─── ATK 成長 (6) ───
+  // ─── ATK 成長 ───
   { id: 'atk_opinion_post',  type: 'growth', targetStat: 'atk', descriptionTemplate: '自分の意見を {N} 個発信せよ',         requiredCountFn: scaleLv(3), xpRewardFn: n => 50 + n * 10, expectedActionTypes: ['opinion_post'] },
-  { id: 'atk_debate_reply',  type: 'growth', targetStat: 'atk', descriptionTemplate: '議論に {N} 回参戦せよ',                requiredCountFn: scaleLv(2), xpRewardFn: n => 60 + n * 12, expectedActionTypes: ['opinion_post'] },
+  { id: 'atk_debate_reply',  type: 'growth', targetStat: 'atk', descriptionTemplate: '自分の考えを {N} 回ぶつけよ',         requiredCountFn: scaleLv(2), xpRewardFn: n => 60 + n * 12, expectedActionTypes: ['opinion_post'] },
   { id: 'atk_quote_opinion', type: 'growth', targetStat: 'atk', descriptionTemplate: '誰かの投稿を引用し自分の立場を {N} 回示せ', requiredCountFn: scaleLv(2), xpRewardFn: n => 60 + n * 12, expectedActionTypes: ['opinion_post', 'quote_with_opinion'] },
   { id: 'atk_hot_take',      type: 'growth', targetStat: 'atk', descriptionTemplate: '躊躇せず思ったことを {N} 回ポストせよ', requiredCountFn: scaleLv(3), xpRewardFn: n => 55 + n * 10, expectedActionTypes: ['opinion_post', 'short_burst'] },
-  { id: 'atk_stance_reply',  type: 'growth', targetStat: 'atk', descriptionTemplate: '異論に {N} 回、丁寧に返答せよ',         requiredCountFn: scaleLv(2), xpRewardFn: n => 65 + n * 12, expectedActionTypes: ['opinion_post'] },
-  { id: 'atk_solo_thread',   type: 'growth', targetStat: 'atk', descriptionTemplate: '一つのテーマで連続投稿を {N} 本書け',   requiredCountFn: scaleLv(2), xpRewardFn: n => 70 + n * 15, expectedActionTypes: ['opinion_post', 'analysis_post'] },
 
-  // ─── DEF 成長 (6) ───
+  // ─── DEF 成長 ───
   { id: 'def_thread',         type: 'growth', targetStat: 'def', descriptionTemplate: '自分のスレッドに {N} 件、自分で返信を重ねよ', requiredCountFn: () => 3,     xpRewardFn: n => 50 + n * 10, expectedActionTypes: ['thread_continue', 'analysis_post'] },
   { id: 'def_steady_post',    type: 'growth', targetStat: 'def', descriptionTemplate: '今日のうちに {N} 投稿、地に足をつけよ', requiredCountFn: () => 3,     xpRewardFn: n => 50 + n * 10, expectedActionTypes: ['short_burst', 'analysis_post', 'opinion_post'] },
   { id: 'def_calm_debate',    type: 'growth', targetStat: 'def', descriptionTemplate: '会話に {N} 回、落ち着いて長めに返答せよ', requiredCountFn: scaleLv(2), xpRewardFn: n => 65 + n * 13, expectedActionTypes: ['calm_debate_reply', 'analysis_post'] },
   { id: 'def_deep_reply',     type: 'growth', targetStat: 'def', descriptionTemplate: '会話を {N} 回、深めるように返せ',     requiredCountFn: scaleLv(2), xpRewardFn: n => 60 + n * 12, expectedActionTypes: ['analysis_post', 'calm_debate_reply'] },
   { id: 'def_anchored_series',type: 'growth', targetStat: 'def', descriptionTemplate: 'じっくり考えた投稿を {N} 件書け',     requiredCountFn: () => 3,     xpRewardFn: n => 70 + n * 15, expectedActionTypes: ['analysis_post'] },
-  { id: 'def_supporter_reply',type: 'growth', targetStat: 'def', descriptionTemplate: '困っている投稿に {N} 件、静かに寄り添え', requiredCountFn: scaleLv(2), xpRewardFn: n => 60 + n * 12, expectedActionTypes: ['empathy_reply'] },
 
-  // ─── AGI 成長 (5) ───
-  // ※ 旧 agi_fast_repost (repost_only 必要) は pipeline 未対応のため削除
-  { id: 'agi_short_post',    type: 'growth', targetStat: 'agi', descriptionTemplate: '軽やかに短文を {N} 個連投せよ',        requiredCountFn: scaleLv(3), xpRewardFn: n => 50 + n * 10, expectedActionTypes: ['short_burst'] },
-  { id: 'agi_quick_reply',   type: 'growth', targetStat: 'agi', descriptionTemplate: '短い返信を {N} 件、テンポよく送れ',     requiredCountFn: () => 3,     xpRewardFn: n => 50 + n * 10, expectedActionTypes: ['short_burst'] },
+  // ─── AGI 成長 ───
+  { id: 'agi_short_post',    type: 'growth', targetStat: 'agi', descriptionTemplate: '軽やかに短文を {N} 個書け',           requiredCountFn: scaleLv(3), xpRewardFn: n => 50 + n * 10, expectedActionTypes: ['short_burst'] },
+  { id: 'agi_quick_reply',   type: 'growth', targetStat: 'agi', descriptionTemplate: '短文を {N} 件、テンポよく投稿せよ',   requiredCountFn: () => 3,     xpRewardFn: n => 50 + n * 10, expectedActionTypes: ['short_burst'] },
   { id: 'agi_rhythm_chain',  type: 'growth', targetStat: 'agi', descriptionTemplate: '今日の瞬間を {N} 投稿、リズムを保て', requiredCountFn: scaleLv(3), xpRewardFn: n => 55 + n * 10, expectedActionTypes: ['short_burst'] },
   { id: 'agi_pulse_burst',   type: 'growth', targetStat: 'agi', descriptionTemplate: '思いつきを {N} 回切り取って投稿',     requiredCountFn: scaleLv(3), xpRewardFn: n => 50 + n * 10, expectedActionTypes: ['short_burst'] },
-  { id: 'agi_skim_reply',    type: 'growth', targetStat: 'agi', descriptionTemplate: '気になった投稿に {N} 件、軽く反応',   requiredCountFn: scaleLv(4), xpRewardFn: n => 50 + n * 10, expectedActionTypes: ['short_burst'] },
+  { id: 'agi_skim_reply',    type: 'growth', targetStat: 'agi', descriptionTemplate: '軽い反応を {N} 件記せ',               requiredCountFn: scaleLv(4), xpRewardFn: n => 50 + n * 10, expectedActionTypes: ['short_burst'] },
 
-  // ─── INT 成長 (6) ───
+  // ─── INT 成長 ───
   { id: 'int_long_post',      type: 'growth', targetStat: 'int', descriptionTemplate: '200 字以上の分析を {N} 件書け',        requiredCountFn: () => 2,     xpRewardFn: n => 70 + n * 15, expectedActionTypes: ['analysis_post'] },
   { id: 'int_quote_analysis', type: 'growth', targetStat: 'int', descriptionTemplate: '引用して考察を添えよ、{N} 回',         requiredCountFn: () => 2,     xpRewardFn: n => 60 + n * 12, expectedActionTypes: ['analysis_post', 'quote_with_analysis'] },
-  { id: 'int_long_thread',    type: 'growth', targetStat: 'int', descriptionTemplate: '複数段の分析スレッドを {N} 本書け',    requiredCountFn: () => 1,     xpRewardFn: n => 90 + n * 20, expectedActionTypes: ['analysis_post'] },
-  { id: 'int_citation_post',  type: 'growth', targetStat: 'int', descriptionTemplate: '出典付きの投稿を {N} 件書け',           requiredCountFn: () => 2,     xpRewardFn: n => 75 + n * 15, expectedActionTypes: ['analysis_post'] },
-  { id: 'int_critical_read',  type: 'growth', targetStat: 'int', descriptionTemplate: '読んだ記事に批判的コメントを {N} 回付けよ', requiredCountFn: scaleLv(2), xpRewardFn: n => 70 + n * 14, expectedActionTypes: ['analysis_post', 'opinion_post'] },
-  { id: 'int_research_reply', type: 'growth', targetStat: 'int', descriptionTemplate: '質問に調べた情報を添えて {N} 回返せ',   requiredCountFn: scaleLv(2), xpRewardFn: n => 65 + n * 13, expectedActionTypes: ['analysis_post'] },
+  { id: 'int_critical_read',  type: 'growth', targetStat: 'int', descriptionTemplate: '批判的な観点で {N} 件書け',           requiredCountFn: scaleLv(2), xpRewardFn: n => 70 + n * 14, expectedActionTypes: ['analysis_post', 'opinion_post'] },
+  { id: 'int_research_reply', type: 'growth', targetStat: 'int', descriptionTemplate: '掘り下げた分析を {N} 件書け',         requiredCountFn: scaleLv(2), xpRewardFn: n => 65 + n * 13, expectedActionTypes: ['analysis_post'] },
 
-  // ─── LUK 成長 (4) ───
-  // ※ 旧 luk_underseen (like_underseen) と luk_boost_fresh (repost_only) は
-  //   pipeline 未対応のため削除
+  // ─── LUK 成長 ───
   { id: 'luk_empathy',       type: 'growth', targetStat: 'luk', descriptionTemplate: '{N} 人に共感を贈れ',                   requiredCountFn: scaleLv(5), xpRewardFn: n => 50 + n * 10, expectedActionTypes: ['empathy_reply'] },
   { id: 'luk_warm_welcome',  type: 'growth', targetStat: 'luk', descriptionTemplate: '誰かに {N} 回、優しい声をかけよ',      requiredCountFn: scaleLv(2), xpRewardFn: n => 60 + n * 12, expectedActionTypes: ['empathy_reply'] },
-  { id: 'luk_thank_reply',   type: 'growth', targetStat: 'luk', descriptionTemplate: '感謝の返信を {N} 件送れ',               requiredCountFn: scaleLv(3), xpRewardFn: n => 50 + n * 10, expectedActionTypes: ['empathy_reply'] },
+  { id: 'luk_thank_reply',   type: 'growth', targetStat: 'luk', descriptionTemplate: '感謝の言葉を {N} 件記せ',               requiredCountFn: scaleLv(3), xpRewardFn: n => 50 + n * 10, expectedActionTypes: ['empathy_reply'] },
   { id: 'luk_humor_post',    type: 'growth', targetStat: 'luk', descriptionTemplate: '空気を和ませる投稿を {N} 件書け',       requiredCountFn: scaleLv(2), xpRewardFn: n => 55 + n * 12, expectedActionTypes: ['humor_post'] },
 
-  // ─── 維持 (5) ───
+  // ─── 維持 ───
   { id: 'maintenance_daily_word',   type: 'maintenance', targetStat: 'def', descriptionTemplate: '今日も一言を記せ',                     requiredCountFn: () => 1, xpRewardFn: () => 20, expectedActionTypes: ['short_burst', 'opinion_post', 'analysis_post', 'humor_post', 'empathy_reply'] },
   { id: 'maintenance_one_thought',  type: 'maintenance', targetStat: 'atk', descriptionTemplate: '今日、思ったことを一度だけ書け',       requiredCountFn: () => 1, xpRewardFn: () => 20, expectedActionTypes: ['opinion_post', 'short_burst'] },
-  { id: 'maintenance_gentle_scroll',type: 'maintenance', targetStat: 'agi', descriptionTemplate: 'TL を軽く流し、心に触れた投稿に反応せよ', requiredCountFn: () => 1, xpRewardFn: () => 20, expectedActionTypes: ['short_burst', 'empathy_reply'] },
+  { id: 'maintenance_gentle_scroll',type: 'maintenance', targetStat: 'agi', descriptionTemplate: '気になった投稿に反応を残せ',           requiredCountFn: () => 1, xpRewardFn: () => 20, expectedActionTypes: ['short_burst', 'empathy_reply'] },
   { id: 'maintenance_read_silent',  type: 'maintenance', targetStat: 'int', descriptionTemplate: '読むだけの時間を作り、考えを言葉にしない日', requiredCountFn: () => 0, xpRewardFn: () => 20 },
   { id: 'maintenance_thanks_round', type: 'maintenance', targetStat: 'luk', descriptionTemplate: '誰か一人に静かに「ありがとう」を送れ',   requiredCountFn: () => 1, xpRewardFn: () => 20, expectedActionTypes: ['empathy_reply'] },
 
-  // ─── 節制 (7) ───
-  // ※ 旧 restraint_quick_reply (quick_reply) / restraint_streak (streak_maintain) /
-  //   restraint_repost (repost_only) は pipeline 未対応のため削除
+  // ─── 節制 ───
   { id: 'restraint_opinion',        type: 'restraint', targetStat: 'atk', descriptionTemplate: '今日は意見投稿を控えよ',       requiredCountFn: () => 0, xpRewardFn: () => 80, forbiddenActionTypes: ['opinion_post', 'quote_with_opinion'] },
   { id: 'restraint_hot_take',       type: 'restraint', targetStat: 'atk', descriptionTemplate: '衝動的な発信を一日休め',       requiredCountFn: () => 0, xpRewardFn: () => 80, forbiddenActionTypes: ['opinion_post'] },
   { id: 'restraint_long_analysis',  type: 'restraint', targetStat: 'int', descriptionTemplate: '今日は長文分析を控えよ',       requiredCountFn: () => 0, xpRewardFn: () => 80, forbiddenActionTypes: ['analysis_post', 'quote_with_analysis'] },
   { id: 'restraint_quote_analysis', type: 'restraint', targetStat: 'int', descriptionTemplate: '引用考察を一日置いておけ',     requiredCountFn: () => 0, xpRewardFn: () => 80, forbiddenActionTypes: ['quote_with_analysis'] },
-  { id: 'restraint_short_burst',    type: 'restraint', targetStat: 'agi', descriptionTemplate: '今日は短文連投を控えよ',       requiredCountFn: () => 0, xpRewardFn: () => 80, forbiddenActionTypes: ['short_burst'] },
+  { id: 'restraint_short_burst',    type: 'restraint', targetStat: 'agi', descriptionTemplate: '今日は短文投稿を控えよ',       requiredCountFn: () => 0, xpRewardFn: () => 80, forbiddenActionTypes: ['short_burst'] },
   { id: 'restraint_thread',         type: 'restraint', targetStat: 'def', descriptionTemplate: '連続スレッドは一日休め',       requiredCountFn: () => 0, xpRewardFn: () => 80, forbiddenActionTypes: ['thread_continue'] },
-  { id: 'restraint_empathy',        type: 'restraint', targetStat: 'luk', descriptionTemplate: '共感返信は今日だけ休め',       requiredCountFn: () => 0, xpRewardFn: () => 80, forbiddenActionTypes: ['empathy_reply'] },
+  { id: 'restraint_empathy',        type: 'restraint', targetStat: 'luk', descriptionTemplate: '共感的な投稿は今日だけ休め',   requiredCountFn: () => 0, xpRewardFn: () => 80, forbiddenActionTypes: ['empathy_reply'] },
 ];
 
 /**
@@ -122,7 +112,9 @@ export interface QuestGenInput {
 export function generateDailyQuests(input: QuestGenInput): Quest[] {
   const tmpls = input.templates ?? DEFAULT_QUEST_TEMPLATES;
   const gap = statGap(input.currentStats, input.targetStats);
-  const sortedStats = sortStatsByAbsGap(gap);
+  // 相対ギャップ (|gap| / target) で並べる。target レンジが 7〜44 と幅広いので、
+  // 絶対点数で比較すると小 target stat (例: 遊び人 int=10) の歪みを過小評価する。
+  const sortedStats = sortStatsByRelativeGap(gap, input.targetStats);
 
   const growthStats: Stat[] = [];
   const restraintStat: Stat[] = [];

--- a/packages/core/src/stats.ts
+++ b/packages/core/src/stats.ts
@@ -114,7 +114,18 @@ export function statGap(current: StatVector, target: StatVector): StatVector {
   };
 }
 
-/** 絶対ギャップが大きい順に Stat キーを返す */
-export function sortStatsByAbsGap(gap: StatVector): readonly Stat[] {
-  return [...STATS].sort((a, b) => Math.abs(gap[b]) - Math.abs(gap[a]));
+/**
+ * 「target に対する相対ギャップ」が大きい順に Stat キーを返す。
+ *
+ * 各 stat の target 値域は職業ごとに 7〜44 と 6 倍の幅があるため、絶対点数で
+ * 比較するとレンジが小さい stat (例: 遊び人 int=10) のオーバー/アンダーが
+ * 過小評価される。`|gap| / target` で正規化して相対的な歪みの大きさで並べる。
+ *
+ * target は常に正 (最小 7) なので 0 除算は発生しないが、防御として
+ * `Math.max(target[s], 1)` を入れている。
+ */
+export function sortStatsByRelativeGap(gap: StatVector, target: StatVector): readonly Stat[] {
+  return [...STATS].sort((a, b) =>
+    Math.abs(gap[b]) / Math.max(target[b], 1) - Math.abs(gap[a]) / Math.max(target[a], 1),
+  );
 }


### PR DESCRIPTION
## Summary
3 つの独立した改善をまとめて反映:

1. **カード枠のレアリティ差別化** (commit 3c9c6c2): 各レアリティで枠主色 / シマー / スパークル / トリム色を変える。UR は虹色 conic + 36 スパークル + 虹色トリムで本格ホログラフィック。
2. **相互フォロー絞り込み + 抽選演出オーバーレイ** (commit c6c648f): フレーバー発言者を相互フォローのみに。引き直し時にフルスクリーン演出 (drawing → sensing → reveal の 3 段、rarity 別に演出変化) を表示し、LLM 生成の待ち時間を儀式の時間に。
3. **クエストエンジン改善** (commit 7081efb): stat gap 比較を絶対点数 → 相対 (gap/target) に。文言と実装が乖離していた / 受動的だったテンプレ 5 件削除 + 10 件文言修正。

## Why
- カード枠: rarity の差が一目で分からないので体感の格上げ感が出ない
- フレーバー発言者: 一方的フォロー相手の名前がカードに刻まれるのは気持ち悪い
- 抽選演出: 引き直しが何の演出も無く LLM 待ちで固まっていた
- stat gap 絶対比較: target 値域が 7〜44 と幅広いのに絶対点数で比較するため、target が小さい stat (例: 遊び人 int=10) のオーバー / アンダーが過小評価されていた
- クエスト文言乖離: ユーザーの努力方向と達成判定が一致しないクエストが残っていた (出典 URL、相手の異論、スレッド深さ、相手の困窮度などの判定不能条件を要求)

## Test plan
- [x] \`pnpm --filter @aozoraquest/core test\` 緑 (106 / 106)
- [x] \`pnpm --filter @aozoraquest/web typecheck\` 緑
- [x] \`pnpm --filter @aozoraquest/web test\` 緑 (29 / 29)
- [x] \`pnpm --filter @aozoraquest/web build\` 緑
- [ ] dev で全 6 rarity カードを引き直して演出と枠装飾を確認
- [ ] 目標を遊び人にセット → restraint が int 系に変わることを確認
- [ ] 16 ジョブを順に目標にしてクエスト 3 件が違和感なく出ることを目視

## Notes
- 既存「※ 旧 X は pipeline 未対応のため削除」コメント 3 箇所を除去。削除理由はソースに残してはいけない (commit message に書くもの) という原則に合わせた
- regression テスト 4 件追加 (相対ギャップソート / 遊び人シナリオ / 文言判定不能語 / 返信語と ActionType の整合)

🤖 Generated with [Claude Code](https://claude.com/claude-code)