### PR TITLE
fix(workspace): 通知を 2 番目のデフォルトカラムに + PC 横スクロール引っかかり解消

### DIFF
--- a/apps/web/src/components/workspace.tsx
+++ b/apps/web/src/components/workspace.tsx
@@ -78,6 +78,24 @@ export function Workspace() {
     // 再構築のたびに null を publish するとタブが一瞬チラつくため分離。
   }, [columnCount]);
 
+  // PC で横スワイプ (トラックパッド) したとき、カーソルがカラム本体
+  // (縦スクロールコンテナ) の上にあると横方向が本体に吸われて「引っかかる」。
+  // 横優勢のホイールジェスチャを明示的に workspace スクローラへ流す。
+  // 縦優勢 (deltaY) はそのまま = カラム内縦スクロールを妨げない。
+  // 縦ホイールしかないマウスの横移動は別途スクロールバーで。
+  useEffect(() => {
+    const scroller = scrollerRef.current;
+    if (!scroller) return;
+    const onWheel = (e: WheelEvent) => {
+      if (Math.abs(e.deltaX) <= Math.abs(e.deltaY)) return; // 縦優勢は無視
+      // 横優勢: 親を横スクロールして本体への吸われを防ぐ
+      scroller.scrollLeft += e.deltaX;
+      e.preventDefault();
+    };
+    scroller.addEventListener('wheel', onWheel, { passive: false });
+    return () => scroller.removeEventListener('wheel', onWheel);
+  }, []);
+
   // `/` 離脱時に可視 kind をクリアする (active 残留防止)
   useEffect(() => () => publishVisibleColumn(null), []);
 

