### PR TITLE
feat(workspace): board カラム + ColumnPicker + カラム編集 (マルチカラム PR 4/5)

### DIFF
--- a/apps/web/src/components/column-content/board-column.tsx
+++ b/apps/web/src/components/column-content/board-column.tsx
@@ -1,0 +1,74 @@
+/**
+ * board カラム: 依頼クエスト掲示板 (docs/16-multicolumn.md)。
+ *
+ * 340px のカラム内に board の inner マルチカラム (320px 横並び) は
+ * 物理的に入らないため、カラム内では **inner をタブ切替** で出す。
+ * フル機能 (inner の追加・削除を含む横並び表示) は従来ページ /board に
+ * リンクで誘導する。
+ */
+import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import type { BoardInner } from '@/lib/app-columns';
+import {
+  useBoardData,
+  filterForBoard,
+  isExpiredSummary,
+  emptyMessageForBoard,
+  boardFilterTitle,
+  QuestCard,
+  type BoardFilter,
+} from './board-shared';
+
+const DEFAULT_INNER: BoardInner[] = [{ kind: 'open' }, { kind: 'mine' }];
+
+export function BoardColumn({ inner }: { inner?: BoardInner[] | undefined }) {
+  const tabs: BoardFilter[] = (inner && inner.length > 0) ? inner : DEFAULT_INNER;
+  const [tabIndex, setTabIndex] = useState(0);
+  const active = tabs[Math.min(tabIndex, tabs.length - 1)]!;
+
+  const { index, myQuests, myApplicationQuestUris, err } = useBoardData();
+  const items = useMemo(
+    () => filterForBoard(active, index, myQuests, myApplicationQuestUris),
+    [active, index, myQuests, myApplicationQuestUris],
+  );
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: '0.5em', marginBottom: '0.4em' }}>
+        <Link to="/board" style={{ fontSize: '0.78em' }}>掲示板をフル表示 →</Link>
+        <Link to="/board/new" style={{ fontSize: '0.78em' }}>＋ クエストを出す</Link>
+      </div>
+
+      {tabs.length > 1 && (
+        <div className="dq-tabs" style={{ margin: '0 0 0.5em' }}>
+          {tabs.map((t, i) => (
+            <button
+              key={`${t.kind}:${t.param ?? ''}`}
+              onClick={() => setTabIndex(i)}
+              className={`dq-tab${i === tabIndex ? ' active' : ''}`}
+              style={{ fontSize: '0.8em', padding: '0.35em 0.3em' }}
+            >
+              {boardFilterTitle(t)}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {err && <p style={{ color: 'var(--color-danger)', fontSize: '0.85em' }}>取得に失敗: {err}</p>}
+
+      {items == null ? (
+        <p style={{ fontSize: '0.8em', color: 'var(--color-muted)' }}>読み込み中...</p>
+      ) : items.length === 0 ? (
+        <p style={{ fontSize: '0.8em', color: 'var(--color-muted)' }}>{emptyMessageForBoard(active)}</p>
+      ) : (
+        <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+          {items.map((q) => (
+            <li key={q.uri}>
+              <QuestCard summary={q} expired={isExpiredSummary(q)} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/column-content/board-column.tsx
+++ b/apps/web/src/components/column-content/board-column.tsx
@@ -21,10 +21,23 @@ import {
 
 const DEFAULT_INNER: BoardInner[] = [{ kind: 'open' }, { kind: 'mine' }];
 
+/** タブ表示用ラベル。issuer は DID 全表示だと長く区別もできないため
+ *  末尾を省略して識別子の頭を見せる。 */
+function boardTabLabel(t: BoardFilter): string {
+  if (t.kind === 'issuer' && t.param) {
+    const short = t.param.replace(/^did:plc:/, '').slice(0, 6);
+    return `発行者: ${short}…`;
+  }
+  return boardFilterTitle(t);
+}
+
 export function BoardColumn({ inner }: { inner?: BoardInner[] | undefined }) {
   const tabs: BoardFilter[] = (inner && inner.length > 0) ? inner : DEFAULT_INNER;
   const [tabIndex, setTabIndex] = useState(0);
-  const active = tabs[Math.min(tabIndex, tabs.length - 1)]!;
+  // tabs が縮んだとき (inner 編集の反映等) に範囲外参照と highlight ズレを
+  // 両方防ぐため、clamp した index を表示にも使う
+  const activeIndex = Math.min(tabIndex, tabs.length - 1);
+  const active = tabs[activeIndex]!;
 
   const { index, myQuests, myApplicationQuestUris, err } = useBoardData();
   const items = useMemo(
@@ -40,15 +53,16 @@ export function BoardColumn({ inner }: { inner?: BoardInner[] | undefined }) {
       </div>
 
       {tabs.length > 1 && (
-        <div className="dq-tabs" style={{ margin: '0 0 0.5em' }}>
+        // dq-tabs (flex:1 等分) だと 5-6 タブで日本語が縦折返しして潰れる
+        // ため、横スクロールする chip 行にする (レビュー指摘 ★★★)
+        <div className="board-column-tabs">
           {tabs.map((t, i) => (
             <button
-              key={`${t.kind}:${t.param ?? ''}`}
+              key={`${t.kind}:${t.param ?? ''}:${i}`}
               onClick={() => setTabIndex(i)}
-              className={`dq-tab${i === tabIndex ? ' active' : ''}`}
-              style={{ fontSize: '0.8em', padding: '0.35em 0.3em' }}
+              className={`dq-tab${i === activeIndex ? ' active' : ''}`}
             >
-              {boardFilterTitle(t)}
+              {boardTabLabel(t)}
             </button>
           ))}
         </div>

--- a/apps/web/src/components/column-content/board-shared.tsx
+++ b/apps/web/src/components/column-content/board-shared.tsx
@@ -1,0 +1,173 @@
+/**
+ * 依頼クエスト掲示板の表示部品 (routes/board.tsx と workspace の board カラムで共用)。
+ *
+ * filter は `{ kind, param }` だけを見るので、board-columns.ts の Column
+ * (id あり) と app-columns.ts の BoardInner (id なし) の両方を受けられる。
+ */
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import type { QuestIndex, QuestIndexSummary } from '@/lib/quest-api';
+import { listIssuedQuests, listMyApplications } from '@/lib/quest-api';
+import { getQuestIndexCached } from '@/lib/quest-index-cache';
+import type { UserQuest } from '@aozoraquest/core';
+import { useSession } from '@/lib/session';
+import { Handle } from '@/components/handle';
+
+export interface BoardFilter {
+  kind: 'open' | 'mine' | 'applied' | 'tag' | 'job' | 'issuer';
+  param?: string;
+}
+
+/** board 表示に必要なデータ一式を fetch する hook
+ *  (index は quest-index-cache で重複防止)。 */
+export function useBoardData() {
+  const session = useSession();
+  const [index, setIndex] = useState<QuestIndex | null>(null);
+  const [myQuests, setMyQuests] = useState<UserQuest[] | null>(null);
+  const [myApplicationQuestUris, setMyApplicationQuestUris] = useState<Set<string> | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getQuestIndexCached()
+      .then((idx) => { if (!cancelled) setIndex(idx); })
+      .catch((e) => { if (!cancelled) setErr(String((e as Error)?.message ?? e)); });
+    return () => { cancelled = true; };
+  }, []);
+
+  useEffect(() => {
+    if (session.status !== 'signed-in' || !session.agent || !session.did) return;
+    const agent = session.agent;
+    const did = session.did;
+    let cancelled = false;
+    listIssuedQuests(agent, did)
+      .then((qs) => { if (!cancelled) setMyQuests(qs); })
+      .catch((e) => { if (!cancelled) console.warn('[board] listIssuedQuests', e); });
+    listMyApplications(agent, did)
+      .then((apps) => {
+        if (!cancelled) setMyApplicationQuestUris(new Set(apps.map(a => a.questUri)));
+      })
+      .catch((e) => { if (!cancelled) console.warn('[board] listMyApplications', e); });
+    return () => { cancelled = true; };
+  }, [session.status, session.agent, session.did]);
+
+  return { index, myQuests, myApplicationQuestUris, err, sessionDid: session.did ?? null };
+}
+
+export function filterForBoard(
+  c: BoardFilter,
+  index: QuestIndex | null,
+  myQuests: UserQuest[] | null,
+  myApplicationQuestUris: Set<string> | null,
+): QuestIndexSummary[] | null {
+  if (c.kind === 'open') {
+    if (!index) return null;
+    return index.quests.filter(q => q.status === 'open');
+  }
+  if (c.kind === 'mine') {
+    if (!myQuests) return null;
+    return myQuests.map(toSummary);
+  }
+  if (c.kind === 'applied') {
+    if (!index || !myApplicationQuestUris) return null;
+    return index.quests.filter(q => myApplicationQuestUris.has(q.uri));
+  }
+  if (c.kind === 'tag') {
+    if (!index || !c.param) return null;
+    const target = c.param.replace(/^#/, '').toLowerCase();
+    return index.quests.filter(q =>
+      q.status === 'open' &&
+      q.tags.some(t => t.replace(/^#/, '').toLowerCase() === target),
+    );
+  }
+  if (c.kind === 'job') {
+    // questIndex には targetJob を載せていないため、自分が出したクエストからのみ
+    // filter する (questIndex への targetJob 追加は docs/15-user-quest.md 参照)。
+    if (!myQuests) return null;
+    return myQuests
+      .filter(q => q.status === 'open' && q.targetJob === c.param)
+      .map(toSummary);
+  }
+  if (c.kind === 'issuer') {
+    if (!index || !c.param) return null;
+    return index.quests.filter(q => q.status === 'open' && q.did === c.param);
+  }
+  return [];
+}
+
+export function toSummary(q: UserQuest): QuestIndexSummary {
+  const s: QuestIndexSummary = {
+    uri: q.uri,
+    did: q.did,
+    title: q.title,
+    tags: q.tags,
+    rewardPoints: q.rewardPoints,
+    status: q.status,
+    createdAt: q.createdAt,
+  };
+  if (q.deadline !== undefined) s.deadline = q.deadline;
+  return s;
+}
+
+export function isExpiredSummary(s: QuestIndexSummary): boolean {
+  if (s.status !== 'open') return false;
+  if (!s.deadline) return false;
+  return new Date(s.deadline) < new Date();
+}
+
+export function QuestCard({ summary, expired }: { summary: QuestIndexSummary; expired?: boolean }) {
+  return (
+    <Link to={`/board/${encodeURIComponent(summary.uri)}`} style={{ textDecoration: 'none' }}>
+      <div className="dq-window compact" style={{ borderColor: expired ? 'var(--color-muted)' : undefined }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: '0.5em' }}>
+          <div style={{ fontWeight: 700, fontSize: '0.92em', color: 'var(--color-fg)' }}>{summary.title}</div>
+          <div style={{ fontFamily: 'ui-monospace, monospace', fontSize: '0.78em', color: 'var(--color-accent)', whiteSpace: 'nowrap' }}>
+            <Handle did={summary.did} suffix="P" /> {summary.rewardPoints.toLocaleString()}
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: '0.5em', flexWrap: 'wrap', fontSize: '0.72em', color: 'var(--color-muted)', marginTop: '0.3em' }}>
+          {summary.tags.slice(0, 3).map(t => <span key={t}>#{t.replace(/^#/, '')}</span>)}
+          <span style={{ marginLeft: 'auto' }}>
+            {expired ? '期限切れ' : summary.deadline ? `〆 ${formatDate(summary.deadline)}` : ''}
+            {summary.status !== 'open' && <span style={{ marginLeft: '0.6em' }}>{labelOf(summary.status)}</span>}
+          </span>
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+export function emptyMessageForBoard(c: BoardFilter): string {
+  switch (c.kind) {
+    case 'open':    return 'まだ誰も募集していません。「クエストを出す」から始めてみましょう。';
+    case 'mine':    return 'あなたが発行したクエストはまだありません。';
+    case 'applied': return '応募中のクエストはありません。';
+    case 'tag':     return `#${c.param ?? ''} のクエストは見つかりませんでした。`;
+    case 'job':     return `「${c.param ?? ''}」を求めるクエストはまだありません。`;
+    case 'issuer':  return 'この発行者の募集中クエストはありません。';
+  }
+}
+
+export function boardFilterTitle(c: BoardFilter): string {
+  switch (c.kind) {
+    case 'open':    return '募集中';
+    case 'mine':    return '自分が出した';
+    case 'applied': return '自分が応募した';
+    case 'tag':     return `#${c.param ?? ''}`;
+    case 'job':     return `求めるジョブ: ${c.param ?? ''}`;
+    case 'issuer':  return '発行者別';
+  }
+}
+
+export function labelOf(status: string): string {
+  if (status === 'assigned') return '受託中';
+  if (status === 'reported') return '完了報告中';
+  if (status === 'completed') return '完了';
+  if (status === 'cancelled') return 'キャンセル';
+  return status;
+}
+
+export function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return `${d.getMonth() + 1}/${d.getDate()}`;
+}

--- a/apps/web/src/components/column-content/index.tsx
+++ b/apps/web/src/components/column-content/index.tsx
@@ -1,21 +1,27 @@
 /**
  * AppColumn の kind 別に中身を出し分ける dispatcher (docs/16-multicolumn.md)。
  *
- * 段階導入の途中 (flag なし方針) なので、未実装の kind は従来ページへの
- * リンク付きプレースホルダを出す:
  *  - PR 2: home / bar
- *  - PR 3: notifications / search / profile (本 PR)
- *  - PR 4: board
+ *  - PR 3: notifications / search / profile
+ *  - PR 4: board (本 PR で全 kind 実装完了)
  */
-import { Link } from 'react-router-dom';
 import type { AppColumn } from '@/lib/app-columns';
 import { HomeColumn } from './home-column';
 import { BarColumn } from './bar-column';
+import { BoardColumn } from './board-column';
 import { NotificationsFeed } from '@/routes/notifications';
 import { SearchPanel } from '@/routes/search';
 import { ProfileView } from '@/routes/profile';
 
-export function ColumnContent({ column }: { column: AppColumn }) {
+export function ColumnContent({
+  column,
+  onPatch,
+}: {
+  column: AppColumn;
+  /** カラムの部分更新 (検索カラムの param 追従などに使う)。
+   *  workspace 外 (将来 single 表示等) では undefined。 */
+  onPatch?: ((patch: Partial<AppColumn>) => void) | undefined;
+}) {
   switch (column.kind) {
     case 'home':
       return <HomeColumn />;
@@ -27,35 +33,29 @@ export function ColumnContent({ column }: { column: AppColumn }) {
       return <NotificationsFeed />;
     case 'search':
       return (
-        // key に param/mode を含め、カラム編集 (PR 4) で param が変わったら
-        // remount して initial 値を反映する (useState 初期値のみのため)
+        // key は column.id のみ (param を含めると検索のたび remount して
+        // 結果がチラつく)。カラム内の再検索は onSearch → onPatch で
+        // column.param に書き戻し、ヘッダータイトルが追従する (issue #35)
         <SearchPanel
-          key={`${column.id}:${column.param ?? ''}:${column.mode ?? ''}`}
+          key={column.id}
           {...(column.param !== undefined ? { initialQuery: column.param } : {})}
           {...(column.mode !== undefined ? { initialMode: column.mode } : {})}
+          {...(onPatch
+            ? { onSearch: (q: string, mode: 'posts' | 'users') => onPatch({ param: q, mode } as Partial<AppColumn>) }
+            : {})}
         />
       );
     case 'profile':
       return column.param ? (
+        // profile はカラム内で actor を変える UI がないため、外部編集 =
+        // remount でよい (key に param を含める)
         <ProfileView key={`${column.id}:${column.param}`} actor={column.param} />
       ) : (
-        <MissingParam label="プロフィール" hint="表示するユーザーの指定がありません。今後のアップデートでカラム追加時にハンドルを指定できるようになります。" />
+        <MissingParam label="プロフィール" hint="表示するユーザーの指定がありません。「＋ カラムを追加」からハンドルを指定して追加し直してください。" />
       );
     case 'board':
-      return <PendingColumn label="クエスト掲示板" to="/board" />;
+      return <BoardColumn inner={column.inner} />;
   }
-}
-
-/** カラム化が後続 PR で届く kind の仮表示。従来ページに誘導する。 */
-function PendingColumn({ label, to }: { label: string; to: string }) {
-  return (
-    <div style={{ padding: '0.5em 0' }}>
-      <p style={{ fontSize: '0.85em', color: 'var(--color-muted)', lineHeight: 1.6 }}>
-        {label}のカラム表示は準備中です。今はページとして開けます。
-      </p>
-      <Link to={to}><button style={{ marginTop: '0.4em' }}>{label}を開く</button></Link>
-    </div>
-  );
 }
 
 function MissingParam({ label, hint }: { label: string; hint: string }) {

--- a/apps/web/src/components/column-picker.tsx
+++ b/apps/web/src/components/column-picker.tsx
@@ -2,8 +2,8 @@
  * workspace のカラム追加 UI (docs/16-multicolumn.md)。
  *
  * kind を選び、必要な kind (search / profile) は param を入力して追加する。
- * board の inner 構成は従来ページ (/board) で編集したものが read-time で
- * 反映されるため、ここでは board は無パラメータで追加する。
+ * board の inner 構成は /board ページで編集したものが read-time で反映される
+ * ため、ここでは board は無パラメータで追加する。
  */
 import { useState } from 'react';
 import { makeAppColumn, type AppColumn, type AppColumnKind } from '@/lib/app-columns';
@@ -35,13 +35,17 @@ export function ColumnPicker({
 }) {
   const [paramFor, setParamFor] = useState<'search' | 'profile' | null>(null);
   const [val, setVal] = useState('');
+  const [paramErr, setParamErr] = useState<string | null>(null);
 
-  function add(def: PickerDef) {
+  function pick(def: PickerDef) {
+    setParamErr(null);
     if (def.needsParam) {
+      // param 入力中に別の param kind を押したら入力対象を切り替える
       setParamFor(def.needsParam);
       setVal('');
       return;
     }
+    setParamFor(null);
     onAdd(makeAppColumn(def.kind));
   }
 
@@ -52,12 +56,21 @@ export function ColumnPicker({
       // 空でも追加可 (カラム内で検索すればよい)
       onAdd(v ? makeAppColumn('search', { param: v }) : makeAppColumn('search'));
     } else {
-      // profile はハンドル必須
-      if (!v) return;
-      onAdd(makeAppColumn('profile', { param: v.replace(/^@/, '') }));
+      // profile はハンドル必須。軽い形式チェック (ドット入り handle or DID)
+      const handle = v.replace(/^@/, '');
+      if (!handle) {
+        setParamErr('ハンドルを入力してください。');
+        return;
+      }
+      if (!handle.includes('.') && !handle.startsWith('did:')) {
+        setParamErr('ハンドルは kojira.example のようなドット入りの形式です。');
+        return;
+      }
+      onAdd(makeAppColumn('profile', { param: handle }));
     }
     setParamFor(null);
     setVal('');
+    setParamErr(null);
   }
 
   return (
@@ -70,8 +83,8 @@ export function ColumnPicker({
             <button
               key={def.kind}
               type="button"
-              onClick={() => add(def)}
-              disabled={locked || (paramFor !== null && def.needsParam !== paramFor)}
+              onClick={() => pick(def)}
+              disabled={locked}
               title={locked ? 'サインインすると追加できます' : undefined}
               style={{ textAlign: 'left', fontSize: '0.85em', opacity: locked ? 0.5 : 1 }}
             >
@@ -89,13 +102,15 @@ export function ColumnPicker({
             <input
               id="column-picker-param"
               value={val}
-              onChange={(e) => setVal(e.target.value)}
+              onChange={(e) => { setVal(e.target.value); setParamErr(null); }}
               onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); commitParam(); } }}
               autoFocus
               style={{ flex: 1, fontSize: '0.85em' }}
             />
             <button type="button" onClick={commitParam} style={{ fontSize: '0.8em' }}>追加</button>
+            <button type="button" className="secondary" onClick={() => { setParamFor(null); setVal(''); setParamErr(null); }} style={{ fontSize: '0.8em' }}>戻る</button>
           </div>
+          {paramErr && <p style={{ color: 'var(--color-danger)', fontSize: '0.75em', margin: '0.3em 0 0' }}>{paramErr}</p>}
         </div>
       )}
       <div style={{ marginTop: '0.7em' }}>

--- a/apps/web/src/components/column-picker.tsx
+++ b/apps/web/src/components/column-picker.tsx
@@ -1,0 +1,106 @@
+/**
+ * workspace のカラム追加 UI (docs/16-multicolumn.md)。
+ *
+ * kind を選び、必要な kind (search / profile) は param を入力して追加する。
+ * board の inner 構成は従来ページ (/board) で編集したものが read-time で
+ * 反映されるため、ここでは board は無パラメータで追加する。
+ */
+import { useState } from 'react';
+import { makeAppColumn, type AppColumn, type AppColumnKind } from '@/lib/app-columns';
+
+interface PickerDef {
+  kind: AppColumnKind;
+  label: string;
+  needsParam?: 'search' | 'profile';
+  signedInOnly?: boolean;
+}
+
+const PICKERS: PickerDef[] = [
+  { kind: 'home', label: 'ホーム TL', signedInOnly: true },
+  { kind: 'bar', label: 'BAR ブルスコ', signedInOnly: true },
+  { kind: 'notifications', label: '通知', signedInOnly: true },
+  { kind: 'board', label: 'クエスト掲示板' },
+  { kind: 'search', label: '検索', needsParam: 'search' },
+  { kind: 'profile', label: 'プロフィール', needsParam: 'profile' },
+];
+
+export function ColumnPicker({
+  signedIn,
+  onAdd,
+  onClose,
+}: {
+  signedIn: boolean;
+  onAdd: (col: AppColumn) => void;
+  onClose: () => void;
+}) {
+  const [paramFor, setParamFor] = useState<'search' | 'profile' | null>(null);
+  const [val, setVal] = useState('');
+
+  function add(def: PickerDef) {
+    if (def.needsParam) {
+      setParamFor(def.needsParam);
+      setVal('');
+      return;
+    }
+    onAdd(makeAppColumn(def.kind));
+  }
+
+  function commitParam() {
+    const v = val.trim();
+    if (!paramFor) return;
+    if (paramFor === 'search') {
+      // 空でも追加可 (カラム内で検索すればよい)
+      onAdd(v ? makeAppColumn('search', { param: v }) : makeAppColumn('search'));
+    } else {
+      // profile はハンドル必須
+      if (!v) return;
+      onAdd(makeAppColumn('profile', { param: v.replace(/^@/, '') }));
+    }
+    setParamFor(null);
+    setVal('');
+  }
+
+  return (
+    <div style={{ padding: '0.2em 0' }}>
+      <div style={{ fontSize: '0.85em', fontWeight: 700, marginBottom: '0.5em' }}>カラムを追加</div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.4em' }}>
+        {PICKERS.map((def) => {
+          const locked = def.signedInOnly && !signedIn;
+          return (
+            <button
+              key={def.kind}
+              type="button"
+              onClick={() => add(def)}
+              disabled={locked || (paramFor !== null && def.needsParam !== paramFor)}
+              title={locked ? 'サインインすると追加できます' : undefined}
+              style={{ textAlign: 'left', fontSize: '0.85em', opacity: locked ? 0.5 : 1 }}
+            >
+              ＋ {def.label}{locked ? ' (要サインイン)' : ''}
+            </button>
+          );
+        })}
+      </div>
+      {paramFor && (
+        <div style={{ marginTop: '0.5em' }}>
+          <label htmlFor="column-picker-param" style={{ display: 'block', fontSize: '0.78em', color: 'var(--color-muted)', marginBottom: '0.2em' }}>
+            {paramFor === 'search' ? '検索キーワード (空でも OK)' : 'ハンドル (例: kojira.example)'}
+          </label>
+          <div style={{ display: 'flex', gap: '0.3em' }}>
+            <input
+              id="column-picker-param"
+              value={val}
+              onChange={(e) => setVal(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); commitParam(); } }}
+              autoFocus
+              style={{ flex: 1, fontSize: '0.85em' }}
+            />
+            <button type="button" onClick={commitParam} style={{ fontSize: '0.8em' }}>追加</button>
+          </div>
+        </div>
+      )}
+      <div style={{ marginTop: '0.7em' }}>
+        <button type="button" className="secondary" onClick={onClose} style={{ fontSize: '0.8em' }}>閉じる</button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/workspace.tsx
+++ b/apps/web/src/components/workspace.tsx
@@ -1,41 +1,55 @@
 /**
  * アプリ全体マルチカラムの workspace shell (docs/16-multicolumn.md)。
  *
- * `/` の index route として表示され、loadAppColumns() で読んだカラム構成を
- * 並べる。各カラムは ColumnView (ヘッダー + 縦スクロールする body) で包み、
+ * `/` の index route として表示され、カラム構成をレンダリングする。
+ * カラムの追加 (ColumnPicker) / 並べ替え (← →) / 削除 / 直リンクコピーが
+ * でき、変更は saveAppColumns で localStorage に永続化される
+ * (= ユーザーが編集して初めて保存される。未編集なら read-time 計算のまま)。
+ *
+ * 各カラムは ColumnView (ヘッダー + 縦スクロールする body) で包み、
  * body 要素を ColumnScrollContext で配って内部の VirtualFeed が
  * 「カラム内スクロール」モードで動けるようにする。
- *
- * レイアウトはモバイル = 縦積み、768px 以上 = 横並び (styles.css の
- * .workspace-columns)。横スワイプ (scroll-snap) は PR 5 で追加する。
  */
-import { useMemo, useState, type ReactNode } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 import { useSession } from '@/lib/session';
-import { loadAppColumns, appColumnTitle, type AppColumn } from '@/lib/app-columns';
+import {
+  loadAppColumns,
+  saveAppColumns,
+  resetAppColumns,
+  moveColumnLeft,
+  moveColumnRight,
+  removeColumn,
+  appColumnTitle,
+  type AppColumn,
+} from '@/lib/app-columns';
+import { urlForColumn } from '@/lib/column-router';
 import { ColumnScrollContext } from '@/components/column-scroll-context';
 import { ColumnContent } from '@/components/column-content';
+import { ColumnPicker } from '@/components/column-picker';
 
 export function Workspace() {
   const session = useSession();
-  // 保存がなければ「default 構成 + 旧 board 設定の read-time 変換」が返る。
-  // - サインイン状態の確定を待ってから読む (loading 中に false で読むと
-  //   1 render だけ board 構成が出てチラつくため)
-  // - default 構成は呼ぶたび新しい id を生成するので、useMemo で安定化する
-  //   (毎 render 再計算すると React key が変わり全カラムが remount してしまう)
   const signedIn = session.status === 'signed-in';
-  const cols = useMemo<AppColumn[] | null>(
-    () => (session.status === 'loading' ? null : loadAppColumns(signedIn)),
-    [session.status, signedIn],
-  );
+
+  // columns は編集可能な state。session 確定時に load する
+  // (loading 中に読むと board 構成が 1 render チラつくため)。
+  // load 結果は id を毎回生成するので、effect で 1 回だけ state に入れる。
+  const [columns, setColumns] = useState<AppColumn[] | null>(null);
+  useEffect(() => {
+    if (session.status === 'loading') return;
+    setColumns(loadAppColumns(signedIn));
+  }, [session.status, signedIn]);
+
+  const [pickerOpen, setPickerOpen] = useState(false);
 
   if (session.status === 'loading') {
     return <p>準備しています...</p>;
   }
 
   if (session.status === 'signed-out') {
-    // 未サインインの landing (旧 home.tsx から移設)。board カラムが PR 4 で
-    // 動くようになったら、landing + board カラムの併置に変える。
+    // 未サインインの landing。board カラム等は ColumnPicker で追加可能だが、
+    // 初見の体験としては従来の導入文を出す。
     return (
       <div>
         <h2>あおぞらくえすと</h2>
@@ -43,32 +57,131 @@ export function Workspace() {
           Bluesky で読み書きしながら、あなたの気質をゆっくり見つけていくアプリ。
         </p>
         <Link to="/onboarding"><button style={{ marginTop: '1em' }}>ログインして始める</button></Link>
+        <p style={{ marginTop: '1.5em', fontSize: '0.85em' }}>
+          <Link to="/board">ログインせずにクエスト掲示板をのぞく →</Link>
+        </p>
       </div>
     );
+  }
+
+  /** 編集操作: state 更新と同時に localStorage へ保存する */
+  function edit(updater: (cols: AppColumn[]) => AppColumn[]) {
+    setColumns((prev) => {
+      if (!prev) return prev;
+      const next = updater(prev);
+      if (next !== prev) saveAppColumns(next);
+      return next;
+    });
+  }
+
+  /** カラムの部分更新 (検索カラムの param 追従などに使う) */
+  function patchColumn(id: string, patch: Partial<AppColumn>) {
+    edit((cols) => cols.map((c) => (c.id === id ? ({ ...c, ...patch } as AppColumn) : c)));
   }
 
   return (
     <div data-workspace="1">
       <div className="workspace-columns">
-        {(cols ?? []).map((col) => (
-          <ColumnView key={col.id} column={col}>
-            <ColumnContent column={col} />
+        {(columns ?? []).map((col, i) => (
+          <ColumnView
+            key={col.id}
+            column={col}
+            canMoveLeft={i > 0}
+            canMoveRight={i < (columns?.length ?? 0) - 1}
+            onMoveLeft={() => edit((cols) => moveColumnLeft(cols, col.id))}
+            onMoveRight={() => edit((cols) => moveColumnRight(cols, col.id))}
+            onRemove={() => edit((cols) => removeColumn(cols, col.id))}
+          >
+            <ColumnContent
+              column={col}
+              onPatch={(patch) => patchColumn(col.id, patch)}
+            />
           </ColumnView>
         ))}
+
+        <section className="workspace-column workspace-column-add">
+          <div className="workspace-column-body">
+            {pickerOpen ? (
+              <ColumnPicker
+                signedIn={signedIn}
+                onAdd={(col) => {
+                  edit((cols) => [...cols, col]);
+                  setPickerOpen(false);
+                }}
+                onClose={() => setPickerOpen(false)}
+              />
+            ) : (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '0.6em' }}>
+                <button type="button" onClick={() => setPickerOpen(true)}>＋ カラムを追加</button>
+                <button
+                  type="button"
+                  className="secondary"
+                  style={{ fontSize: '0.8em' }}
+                  onClick={() => {
+                    if (confirm('カラム構成を初期状態に戻しますか?')) {
+                      setColumns(resetAppColumns(signedIn));
+                    }
+                  }}
+                >
+                  初期構成に戻す
+                </button>
+              </div>
+            )}
+          </div>
+        </section>
       </div>
     </div>
   );
 }
 
-function ColumnView({ column, children }: { column: AppColumn; children: ReactNode }) {
+interface ColumnViewProps {
+  column: AppColumn;
+  canMoveLeft: boolean;
+  canMoveRight: boolean;
+  onMoveLeft: () => void;
+  onMoveRight: () => void;
+  onRemove: () => void;
+  children: ReactNode;
+}
+
+function ColumnView({ column, canMoveLeft, canMoveRight, onMoveLeft, onMoveRight, onRemove, children }: ColumnViewProps) {
   // body 要素を state で持つ (callback ref)。要素の出現が props 変化として
   // 子に伝わり、VirtualFeed がカラム内スクロールへ自然に切り替わる。
   const [bodyEl, setBodyEl] = useState<HTMLElement | null>(null);
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  async function copyLink() {
+    const url = `${location.origin}${urlForColumn(column)}`;
+    try {
+      await navigator.clipboard.writeText(url);
+    } catch {
+      prompt('このカラムの URL:', url);
+    }
+    setMenuOpen(false);
+  }
+
   return (
     <section className="workspace-column" data-column-kind={column.kind}>
       <header className="workspace-column-header">
         <span className="workspace-column-title">{appColumnTitle(column)}</span>
+        <button
+          type="button"
+          className="workspace-column-menu-btn"
+          aria-label="カラム操作メニュー"
+          onClick={() => setMenuOpen((v) => !v)}
+        >
+          ⋯
+        </button>
       </header>
+      {menuOpen && (
+        <div className="workspace-column-menu" role="menu">
+          <button type="button" disabled={!canMoveLeft} onClick={() => { onMoveLeft(); setMenuOpen(false); }}>← 左へ移動</button>
+          <button type="button" disabled={!canMoveRight} onClick={() => { onMoveRight(); setMenuOpen(false); }}>→ 右へ移動</button>
+          <button type="button" onClick={copyLink}>このカラムの直リンクをコピー</button>
+          <button type="button" onClick={() => { onRemove(); setMenuOpen(false); }}>✕ カラムを削除</button>
+          <button type="button" className="secondary" onClick={() => setMenuOpen(false)}>閉じる</button>
+        </div>
+      )}
       <div className="workspace-column-body" ref={setBodyEl}>
         <ColumnScrollContext.Provider value={bodyEl}>
           {children}

--- a/apps/web/src/components/workspace.tsx
+++ b/apps/web/src/components/workspace.tsx
@@ -4,13 +4,14 @@
  * `/` の index route として表示され、カラム構成をレンダリングする。
  * カラムの追加 (ColumnPicker) / 並べ替え (← →) / 削除 / 直リンクコピーが
  * でき、変更は saveAppColumns で localStorage に永続化される
- * (= ユーザーが編集して初めて保存される。未編集なら read-time 計算のまま)。
+ * (= ユーザーが編集して初めて保存される。未編集なら read-time 計算のまま。
+ *  board カラムの inner は保存対象外で、常に /board での編集が正)。
  *
  * 各カラムは ColumnView (ヘッダー + 縦スクロールする body) で包み、
  * body 要素を ColumnScrollContext で配って内部の VirtualFeed が
  * 「カラム内スクロール」モードで動けるようにする。
  */
-import { useEffect, useState, type ReactNode } from 'react';
+import { Fragment, useEffect, useState, type ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 import { useSession } from '@/lib/session';
 import {
@@ -28,6 +29,9 @@ import { ColumnScrollContext } from '@/components/column-scroll-context';
 import { ColumnContent } from '@/components/column-content';
 import { ColumnPicker } from '@/components/column-picker';
 
+/** picker の表示位置: 'end' = 末尾タイル、数値 = そのカラムの直右 */
+type PickerAnchor = number | 'end' | null;
+
 export function Workspace() {
   const session = useSession();
   const signedIn = session.status === 'signed-in';
@@ -41,7 +45,7 @@ export function Workspace() {
     setColumns(loadAppColumns(signedIn));
   }, [session.status, signedIn]);
 
-  const [pickerOpen, setPickerOpen] = useState(false);
+  const [pickerAnchor, setPickerAnchor] = useState<PickerAnchor>(null);
 
   if (session.status === 'loading') {
     return <p>準備しています...</p>;
@@ -74,51 +78,74 @@ export function Workspace() {
     });
   }
 
-  /** カラムの部分更新 (検索カラムの param 追従などに使う) */
+  /** カラムの部分更新 (検索カラムの param 追従などに使う)。
+   *  onPatch は対象カラムの id に束縛されるため、kind を跨ぐ patch は
+   *  構造上発生しない (dispatcher 参照)。 */
   function patchColumn(id: string, patch: Partial<AppColumn>) {
     edit((cols) => cols.map((c) => (c.id === id ? ({ ...c, ...patch } as AppColumn) : c)));
   }
+
+  /** anchor 位置にカラムを挿入する */
+  function insertColumn(col: AppColumn, anchor: PickerAnchor) {
+    edit((cols) => {
+      if (anchor === 'end' || anchor === null) return [...cols, col];
+      const next = [...cols];
+      next.splice(anchor + 1, 0, col);
+      return next;
+    });
+    setPickerAnchor(null);
+  }
+
+  const picker = (
+    <section className="workspace-column workspace-column-add">
+      <div className="workspace-column-body">
+        <ColumnPicker
+          signedIn={signedIn}
+          onAdd={(col) => insertColumn(col, pickerAnchor)}
+          onClose={() => setPickerAnchor(null)}
+        />
+      </div>
+    </section>
+  );
 
   return (
     <div data-workspace="1">
       <div className="workspace-columns">
         {(columns ?? []).map((col, i) => (
-          <ColumnView
-            key={col.id}
-            column={col}
-            canMoveLeft={i > 0}
-            canMoveRight={i < (columns?.length ?? 0) - 1}
-            onMoveLeft={() => edit((cols) => moveColumnLeft(cols, col.id))}
-            onMoveRight={() => edit((cols) => moveColumnRight(cols, col.id))}
-            onRemove={() => edit((cols) => removeColumn(cols, col.id))}
-          >
-            <ColumnContent
+          <Fragment key={col.id}>
+            <ColumnView
               column={col}
-              onPatch={(patch) => patchColumn(col.id, patch)}
-            />
-          </ColumnView>
+              canMoveLeft={i > 0}
+              canMoveRight={i < (columns?.length ?? 0) - 1}
+              onMoveLeft={() => edit((cols) => moveColumnLeft(cols, col.id))}
+              onMoveRight={() => edit((cols) => moveColumnRight(cols, col.id))}
+              onRemove={() => edit((cols) => removeColumn(cols, col.id))}
+              onAddRight={() => setPickerAnchor(i)}
+            >
+              <ColumnContent
+                column={col}
+                onPatch={(patch) => patchColumn(col.id, patch)}
+              />
+            </ColumnView>
+            {/* 「右にカラムを追加」: そのカラムの直右に picker を出す
+                (モバイルで末尾までスワイプしなくても追加できる副導線) */}
+            {pickerAnchor === i && picker}
+          </Fragment>
         ))}
 
-        <section className="workspace-column workspace-column-add">
-          <div className="workspace-column-body">
-            {pickerOpen ? (
-              <ColumnPicker
-                signedIn={signedIn}
-                onAdd={(col) => {
-                  edit((cols) => [...cols, col]);
-                  setPickerOpen(false);
-                }}
-                onClose={() => setPickerOpen(false)}
-              />
-            ) : (
+        {pickerAnchor === 'end' ? (
+          picker
+        ) : (
+          <section className="workspace-column workspace-column-add">
+            <div className="workspace-column-body">
               <div style={{ display: 'flex', flexDirection: 'column', gap: '0.6em' }}>
-                <button type="button" onClick={() => setPickerOpen(true)}>＋ カラムを追加</button>
+                <button type="button" onClick={() => setPickerAnchor('end')}>＋ カラムを追加</button>
                 <button
                   type="button"
                   className="secondary"
                   style={{ fontSize: '0.8em' }}
                   onClick={() => {
-                    if (confirm('カラム構成を初期状態に戻しますか?')) {
+                    if (confirm('カラム構成を初期状態に戻しますか?\n(追加したカラムや並び順の変更は消えます)')) {
                       setColumns(resetAppColumns(signedIn));
                     }
                   }}
@@ -126,9 +153,9 @@ export function Workspace() {
                   初期構成に戻す
                 </button>
               </div>
-            )}
-          </div>
-        </section>
+            </div>
+          </section>
+        )}
       </div>
     </div>
   );
@@ -141,21 +168,37 @@ interface ColumnViewProps {
   onMoveLeft: () => void;
   onMoveRight: () => void;
   onRemove: () => void;
+  onAddRight: () => void;
   children: ReactNode;
 }
 
-function ColumnView({ column, canMoveLeft, canMoveRight, onMoveLeft, onMoveRight, onRemove, children }: ColumnViewProps) {
+function ColumnView({ column, canMoveLeft, canMoveRight, onMoveLeft, onMoveRight, onRemove, onAddRight, children }: ColumnViewProps) {
   // body 要素を state で持つ (callback ref)。要素の出現が props 変化として
   // 子に伝わり、VirtualFeed がカラム内スクロールへ自然に切り替わる。
   const [bodyEl, setBodyEl] = useState<HTMLElement | null>(null);
   const [menuOpen, setMenuOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  // home / bar は専用 URL を持たない (urlForColumn が '/' を返す) ので
+  // 直リンク項目を出さない
+  const linkUrl = urlForColumn(column);
+  const hasDirectLink = linkUrl !== '/';
 
   async function copyLink() {
-    const url = `${location.origin}${urlForColumn(column)}`;
+    const url = `${location.origin}${linkUrl}`;
     try {
       await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => { setCopied(false); setMenuOpen(false); }, 1200);
     } catch {
       prompt('このカラムの URL:', url);
+      setMenuOpen(false);
+    }
+  }
+
+  function confirmRemove() {
+    if (confirm(`「${appColumnTitle(column)}」カラムを削除しますか?`)) {
+      onRemove();
     }
     setMenuOpen(false);
   }
@@ -168,17 +211,23 @@ function ColumnView({ column, canMoveLeft, canMoveRight, onMoveLeft, onMoveRight
           type="button"
           className="workspace-column-menu-btn"
           aria-label="カラム操作メニュー"
+          aria-expanded={menuOpen}
           onClick={() => setMenuOpen((v) => !v)}
         >
           ⋯
         </button>
       </header>
       {menuOpen && (
-        <div className="workspace-column-menu" role="menu">
+        <div className="workspace-column-menu">
           <button type="button" disabled={!canMoveLeft} onClick={() => { onMoveLeft(); setMenuOpen(false); }}>← 左へ移動</button>
           <button type="button" disabled={!canMoveRight} onClick={() => { onMoveRight(); setMenuOpen(false); }}>→ 右へ移動</button>
-          <button type="button" onClick={copyLink}>このカラムの直リンクをコピー</button>
-          <button type="button" onClick={() => { onRemove(); setMenuOpen(false); }}>✕ カラムを削除</button>
+          <button type="button" onClick={() => { onAddRight(); setMenuOpen(false); }}>＋ 右にカラムを追加</button>
+          {hasDirectLink && (
+            <button type="button" onClick={copyLink}>
+              {copied ? 'コピーしました ✓' : 'このカラムの直リンクをコピー'}
+            </button>
+          )}
+          <button type="button" onClick={confirmRemove}>✕ カラムを削除</button>
           <button type="button" className="secondary" onClick={() => setMenuOpen(false)}>閉じる</button>
         </div>
       )}

--- a/apps/web/src/lib/app-columns.test.ts
+++ b/apps/web/src/lib/app-columns.test.ts
@@ -168,6 +168,24 @@ describe('旧 boardColumns:v1 の read-time 変換', () => {
     localStorage.setItem('aozoraquest:boardColumns:v1', JSON.stringify([{ id: 'x', kind: 'open' }]));
     expect(loadAppColumns(true).map(c => c.kind)).toEqual(['search']);
   });
+
+  it('★ saveAppColumns は board の inner を保存しない (正は boardColumns:v1)', () => {
+    saveAppColumns([makeAppColumn('board', { inner: [{ kind: 'open' }] })]);
+    const raw = JSON.parse(localStorage.getItem('aozoraquest:appColumns:v1')!) as Array<Record<string, unknown>>;
+    expect(raw[0]!.kind).toBe('board');
+    expect(raw[0]!.inner).toBeUndefined();
+  });
+
+  it('★ 保存済み構成の load でも board の inner は read-time 注入される', () => {
+    // ユーザーがカラム編集して保存済み (board は inner なしで保存される)
+    saveAppColumns([makeAppColumn('board'), makeAppColumn('home')]);
+    // その後 /board ページで inner を編集
+    localStorage.setItem('aozoraquest:boardColumns:v1', JSON.stringify([
+      { id: 'x', kind: 'tag', param: 'art' },
+    ]));
+    const board = loadAppColumns(true).find(c => c.kind === 'board')!;
+    expect(board.kind === 'board' && board.inner).toEqual([{ kind: 'tag', param: 'art' }]);
+  });
 });
 
 describe('moveColumnLeft / moveColumnRight / removeColumn', () => {

--- a/apps/web/src/lib/app-columns.ts
+++ b/apps/web/src/lib/app-columns.ts
@@ -62,14 +62,7 @@ export function defaultColumns(signedIn: boolean): AppColumn[] {
         { id: makeColumnId(), kind: 'board' },
       ]
     : [{ id: makeColumnId(), kind: 'board' }];
-  // 旧 board 設定があれば board カラムの inner として read-time で取り込む。
-  // ここでは保存しない (= サインイン状態確定前の永続化事故を防ぐ)。
-  const inner = readLegacyBoardInner();
-  if (inner.length > 0) {
-    const board = cols.find(c => c.kind === 'board');
-    if (board && board.kind === 'board') board.inner = inner;
-  }
-  return cols;
+  return injectBoardInner(cols);
 }
 
 export function loadAppColumns(signedIn: boolean): AppColumn[] {
@@ -80,18 +73,41 @@ export function loadAppColumns(signedIn: boolean): AppColumn[] {
     if (!Array.isArray(parsed) || parsed.length === 0) return defaultColumns(signedIn);
     const valid = parsed.filter(isValidAppColumn);
     if (valid.length === 0) return defaultColumns(signedIn);
-    return valid;
+    // 保存済み構成にも board の inner を read-time で注入する
+    // (inner の正は常に旧 boardColumns:v1 = /board ページでの編集)
+    return injectBoardInner(valid);
   } catch {
     return defaultColumns(signedIn);
   }
 }
 
-/** 保存はユーザーの明示操作 (カラム追加・削除・並べ替え) 時のみ呼ぶこと。
- *  default 構成や read-time 変換結果を機械的に保存してはいけない
- *  (サインイン前に board だけの構成が固定される事故のもと)。 */
+/** board カラムの inner は保存しない。inner の唯一の正は
+ *  旧 boardColumns:v1 (= /board ページでの編集) で、load 時に毎回
+ *  read-time で注入する。これにより検索カラムの param 保存などで
+ *  appColumns:v1 が確定した後も /board での inner 編集が workspace に
+ *  反映され続ける。 */
+function injectBoardInner(cols: AppColumn[]): AppColumn[] {
+  const inner = readLegacyBoardInner();
+  return cols.map((c) => {
+    if (c.kind !== 'board') return c;
+    if (inner.length > 0) return { ...c, inner };
+    const { inner: _drop, ...rest } = c;
+    return rest as AppColumn;
+  });
+}
+
+/** 保存はユーザーの明示操作 (カラム追加・削除・並べ替え・検索 param 更新)
+ *  時のみ呼ぶこと。default 構成や read-time 変換結果を機械的に保存しては
+ *  いけない (サインイン前に board だけの構成が固定される事故のもと)。
+ *  board カラムの inner は strip して保存する (正は boardColumns:v1)。 */
 export function saveAppColumns(columns: AppColumn[]): void {
   try {
-    localStorage.setItem(KEY, JSON.stringify(columns));
+    const stripped = columns.map((c) => {
+      if (c.kind !== 'board') return c;
+      const { inner: _drop, ...rest } = c;
+      return rest as AppColumn;
+    });
+    localStorage.setItem(KEY, JSON.stringify(stripped));
   } catch {/* no-op */}
 }
 
@@ -201,8 +217,9 @@ function readLegacyBoardInner(): BoardInner[] {
 }
 
 /** 16 ジョブの選択肢 (board inner の job filter で使う)。
- *  board-columns.ts にも同名 export があるが、あちらは PR 4 で削除予定の
- *  deprecated ファイルなので import せずここに正本を置く。 */
+ *  board-columns.ts にも同名 export があるが、あちらは /board フル表示
+ *  ページ専用 (inner 編集の正)。workspace 側はここを正本として参照する。
+ *  将来 inner 編集を workspace に統合したら board-columns.ts ごと削除する。 */
 export const JOB_OPTIONS: Archetype[] = [
   'sage', 'mage', 'shogun', 'bard',
   'seer', 'poet', 'paladin', 'explorer',

--- a/apps/web/src/lib/column-router.ts
+++ b/apps/web/src/lib/column-router.ts
@@ -1,0 +1,26 @@
+/**
+ * AppColumn → URL の変換 (docs/16-multicolumn.md)。
+ *
+ * 「このカラムへの直リンク」シェア用。カラムの中身は従来 route として
+ * URL を持っているので、そこへ誘導する。
+ *
+ * 逆方向 (URL → AppColumn) は現状消費者がいないため実装しない
+ * (必要になった時点で columnFromUrl を追加する)。
+ */
+import type { AppColumn } from './app-columns';
+
+export function urlForColumn(c: AppColumn): string {
+  switch (c.kind) {
+    case 'home':          return '/';
+    case 'bar':           return '/';
+    case 'notifications': return '/notifications';
+    case 'search': {
+      if (!c.param) return '/search';
+      const params = new URLSearchParams({ q: c.param });
+      if (c.mode === 'posts') params.set('mode', 'posts');
+      return `/search?${params.toString()}`;
+    }
+    case 'board':         return '/board';
+    case 'profile':       return c.param ? `/profile/${encodeURIComponent(c.param)}` : '/me';
+  }
+}

--- a/apps/web/src/lib/quest-index-cache.ts
+++ b/apps/web/src/lib/quest-index-cache.ts
@@ -1,0 +1,39 @@
+/**
+ * fetchQuestIndex の共有キャッシュ (docs/16-multicolumn.md §データ取得の重複防止)。
+ *
+ * board カラムを複数並べたり、route の /board と workspace の board カラムが
+ * 同時に mount されても、index の fetch は TTL 内 1 回に抑える。
+ */
+import { fetchQuestIndex, type QuestIndex } from './quest-api';
+
+const TTL_MS = 30_000;
+
+let cached: { index: QuestIndex; ts: number } | null = null;
+let inflight: Promise<QuestIndex> | null = null;
+
+export async function getQuestIndexCached(): Promise<QuestIndex> {
+  if (cached && Date.now() - cached.ts < TTL_MS) return cached.index;
+  if (inflight) return inflight;
+  inflight = (async () => {
+    try {
+      const index = await fetchQuestIndex();
+      cached = { index, ts: Date.now() };
+      return index;
+    } finally {
+      inflight = null;
+    }
+  })();
+  return inflight;
+}
+
+/** リフレッシュ操作用: キャッシュを捨てて取り直す */
+export async function refreshQuestIndex(): Promise<QuestIndex> {
+  cached = null;
+  return getQuestIndexCached();
+}
+
+/** テスト用 */
+export function clearQuestIndexCache(): void {
+  cached = null;
+  inflight = null;
+}

--- a/apps/web/src/routes/board-detail.tsx
+++ b/apps/web/src/routes/board-detail.tsx
@@ -25,6 +25,7 @@ import {
 } from '@/lib/quest-api';
 import { createPost } from '@/lib/atproto';
 import { getPostQuestNotifications } from '@/lib/prefs';
+import { refreshQuestIndex } from '@/lib/quest-index-cache';
 import { Handle } from '@/components/handle';
 import { resolveHandle } from '@/lib/handle-cache';
 import {
@@ -72,6 +73,9 @@ export function BoardDetail() {
 
   const refresh = useCallback(async () => {
     if (!uri || !session.agent) return;
+    // 状態を変える操作の後に呼ばれるので、共有 index キャッシュも破棄して
+    // board 一覧 (募集中カラム等) に反映されるようにする
+    void refreshQuestIndex();
     try {
       const q = await getQuest(session.agent, uri);
       setQuest(q);

--- a/apps/web/src/routes/board-new.tsx
+++ b/apps/web/src/routes/board-new.tsx
@@ -10,6 +10,7 @@ import { useNavigate } from 'react-router-dom';
 import { ARCHETYPES, JOBS_BY_ID, jobDisplayName, formatQuestAnnouncement, checkIssuanceLimits } from '@aozoraquest/core';
 import { useSession } from '@/lib/session';
 import { createQuest, listIssuedQuests } from '@/lib/quest-api';
+import { refreshQuestIndex } from '@/lib/quest-index-cache';
 import { createTaggedPost } from '@/lib/atproto';
 import { getPostQuestNotifications, getPostQuestNotificationsDefault } from '@/lib/prefs';
 
@@ -95,6 +96,8 @@ export function BoardNew() {
           console.warn('[board-new] bluesky announce failed', e);
         }
       }
+      // index キャッシュを破棄 (発行直後に「募集中」一覧へ反映されるように)
+      void refreshQuestIndex();
       navigate(`/board/${encodeURIComponent(quest.uri)}`);
     } catch (e) {
       setErr(String((e as Error)?.message ?? e));

--- a/apps/web/src/routes/board.tsx
+++ b/apps/web/src/routes/board.tsx
@@ -1,28 +1,13 @@
 /**
  * 依頼クエスト掲示板 (docs/15-user-quest.md §UI 設計 B + E)。
  *
- * Phase 3 マルチカラム:
- *  - デスクトップ (>= 768px): 横並び複数カラム
- *  - モバイル (< 768px): 縦並び 1 カラムずつ
- *
- * 各カラム種類: open / mine / applied / tag / job / issuer
- * (board-columns.ts 参照)
+ * フル表示ページ: inner カラム (open / mine / applied / tag / job / issuer)
+ * を追加・削除しながら横並びで見る。表示部品とデータ取得は
+ * components/column-content/board-shared.tsx に共用化されており、
+ * workspace の board カラム (タブ切替式) と同じものを使う。
  */
-import { useEffect, useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
-import { useSession } from '@/lib/session';
-import {
-  fetchQuestIndex,
-  listIssuedQuests,
-  listMyApplications,
-  type QuestIndex,
-  type QuestIndexSummary,
-} from '@/lib/quest-api';
-import {
-  isExpired,
-  jobDisplayName,
-  type UserQuest,
-} from '@aozoraquest/core';
+import { useMemo, useState } from 'react';
+import { jobDisplayName } from '@aozoraquest/core';
 import {
   loadColumns,
   saveColumns,
@@ -33,43 +18,21 @@ import {
   type Column,
   type ColumnKind,
 } from '@/lib/board-columns';
+import {
+  useBoardData,
+  filterForBoard,
+  isExpiredSummary,
+  emptyMessageForBoard,
+  QuestCard,
+} from '@/components/column-content/board-shared';
 import { BookIcon, PlusIcon, CalendarIcon } from '@/components/icons';
 import { ActionLink } from '@/components/action-link';
-import { Handle } from '@/components/handle';
+import { useSession } from '@/lib/session';
 
 export function Board() {
   const session = useSession();
-  const [index, setIndex] = useState<QuestIndex | null>(null);
-  const [myQuests, setMyQuests] = useState<UserQuest[] | null>(null);
-  const [myApplicationQuestUris, setMyApplicationQuestUris] = useState<Set<string> | null>(null);
   const [columns, setColumns] = useState<Column[]>(() => loadColumns());
-  const [err, setErr] = useState<string | null>(null);
-
-  // 公開 index
-  useEffect(() => {
-    let cancelled = false;
-    fetchQuestIndex()
-      .then((idx) => { if (!cancelled) setIndex(idx); })
-      .catch((e) => { if (!cancelled) setErr(String((e as Error)?.message ?? e)); });
-    return () => { cancelled = true; };
-  }, []);
-
-  // 自分の発注 + 応募
-  useEffect(() => {
-    if (session.status !== 'signed-in' || !session.agent || !session.did) return;
-    const agent = session.agent;
-    const did = session.did;
-    let cancelled = false;
-    listIssuedQuests(agent, did)
-      .then((qs) => { if (!cancelled) setMyQuests(qs); })
-      .catch((e) => { if (!cancelled) console.warn('[board] listIssuedQuests', e); });
-    listMyApplications(agent, did)
-      .then((apps) => {
-        if (!cancelled) setMyApplicationQuestUris(new Set(apps.map(a => a.questUri)));
-      })
-      .catch((e) => { if (!cancelled) console.warn('[board] listMyApplications', e); });
-    return () => { cancelled = true; };
-  }, [session.status, session.agent, session.did]);
+  const { index, myQuests, myApplicationQuestUris, err } = useBoardData();
 
   function persistColumns(next: Column[]) {
     setColumns(next);
@@ -115,13 +78,10 @@ export function Board() {
 
       <div className="board-columns">
         {columns.map((col) => (
-          <ColumnView
+          <BoardInnerColumnView
             key={col.id}
             column={col}
-            index={index}
-            myQuests={myQuests}
-            myApplicationQuestUris={myApplicationQuestUris}
-            sessionDid={session.did ?? null}
+            indexData={{ index, myQuests, myApplicationQuestUris }}
             onRemove={() => removeColumn(col.id)}
           />
         ))}
@@ -189,17 +149,22 @@ function SmallBtn(props: { onClick: () => void; children: React.ReactNode }) {
   );
 }
 
-interface ColumnViewProps {
+interface BoardInnerColumnViewProps {
   column: Column;
-  index: QuestIndex | null;
-  myQuests: UserQuest[] | null;
-  myApplicationQuestUris: Set<string> | null;
-  sessionDid: string | null;
+  indexData: {
+    index: ReturnType<typeof useBoardData>['index'];
+    myQuests: ReturnType<typeof useBoardData>['myQuests'];
+    myApplicationQuestUris: ReturnType<typeof useBoardData>['myApplicationQuestUris'];
+  };
   onRemove: () => void;
 }
 
-function ColumnView({ column, index, myQuests, myApplicationQuestUris, sessionDid, onRemove }: ColumnViewProps) {
-  const items = useMemo(() => filterForColumn(column, index, myQuests, myApplicationQuestUris, sessionDid), [column, index, myQuests, myApplicationQuestUris, sessionDid]);
+function BoardInnerColumnView({ column, indexData, onRemove }: BoardInnerColumnViewProps) {
+  const { index, myQuests, myApplicationQuestUris } = indexData;
+  const items = useMemo(
+    () => filterForBoard(column, index, myQuests, myApplicationQuestUris),
+    [column, index, myQuests, myApplicationQuestUris],
+  );
   return (
     <section className="board-column">
       <header style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '0.4em' }}>
@@ -212,7 +177,7 @@ function ColumnView({ column, index, myQuests, myApplicationQuestUris, sessionDi
       {items == null ? (
         <p style={{ fontSize: '0.8em', color: 'var(--color-muted)' }}>読み込み中...</p>
       ) : items.length === 0 ? (
-        <p style={{ fontSize: '0.8em', color: 'var(--color-muted)' }}>{emptyMessageFor(column)}</p>
+        <p style={{ fontSize: '0.8em', color: 'var(--color-muted)' }}>{emptyMessageForBoard(column)}</p>
       ) : (
         <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
           {items.map((q) => (
@@ -224,114 +189,4 @@ function ColumnView({ column, index, myQuests, myApplicationQuestUris, sessionDi
       )}
     </section>
   );
-}
-
-function filterForColumn(
-  c: Column,
-  index: QuestIndex | null,
-  myQuests: UserQuest[] | null,
-  myApplicationQuestUris: Set<string> | null,
-  sessionDid: string | null,
-): QuestIndexSummary[] | null {
-  if (c.kind === 'open') {
-    if (!index) return null;
-    return index.quests.filter(q => q.status === 'open');
-  }
-  if (c.kind === 'mine') {
-    if (!myQuests) return null;
-    return myQuests.map(toSummary);
-  }
-  if (c.kind === 'applied') {
-    if (!index || !myApplicationQuestUris) return null;
-    return index.quests.filter(q => myApplicationQuestUris.has(q.uri));
-  }
-  if (c.kind === 'tag') {
-    if (!index || !c.param) return null;
-    const target = c.param.replace(/^#/, '').toLowerCase();
-    return index.quests.filter(q =>
-      q.status === 'open' &&
-      q.tags.some(t => t.replace(/^#/, '').toLowerCase() === target),
-    );
-  }
-  if (c.kind === 'job') {
-    // questIndex には targetJob を載せていないため、発注者 PDS の値が必要。
-    // MVP では index にない情報なので、自分が出したクエストからのみ filter する。
-    // (Phase 3 後半で questIndex に targetJob を追加する想定。設計書参照)
-    void sessionDid; // 将来 issuer/me filter で使う
-    if (!myQuests) return null;
-    return myQuests
-      .filter(q => q.status === 'open' && q.targetJob === c.param)
-      .map(toSummary);
-  }
-  if (c.kind === 'issuer') {
-    if (!index || !c.param) return null;
-    return index.quests.filter(q => q.status === 'open' && q.did === c.param);
-  }
-  return [];
-}
-
-function toSummary(q: UserQuest): QuestIndexSummary {
-  const s: QuestIndexSummary = {
-    uri: q.uri,
-    did: q.did,
-    title: q.title,
-    tags: q.tags,
-    rewardPoints: q.rewardPoints,
-    status: q.status,
-    createdAt: q.createdAt,
-  };
-  if (q.deadline !== undefined) s.deadline = q.deadline;
-  return s;
-}
-
-function isExpiredSummary(s: QuestIndexSummary): boolean {
-  if (s.status !== 'open') return false;
-  if (!s.deadline) return false;
-  return new Date(s.deadline) < new Date();
-}
-
-function QuestCard({ summary, expired }: { summary: QuestIndexSummary; expired?: boolean }) {
-  return (
-    <Link to={`/board/${encodeURIComponent(summary.uri)}`} style={{ textDecoration: 'none' }}>
-      <div className="dq-window compact" style={{ borderColor: expired ? 'var(--color-muted)' : undefined }}>
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: '0.5em' }}>
-          <div style={{ fontWeight: 700, fontSize: '0.92em', color: 'var(--color-fg)' }}>{summary.title}</div>
-          <div style={{ fontFamily: 'ui-monospace, monospace', fontSize: '0.78em', color: 'var(--color-accent)', whiteSpace: 'nowrap' }}>
-            <Handle did={summary.did} suffix="P" /> {summary.rewardPoints.toLocaleString()}
-          </div>
-        </div>
-        <div style={{ display: 'flex', gap: '0.5em', flexWrap: 'wrap', fontSize: '0.72em', color: 'var(--color-muted)', marginTop: '0.3em' }}>
-          {summary.tags.slice(0, 3).map(t => <span key={t}>#{t.replace(/^#/, '')}</span>)}
-          <span style={{ marginLeft: 'auto' }}>
-            {expired ? '期限切れ' : summary.deadline ? `〆 ${formatDate(summary.deadline)}` : ''}
-            {summary.status !== 'open' && <span style={{ marginLeft: '0.6em' }}>{labelOf(summary.status)}</span>}
-          </span>
-        </div>
-      </div>
-    </Link>
-  );
-}
-
-function emptyMessageFor(col: Column): string {
-  switch (col.kind) {
-    case 'open':    return 'まだ誰も募集していません。「クエストを出す」から始めてみましょう。';
-    case 'mine':    return 'あなたが発行したクエストはまだありません。';
-    case 'applied': return '応募中のクエストはありません。';
-    case 'tag':     return `#${col.param ?? ''} のクエストは見つかりませんでした。`;
-    case 'job':     return `「${col.param ?? ''}」を求めるクエストはまだありません。`;
-    case 'issuer':  return 'この発行者の募集中クエストはありません。';
-  }
-}
-
-function labelOf(status: string): string {
-  if (status === 'assigned') return '受託中';
-  if (status === 'reported') return '完了報告中';
-  if (status === 'completed') return '完了';
-  if (status === 'cancelled') return 'キャンセル';
-  return status;
-}
-
-function formatDate(iso: string): string {
-  const d = new Date(iso);
-  return `${d.getMonth() + 1}/${d.getDate()}`;
 }

--- a/apps/web/src/routes/search.tsx
+++ b/apps/web/src/routes/search.tsx
@@ -22,16 +22,20 @@ export function Search() {
 /**
  * 検索 UI 本体。route (syncUrl=true) と workspace の search カラム
  * (syncUrl=false、initialQuery/initialMode を column から注入) の両用。
- * カラムでは複数の検索カラムが並ぶため URL とは同期しない。
+ * カラムでは複数の検索カラムが並ぶため URL とは同期せず、代わりに
+ * onSearch で検索内容を親 (= カラム設定) に通知する。
  */
 export function SearchPanel({
   syncUrl = false,
   initialQuery,
   initialMode,
+  onSearch,
 }: {
   syncUrl?: boolean;
   initialQuery?: string;
   initialMode?: Mode;
+  /** 検索実行時に呼ばれる (カラムの param/title 追従用) */
+  onSearch?: ((q: string, mode: Mode) => void) | undefined;
 }) {
   const session = useSession();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -87,6 +91,8 @@ export function SearchPanel({
     const t = q.trim();
     if (!t) return;
     setSubmittedQ(t);
+    const effectiveMode: Mode = mode === 'posts' || t.startsWith('#') ? 'posts' : mode;
+    onSearch?.(t, effectiveMode);
     if (!syncUrl) return;
     // ブックマーク・共有ができるよう URL に反映 (#始まりは posts モードも一緒に書く)
     const next = new URLSearchParams(searchParams);

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -318,6 +318,23 @@ p { margin: 0.4em 0; }
   display: none;
 }
 
+/* board カラム内の inner タブ: 等分 (dq-tabs) だと多タブで潰れるため、
+   折り返さない chip の横スクロール行にする */
+.board-column-tabs {
+  display: flex;
+  gap: 0.3em;
+  overflow-x: auto;
+  margin: 0 0 0.5em;
+  padding-bottom: 0.2em;
+  -webkit-overflow-scrolling: touch;
+}
+.board-column-tabs .dq-tab {
+  flex: 0 0 auto;
+  white-space: nowrap;
+  font-size: 0.8em;
+  padding: 0.35em 0.6em;
+}
+
 .workspace-column-body {
   flex: 1 1 auto;
   overflow-y: auto;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -272,10 +272,50 @@ p { margin: 0.4em 0; }
 
 .workspace-column-header {
   flex: 0 0 auto;
-  padding: 0.45em 0.8em;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5em;
+  padding: 0.45em 0.5em 0.45em 0.8em;
   font-size: 0.92em;
   font-weight: 700;
   border-bottom: 2px solid var(--color-window-inner-border);
+}
+
+.workspace-column-menu-btn {
+  padding: 0 0.5em;
+  font-size: 1em;
+  line-height: 1.4;
+  background: transparent;
+  border-color: transparent;
+  box-shadow: none;
+}
+.workspace-column-menu-btn:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.workspace-column-menu {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35em;
+  padding: 0.5em 0.7em;
+  border-bottom: 2px solid var(--color-window-inner-border);
+  background: rgba(0, 0, 0, 0.35);
+}
+.workspace-column-menu button {
+  font-size: 0.8em;
+  text-align: left;
+}
+
+.workspace-column-add {
+  /* 追加タイルはカラムより控えめな見た目 (破線枠) */
+  border-style: dashed;
+  background: rgba(0, 0, 0, 0.35);
+}
+.workspace-column-add::before,
+.workspace-column-add::after {
+  display: none;
 }
 
 .workspace-column-body {


### PR DESCRIPTION
## Summary

マルチカラム化の **PR 4/5**。全 6 kind が実体化し、カラムの追加・並べ替え・削除・直リンクができるようになる。

- **board カラム**: inner (open / mine / applied / tag / job / issuer) を**横スクロール chip タブ**で表示。フル機能は /board へ誘導。`board-shared.tsx` に表示部品 + `useBoardData` を共用化
- **quest-index-cache.ts**: fetchQuestIndex の inflight + 30s TTL。発行 / 各操作後に refreshQuestIndex で破棄
- **カラム編集**: ⋯メニュー (左へ / 右へ / **右にカラムを追加** / 直リンクコピー / 削除[confirm 付き])、末尾「＋ カラムを追加」タイル、「初期構成に戻す」
- **inner の保存規約**: board カラムの inner は appColumns:v1 に**保存しない** (= 唯一の正は /board ページで編集する boardColumns:v1、load 時に毎回 read-time 注入)
- **issue #35 解消**: SearchPanel の onSearch → column.param 書き戻しでタイトル追従

## Review

2 並列 subagent レビュー (設計+実装 / UX+regression) を実施。**★★★ 1 / ★★ 5 (統合) / ★ 10**。commit af00141 で対応:

| 指摘 | 重要度 | 対応 |
|---|---|---|
| board カラムのタブが inner 5-6 個で縦折返しして判読不能 (dq-tabs の flex:1 等分) | ★★★ | 横スクロール chip 行 (.board-column-tabs) に変更。issuer は DID 短縮表示 |
| index 30s TTL 化で発行直後に「募集中」へ反映されない (refreshQuestIndex 呼び手ゼロ) | ★★ | 発行成功時 + board-detail の各操作後に配線 |
| 検索 1 回で全構成が永続化され /board の inner 編集が workspace に反映されなくなる | ★★ | inner を save 時 strip + load 時 read-time 注入の規約に変更 (テスト 2 件追加) |
| 「✕ カラムを削除」が confirm なしで誤タップ消失 | ★★ | カラム名入り confirm を追加 |
| ColumnPicker: param 入力中に他 kind 全 disabled / 戻れない / profile 空で無反応 | ★★ | kind 切替可・「戻る」追加・handle 形式チェック + エラー表示 |
| ＋タイルが末尾のみでモバイル発見性不足 | ★★ | ⋯メニューに「右にカラムを追加」(picker をそのカラム直右に表示) |
| タブ highlight が clamp 前 index 比較でズレうる | ★ | clamp 済み index に統一 |
| コピー成功フィードバックなし / home・bar の直リンクが `/` / role="menu" 不正 / confirm 文言 / コメント齟齬 / issuer タブ区別不能 | ★ | すべて対応 (フィードバック表示・項目非表示・role 除去・文言明記・修正・短縮表示) |
| profile param 無検証 | ★ | ドット入り handle / did: の軽い形式チェック |

レビューで「問題なし」と確認: /board の regression なし (フィルタ・QuestCard・操作とも旧実装一致)、循環 import なし、moveColumn 境界の同一参照 save スキップ、onSearch 片方向同期のループなし。

## 動作確認
- [x] typecheck / vitest 121 / build 緑
- [x] playwright smoke: `/` `/board` `/notifications` `/search` + console エラーなし
- [ ] サインイン後のカラム編集・board タブは dev.aozoraquest.app で実機確認

Closes #35