### PR TITLE
feat(workspace): VirtualFeed dual-mode + AppColumn データモデル基盤 (マルチカラム PR 1/5)

### DIFF
--- a/apps/web/src/components/virtual-feed.tsx
+++ b/apps/web/src/components/virtual-feed.tsx
@@ -1,10 +1,14 @@
-import { type ReactNode, useEffect, useRef } from 'react';
+import { type ReactNode, type RefObject, useEffect, useRef, useState } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 
 /**
- * ウィンドウ (ビューポート) を仮想スクローラとして使う。
- * DOM 上に存在するのは可視範囲 ± overscan のアイテムだけ。
+ * 仮想スクローラ。DOM 上に存在するのは可視範囲 ± overscan のアイテムだけ。
  * 可変高に対応 (measureElement で各要素の高さを実測)。
+ *
+ * スクロール元は 2 モード:
+ *  - 既定: ウィンドウ (ビューポート) スクロール
+ *  - `scrollParentRef` 指定時: その要素内のスクロール
+ *    (マルチカラム workspace の column-body 等、docs/16-multicolumn.md)
  *
  * data 配列自体は成長するため真に無限な memory bound ではないが、
  * DOM 側は件数によらず一定、これが体感メモリの主因なのでこれでほぼ解決する。
@@ -21,6 +25,8 @@ export interface VirtualFeedProps<T> {
   renderItem: (item: T, index: number) => ReactNode;
   /** 末尾に置くフッター (読み込み中表示など) */
   footer?: ReactNode;
+  /** 未指定なら window スクロール (後方互換)。指定するとその要素内スクロール。 */
+  scrollParentRef?: RefObject<HTMLElement | null> | undefined;
 }
 
 export function VirtualFeed<T>(props: VirtualFeedProps<T>) {
@@ -33,19 +39,29 @@ export function VirtualFeed<T>(props: VirtualFeedProps<T>) {
     endReachedThreshold = 800,
     renderItem,
     footer,
+    scrollParentRef,
   } = props;
 
-  // window スクロールを使う。parentRef は offsetTop 計算用のダミー。
+  // window モードでは parentRef は offsetTop 計算用。container モードでは不要 (margin 0)。
   const parentRef = useRef<HTMLDivElement>(null);
+
+  // ref.current は commit 後に入るので、render 中に直接読むと初回 null のまま固定される。
+  // effect で state に同期して、container が入った時点で再 render させる。
+  const [containerEl, setContainerEl] = useState<HTMLElement | null>(null);
+  useEffect(() => {
+    setContainerEl(scrollParentRef?.current ?? null);
+  });
 
   const rowVirtualizer = useVirtualizer({
     count: items.length,
-    getScrollElement: () => (typeof window === 'undefined' ? null : (document.scrollingElement as HTMLElement)),
+    getScrollElement: () =>
+      containerEl ?? (typeof window === 'undefined' ? null : (document.scrollingElement as HTMLElement)),
     estimateSize: () => estimateSize,
     overscan,
     getItemKey: (i) => keyOf(items[i]!),
-    // window スクロールで parentRef が描画ツリー内のどこにあるかをオフセットとして渡す
-    scrollMargin: parentRef.current?.offsetTop ?? 0,
+    // window スクロールで parentRef が描画ツリー内のどこにあるかをオフセットとして渡す。
+    // container モードでは container 先頭 = リスト先頭なので 0。
+    scrollMargin: containerEl ? 0 : (parentRef.current?.offsetTop ?? 0),
     measureElement: (el) => el.getBoundingClientRect().height,
   });
 
@@ -53,24 +69,26 @@ export function VirtualFeed<T>(props: VirtualFeedProps<T>) {
   useEffect(() => {
     if (!onEndReached) return;
     const check = () => {
-      const scrollEl = document.scrollingElement;
+      const scrollEl: Element | null = containerEl ?? document.scrollingElement;
       if (!scrollEl) return;
       const remaining = scrollEl.scrollHeight - scrollEl.scrollTop - scrollEl.clientHeight;
       if (remaining < endReachedThreshold) onEndReached();
     };
-    window.addEventListener('scroll', check, { passive: true });
+    // scroll イベントは bubbling しないので、container モードでは container 自身に貼る
+    const target: EventTarget = containerEl ?? window;
+    target.addEventListener('scroll', check, { passive: true });
     window.addEventListener('resize', check);
     // 初回の描画直後にも 1 度呼ぶ (items が少ないときに即時 loadMore)
     check();
     return () => {
-      window.removeEventListener('scroll', check);
+      target.removeEventListener('scroll', check);
       window.removeEventListener('resize', check);
     };
-  }, [onEndReached, endReachedThreshold, items.length]);
+  }, [onEndReached, endReachedThreshold, items.length, containerEl]);
 
   const virtualItems = rowVirtualizer.getVirtualItems();
   const totalSize = rowVirtualizer.getTotalSize();
-  const scrollMargin = parentRef.current?.offsetTop ?? 0;
+  const scrollMargin = containerEl ? 0 : (parentRef.current?.offsetTop ?? 0);
 
   return (
     <div ref={parentRef} style={{ position: 'relative' }}>

--- a/apps/web/src/components/virtual-feed.tsx
+++ b/apps/web/src/components/virtual-feed.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, type RefObject, useEffect, useRef, useState } from 'react';
+import { type ReactNode, useEffect, useRef } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 
 /**
@@ -7,8 +7,12 @@ import { useVirtualizer } from '@tanstack/react-virtual';
  *
  * スクロール元は 2 モード:
  *  - 既定: ウィンドウ (ビューポート) スクロール
- *  - `scrollParentRef` 指定時: その要素内のスクロール
+ *  - `scrollParent` 指定時: その要素内のスクロール
  *    (マルチカラム workspace の column-body 等、docs/16-multicolumn.md)
+ *
+ * scrollParent は RefObject ではなく要素そのものを受け取る。利用側は
+ * `useState<HTMLElement | null>` + callback ref で要素を管理して渡すこと
+ * (要素の出現・差し替えが props 変化として自然に再 render を起こすため)。
  *
  * data 配列自体は成長するため真に無限な memory bound ではないが、
  * DOM 側は件数によらず一定、これが体感メモリの主因なのでこれでほぼ解決する。
@@ -25,8 +29,8 @@ export interface VirtualFeedProps<T> {
   renderItem: (item: T, index: number) => ReactNode;
   /** 末尾に置くフッター (読み込み中表示など) */
   footer?: ReactNode;