--- a/apps/web/src/lib/app-columns.test.ts
+++ b/apps/web/src/lib/app-columns.test.ts
@@ -32,9 +32,9 @@ beforeEach(() => {
 });
 
 describe('defaultColumns', () => {
-  it('サインイン済み: home / bar / notifications / board の 4 カラム', () => {
+  it('サインイン済み: home / notifications / bar / board の 4 カラム', () => {
     const cols = defaultColumns(true);
-    expect(cols.map(c => c.kind)).toEqual(['home', 'bar', 'notifications', 'board']);
+    expect(cols.map(c => c.kind)).toEqual(['home', 'notifications', 'bar', 'board']);
   });
 
   it('未サインイン: board 1 カラムのみ', () => {
@@ -53,7 +53,7 @@ describe('defaultColumns', () => {
 
 describe('loadAppColumns / saveAppColumns', () => {
   it('保存なし → default 構成 (localStorage への書き込みは発生しない)', () => {
-    expect(loadAppColumns(true).map(c => c.kind)).toEqual(['home', 'bar', 'notifications', 'board']);
+    expect(loadAppColumns(true).map(c => c.kind)).toEqual(['home', 'notifications', 'bar', 'board']);
     expect(localStorage.getItem('aozoraquest:appColumns:v1')).toBeNull();
   });
 
@@ -119,7 +119,7 @@ describe('旧 boardColumns:v1 の read-time 変換', () => {
     // セッション解決前 (signedIn=false) に先に読まれるケース
     expect(loadAppColumns(false).map(c => c.kind)).toEqual(['board']);
     // サインイン後はフル構成に戻る (read-time なので固定化しない)
-    expect(loadAppColumns(true).map(c => c.kind)).toEqual(['home', 'bar', 'notifications', 'board']);
+    expect(loadAppColumns(true).map(c => c.kind)).toEqual(['home', 'notifications', 'bar', 'board']);
   });
 
   it('★ 旧キーが後から更新されても次回 load に反映される (鮮度維持)', () => {

--- a/apps/web/src/lib/app-columns.ts
+++ b/apps/web/src/lib/app-columns.ts
@@ -57,8 +57,8 @@ export function defaultColumns(signedIn: boolean): AppColumn[] {
   const cols: AppColumn[] = signedIn
     ? [
         { id: makeColumnId(), kind: 'home' },
-        { id: makeColumnId(), kind: 'bar' },
         { id: makeColumnId(), kind: 'notifications' },
+        { id: makeColumnId(), kind: 'bar' },
         { id: makeColumnId(), kind: 'board' },
       ]
     : [{ id: makeColumnId(), kind: 'board' }];

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -347,7 +347,12 @@ p { margin: 0.4em 0; }
 .workspace-column-body {
   flex: 1 1 auto;
   overflow-y: auto;
-  overscroll-behavior: contain;   /* 縦終端が外側に漏れない */
+  overflow-x: hidden;             /* 本体は横スクロールしない (横は親が担う) */
+  /* 縦だけ contain (縦終端が外側に漏れない)。横は auto にして、本体の上を
+     横スクロールしたとき .workspace-columns へ連鎖させる
+     (contain だと横スクロールが本体に吸われて「引っかかる」)。 */
+  overscroll-behavior-y: contain;
+  overscroll-behavior-x: auto;
   padding: 0.6em 0.7em;
   /* 縦は body 内、横はカラム送り、の両ジェスチャを許可 */
   touch-action: pan-y pan-x;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -348,11 +348,9 @@ p { margin: 0.4em 0; }
   flex: 1 1 auto;
   overflow-y: auto;
   overflow-x: hidden;             /* 本体は横スクロールしない (横は親が担う) */
-  /* 縦だけ contain (縦終端が外側に漏れない)。横は auto にして、本体の上を
-     横スクロールしたとき .workspace-columns へ連鎖させる
-     (contain だと横スクロールが本体に吸われて「引っかかる」)。 */
+  /* 縦だけ contain (縦終端でページ全体が動くのを防ぐ)。
+     PC の横スワイプ引っかかりは workspace.tsx の wheel ハンドラで親へ流す。 */
   overscroll-behavior-y: contain;
-  overscroll-behavior-x: auto;
   padding: 0.6em 0.7em;
   /* 縦は body 内、横はカラム送り、の両ジェスチャを許可 */
   touch-action: pan-y pan-x;

--- a/docs/16-multicolumn.md
+++ b/docs/16-multicolumn.md
@@ -62,7 +62,7 @@ export type AppColumn =
 - 保存キー: `aozoraquest:appColumns:v1`
 - **保存はユーザーの明示操作 (saveAppColumns) のみ**。default 構成や変換結果を機械的に保存しない
 - 保存がない限り `loadAppColumns(signedIn)` は毎回「default 構成 + 旧 `boardColumns:v1` の read-time 変換」を計算するため、サインイン状態の変化や旧キーの更新に常に追従する (= セッション解決前に board だけの構成が固定化される事故を構造的に防ぐ)
-- デフォルト構成: サインイン済み `[home, bar, notifications, board]`、未サインイン `[board]`
+- デフォルト構成: サインイン済み `[home, notifications, bar, board]` (通知は 2 番目)、未サインイン `[board]`
 - PDS 同期 (`app.aozoraquest.layout`) は将来の opt-in 機能 (Phase 4+)
 
 ## レイアウト CSS


### PR DESCRIPTION
## Summary

ユーザー要望 2 件。

- **デフォルトカラム順を変更**: `[home, bar, notifications, board]` → `[home, notifications, bar, board]` (通知を 2 番目に)。保存済み構成があるユーザーはそのまま (default は初回のみ)
- **PC で横スクロールの引っかかり解消**: カラム本体が縦スクロールコンテナのため、PC トラックパッドの横スワイプが本体に吸われて引っかかっていた。workspace スクローラに wheel ハンドラを追加し、**横優勢のジェスチャ (|deltaX| > |deltaY|) を scrollLeft に明示転送**。カーソルがどのカラム上でも横スワイプが確実に親へ流れる。縦優勢はそのまま (カラム内縦スクロールを妨げない)。CSS は `overflow-x: hidden` + `overscroll-behavior-y: contain` を残す

## Review

CSS 挙動レビューで「`overscroll-behavior-x: auto` は overflow-x: hidden の要素に対して実質ノーオペで、引っかかりの根本原因を特定せず値を変えている」(★★) と指摘。これを受けて:
- 飾りだった `overscroll-behavior-x: auto` を削除
- 引っかかりの実体 (カラム本体への横スワイプ吸われ) を **wheel ハンドラで根治** (横優勢を親へ明示転送)

レビューで確認された安全性: 副作用なし (board の inner タブは自前 overflow-x で独立スクロール、投稿カードは折返し前提)、縦 contain 維持、モバイル無影響、デフォルト順は初回のみ・テスト整合。

## Test plan
- [x] typecheck / vitest 121 / build 緑
- [ ] **PC (トラックパッド) で workspace の横スワイプがカラムをまたいでスムーズに動くか dev 実機確認** (workspace はサインイン必須で headless 検証不可)