### PR TITLE
feat(workspace): notifications / search / profile カラム化 (マルチカラム PR 3/5)

### DIFF
--- a/apps/web/src/components/column-content/index.tsx
+++ b/apps/web/src/components/column-content/index.tsx
@@ -22,19 +22,24 @@ export function ColumnContent({ column }: { column: AppColumn }) {
     case 'bar':
       return <BarColumn />;
     case 'notifications':
+      // markSeen は渡さない (= カラム表示では既読化しない。通知ページを
+      // 開いたときだけ既読化する。可視判定ベースは PR 5)
       return <NotificationsFeed />;
     case 'search':
       return (
+        // key に param/mode を含め、カラム編集 (PR 4) で param が変わったら
+        // remount して initial 値を反映する (useState 初期値のみのため)
         <SearchPanel
+          key={`${column.id}:${column.param ?? ''}:${column.mode ?? ''}`}
           {...(column.param !== undefined ? { initialQuery: column.param } : {})}
           {...(column.mode !== undefined ? { initialMode: column.mode } : {})}
         />
       );
     case 'profile':
       return column.param ? (
-        <ProfileView actor={column.param} />
+        <ProfileView key={`${column.id}:${column.param}`} actor={column.param} />
       ) : (
-        <MissingParam label="プロフィール" hint="表示するユーザーの指定がありません。カラム追加 UI (PR 4) からハンドルを指定できるようになります。" />
+        <MissingParam label="プロフィール" hint="表示するユーザーの指定がありません。今後のアップデートでカラム追加時にハンドルを指定できるようになります。" />
       );
     case 'board':
       return <PendingColumn label="クエスト掲示板" to="/board" />;

--- a/apps/web/src/components/column-content/index.tsx
+++ b/apps/web/src/components/column-content/index.tsx
@@ -3,14 +3,17 @@
  *
  * 段階導入の途中 (flag なし方針) なので、未実装の kind は従来ページへの
  * リンク付きプレースホルダを出す:
- *  - PR 2 (本 PR): home / bar
- *  - PR 3: notifications / search / profile
+ *  - PR 2: home / bar
+ *  - PR 3: notifications / search / profile (本 PR)
  *  - PR 4: board
  */
 import { Link } from 'react-router-dom';
 import type { AppColumn } from '@/lib/app-columns';
 import { HomeColumn } from './home-column';
 import { BarColumn } from './bar-column';
+import { NotificationsFeed } from '@/routes/notifications';
+import { SearchPanel } from '@/routes/search';
+import { ProfileView } from '@/routes/profile';
 
 export function ColumnContent({ column }: { column: AppColumn }) {
   switch (column.kind) {
@@ -19,13 +22,22 @@ export function ColumnContent({ column }: { column: AppColumn }) {
     case 'bar':
       return <BarColumn />;
     case 'notifications':
-      return <PendingColumn label="通知" to="/notifications" />;
+      return <NotificationsFeed />;
     case 'search':
-      return <PendingColumn label="検索" to={column.param ? `/search?q=${encodeURIComponent(column.param)}` : '/search'} />;
+      return (
+        <SearchPanel
+          {...(column.param !== undefined ? { initialQuery: column.param } : {})}
+          {...(column.mode !== undefined ? { initialMode: column.mode } : {})}
+        />
+      );
+    case 'profile':
+      return column.param ? (
+        <ProfileView actor={column.param} />
+      ) : (
+        <MissingParam label="プロフィール" hint="表示するユーザーの指定がありません。カラム追加 UI (PR 4) からハンドルを指定できるようになります。" />
+      );
     case 'board':
       return <PendingColumn label="クエスト掲示板" to="/board" />;
-    case 'profile':
-      return <PendingColumn label="プロフィール" to={column.param ? `/profile/${column.param}` : '/me'} />;
   }
 }
 
@@ -38,5 +50,13 @@ function PendingColumn({ label, to }: { label: string; to: string }) {
       </p>
       <Link to={to}><button style={{ marginTop: '0.4em' }}>{label}を開く</button></Link>
     </div>
+  );
+}
+
+function MissingParam({ label, hint }: { label: string; hint: string }) {
+  return (
+    <p style={{ fontSize: '0.85em', color: 'var(--color-muted)', lineHeight: 1.6 }}>
+      {label}: {hint}
+    </p>
   );
 }

--- a/apps/web/src/lib/profile-cache.ts
+++ b/apps/web/src/lib/profile-cache.ts
@@ -1,0 +1,56 @@
+/**
+ * agent.getProfile の共有キャッシュ (docs/16-multicolumn.md §データ取得の重複防止)。
+ *
+ * マルチカラム化で同じ profile を複数カラムが同時に開けるようになったため、
+ * actor (handle or DID) 単位で inflight dedup + 短い TTL のメモリキャッシュを敷く。
+ * localStorage には書かない (プロフィールは鮮度重視、30 秒で十分)。
+ *
+ * handle-cache.ts (did → handle 解決、24h) とは目的が違う別キャッシュ。
+ */
+import type { Agent, AppBskyActorDefs } from '@atproto/api';
+
+const TTL_MS = 30_000;
+
+interface Entry {
+  profile: AppBskyActorDefs.ProfileViewDetailed;
+  ts: number;
+}
+
+const cache = new Map<string, Entry>();
+const inflight = new Map<string, Promise<AppBskyActorDefs.ProfileViewDetailed>>();
+
+/** getProfile の dedup 付きラッパ。30s TTL のメモリキャッシュ。
+ *  失敗はキャッシュしない (= 次の呼び出しで再試行する)。 */
+export async function getProfileCached(
+  agent: Agent,
+  actor: string,
+): Promise<AppBskyActorDefs.ProfileViewDetailed> {
+  const hit = cache.get(actor);
+  if (hit && Date.now() - hit.ts < TTL_MS) return hit.profile;
+
+  const existing = inflight.get(actor);
+  if (existing) return existing;
+
+  const p = (async () => {
+    try {
+      const res = await agent.getProfile({ actor });
+      const profile = res.data;
+      // handle と did の両方の key で引けるようにしておく
+      // (カラムは handle、通知由来は did で来ることがある)
+      cache.set(actor, { profile, ts: Date.now() });
+      cache.set(profile.did, { profile, ts: Date.now() });
+      if (profile.handle) cache.set(profile.handle, { profile, ts: Date.now() });
+      return profile;
+    } finally {
+      inflight.delete(actor);
+    }
+  })();
+  inflight.set(actor, p);
+  return p;
+}
+
+/** テスト用 */
+export function clearProfileCache(): void {
+  cache.clear();
+  inflight.clear();
+}

--- a/apps/web/src/lib/profile-cache.ts
+++ b/apps/web/src/lib/profile-cache.ts
@@ -36,10 +36,15 @@ export async function getProfileCached(
       const res = await agent.getProfile({ actor });
       const profile = res.data;
       // handle と did の両方の key で引けるようにしておく
-      // (カラムは handle、通知由来は did で来ることがある)
-      cache.set(actor, { profile, ts: Date.now() });
-      cache.set(profile.did, { profile, ts: Date.now() });
-      if (profile.handle) cache.set(profile.handle, { profile, ts: Date.now() });
+      // (カラムは handle、通知由来は did で来ることがある)。
+      // handle.invalid (凍結等で handle 解決不能) は固有名でないため
+      // key にしない (別人の profile が 30s 間混ざるのを防ぐ)。
+      const entry: Entry = { profile, ts: Date.now() };
+      cache.set(actor, entry);
+      cache.set(profile.did, entry);
+      if (profile.handle && profile.handle !== 'handle.invalid') {
+        cache.set(profile.handle, entry);
+      }
       return profile;
     } finally {
       inflight.delete(actor);
@@ -47,6 +52,19 @@ export async function getProfileCached(
   })();
   inflight.set(actor, p);
   return p;
+}
+
+/** 指定 actor (handle or DID) のキャッシュを無効化する。
+ *  フォロー / フォロー解除のように viewer 状態 (viewer.following 等) を
+ *  変えた直後に呼ぶこと (= 30s TTL 内の stale 表示で二重フォロー等の
+ *  事故になるのを防ぐ)。 */
+export function invalidateProfile(actor: string): void {
+  const hit = cache.get(actor);
+  cache.delete(actor);
+  if (hit) {
+    cache.delete(hit.profile.did);
+    if (hit.profile.handle) cache.delete(hit.profile.handle);
+  }
 }
 
 /** テスト用 */