-  /** 未指定なら window スクロール (後方互換)。指定するとその要素内スクロール。 */
-  scrollParentRef?: RefObject<HTMLElement | null> | undefined;
+  /** 未指定 / null なら window スクロール (後方互換)。指定するとその要素内スクロール。 */
+  scrollParent?: HTMLElement | null | undefined;
 }
 
 export function VirtualFeed<T>(props: VirtualFeedProps<T>) {
@@ -39,18 +43,18 @@ export function VirtualFeed<T>(props: VirtualFeedProps<T>) {
     endReachedThreshold = 800,
     renderItem,
     footer,
-    scrollParentRef,
+    scrollParent,
   } = props;
 
   // window モードでは parentRef は offsetTop 計算用。container モードでは不要 (margin 0)。
   const parentRef = useRef<HTMLDivElement>(null);
+  const containerEl = scrollParent ?? null;
 
-  // ref.current は commit 後に入るので、render 中に直接読むと初回 null のまま固定される。
-  // effect で state に同期して、container が入った時点で再 render させる。
-  const [containerEl, setContainerEl] = useState<HTMLElement | null>(null);
-  useEffect(() => {
-    setContainerEl(scrollParentRef?.current ?? null);
-  });
+  // 既知の制約 (旧実装から同じ): window モードの scrollMargin は render 中に
+  // parentRef.current を読むため、初回 render では 0 のまま確定する。
+  // リストがページ先頭近くに置かれる現状のレイアウトでは実害がないので
+  // 据え置き (直すなら offsetTop を state 化して mount 後に再 render する)。
+  const scrollMargin = containerEl ? 0 : (parentRef.current?.offsetTop ?? 0);
 
   const rowVirtualizer = useVirtualizer({
     count: items.length,
@@ -60,8 +64,9 @@ export function VirtualFeed<T>(props: VirtualFeedProps<T>) {
     overscan,
     getItemKey: (i) => keyOf(items[i]!),
     // window スクロールで parentRef が描画ツリー内のどこにあるかをオフセットとして渡す。
-    // container モードでは container 先頭 = リスト先頭なので 0。
-    scrollMargin: containerEl ? 0 : (parentRef.current?.offsetTop ?? 0),
+    // container モードでは container 先頭 = リスト先頭なので 0
+    // (column 内にヘッダー等を挟む場合は利用側で要再考)。
+    scrollMargin,
     measureElement: (el) => el.getBoundingClientRect().height,
   });
 
@@ -88,7 +93,6 @@ export function VirtualFeed<T>(props: VirtualFeedProps<T>) {
 
   const virtualItems = rowVirtualizer.getVirtualItems();
   const totalSize = rowVirtualizer.getTotalSize();
-  const scrollMargin = containerEl ? 0 : (parentRef.current?.offsetTop ?? 0);
 
   return (
     <div ref={parentRef} style={{ position: 'relative' }}>

--- a/apps/web/src/lib/app-columns.test.ts
+++ b/apps/web/src/lib/app-columns.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import {
+  loadAppColumns,
+  saveAppColumns,
+  resetAppColumns,
+  defaultColumns,
+  makeAppColumn,
+  moveColumnLeft,
+  moveColumnRight,
+  removeColumn,
+  appColumnTitle,
+  isValidAppColumn,
+  type AppColumn,
+} from './app-columns';
+
+beforeAll(() => {
+  if (typeof globalThis.localStorage === 'undefined') {
+    const store = new Map<string, string>();
+    (globalThis as unknown as { localStorage: Storage }).localStorage = {
+      getItem: (k) => (store.has(k) ? store.get(k)! : null),
+      setItem: (k, v) => { store.set(k, String(v)); },
+      removeItem: (k) => { store.delete(k); },
+      clear: () => { store.clear(); },
+      key: (i) => Array.from(store.keys())[i] ?? null,
+      get length() { return store.size; },
+    };
+  }
+});
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('defaultColumns', () => {
+  it('サインイン済み: home / bar / notifications / board の 4 カラム', () => {
+    const cols = defaultColumns(true);
+    expect(cols.map(c => c.kind)).toEqual(['home', 'bar', 'notifications', 'board']);
+  });
+
+  it('未サインイン: board 1 カラムのみ', () => {
+    const cols = defaultColumns(false);
+    expect(cols.map(c => c.kind)).toEqual(['board']);
+  });
+
+  it('id は毎回ユニーク', () => {
+    const a = defaultColumns(true);
+    const b = defaultColumns(true);
+    expect(a[0]!.id).not.toBe(b[0]!.id);
+  });
+});
+
+describe('loadAppColumns / saveAppColumns', () => {
+  it('保存なし → default 構成', () => {
+    expect(loadAppColumns(true).map(c => c.kind)).toEqual(['home', 'bar', 'notifications', 'board']);
+  });
+
+  it('save → load で同じ内容が戻る', () => {
+    const cols = [
+      makeAppColumn('search', 'illust', { kind: 'search', mode: 'posts' }),
+      makeAppColumn('profile', 'kojira.example', { kind: 'profile', section: 'portfolio' }),
+    ];
+    saveAppColumns(cols);
+    const loaded = loadAppColumns(true);
+    expect(loaded.map(c => ({ kind: c.kind, param: c.param }))).toEqual([
+      { kind: 'search', param: 'illust' },
+      { kind: 'profile', param: 'kojira.example' },
+    ]);
+  });
+
+  it('壊れた JSON は default に fallback', () => {
+    localStorage.setItem('aozoraquest:appColumns:v1', 'not json {');
+    expect(loadAppColumns(false).map(c => c.kind)).toEqual(['board']);
+  });
+
+  it('空配列は default に fallback', () => {
+    localStorage.setItem('aozoraquest:appColumns:v1', '[]');
+    expect(loadAppColumns(true)).toHaveLength(4);
+  });
+
+  it('未知 kind は filter で除外、全滅なら default', () => {
+    localStorage.setItem('aozoraquest:appColumns:v1', JSON.stringify([
+      { id: 'a', kind: 'home' },
+      { id: 'b', kind: 'unknown-kind' },
+    ]));
+    expect(loadAppColumns(true).map(c => c.kind)).toEqual(['home']);
+
+    localStorage.setItem('aozoraquest:appColumns:v1', JSON.stringify([
+      { id: 'b', kind: 'unknown-kind' },
+    ]));
+    expect(loadAppColumns(false).map(c => c.kind)).toEqual(['board']);
+  });
+});
+
+describe('旧 boardColumns:v1 マイグレーション', () => {
+  it('旧 board カラム設定が board カラムの inner に埋め込まれる', () => {
+    localStorage.setItem('aozoraquest:boardColumns:v1', JSON.stringify([
+      { id: 'x', kind: 'open' },
+      { id: 'y', kind: 'tag', param: 'illust' },
+    ]));
+    const cols = loadAppColumns(true);
+    const board = cols.find(c => c.kind === 'board')!;
+    expect(board.opts).toEqual({
+      kind: 'board',
+      inner: [{ kind: 'open' }, { kind: 'tag', param: 'illust' }],
+    });
+    // マイグレーション結果が永続化されている
+    const reloaded = loadAppColumns(true);
+    expect(reloaded.find(c => c.kind === 'board')!.opts).toEqual(board.opts);
+  });
+
+  it('旧設定に未知 kind が混ざっていても有効分だけ取り込む', () => {
+    localStorage.setItem('aozoraquest:boardColumns:v1', JSON.stringify([
+      { id: 'x', kind: 'nonsense' },
+      { id: 'y', kind: 'mine' },
+    ]));
+    const cols = loadAppColumns(true);
+    const board = cols.find(c => c.kind === 'board')!;
+    expect(board.opts).toEqual({ kind: 'board', inner: [{ kind: 'mine' }] });
+  });
+
+  it('旧設定が壊れた JSON でも default に fallback して落ちない', () => {
+    localStorage.setItem('aozoraquest:boardColumns:v1', '{broken');
+    expect(loadAppColumns(true)).toHaveLength(4);
+  });
+});
+
+describe('moveColumnLeft / moveColumnRight / removeColumn', () => {
+  function cols3(): AppColumn[] {
+    return [
+      { id: 'a', kind: 'home' },
+      { id: 'b', kind: 'notifications' },
+      { id: 'c', kind: 'board' },
+    ];
+  }
+
+  it('左へ移動', () => {
+    expect(moveColumnLeft(cols3(), 'b').map(c => c.id)).toEqual(['b', 'a', 'c']);
+  });
+
+  it('先頭はそれ以上左へ動かない', () => {
+    expect(moveColumnLeft(cols3(), 'a').map(c => c.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('右へ移動', () => {
+    expect(moveColumnRight(cols3(), 'b').map(c => c.id)).toEqual(['a', 'c', 'b']);
+  });
+
+  it('末尾はそれ以上右へ動かない', () => {
+    expect(moveColumnRight(cols3(), 'c').map(c => c.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('存在しない id は no-op', () => {
+    expect(moveColumnLeft(cols3(), 'zz').map(c => c.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('削除', () => {
+    expect(removeColumn(cols3(), 'b').map(c => c.id)).toEqual(['a', 'c']);
+  });
+});
+
+describe('resetAppColumns', () => {
+  it('default に戻して保存する', () => {
+    saveAppColumns([makeAppColumn('search', 'x')]);
+    const cols = resetAppColumns(true);
+    expect(cols).toHaveLength(4);
+    expect(loadAppColumns(true)).toHaveLength(4);
+  });
+});
+
+describe('appColumnTitle', () => {
+  it('title 明示があれば優先', () => {
+    expect(appColumnTitle({ id: '1', kind: 'home', title: 'カスタム' })).toBe('カスタム');
+  });
+
+  it('kind 別の自動 title', () => {
+    expect(appColumnTitle({ id: '1', kind: 'home' })).toBe('ホーム');
+    expect(appColumnTitle({ id: '1', kind: 'bar' })).toBe('BAR ブルスコ');
+    expect(appColumnTitle({ id: '1', kind: 'notifications' })).toBe('通知');
+    expect(appColumnTitle({ id: '1', kind: 'search', param: 'foo' })).toBe('検索: foo');
+    expect(appColumnTitle({ id: '1', kind: 'search' })).toBe('検索');
+    expect(appColumnTitle({ id: '1', kind: 'board' })).toBe('クエスト掲示板');
+    expect(appColumnTitle({ id: '1', kind: 'profile', param: 'kojira.example' })).toBe('@kojira.example');
+  });
+});
+
+describe('isValidAppColumn', () => {
+  it('id 欠落 / kind 不正を弾く', () => {
+    expect(isValidAppColumn({ kind: 'home' })).toBe(false);
+    expect(isValidAppColumn({ id: 'a', kind: 'nope' })).toBe(false);
+    expect(isValidAppColumn(null)).toBe(false);
+    expect(isValidAppColumn({ id: 'a', kind: 'profile', param: 'h' })).toBe(true);
+  });
+});

--- a/apps/web/src/lib/app-columns.test.ts
+++ b/apps/web/src/lib/app-columns.test.ts
@@ -46,22 +46,25 @@ describe('defaultColumns', () => {
     const a = defaultColumns(true);
     const b = defaultColumns(true);
     expect(a[0]!.id).not.toBe(b[0]!.id);
+    // 同一呼び出し内の 4 カラムも互いにユニーク
+    expect(new Set(a.map(c => c.id)).size).toBe(4);
   });
 });
 
 describe('loadAppColumns / saveAppColumns', () => {
-  it('保存なし → default 構成', () => {
+  it('保存なし → default 構成 (localStorage への書き込みは発生しない)', () => {
     expect(loadAppColumns(true).map(c => c.kind)).toEqual(['home', 'bar', 'notifications', 'board']);
+    expect(localStorage.getItem('aozoraquest:appColumns:v1')).toBeNull();
   });
 
   it('save → load で同じ内容が戻る', () => {
     const cols = [
-      makeAppColumn('search', 'illust', { kind: 'search', mode: 'posts' }),
-      makeAppColumn('profile', 'kojira.example', { kind: 'profile', section: 'portfolio' }),
+      makeAppColumn('search', { param: 'illust', mode: 'posts' }),
+      makeAppColumn('profile', { param: 'kojira.example', section: 'portfolio' }),
     ];
     saveAppColumns(cols);
     const loaded = loadAppColumns(true);
-    expect(loaded.map(c => ({ kind: c.kind, param: c.param }))).toEqual([
+    expect(loaded.map(c => ({ kind: c.kind, param: 'param' in c ? c.param : undefined }))).toEqual([
       { kind: 'search', param: 'illust' },
       { kind: 'profile', param: 'kojira.example' },
     ]);
@@ -91,21 +94,49 @@ describe('loadAppColumns / saveAppColumns', () => {
   });
 });
 
-describe('旧 boardColumns:v1 マイグレーション', () => {
-  it('旧 board カラム設定が board カラムの inner に埋め込まれる', () => {
+describe('旧 boardColumns:v1 の read-time 変換', () => {
+  it('旧 board カラム設定が board カラムの inner として読める', () => {
     localStorage.setItem('aozoraquest:boardColumns:v1', JSON.stringify([
       { id: 'x', kind: 'open' },
       { id: 'y', kind: 'tag', param: 'illust' },
     ]));
     const cols = loadAppColumns(true);
     const board = cols.find(c => c.kind === 'board')!;
-    expect(board.opts).toEqual({
-      kind: 'board',
-      inner: [{ kind: 'open' }, { kind: 'tag', param: 'illust' }],
-    });
-    // マイグレーション結果が永続化されている
-    const reloaded = loadAppColumns(true);
-    expect(reloaded.find(c => c.kind === 'board')!.opts).toEqual(board.opts);
+    expect(board.kind === 'board' && board.inner).toEqual([
+      { kind: 'open' },
+      { kind: 'tag', param: 'illust' },
+    ]);
+  });
+
+  it('変換結果は永続化されない (= read-time、appColumns:v1 は書かれない)', () => {
+    localStorage.setItem('aozoraquest:boardColumns:v1', JSON.stringify([{ id: 'x', kind: 'open' }]));
+    loadAppColumns(false);
+    expect(localStorage.getItem('aozoraquest:appColumns:v1')).toBeNull();
+  });
+
+  it('★ 未サインインで読んだ後にサインインしても構成が固定されない', () => {
+    localStorage.setItem('aozoraquest:boardColumns:v1', JSON.stringify([{ id: 'x', kind: 'mine' }]));
+    // セッション解決前 (signedIn=false) に先に読まれるケース
+    expect(loadAppColumns(false).map(c => c.kind)).toEqual(['board']);
+    // サインイン後はフル構成に戻る (read-time なので固定化しない)
+    expect(loadAppColumns(true).map(c => c.kind)).toEqual(['home', 'bar', 'notifications', 'board']);
+  });
+
+  it('★ 旧キーが後から更新されても次回 load に反映される (鮮度維持)', () => {
+    localStorage.setItem('aozoraquest:boardColumns:v1', JSON.stringify([{ id: 'x', kind: 'open' }]));
+    const first = loadAppColumns(true).find(c => c.kind === 'board')!;
+    expect(first.kind === 'board' && first.inner).toEqual([{ kind: 'open' }]);
+
+    // board.tsx (PR 4 まで現役) が旧キーを更新したと想定
+    localStorage.setItem('aozoraquest:boardColumns:v1', JSON.stringify([
+      { id: 'x', kind: 'open' },
+      { id: 'z', kind: 'tag', param: 'art' },
+    ]));
+    const second = loadAppColumns(true).find(c => c.kind === 'board')!;
+    expect(second.kind === 'board' && second.inner).toEqual([
+      { kind: 'open' },
+      { kind: 'tag', param: 'art' },
+    ]);
   });
 
   it('旧設定に未知 kind が混ざっていても有効分だけ取り込む', () => {
@@ -113,14 +144,29 @@ describe('旧 boardColumns:v1 マイグレーション', () => {
       { id: 'x', kind: 'nonsense' },
       { id: 'y', kind: 'mine' },
     ]));
-    const cols = loadAppColumns(true);
-    const board = cols.find(c => c.kind === 'board')!;
-    expect(board.opts).toEqual({ kind: 'board', inner: [{ kind: 'mine' }] });
+    const board = loadAppColumns(true).find(c => c.kind === 'board')!;
+    expect(board.kind === 'board' && board.inner).toEqual([{ kind: 'mine' }]);
+  });
+
+  it('旧設定が空配列 / 全 invalid なら inner なし', () => {
+    localStorage.setItem('aozoraquest:boardColumns:v1', '[]');
+    const a = loadAppColumns(true).find(c => c.kind === 'board')!;
+    expect(a.kind === 'board' && a.inner).toBeUndefined();
+
+    localStorage.setItem('aozoraquest:boardColumns:v1', JSON.stringify([{ id: 'b', kind: 'bogus' }]));
+    const b = loadAppColumns(true).find(c => c.kind === 'board')!;
+    expect(b.kind === 'board' && b.inner).toBeUndefined();
   });
 
   it('旧設定が壊れた JSON でも default に fallback して落ちない', () => {
     localStorage.setItem('aozoraquest:boardColumns:v1', '{broken');
     expect(loadAppColumns(true)).toHaveLength(4);
+  });
+
+  it('保存済み appColumns:v1 があれば旧キーより優先される', () => {
+    saveAppColumns([makeAppColumn('search', { param: 'q' })]);
+    localStorage.setItem('aozoraquest:boardColumns:v1', JSON.stringify([{ id: 'x', kind: 'open' }]));
+    expect(loadAppColumns(true).map(c => c.kind)).toEqual(['search']);
   });
 });
 
@@ -133,16 +179,22 @@ describe('moveColumnLeft / moveColumnRight / removeColumn', () => {
     ];
   }
 
-  it('左へ移動', () => {
-    expect(moveColumnLeft(cols3(), 'b').map(c => c.id)).toEqual(['b', 'a', 'c']);
+  it('左へ移動 (入力配列は mutate しない)', () => {
+    const input = cols3();
+    const moved = moveColumnLeft(input, 'b');
+    expect(moved.map(c => c.id)).toEqual(['b', 'a', 'c']);
+    expect(input.map(c => c.id)).toEqual(['a', 'b', 'c']);
   });
 
   it('先頭はそれ以上左へ動かない', () => {
     expect(moveColumnLeft(cols3(), 'a').map(c => c.id)).toEqual(['a', 'b', 'c']);
   });
 
-  it('右へ移動', () => {
-    expect(moveColumnRight(cols3(), 'b').map(c => c.id)).toEqual(['a', 'c', 'b']);
+  it('右へ移動 (入力配列は mutate しない)', () => {
+    const input = cols3();
+    const moved = moveColumnRight(input, 'b');
+    expect(moved.map(c => c.id)).toEqual(['a', 'c', 'b']);
+    expect(input.map(c => c.id)).toEqual(['a', 'b', 'c']);
   });
 
   it('末尾はそれ以上右へ動かない', () => {
@@ -153,16 +205,21 @@ describe('moveColumnLeft / moveColumnRight / removeColumn', () => {
     expect(moveColumnLeft(cols3(), 'zz').map(c => c.id)).toEqual(['a', 'b', 'c']);
   });
 
-  it('削除', () => {
-    expect(removeColumn(cols3(), 'b').map(c => c.id)).toEqual(['a', 'c']);
+  it('削除 (入力配列は mutate しない)', () => {
+    const input = cols3();
+    const removed = removeColumn(input, 'b');
+    expect(removed.map(c => c.id)).toEqual(['a', 'c']);
+    expect(input).toHaveLength(3);
   });
 });
 
 describe('resetAppColumns', () => {
-  it('default に戻して保存する', () => {
-    saveAppColumns([makeAppColumn('search', 'x')]);
+  it('保存済み構成を破棄して default に戻す', () => {
+    saveAppColumns([makeAppColumn('search', { param: 'x' })]);
     const cols = resetAppColumns(true);
     expect(cols).toHaveLength(4);
+    // key が消えるので以後は read-time 計算に従う
+    expect(localStorage.getItem('aozoraquest:appColumns:v1')).toBeNull();
     expect(loadAppColumns(true)).toHaveLength(4);
   });
 });
@@ -180,6 +237,7 @@ describe('appColumnTitle', () => {
     expect(appColumnTitle({ id: '1', kind: 'search' })).toBe('検索');
     expect(appColumnTitle({ id: '1', kind: 'board' })).toBe('クエスト掲示板');
     expect(appColumnTitle({ id: '1', kind: 'profile', param: 'kojira.example' })).toBe('@kojira.example');
+    expect(appColumnTitle({ id: '1', kind: 'profile' })).toBe('プロフィール');
   });
 });
 
@@ -189,5 +247,24 @@ describe('isValidAppColumn', () => {
     expect(isValidAppColumn({ id: 'a', kind: 'nope' })).toBe(false);
     expect(isValidAppColumn(null)).toBe(false);
     expect(isValidAppColumn({ id: 'a', kind: 'profile', param: 'h' })).toBe(true);
+  });
+
+  it('board の inner が壊れていたら弾く', () => {
+    expect(isValidAppColumn({ id: 'a', kind: 'board', inner: [{ kind: 'open' }] })).toBe(true);
+    expect(isValidAppColumn({ id: 'a', kind: 'board', inner: [{ kind: 'bogus' }] })).toBe(false);
+    expect(isValidAppColumn({ id: 'a', kind: 'board', inner: 'not-array' })).toBe(false);
+    expect(isValidAppColumn({ id: 'a', kind: 'board' })).toBe(true);
+  });
+});
+
+describe('makeAppColumn (discriminated union)', () => {
+  it('kind 別フィールドが平坦に入る', () => {
+    const s = makeAppColumn('search', { param: 'q', mode: 'users' });
+    expect(s).toMatchObject({ kind: 'search', param: 'q', mode: 'users' });
+    const b = makeAppColumn('board', { inner: [{ kind: 'open' }] });
+    expect(b).toMatchObject({ kind: 'board', inner: [{ kind: 'open' }] });
+    const h = makeAppColumn('home');
+    expect(h.kind).toBe('home');
+    expect(h.id).toMatch(/^col-/);
   });
 });

--- a/apps/web/src/lib/app-columns.ts
+++ b/apps/web/src/lib/app-columns.ts
@@ -1,0 +1,199 @@
+/**
+ * アプリ全体マルチカラム (workspace) のカラム設定 (docs/16-multicolumn.md)。
+ *
+ * カラム種類 (AppColumnKind):
+ *  - home          : 自分のフォロー TL
+ *  - bar           : ブルスコ酒場 (= 共鳴 TL、aozoraquest 利用者の集い)
+ *  - notifications : 自分の通知
+ *  - search        : 検索結果 (param = query)
+ *  - board         : 依頼クエスト掲示板 (内側に BoardInner の sub column)
+ *  - profile       : 特定プロフィール (param = handle)
+ *
+ * 既存の board 内マルチカラム (board-columns.ts) は `board` カラムの
+ * inner として包含される二段構造。
+ *
+ * 設定は localStorage に保存。モバイルは横スワイプ (scroll-snap)、
+ * デスクトップは横並びで表示する。
+ */
+
+import type { Archetype } from '@aozoraquest/core';
+
+export type AppColumnKind = 'home' | 'bar' | 'notifications' | 'search' | 'board' | 'profile';
+
+/** board カラム内側のサブカラム (旧 board-columns.ts の Column と同形) */
+export interface BoardInner {
+  kind: 'open' | 'mine' | 'applied' | 'tag' | 'job' | 'issuer';
+  param?: string;
+}
+
+export type ColumnOpts =
+  | { kind: 'search'; mode?: 'posts' | 'users' }
+  | { kind: 'profile'; section?: 'posts' | 'portfolio' }
+  | { kind: 'board'; inner?: BoardInner[] };
+
+export interface AppColumn {
+  id: string;
+  kind: AppColumnKind;
+  /** kind 別の主パラメータ (search = query, profile = handle) */
+  param?: string;
+  /** kind 別の追加オプション */
+  opts?: ColumnOpts;
+  /** ヘッダー表示の上書き。未設定なら kind+param から推定。 */
+  title?: string;
+}
+
+const KEY = 'aozoraquest:appColumns:v1';
+/** 旧 board 内マルチカラムの保存キー (マイグレーション元) */
+const LEGACY_BOARD_KEY = 'aozoraquest:boardColumns:v1';
+
+const SIGNED_IN_DEFAULT: ReadonlyArray<Omit<AppColumn, 'id'>> = [
+  { kind: 'home', title: 'ホーム' },
+  { kind: 'bar', title: 'BAR ブルスコ' },
+  { kind: 'notifications', title: '通知' },
+  { kind: 'board', title: 'クエスト掲示板' },
+];
+
+const SIGNED_OUT_DEFAULT: ReadonlyArray<Omit<AppColumn, 'id'>> = [
+  { kind: 'board', title: 'クエスト掲示板' },
+];
+
+export function defaultColumns(signedIn: boolean): AppColumn[] {
+  const base = signedIn ? SIGNED_IN_DEFAULT : SIGNED_OUT_DEFAULT;
+  return base.map(c => ({ ...c, id: makeColumnId() }));
+}
+
+export function loadAppColumns(signedIn: boolean): AppColumn[] {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) {
+      // 初回: 旧 boardColumns:v1 があれば board カラムの inner として取り込む
+      const migrated = migrateLegacyBoardColumns(signedIn);
+      if (migrated) return migrated;
+      return defaultColumns(signedIn);
+    }
+    const parsed = JSON.parse(raw) as AppColumn[];
+    if (!Array.isArray(parsed) || parsed.length === 0) return defaultColumns(signedIn);
+    const valid = parsed.filter(isValidAppColumn);
+    if (valid.length === 0) return defaultColumns(signedIn);
+    return valid;
+  } catch {
+    return defaultColumns(signedIn);
+  }
+}
+
+export function saveAppColumns(columns: AppColumn[]): void {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(columns));
+  } catch {/* no-op */}
+}
+
+export function resetAppColumns(signedIn: boolean): AppColumn[] {
+  const cols = defaultColumns(signedIn);
+  saveAppColumns(cols);
+  return cols;
+}
+
+export function makeColumnId(): string {
+  return `col-${Math.random().toString(36).slice(2, 8)}-${Date.now().toString(36)}`;
+}
+
+export function makeAppColumn(kind: AppColumnKind, param?: string, opts?: ColumnOpts, title?: string): AppColumn {
+  const col: AppColumn = { id: makeColumnId(), kind };
+  if (param !== undefined) col.param = param;
+  if (opts !== undefined) col.opts = opts;
+  if (title !== undefined) col.title = title;
+  return col;
+}
+
+// ─── 並べ替え / 削除 (MVP は矢印ボタンのみ、DnD なし) ──────
+
+export function moveColumnLeft(columns: AppColumn[], id: string): AppColumn[] {
+  const i = columns.findIndex(c => c.id === id);
+  if (i <= 0) return columns;
+  const next = [...columns];
+  [next[i - 1], next[i]] = [next[i]!, next[i - 1]!];
+  return next;
+}
+
+export function moveColumnRight(columns: AppColumn[], id: string): AppColumn[] {
+  const i = columns.findIndex(c => c.id === id);
+  if (i < 0 || i >= columns.length - 1) return columns;
+  const next = [...columns];
+  [next[i], next[i + 1]] = [next[i + 1]!, next[i]!];
+  return next;
+}
+
+export function removeColumn(columns: AppColumn[], id: string): AppColumn[] {
+  return columns.filter(c => c.id !== id);
+}
+
+// ─── 表示名 ────────────────────────────────────────────
+
+export function appColumnTitle(c: AppColumn): string {
+  if (c.title) return c.title;
+  switch (c.kind) {
+    case 'home':          return 'ホーム';
+    case 'bar':           return 'BAR ブルスコ';
+    case 'notifications': return '通知';
+    case 'search':        return c.param ? `検索: ${c.param}` : '検索';
+    case 'board':         return 'クエスト掲示板';
+    case 'profile':       return c.param ? `@${c.param}` : 'プロフィール';
+  }
+}
+
+// ─── validation ───────────────────────────────────────
+
+const APP_KINDS: AppColumnKind[] = ['home', 'bar', 'notifications', 'search', 'board', 'profile'];
+const BOARD_INNER_KINDS: BoardInner['kind'][] = ['open', 'mine', 'applied', 'tag', 'job', 'issuer'];
+
+export function isValidAppColumn(c: unknown): c is AppColumn {
+  if (!c || typeof c !== 'object') return false;
+  const obj = c as Record<string, unknown>;
+  if (typeof obj.id !== 'string') return false;
+  if (!APP_KINDS.includes(obj.kind as AppColumnKind)) return false;
+  return true;
+}
+
+export function isValidBoardInner(v: unknown): v is BoardInner {
+  if (!v || typeof v !== 'object') return false;
+  const obj = v as Record<string, unknown>;
+  return BOARD_INNER_KINDS.includes(obj.kind as BoardInner['kind']);
+}
+
+// ─── 旧 boardColumns:v1 からのマイグレーション ──────────
+
+/** 旧 board 内マルチカラムの保存があれば、デフォルト構成の board カラムの
+ *  inner として埋め込んだ構成を返して保存する。なければ null。 */
+function migrateLegacyBoardColumns(signedIn: boolean): AppColumn[] | null {
+  try {
+    const raw = localStorage.getItem(LEGACY_BOARD_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Array<{ kind?: unknown; param?: unknown }>;
+    if (!Array.isArray(parsed)) return null;
+    const inner: BoardInner[] = [];
+    for (const item of parsed) {
+      if (isValidBoardInner(item)) {
+        const bi: BoardInner = { kind: item.kind as BoardInner['kind'] };
+        if (typeof item.param === 'string') bi.param = item.param;
+        inner.push(bi);
+      }
+    }
+    const cols = defaultColumns(signedIn);
+    if (inner.length > 0) {
+      const board = cols.find(c => c.kind === 'board');
+      if (board) board.opts = { kind: 'board', inner };
+    }
+    saveAppColumns(cols);
+    return cols;
+  } catch {
+    return null;
+  }
+}
+
+/** 16 ジョブの選択肢 (board inner の job filter で使う) */
+export const JOB_OPTIONS: Archetype[] = [
+  'sage', 'mage', 'shogun', 'bard',
+  'seer', 'poet', 'paladin', 'explorer',
+  'warrior', 'guardian', 'fighter', 'artist',
+  'captain', 'miko', 'ninja', 'performer',
+];

--- a/apps/web/src/lib/app-columns.ts
+++ b/apps/web/src/lib/app-columns.ts
@@ -5,72 +5,77 @@
  *  - home          : 自分のフォロー TL
  *  - bar           : ブルスコ酒場 (= 共鳴 TL、aozoraquest 利用者の集い)
  *  - notifications : 自分の通知
- *  - search        : 検索結果 (param = query)
+ *  - search        : 検索結果 (query / mode)
  *  - board         : 依頼クエスト掲示板 (内側に BoardInner の sub column)
- *  - profile       : 特定プロフィール (param = handle)
+ *  - profile       : 特定プロフィール (handle / section)
  *
- * 既存の board 内マルチカラム (board-columns.ts) は `board` カラムの
- * inner として包含される二段構造。
+ * AppColumn は kind ごとの discriminated union (= kind とフィールドの
+ * 不整合が型レベルで起きない)。既存の board 内マルチカラム
+ * (board-columns.ts) は `board` カラムの inner として包含される二段構造。
  *
- * 設定は localStorage に保存。モバイルは横スワイプ (scroll-snap)、
- * デスクトップは横並びで表示する。
+ * 永続化は localStorage。**保存はユーザーの明示操作時のみ**
+ * (saveAppColumns 経由)。保存がない限り loadAppColumns は毎回
+ * 「default 構成 + 旧 boardColumns:v1 の read-time 変換」を返すので、
+ * サインイン状態の変化や旧キーの更新 (PR 4 まで board.tsx が書く) に
+ * 常に追従する。
  */
 
 import type { Archetype } from '@aozoraquest/core';
 
 export type AppColumnKind = 'home' | 'bar' | 'notifications' | 'search' | 'board' | 'profile';
 
-/** board カラム内側のサブカラム (旧 board-columns.ts の Column と同形) */
+/** board カラム内側のサブカラム (旧 board-columns.ts の Column と同形)。
+ *  id は持たない (= 永続データとしては種類 + param が本体)。PR 4 で
+ *  board ColumnContent が React key 用の id を mount 時に付与して
+ *  橋渡しする (削除・並べ替えは index ベースで書き戻す)。 */
 export interface BoardInner {
   kind: 'open' | 'mine' | 'applied' | 'tag' | 'job' | 'issuer';
   param?: string;
 }
 
-export type ColumnOpts =
-  | { kind: 'search'; mode?: 'posts' | 'users' }
-  | { kind: 'profile'; section?: 'posts' | 'portfolio' }
-  | { kind: 'board'; inner?: BoardInner[] };
-
-export interface AppColumn {
+interface ColumnBase {
   id: string;
-  kind: AppColumnKind;
-  /** kind 別の主パラメータ (search = query, profile = handle) */
-  param?: string;
-  /** kind 別の追加オプション */
-  opts?: ColumnOpts;
   /** ヘッダー表示の上書き。未設定なら kind+param から推定。 */
   title?: string;
 }
 
+export type AppColumn =
+  | (ColumnBase & { kind: 'home' })
+  | (ColumnBase & { kind: 'bar' })
+  | (ColumnBase & { kind: 'notifications' })
+  | (ColumnBase & { kind: 'search'; param?: string; mode?: 'posts' | 'users' })
+  | (ColumnBase & { kind: 'board'; inner?: BoardInner[] })
+  | (ColumnBase & { kind: 'profile'; param?: string; section?: 'posts' | 'portfolio' });
+
 const KEY = 'aozoraquest:appColumns:v1';
-/** 旧 board 内マルチカラムの保存キー (マイグレーション元) */
+/** 旧 board 内マルチカラムの保存キー (read-time 変換元)。
+ *  PR 4 で board.tsx が ColumnContent に包含されるまでは board.tsx が
+ *  このキーを読み書きし続けるため、消さない・上書きしない。 */
 const LEGACY_BOARD_KEY = 'aozoraquest:boardColumns:v1';
 
-const SIGNED_IN_DEFAULT: ReadonlyArray<Omit<AppColumn, 'id'>> = [
-  { kind: 'home', title: 'ホーム' },
-  { kind: 'bar', title: 'BAR ブルスコ' },
-  { kind: 'notifications', title: '通知' },
-  { kind: 'board', title: 'クエスト掲示板' },
-];
-
-const SIGNED_OUT_DEFAULT: ReadonlyArray<Omit<AppColumn, 'id'>> = [
-  { kind: 'board', title: 'クエスト掲示板' },
-];
-
 export function defaultColumns(signedIn: boolean): AppColumn[] {
-  const base = signedIn ? SIGNED_IN_DEFAULT : SIGNED_OUT_DEFAULT;
-  return base.map(c => ({ ...c, id: makeColumnId() }));
+  const cols: AppColumn[] = signedIn
+    ? [
+        { id: makeColumnId(), kind: 'home' },
+        { id: makeColumnId(), kind: 'bar' },
+        { id: makeColumnId(), kind: 'notifications' },
+        { id: makeColumnId(), kind: 'board' },
+      ]
+    : [{ id: makeColumnId(), kind: 'board' }];
+  // 旧 board 設定があれば board カラムの inner として read-time で取り込む。
+  // ここでは保存しない (= サインイン状態確定前の永続化事故を防ぐ)。
+  const inner = readLegacyBoardInner();
+  if (inner.length > 0) {
+    const board = cols.find(c => c.kind === 'board');
+    if (board && board.kind === 'board') board.inner = inner;
+  }
+  return cols;
 }
 
 export function loadAppColumns(signedIn: boolean): AppColumn[] {
   try {
     const raw = localStorage.getItem(KEY);
-    if (!raw) {
-      // 初回: 旧 boardColumns:v1 があれば board カラムの inner として取り込む
-      const migrated = migrateLegacyBoardColumns(signedIn);
-      if (migrated) return migrated;
-      return defaultColumns(signedIn);
-    }
+    if (!raw) return defaultColumns(signedIn);
     const parsed = JSON.parse(raw) as AppColumn[];
     if (!Array.isArray(parsed) || parsed.length === 0) return defaultColumns(signedIn);
     const valid = parsed.filter(isValidAppColumn);
@@ -81,31 +86,37 @@ export function loadAppColumns(signedIn: boolean): AppColumn[] {
   }
 }
 
+/** 保存はユーザーの明示操作 (カラム追加・削除・並べ替え) 時のみ呼ぶこと。
+ *  default 構成や read-time 変換結果を機械的に保存してはいけない
+ *  (サインイン前に board だけの構成が固定される事故のもと)。 */
 export function saveAppColumns(columns: AppColumn[]): void {
   try {
     localStorage.setItem(KEY, JSON.stringify(columns));
   } catch {/* no-op */}
 }
 
+/** 保存済み構成を破棄して default に戻す (= 以後また read-time 計算に従う) */
 export function resetAppColumns(signedIn: boolean): AppColumn[] {
-  const cols = defaultColumns(signedIn);
-  saveAppColumns(cols);
-  return cols;
+  try {
+    localStorage.removeItem(KEY);
+  } catch {/* no-op */}
+  return defaultColumns(signedIn);
 }
 
 export function makeColumnId(): string {
-  return `col-${Math.random().toString(36).slice(2, 8)}-${Date.now().toString(36)}`;
+  const rand = Math.random().toString(36).slice(2, 8).padEnd(6, '0');
+  return `col-${rand}-${Date.now().toString(36)}`;
 }
 
-export function makeAppColumn(kind: AppColumnKind, param?: string, opts?: ColumnOpts, title?: string): AppColumn {
-  const col: AppColumn = { id: makeColumnId(), kind };
-  if (param !== undefined) col.param = param;
-  if (opts !== undefined) col.opts = opts;
-  if (title !== undefined) col.title = title;
-  return col;
+export function makeAppColumn<K extends AppColumnKind>(
+  kind: K,
+  fields?: Omit<Extract<AppColumn, { kind: K }>, 'id' | 'kind'>,
+): AppColumn {
+  return { id: makeColumnId(), kind, ...fields } as AppColumn;
 }
 
 // ─── 並べ替え / 削除 (MVP は矢印ボタンのみ、DnD なし) ──────
+// いずれも入力配列を mutate しない (新しい配列を返す)。
 
 export function moveColumnLeft(columns: AppColumn[], id: string): AppColumn[] {
   const i = columns.findIndex(c => c.id === id);
@@ -151,6 +162,10 @@ export function isValidAppColumn(c: unknown): c is AppColumn {
   const obj = c as Record<string, unknown>;
   if (typeof obj.id !== 'string') return false;
   if (!APP_KINDS.includes(obj.kind as AppColumnKind)) return false;
+  // kind 別フィールドの軽い検証 (壊れた値は load 時に丸ごと除外する)
+  if (obj.kind === 'board' && obj.inner !== undefined) {
+    if (!Array.isArray(obj.inner) || !obj.inner.every(isValidBoardInner)) return false;
+  }
   return true;
 }
 
@@ -160,16 +175,17 @@ export function isValidBoardInner(v: unknown): v is BoardInner {
   return BOARD_INNER_KINDS.includes(obj.kind as BoardInner['kind']);
 }
 
-// ─── 旧 boardColumns:v1 からのマイグレーション ──────────
+// ─── 旧 boardColumns:v1 の read-time 変換 ───────────────
 
-/** 旧 board 内マルチカラムの保存があれば、デフォルト構成の board カラムの
- *  inner として埋め込んだ構成を返して保存する。なければ null。 */
-function migrateLegacyBoardColumns(signedIn: boolean): AppColumn[] | null {
+/** 旧 board 内マルチカラムの保存を BoardInner[] として読む。
+ *  保存はしない (read-time 変換)。旧キーが board.tsx (PR 4 まで現役) に
+ *  更新されても、appColumns:v1 未保存の限り常に最新が反映される。 */
+function readLegacyBoardInner(): BoardInner[] {
   try {
     const raw = localStorage.getItem(LEGACY_BOARD_KEY);
-    if (!raw) return null;
+    if (!raw) return [];
     const parsed = JSON.parse(raw) as Array<{ kind?: unknown; param?: unknown }>;
-    if (!Array.isArray(parsed)) return null;
+    if (!Array.isArray(parsed)) return [];
     const inner: BoardInner[] = [];
     for (const item of parsed) {
       if (isValidBoardInner(item)) {
@@ -178,19 +194,15 @@ function migrateLegacyBoardColumns(signedIn: boolean): AppColumn[] | null {
         inner.push(bi);
       }
     }
-    const cols = defaultColumns(signedIn);
-    if (inner.length > 0) {
-      const board = cols.find(c => c.kind === 'board');
-      if (board) board.opts = { kind: 'board', inner };
-    }
-    saveAppColumns(cols);
-    return cols;
+    return inner;
   } catch {
-    return null;
+    return [];
   }
 }
 
-/** 16 ジョブの選択肢 (board inner の job filter で使う) */
+/** 16 ジョブの選択肢 (board inner の job filter で使う)。
+ *  board-columns.ts にも同名 export があるが、あちらは PR 4 で削除予定の
+ *  deprecated ファイルなので import せずここに正本を置く。 */
 export const JOB_OPTIONS: Archetype[] = [
   'sage', 'mage', 'shogun', 'bard',
   'seer', 'poet', 'paladin', 'explorer',

--- a/apps/web/src/lib/board-columns.ts
+++ b/apps/web/src/lib/board-columns.ts
@@ -1,4 +1,11 @@
 /**
+ * @deprecated アプリ全体マルチカラム化 (docs/16-multicolumn.md) に伴い、
+ * この board 限定カラム設定は app-columns.ts の `board` カラム内
+ * `BoardInner` に統合される。旧保存キー `boardColumns:v1` は
+ * app-columns.ts 側で片方向マイグレーションされる。
+ * board.tsx が workspace の ColumnContent に包含されるまで (PR 4) は
+ * 本ファイルが現役。新規コードからは参照しないこと。
+ *
  * 依頼クエスト掲示板のマルチカラム設定 (docs/15-user-quest.md §UI 設計 E)。
  *
  * カラム種類:


### PR DESCRIPTION
## Summary

アプリ全体 TweetDeck 風マルチカラム化の **PR 1/5 (基盤)**。UI には一切影響しない。

- **VirtualFeed dual-mode 化**: `scrollParent?: HTMLElement | null` を optional prop で追加。指定時はその要素内スクロール (workspace の column-body 用)、未指定なら従来の window スクロール (= 既存呼び出し無修正)
- **AppColumn データモデル** (`lib/app-columns.ts` 新規): kind = `home | bar | notifications | search | board | profile` の 6 種の **discriminated union** (kind ごとのフィールドを平坦に持つ)。board は `inner: BoardInner[]` で旧 board 内サブカラムを包含する二段構造
- **旧 `boardColumns:v1` の read-time 変換**: 保存はユーザーの明示操作 (saveAppColumns) のみ。未保存の限り load は毎回「default + 旧キー変換」を計算するため、サインイン状態の変化や旧キーの更新に常に追従する
- `board-columns.ts` に @deprecated 注記 (実装は PR 4 で board が ColumnContent に包含されるまで現役)

## ロードマップ (5 PR)

1. **本 PR**: VirtualFeed dual-mode + AppColumn 基盤
2. Workspace shell + home/bar カラム
3. notifications / search / profile カラム化
4. board カラム + ColumnPicker + 矢印操作
5. モバイル横スワイプ + footer-nav 再定義 + 仕上げ

## Review

CI 緑後に 3 並列 subagent レビュー (設計 / 実装 / 影響範囲) を実施。**★★★ 0 件 / ★★ 4 件 (統合) / ★ 6 件**。★★ はすべて commit 2fdc298 で PR 内対応済み:

| 指摘 | 重要度 | 対応 |
|---|---|---|
| `AppColumn.kind` と `opts.kind` の整合が型保証されない | ★★ | opts を廃止し kind ごとのフィールドを平坦に持つ discriminated union に変更。`makeAppColumn` は `Extract<AppColumn, {kind: K}>` で型安全に |
| migration の snapshot が PR 2〜4 の間に board.tsx 側更新と乖離 | ★★ | snapshot 永続化をやめ **read-time 変換** に変更。appColumns 未保存の限り常に旧キーの最新を反映 |
| セッション解決前の `loadAppColumns(false)` で board のみ構成が永続固定 | ★★ | 同上 (read-time 化で保存自体が起きない)。テストでサインイン遷移シナリオを検証 |
| `scrollParentRef` (RefObject) の commit タイミング / memo 化での stale 参照 | ★★ | RefObject をやめ **element そのもの** (`scrollParent`) を受ける API に変更。利用側は useState + callback ref 規約 |
| `makeColumnId` のエントロピー非保証 (6 文字未満になりうる) | ★ | `padEnd(6, '0')` |
| window モード scrollMargin の初回 0 固定 (旧実装からの既知挙動) | ★ | 既知制約としてコメント明記 (現レイアウトでは実害なし、悪化なし) |
| `JOB_OPTIONS` 等の二重定義 | ★ | app-columns 側を正本とコメント明記 (board-columns は PR 4 で削除予定) |
| BoardInner に id がない設計の PR 4 橋渡し | ★ | 橋渡し方針 (mount 時 id 付与 + index ベース書き戻し) をコメント化 |
| テスト漏れ (非破壊 assert / signedIn 遷移 / legacy 空 等) | ★ | 7 ケース追加 (app-columns 28 件 / 全 119 件緑) |
| 影響範囲レビュー: 既存 VirtualFeed 利用 7 箇所の regression | — | **リスクなしと検証済み** (scrollParent 未指定時は旧実装と完全同値) |

## Test plan
- [x] typecheck 緑
- [x] vitest 119 件緑 (app-columns 28 件)
- [x] build 緑
- [x] UI 無変更 (影響範囲レビューで 7 箇所の既存利用を検証済み)