--- a/apps/web/src/routes/notifications.tsx
+++ b/apps/web/src/routes/notifications.tsx
@@ -5,6 +5,7 @@ import { fetchPosts, listNotifications, updateNotificationsSeen } from '@/lib/at
 import { useInfiniteFeed } from '@/lib/use-infinite-feed';
 import { VirtualFeed } from '@/components/virtual-feed';
 import { NotificationItem } from '@/components/notification-item';
+import { useColumnScrollEl } from '@/components/column-scroll-context';
 import {
   groupNotifications,
   postUrisForGroups,
@@ -12,15 +13,28 @@ import {
   type Notification,
 } from '@/lib/notifications';
 
+/** 通知ページ (route)。中身は NotificationsFeed (workspace カラムと共用)。 */
+export function Notifications() {
+  return (
+    <div>
+      <h2>通知</h2>
+      <NotificationsFeed />
+    </div>
+  );
+}
+
 /**
- * 通知タブ: listNotifications でページングしつつ、グループ単位で表示。
- * - 初回ロード後に updateNotificationsSeen を発火 (未読バッジをクリア)
+ * 通知フィード本体: listNotifications でページングしつつ、グループ単位で表示。
+ * - 初回ロード後に updateNotificationsSeen を発火 (未読バッジをクリア)。
+ *   workspace カラムとして常時 mount される場合も「カラムが表示された =
+ *   見た」として扱う (可視判定ベースへの改善は PR 5 の検討事項)
  * - 各ページ分の関連投稿 URI をまとめて getPosts で取得し、Map にキャッシュ
  * - グルーピングはページ単位ではなく **全 items の連結** に対して再計算
  *   (ページ境界で連続マージが成り立つように)
  */
-export function Notifications() {
+export function NotificationsFeed() {
   const session = useSession();
+  const scrollEl = useColumnScrollEl();
   const agent = session.agent;
   const seenSent = useRef(false);
   const [postCache, setPostCache] = useState<Map<string, AppBskyFeedDefs.PostView>>(
@@ -77,7 +91,6 @@ export function Notifications() {
 
   return (
     <div>
-      <h2>通知</h2>
       {feed.err && (
         <p style={{ color: 'var(--color-danger)' }}>うまく読み込めませんでした: {feed.err}</p>
       )}
@@ -88,6 +101,7 @@ export function Notifications() {
         items={groups}
         keyOf={(g) => g.id}
         estimateSize={220}
+        scrollParent={scrollEl}
         renderItem={(g) => <NotificationItem group={g} postCache={postCache} />}
         onEndReached={feed.done ? undefined : feed.loadMore}
         footer={

--- a/apps/web/src/routes/notifications.tsx
+++ b/apps/web/src/routes/notifications.tsx
@@ -13,26 +13,29 @@ import {
   type Notification,
 } from '@/lib/notifications';
 
-/** 通知ページ (route)。中身は NotificationsFeed (workspace カラムと共用)。 */
+/** 通知ページ (route)。中身は NotificationsFeed (workspace カラムと共用)。
+ *  既読化 (markSeen) はこのページを開いたときだけ発火する。 */
 export function Notifications() {
   return (
     <div>
       <h2>通知</h2>
-      <NotificationsFeed />
+      <NotificationsFeed markSeen />
     </div>
   );
 }
 
 /**
  * 通知フィード本体: listNotifications でページングしつつ、グループ単位で表示。
- * - 初回ロード後に updateNotificationsSeen を発火 (未読バッジをクリア)。
- *   workspace カラムとして常時 mount される場合も「カラムが表示された =
- *   見た」として扱う (可視判定ベースへの改善は PR 5 の検討事項)
+ * - markSeen=true のとき初回ロード後に updateNotificationsSeen を発火
+ *   (未読バッジをクリア)。**workspace カラムでは発火しない** —
+ *   default 構成に通知カラムが入るため、`/` を開いただけで未読バッジが
+ *   死ぬのを防ぐ (レビュー指摘 ★★★)。カラムでの既読化は可視判定
+ *   (IntersectionObserver) と合わせて PR 5 で導入する
  * - 各ページ分の関連投稿 URI をまとめて getPosts で取得し、Map にキャッシュ
  * - グルーピングはページ単位ではなく **全 items の連結** に対して再計算
  *   (ページ境界で連続マージが成り立つように)
  */
-export function NotificationsFeed() {
+export function NotificationsFeed({ markSeen = false }: { markSeen?: boolean }) {
   const session = useSession();
   const scrollEl = useColumnScrollEl();
   const agent = session.agent;
@@ -55,14 +58,14 @@ export function NotificationsFeed() {
     },
   });
 
-  // 初回 items 取得後に updateSeen を fire-and-forget
+  // 初回 items 取得後に updateSeen を fire-and-forget (markSeen のときのみ)
   useEffect(() => {
-    if (!agent) return;
+    if (!markSeen || !agent) return;
     if (seenSent.current) return;
     if (feed.items.length === 0 && !feed.done) return;
     seenSent.current = true;
     void updateNotificationsSeen(agent);
-  }, [agent, feed.items.length, feed.done]);
+  }, [markSeen, agent, feed.items.length, feed.done]);
 
   const groups = useMemo(() => groupNotifications(feed.items), [feed.items]);
 

--- a/apps/web/src/routes/profile.tsx
+++ b/apps/web/src/routes/profile.tsx
@@ -17,6 +17,8 @@ import { TranslationControls } from '@/components/post-body';
 import { VirtualFeed } from '@/components/virtual-feed';
 import { useInfiniteFeed } from '@/lib/use-infinite-feed';
 import { useTranslation } from '@/lib/translate';
+import { getProfileCached } from '@/lib/profile-cache';
+import { useColumnScrollEl } from '@/components/column-scroll-context';
 
 interface LoadState {
   kind: 'loading' | 'not-found' | 'ok' | 'error';
@@ -29,19 +31,27 @@ interface LoadState {
 
 export function Profile() {
   const { handle } = useParams<{ handle: string }>();
+  if (!handle) return <p>URL が壊れています。</p>;
+  return <ProfileView actor={handle} />;
+}
+
+/** プロフィール表示本体。route (useParams) と workspace の profile カラム
+ *  (column.param) の両方から actor を受けて使う。 */
+export function ProfileView({ actor }: { actor: string }) {
   const session = useSession();
   const [state, setState] = useState<LoadState>({ kind: 'loading' });
 
   useEffect(() => {
-    if (session.status !== 'signed-in' || !session.agent || !handle) return;
+    if (session.status !== 'signed-in' || !session.agent) return;
     const agent = session.agent;
     const myDid = session.did;
     let cancelled = false;
+    setState({ kind: 'loading' });
     (async () => {
       try {
-        const pRes = await agent.getProfile({ actor: handle });
+        // 共有キャッシュ経由 (同じ profile を複数カラムで開いても fetch は 1 回)
+        const profile = await getProfileCached(agent, actor);
         if (cancelled) return;
-        const profile = pRes.data;
         const theirDid = profile.did;
 
         const [theirDiag, myDiag] = await Promise.all([
@@ -62,12 +72,12 @@ export function Profile() {
       }
     })();
     return () => { cancelled = true; };
-  }, [session.status, session.agent, session.did, handle]);
+  }, [session.status, session.agent, session.did, actor]);
 
   if (session.status !== 'signed-in' || !session.agent) {
     return (
       <div>
-        <h2>@{handle}</h2>
+        <h2>@{actor}</h2>
         <p>まずはログインしてください。</p>
       </div>
     );
@@ -76,13 +86,13 @@ export function Profile() {
   if (state.kind === 'loading') return <p>読み込み中...</p>;
   if (state.kind === 'not-found') return (
     <div>
-      <h2>@{handle}</h2>
+      <h2>@{actor}</h2>
       <p style={{ color: 'var(--color-muted)' }}>このユーザーは見つかりませんでした。</p>
     </div>
   );
   if (state.kind === 'error') return (
     <div>
-      <h2>@{handle}</h2>
+      <h2>@{actor}</h2>
       <p style={{ color: 'var(--color-danger)' }}>うまく読み込めませんでした: {state.error}</p>
     </div>
   );
@@ -314,6 +324,8 @@ function toVec(s: StatArray) {
 }
 
 function RecentPosts({ agent, did }: { agent: Agent; did: string }) {
+  // workspace のカラム内ではカラム内スクロール、単独ページでは window スクロール
+  const scrollEl = useColumnScrollEl();
   const feed = useInfiniteFeed<AppBskyFeedDefs.FeedViewPost>({
     enabled: !!agent && !!did,
     keyOf: (x) => x.post.uri,
@@ -344,6 +356,7 @@ function RecentPosts({ agent, did }: { agent: Agent; did: string }) {
       <VirtualFeed
         items={feed.items}
         keyOf={(x) => x.post.uri}
+        scrollParent={scrollEl}
         renderItem={(item) => <PostArticle post={item.post} expandable />}
         onEndReached={feed.done ? undefined : feed.loadMore}
         footer={

--- a/apps/web/src/routes/profile.tsx
+++ b/apps/web/src/routes/profile.tsx
@@ -17,7 +17,7 @@ import { TranslationControls } from '@/components/post-body';
 import { VirtualFeed } from '@/components/virtual-feed';
 import { useInfiniteFeed } from '@/lib/use-infinite-feed';
 import { useTranslation } from '@/lib/translate';
-import { getProfileCached } from '@/lib/profile-cache';
+import { getProfileCached, invalidateProfile } from '@/lib/profile-cache';
 import { useColumnScrollEl } from '@/components/column-scroll-context';
 
 interface LoadState {
@@ -477,6 +477,9 @@ function FollowButton({
         const res = await agent.follow(did);
         setFollowUri(res.uri);
       }
+      // viewer.following が変わったので profile キャッシュを無効化
+      // (30s TTL 内の stale 初期値で二重フォロー等にならないように)
+      invalidateProfile(did);
     } catch (e) {
       console.warn('[follow] toggle failed', e);
       setFollowUri(prev);

--- a/apps/web/src/routes/search.tsx
+++ b/apps/web/src/routes/search.tsx
@@ -10,17 +10,38 @@ import { Avatar } from '@/components/avatar';
 import { PostArticle } from '@/components/post-article';
 import { PostText } from '@/components/post-text';
 import { useArchetypes } from '@/lib/archetype-cache';
+import { useColumnScrollEl } from '@/components/column-scroll-context';
 
 type Mode = 'users' | 'posts';
 
+/** 検索ページ (route)。URL の ?q= / ?mode= と同期する。 */
 export function Search() {
+  return <SearchPanel syncUrl />;
+}
+
+/**
+ * 検索 UI 本体。route (syncUrl=true) と workspace の search カラム
+ * (syncUrl=false、initialQuery/initialMode を column から注入) の両用。
+ * カラムでは複数の検索カラムが並ぶため URL とは同期しない。
+ */
+export function SearchPanel({
+  syncUrl = false,
+  initialQuery,
+  initialMode,
+}: {
+  syncUrl?: boolean;
+  initialQuery?: string;
+  initialMode?: Mode;
+}) {
   const session = useSession();
   const [searchParams, setSearchParams] = useSearchParams();
   // URL の ?q= を初期値にセット。ハッシュタグ (#...) や引用記法から飛んできた時に
   // そのまま投稿モードで検索が走るよう、# 始まりは mode=posts に振る。
-  const initialQ = searchParams.get('q') ?? '';
-  const initialMode: Mode = searchParams.get('mode') === 'posts' || initialQ.startsWith('#') ? 'posts' : 'users';
-  const [mode, setMode] = useState<Mode>(initialMode);
+  const initialQ = syncUrl ? (searchParams.get('q') ?? '') : (initialQuery ?? '');
+  const urlMode = syncUrl ? searchParams.get('mode') : null;
+  const computedInitialMode: Mode =
+    initialMode ?? (urlMode === 'posts' || initialQ.startsWith('#') ? 'posts' : 'users');
+  const [mode, setMode] = useState<Mode>(computedInitialMode);
   const [q, setQ] = useState(initialQ);
   const [submittedQ, setSubmittedQ] = useState(initialQ);
 
@@ -66,6 +87,7 @@ export function Search() {
     const t = q.trim();
     if (!t) return;
     setSubmittedQ(t);
+    if (!syncUrl) return;
     // ブックマーク・共有ができるよう URL に反映 (#始まりは posts モードも一緒に書く)
     const next = new URLSearchParams(searchParams);
     next.set('q', t);
@@ -76,7 +98,7 @@ export function Search() {
   /** タブ切替時に mode を変えつつ、すでに検索済みなら URL の mode= も書き戻す。 */
   function switchMode(next: Mode) {
     setMode(next);
-    if (!submittedQ) return; // 未検索ならまだ URL には書かない
+    if (!syncUrl || !submittedQ) return; // カラム or 未検索ならまだ URL には書かない
     const params = new URLSearchParams(searchParams);
     if (next === 'posts') params.set('mode', 'posts'); else params.delete('mode');
     setSearchParams(params, { replace: true });
@@ -84,6 +106,7 @@ export function Search() {
 
   // URL の q が外部 (戻る/進む、別ページからのリンク) で変わったら state に追従
   useEffect(() => {
+    if (!syncUrl) return;
     const qFromUrl = searchParams.get('q') ?? '';
     if (qFromUrl !== submittedQ) {
       setQ(qFromUrl);
@@ -93,9 +116,10 @@ export function Search() {
     }
     // submittedQ を deps に入れると loop するので意図的に除外
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchParams]);
+  }, [searchParams, syncUrl]);
 
   // 以下は早期 return より前に置く (Hooks ルール: 順序を維持)
+  const scrollEl = useColumnScrollEl();
   const userDids = useMemo(() => users.items.map((u) => u.did), [users.items]);
   const postAuthorDids = useMemo(() => posts.items.map((p) => p.author.did), [posts.items]);
   const usersArchetypes = useArchetypes(agent ?? null, userDids);
@@ -104,7 +128,7 @@ export function Search() {
   if (session.status !== 'signed-in') {
     return (
       <div>
-        <h2>検索</h2>
+        {syncUrl && <h2>検索</h2>}
         <p>まずはログインしてください。</p>
         <Link to="/onboarding"><button>ログイン</button></Link>
       </div>
@@ -115,7 +139,7 @@ export function Search() {
 
   return (
     <div>
-      <h2>検索</h2>
+      {syncUrl && <h2>検索</h2>}
 
       <div className="dq-tabs">
         <button className={`dq-tab${mode === 'users' ? ' active' : ''}`} onClick={() => switchMode('users')}>ユーザー</button>
@@ -144,6 +168,7 @@ export function Search() {
             items={users.items}
             keyOf={(u) => u.did}
             estimateSize={120}
+            scrollParent={scrollEl}
             renderItem={(u) => <UserCard user={u} archetype={usersArchetypes.get(u.did) ?? null} />}
             onEndReached={users.done ? undefined : users.loadMore}
             footer={
@@ -163,6 +188,7 @@ export function Search() {
           <VirtualFeed
             items={posts.items}
             keyOf={(p) => p.uri}
+            scrollParent={scrollEl}
             renderItem={(p) => <PostHit post={p} archetype={postsArchetypes.get(p.author.did) ?? null} />}
             onEndReached={posts.done ? undefined : posts.loadMore}
             footer={

--- a/docs/16-multicolumn.md
+++ b/docs/16-multicolumn.md
@@ -1,0 +1,131 @@
+# 16 - アプリ全体マルチカラム (workspace)
+
+## 概要
+
+aozoraquest の UI を「縦 1 列の冒険手帳」から **TweetDeck 風のマルチカラム (workspace)** に拡張する。デスクトップでは「ホーム TL / BAR ブルスコ / 通知 / クエスト掲示板 / プロフィール / 検索結果」を自由に並べて見られ、モバイルでは横スワイプ (scroll-snap) でカラム間を移動する。
+
+`docs/15-user-quest.md` Phase 3 で実装した「board 内マルチカラム」は、本書のアーキテクチャでは **`board` カラムの内側のサブカラム (BoardInner)** に位置づけ直される。
+
+メタファー: **カラムが手帳 1 ページ、workspace は手帳の見開き**。各カラムは DQ ウィンドウ (3px 白枠 + 四隅装飾) で、`.content` の大枠 (二重枠) は workspace モードでは透明化する。
+
+## 確定要件
+
+1. **カラム種類は 6 種** (MVP):
+   - `home` — 自分のフォロー TL
+   - `bar` — **BAR ブルスコ** (= 共鳴 TL を「aozoraquest 利用者が集う酒場」のメタファーで独立カラム化)
+   - `notifications` — 自分の通知
+   - `search` — 検索結果 (param = query, mode = posts | users)
+   - `board` — 依頼クエスト掲示板 (内側に `BoardInner` のサブカラム)
+   - `profile` — 特定プロフィール (param = handle, 複数同時表示可)
+2. **モバイルも横スワイプ** (CSS `scroll-snap-type: x mandatory`、1 スワイプ = 1 カラム送り)
+3. **feature flag なし**。各 PR で「壊れない状態」を維持しながら段階導入する
+
+## アーキテクチャ: 「Workspace as default route」
+
+- ルートパス `/` の index route が **Workspace** (`apps/web/src/components/workspace.tsx`)
+- Workspace は `loadAppColumns()` で読んだカラム構成をレンダリングし、各列が `ColumnContent` (kind 別 dispatcher) を描画する
+- **既存 URL (`/profile/:handle`, `/search?q=`, `/notifications` 等) は従来ページとして維持**。直リンク・シェア・SEO は壊れない。表示本体のコンポーネントを route と カラムで共用する (後述)
+
+### route と カラムの共用パターン
+
+各 route から表示本体を named export で切り出し、route は thin wrapper として残す:
+
+| route | 切り出したコンポーネント | カラムでの使い方 |
+|---|---|---|
+| (旧 home.tsx → 削除) | `HomeColumn` / `BarColumn` (column-content/) | そのまま |
+| notifications.tsx | `NotificationsFeed` | そのまま |
+| search.tsx | `SearchPanel({ syncUrl, initialQuery, initialMode })` | syncUrl=false で URL 非同期 |
+| profile.tsx | `ProfileView({ actor })` | column.param を渡す |
+| board.tsx | (PR 4 で `BoardPanel` 化予定) | BoardInner を渡す |
+
+**スクロールの自動切替**: 表示本体は `useColumnScrollEl()` (column-scroll-context.ts) で自分のスクロール親を取得して `VirtualFeed` の `scrollParent` に渡す。workspace 内ではカラムの `column-body` 要素、workspace 外 (= 従来ページ) では null = window スクロール。**route 側の挙動は無変更で済む**のがこの設計の利点。
+
+## データモデル: `app-columns.ts`
+
+```ts
+export type AppColumnKind = 'home' | 'bar' | 'notifications' | 'search' | 'board' | 'profile';
+
+export type AppColumn =
+  | (ColumnBase & { kind: 'home' })
+  | (ColumnBase & { kind: 'bar' })
+  | (ColumnBase & { kind: 'notifications' })
+  | (ColumnBase & { kind: 'search'; param?: string; mode?: 'posts' | 'users' })
+  | (ColumnBase & { kind: 'board'; inner?: BoardInner[] })
+  | (ColumnBase & { kind: 'profile'; param?: string; section?: 'posts' | 'portfolio' });
+```
+
+- **kind ごとの discriminated union** (フィールドを平坦に持つ)。kind とフィールドの不整合が型レベルで起きない
+- board は `inner: BoardInner[]` で旧 board 内サブカラム (open / mine / applied / tag / job / issuer) を包含する二段構造
+
+### 永続化: localStorage + read-time 変換
+
+- 保存キー: `aozoraquest:appColumns:v1`
+- **保存はユーザーの明示操作 (saveAppColumns) のみ**。default 構成や変換結果を機械的に保存しない
+- 保存がない限り `loadAppColumns(signedIn)` は毎回「default 構成 + 旧 `boardColumns:v1` の read-time 変換」を計算するため、サインイン状態の変化や旧キーの更新に常に追従する (= セッション解決前に board だけの構成が固定化される事故を構造的に防ぐ)
+- デフォルト構成: サインイン済み `[home, bar, notifications, board]`、未サインイン `[board]`
+- PDS 同期 (`app.aozoraquest.layout`) は将来の opt-in 機能 (Phase 4+)
+
+## レイアウト CSS
+
+```css
+/* モバイル: 1 スワイプ = 1 カラム送り。次のカラムの端をチラ見せ */
+.workspace-columns {
+  display: flex; flex-direction: row; overflow-x: auto;
+  scroll-snap-type: x mandatory; overscroll-behavior-x: contain;
+}
+.workspace-column {
+  flex: 0 0 calc(100% - 1.6em);
+  scroll-snap-align: start; scroll-snap-stop: always;
+  height: calc(100dvh - 10.5em);   /* 実測 CSS 変数化は PR 5 */
+}
+.workspace-column-body { overflow-y: auto; overscroll-behavior: contain; }
+
+@media (min-width: 768px) {
+  .workspace-column { flex: 0 0 340px; }
+  .workspace-columns { scroll-snap-type: none; }  /* PC は自由スクロール */
+}
+```
+
+- 幅緩和 (`max-width: min(100vw - 1.5em, 1480px)`) は **768px から** 適用 (1100px 始まりだとタブレット縦持ちで破綻)
+- workspace モードでは `.content` の大枠を透明化 (`:has([data-workspace="1"])`)
+
+## VirtualFeed の dual-mode
+
+- `scrollParent?: HTMLElement | null` を optional prop で受ける。未指定 = window スクロール (後方互換)
+- **RefObject ではなく要素そのもの** を渡す (commit タイミング / memo 化での stale 参照を構造ごと排除)。利用側は `useState` + callback ref で要素を管理
+- container モードの scrollMargin は「リスト先頭の container 内オフセット」を実測 (ResizeObserver で上部コンテンツの高さ変化に追従)
+
+## データ取得の重複防止
+
+| キャッシュ | 対象 | 方式 |
+|---|---|---|
+| `lib/use-self-diagnosis.ts` | 自分の診断 (home / bar が共用) | module-level キャッシュ + 購読 + settle フラグ。`refreshSelfDiagnosis()` で全購読者に伝播 |
+| `lib/profile-cache.ts` | `agent.getProfile` (複数 profile カラム) | actor 単位の inflight dedup + 30s TTL メモリ |
+| `lib/handle-cache.ts` (既存) | did → handle 解決 | 24h localStorage |
+| `useQuestIndex` (PR 4 予定) | fetchQuestIndex | inflight + メモリ |
+
+bar カラムの `buildResonanceTimeline` (最大 30 DID × 2 req) は **自分の診断が settle してから 1 回だけ** 実行し、epoch ガードで古い実行の後着上書きを防ぐ。
+
+## 実装ロードマップ (5 PR)
+
+| PR | 内容 | 状態 |
+|---|---|---|
+| 1 (#32) | VirtualFeed dual-mode + AppColumn データモデル | done |
+| 2 (#33) | Workspace shell + home / bar カラム + モバイル横スワイプ基本形 | done |
+| 3 (#34) | notifications / search / profile カラム化 + profile-cache | done |
+| 4 | board カラム (BoardPanel 化) + ColumnPicker (追加 UI) + 矢印並べ替え + column-router (URL ↔ AppColumn) + 「このカラムへの直リンク」 | 予定 |
+| 5 | snap 磨き込み + footer-nav 連動 (scrollIntoView / IntersectionObserver) + `--shell-chrome-height` 実測 + 通知既読の可視判定 + e2e + docs 整合 | 予定 |
+
+## 既知の制約 / 検討事項 (PR 4-5 で対応)
+
+- **通知の既読化**: NotificationsFeed はカラムとして mount された時点で `updateNotificationsSeen` を発火する。workspace の default 構成に notifications が入っているため、`/` を開くだけで未読バッジが消える。可視判定 (IntersectionObserver) ベースへの変更を PR 5 で検討
+- **search カラムの param 追従**: SearchPanel は initialQuery を useState 初期値でしか読まないため、PR 4 のカラム編集で param が変わったときは `key` で remount させる
+- **column-content → routes の import 方向**: PR 4 で board を取り込むと循環のリスクがあるため、panel 群を components/ 配下へ移すことを検討
+- **DM カラム / List カラム**: Bluesky の DM・List API 調査が別途必要 (Phase 5+)
+- **drag & drop 並べ替え**: MVP は矢印ボタンのみ。要望次第で dnd-kit
+
+## 関連ドキュメント
+
+- `docs/15-user-quest.md` — 依頼クエスト機能 (§UI 設計 E の board 内マルチカラムは本書の BoardInner に統合)
+- `DESIGN.md` — DQ ウィンドウ様式・カラーパレット (workspace のカラムは `.dq-window` 様式を踏襲)
+- `docs/07-ui-design.md` — UI 全般


### PR DESCRIPTION
## Summary

マルチカラム化の **PR 3/5**。workspace の残り 3 kind (notifications / search / profile) を実体化。

設計方針: 既存 route コンポーネントから表示本体を named export で切り出し、**route は thin wrapper として残す**。`ColumnScrollContext` が workspace 外では null を返すため、単独ページでは従来通り window スクロールで動き、**route の挙動は無変更**。

- `NotificationsFeed({ markSeen })` — 既読化は通知ページを開いたときのみ (カラムでは発火しない)
- `SearchPanel({ syncUrl, initialQuery, initialMode })` — route は URL 同期、カラムは非同期で複数並べても URL を取り合わない
- `ProfileView({ actor })` — route は useParams、カラムは column.param。`profile-cache.ts` (inflight dedup + 30s TTL + invalidate) で複数カラムの重複 fetch を防止
- `docs/16-multicolumn.md` 新規 (本シリーズの設計書)

### プランからの変更
- **column-router.ts は PR 4 へ移動** (今 PR では消費者がなく dead code になるため)
- **route の single-override 化は見送り** (既存 route ページが直リンクとして機能しており、固定高カラムへの強制は UX 退行になるため)

## Review

2 並列 subagent レビュー (設計+実装 / UX+影響範囲) を実施。**★★★ 1 / ★★ 5 / ★ 5**。commit d24ea1c で対応:

| 指摘 | 重要度 | 対応 |
|---|---|---|
| `/` を開くだけで updateNotificationsSeen が発火し未読バッジが恒久無意味化 (モバイルでは画面外なのに既読化) | ★★★ | `markSeen` prop (default false)。既読化は通知ページのみ。可視判定ベースは PR 5 |
| SearchPanel が column.param 変更に追従しない (useState 初期値のみ、PR 4 で詰まる) | ★★ | dispatcher で `key={id:param:mode}` を付与し remount で反映 |
| docs/16-multicolumn.md がコメントから多数参照されるのに repo に存在しない | ★★ | 設計書として新規作成 |
| 検索カラムのヘッダータイトルが再検索に追従しない | ★★ | **issue #35** (PR 4 のカラム編集に内包) |
| プレースホルダ文言に PR 番号 (開発内部用語) が露出 | ★★ | 「今後のアップデートで〜」に修正 |
| profile-cache の 30s TTL に viewer.following が乗り、フォロー直後の stale 初期値で二重フォローの恐れ | ★★ | `invalidateProfile()` を追加し FollowButton の toggle 成功時に呼ぶ |
| handle.invalid が cache key になり別人の profile が混ざりうる | ★ | key 格納から除外 |
| profile カラムの情報過多 (相性 + 推し量り + 投稿のフル盛り) | ★ | **issue #36** (compact 版、PR 5 以降) |
| column-content → routes の import 方向 (PR 4 で cycle リスク) | ★ | PR 4 の board 取り込み時に panel 移設を検討 (docs に記録) |

レビューで「問題なし」と確認: route の regression なし (h2 条件分岐含め旧実装と同一)、検索カラム幅 340px に tabs + フィールド収まる、DESIGN.md 準拠継続、循環 import なし、discriminated union の narrowing 正常。

## 動作確認
- [x] typecheck / vitest 119 / build 緑
- [x] playwright smoke: `/` `/notifications` `/search?q=` `/profile/:handle` `/board` 表示 + console エラーなし
- [ ] サインイン後のカラム表示は dev.aozoraquest.app で実機確認