### PR TITLE
feat(board): 募集期限の日時指定をカレンダー UI に

### DIFF
--- a/apps/web/src/components/date-time-picker.tsx
+++ b/apps/web/src/components/date-time-picker.tsx
@@ -35,6 +35,8 @@ export interface DateTimePickerProps {
   ariaLabel?: string;
   /** 初回に日付を選んだときのデフォルト時刻 (省略時 23:59 = 締切らしい終端) */
   defaultTime?: { hh: number; mm: number };
+  /** 過去日を選べなくする (省略時 true)。締切用途では過去日を弾く。 */
+  disablePast?: boolean;
   className?: string;
 }
 
@@ -44,6 +46,7 @@ export function DateTimePicker({
   id,
   ariaLabel = '日時を選択',
   defaultTime = { hh: 23, mm: 59 },
+  disablePast = true,
   className,
 }: DateTimePickerProps) {
   const reactId = useId();
@@ -61,18 +64,31 @@ export function DateTimePicker({
       : { year: today.getFullYear(), month1: today.getMonth() + 1 },
   );
 
-  // value が外部 / クリアで変わったら表示月も追従 (選択日の月へ)
+  // value の「月」が変わったときだけ表示月を追従する。
+  // 時刻だけ変更 (= 月は同じ) では view を動かさない
+  // (ユーザーが別の月を眺めている最中に巻き戻さないため)。
+  const lastSyncedMonth = useRef<string | null>(parsed ? `${parsed.y}-${parsed.m}` : null);
   useEffect(() => {
-    if (parsed) setView({ year: parsed.y, month1: parsed.m });
-    // parsed は value 由来。value の変化のみ監視。
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const p = parseLocal(value);
+    const key = p ? `${p.y}-${p.m}` : null;
+    if (key && key !== lastSyncedMonth.current) {
+      setView({ year: p!.y, month1: p!.m });
+    }
+    lastSyncedMonth.current = key;
   }, [value]);
 
-  // パネル外クリック / Esc で閉じる
+  // パネル外クリック / Esc で閉じる。
+  // ネイティブ <select> の操作中 (focus がパネル内) は閉じない
+  // (モバイルでネイティブピッカーのオーバーレイを触ると mousedown が
+  //  ルート外と判定され、時刻選択中にパネルが消える事故を防ぐ)。
   useEffect(() => {
     if (!open) return;
     const onDocClick = (e: MouseEvent) => {
-      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false);
+      const root = rootRef.current;
+      if (!root) return;
+      if (root.contains(e.target as Node)) return;
+      if (document.activeElement && root.contains(document.activeElement)) return;
+      setOpen(false);
     };
     const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false); };
     document.addEventListener('mousedown', onDocClick);
@@ -89,17 +105,11 @@ export function DateTimePicker({
     onChange(formatLocal(view.year, view.month1, day, hh, mm));
   }
 
+  // 時刻 select は「日付を選んでから」のみ有効 (parsed があるとき)。
+  // 日付未選択で時刻だけ触っても勝手に日付が確定しないようにする。
   function setTime(hh: number, mm: number) {
-    // 日付未選択なら表示中の月の「今日 or 1日」に時刻を乗せる
-    const base = parsed ?? {
-      y: view.year,
-      m: view.month1,
-      d:
-        view.year === today.getFullYear() && view.month1 === today.getMonth() + 1
-          ? today.getDate()
-          : 1,
-    };
-    onChange(formatLocal(base.y, base.m, base.d, hh, mm));
+    if (!parsed) return;
+    onChange(formatLocal(parsed.y, parsed.m, parsed.d, hh, mm));
   }
 
   function shiftMonth(delta: number) {
@@ -123,6 +133,18 @@ export function DateTimePicker({
 
   const isSelectedMonth = !!parsed && parsed.y === view.year && parsed.m === view.month1;
   const isThisMonth = today.getFullYear() === view.year && today.getMonth() + 1 === view.month1;
+  // 表示月が今日より前か (= 月まるごと過去か) の判定に使う
+  const todayDay = today.getDate();
+  const viewBeforeToday =
+    view.year < today.getFullYear() ||
+    (view.year === today.getFullYear() && view.month1 < today.getMonth() + 1);
+
+  function isPast(day: number): boolean {
+    if (!disablePast) return false;
+    if (viewBeforeToday) return true;
+    if (isThisMonth) return day < todayDay;
+    return false;
+  }
 
   return (
     <div className={`dtp${className ? ` ${className}` : ''}`} ref={rootRef}>
@@ -156,11 +178,12 @@ export function DateTimePicker({
             ))}
           </div>
 
-          <div className="dtp-grid" role="grid">
+          <div className="dtp-grid">
             {cells.map((day, i) => {
               if (day === null) return <span key={`e${i}`} className="dtp-day empty" aria-hidden />;
               const selected = isSelectedMonth && parsed!.d === day;
-              const isToday = isThisMonth && today.getDate() === day;
+              const isToday = isThisMonth && todayDay === day;
+              const past = isPast(day);
               const dow = (firstWeekday + day - 1) % 7;
               return (
                 <button
@@ -169,6 +192,7 @@ export function DateTimePicker({
                   className={`dtp-day${selected ? ' selected' : ''}${isToday ? ' today' : ''}${dow === 0 ? ' sun' : dow === 6 ? ' sat' : ''}`}
                   aria-pressed={selected}
                   aria-label={`${view.year}年${view.month1}月${day}日`}
+                  disabled={past}
                   onClick={() => selectDay(day)}
                 >
                   {day}
@@ -181,6 +205,7 @@ export function DateTimePicker({
             <label className="dtp-time-label">時刻</label>
             <select
               aria-label="時"
+              disabled={!parsed}
               value={parsed ? parsed.hh : defaultTime.hh}
               onChange={(e) => setTime(Number(e.target.value), parsed ? parsed.mm : defaultTime.mm)}
             >
@@ -191,6 +216,7 @@ export function DateTimePicker({
             <span className="dtp-colon">:</span>
             <select
               aria-label="分"
+              disabled={!parsed}
               value={parsed ? parsed.mm : defaultTime.mm}
               onChange={(e) => setTime(parsed ? parsed.hh : defaultTime.hh, Number(e.target.value))}
             >
@@ -199,10 +225,13 @@ export function DateTimePicker({
                 <option key={mm} value={mm}>{pad(mm)}</option>
               ))}
             </select>
+            {!parsed && <span className="dtp-time-hint">日付を選ぶと指定できます</span>}
           </div>
 
           <div className="dtp-actions">
-            <button type="button" className="secondary dtp-clear" onClick={clear}>クリア</button>
+            <button type="button" className="secondary dtp-clear" onClick={clear} disabled={!parsed}>
+              未設定に戻す
+            </button>
             <button type="button" onClick={() => setOpen(false)}>決定</button>
           </div>
         </div>

--- a/apps/web/src/components/date-time-picker.tsx
+++ b/apps/web/src/components/date-time-picker.tsx
@@ -1,0 +1,222 @@
+/**
+ * DQ ウィンドウ様式のカレンダー日時ピッカー (DESIGN.md 準拠)。
+ *
+ * 募集期限のような日時入力に使う。OS ごとに見た目が違う
+ * `<input type="datetime-local">` を置き換え、aozoraquest の世界観に
+ * 揃った月グリッド + 時刻選択を提供する。
+ *
+ * 値のフォーマットは datetime-local と同じローカル文字列
+ * `YYYY-MM-DDTHH:mm` (= `new Date(value)` でそのまま解釈できる)。
+ * これにより既存の `new Date(deadline).toISOString()` 系ロジックを
+ * 一切変えずに drop-in 置換できる。空文字 = 未設定。
+ *
+ * パネルは絶対配置ではなくインライン展開 (アコーディオン) にしている。
+ * workspace のカラムスクローラや board-detail の dq-window の中でも
+ * クリップされず確実に開けるため。
+ */
+import { useEffect, useId, useRef, useState } from 'react';
+import {
+  WEEKDAYS_JA as WEEKDAYS,
+  parseLocal,
+  formatLocal,
+  formatDisplay,
+  daysInMonth,
+  minuteOptions,
+} from '@/lib/datetime';
+
+const pad = (n: number) => String(n).padStart(2, '0');
+
+export interface DateTimePickerProps {
+  /** ローカル日時文字列 `YYYY-MM-DDTHH:mm`、または '' で未設定 */
+  value: string;
+  onChange: (value: string) => void;
+  /** trigger に付ける id (label htmlFor 連携用) */
+  id?: string;
+  ariaLabel?: string;
+  /** 初回に日付を選んだときのデフォルト時刻 (省略時 23:59 = 締切らしい終端) */
+  defaultTime?: { hh: number; mm: number };
+  className?: string;
+}
+
+export function DateTimePicker({
+  value,
+  onChange,
+  id,
+  ariaLabel = '日時を選択',
+  defaultTime = { hh: 23, mm: 59 },
+  className,
+}: DateTimePickerProps) {
+  const reactId = useId();
+  const triggerId = id ?? `dtp-${reactId}`;
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  const parsed = parseLocal(value);
+
+  // 表示中の月 (year, month1)。value があればその月、なければ今日。
+  const today = new Date();
+  const [view, setView] = useState<{ year: number; month1: number }>(() =>
+    parsed
+      ? { year: parsed.y, month1: parsed.m }
+      : { year: today.getFullYear(), month1: today.getMonth() + 1 },
+  );
+
+  // value が外部 / クリアで変わったら表示月も追従 (選択日の月へ)
+  useEffect(() => {
+    if (parsed) setView({ year: parsed.y, month1: parsed.m });
+    // parsed は value 由来。value の変化のみ監視。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value]);
+
+  // パネル外クリック / Esc で閉じる
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false); };
+    document.addEventListener('mousedown', onDocClick);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDocClick);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  function selectDay(day: number) {
+    const hh = parsed ? parsed.hh : defaultTime.hh;
+    const mm = parsed ? parsed.mm : defaultTime.mm;
+    onChange(formatLocal(view.year, view.month1, day, hh, mm));
+  }
+
+  function setTime(hh: number, mm: number) {
+    // 日付未選択なら表示中の月の「今日 or 1日」に時刻を乗せる
+    const base = parsed ?? {
+      y: view.year,
+      m: view.month1,
+      d:
+        view.year === today.getFullYear() && view.month1 === today.getMonth() + 1
+          ? today.getDate()
+          : 1,
+    };
+    onChange(formatLocal(base.y, base.m, base.d, hh, mm));
+  }
+
+  function shiftMonth(delta: number) {
+    setView((v) => {
+      const next = new Date(v.year, v.month1 - 1 + delta, 1);
+      return { year: next.getFullYear(), month1: next.getMonth() + 1 };
+    });
+  }
+
+  function clear() {
+    onChange('');
+    setView({ year: today.getFullYear(), month1: today.getMonth() + 1 });
+  }
+
+  // グリッド生成: 先頭の空セル (月初の曜日) + 各日
+  const firstWeekday = new Date(view.year, view.month1 - 1, 1).getDay();
+  const dim = daysInMonth(view.year, view.month1);
+  const cells: (number | null)[] = [];
+  for (let i = 0; i < firstWeekday; i++) cells.push(null);
+  for (let d = 1; d <= dim; d++) cells.push(d);
+
+  const isSelectedMonth = !!parsed && parsed.y === view.year && parsed.m === view.month1;
+  const isThisMonth = today.getFullYear() === view.year && today.getMonth() + 1 === view.month1;
+
+  return (
+    <div className={`dtp${className ? ` ${className}` : ''}`} ref={rootRef}>
+      <button
+        type="button"
+        id={triggerId}
+        className="dtp-trigger"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-label={ariaLabel}
+        onClick={() => setOpen((o) => !o)}
+      >
+        <CalendarIcon />
+        <span className={`dtp-trigger-text${parsed ? '' : ' is-empty'}`}>
+          {parsed ? formatDisplay(parsed) : '未設定'}
+        </span>
+        <span className="dtp-caret" aria-hidden>{open ? '▴' : '▾'}</span>
+      </button>
+
+      {open && (
+        <div className="dtp-panel dq-window compact" role="dialog" aria-label={ariaLabel}>
+          <div className="dtp-cal-head">
+            <button type="button" className="dtp-nav" aria-label="前の月" onClick={() => shiftMonth(-1)}>‹</button>
+            <span className="dtp-cal-title">{view.year}年 {view.month1}月</span>
+            <button type="button" className="dtp-nav" aria-label="次の月" onClick={() => shiftMonth(1)}>›</button>
+          </div>
+
+          <div className="dtp-grid dtp-weekrow" aria-hidden>
+            {WEEKDAYS.map((w, i) => (
+              <span key={w} className={`dtp-weekday${i === 0 ? ' sun' : i === 6 ? ' sat' : ''}`}>{w}</span>
+            ))}
+          </div>
+
+          <div className="dtp-grid" role="grid">
+            {cells.map((day, i) => {
+              if (day === null) return <span key={`e${i}`} className="dtp-day empty" aria-hidden />;
+              const selected = isSelectedMonth && parsed!.d === day;
+              const isToday = isThisMonth && today.getDate() === day;
+              const dow = (firstWeekday + day - 1) % 7;
+              return (
+                <button
+                  type="button"
+                  key={day}
+                  className={`dtp-day${selected ? ' selected' : ''}${isToday ? ' today' : ''}${dow === 0 ? ' sun' : dow === 6 ? ' sat' : ''}`}
+                  aria-pressed={selected}
+                  aria-label={`${view.year}年${view.month1}月${day}日`}
+                  onClick={() => selectDay(day)}
+                >
+                  {day}
+                </button>
+              );
+            })}
+          </div>
+
+          <div className="dtp-time">
+            <label className="dtp-time-label">時刻</label>
+            <select
+              aria-label="時"
+              value={parsed ? parsed.hh : defaultTime.hh}
+              onChange={(e) => setTime(Number(e.target.value), parsed ? parsed.mm : defaultTime.mm)}
+            >
+              {Array.from({ length: 24 }, (_, h) => (
+                <option key={h} value={h}>{pad(h)}</option>
+              ))}
+            </select>
+            <span className="dtp-colon">:</span>
+            <select
+              aria-label="分"
+              value={parsed ? parsed.mm : defaultTime.mm}
+              onChange={(e) => setTime(parsed ? parsed.hh : defaultTime.hh, Number(e.target.value))}
+            >
+              {/* 5 分刻み + 現在値が刻みから外れていても表示できるよう補完 */}
+              {minuteOptions(parsed?.mm).map((mm) => (
+                <option key={mm} value={mm}>{pad(mm)}</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="dtp-actions">
+            <button type="button" className="secondary dtp-clear" onClick={clear}>クリア</button>
+            <button type="button" onClick={() => setOpen(false)}>決定</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CalendarIcon() {
+  return (
+    <svg className="dtp-icon" width="15" height="15" viewBox="0 0 16 16" fill="none" aria-hidden focusable="false">
+      <rect x="1.5" y="2.5" width="13" height="12" rx="1.5" stroke="currentColor" strokeWidth="1.4" />
+      <path d="M1.5 6H14.5" stroke="currentColor" strokeWidth="1.4" />
+      <path d="M5 1V3.5M11 1V3.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+    </svg>
+  );
+}

--- a/apps/web/src/lib/datetime.test.ts
+++ b/apps/web/src/lib/datetime.test.ts
@@ -5,6 +5,7 @@ import {
   formatDisplay,
   daysInMonth,
   minuteOptions,
+  isoToLocalInput,
 } from './datetime';
 
 describe('parseLocal', () => {
@@ -12,7 +13,7 @@ describe('parseLocal', () => {
     expect(parseLocal('2026-06-20T23:59')).toEqual({ y: 2026, m: 6, d: 20, hh: 23, mm: 59 });
   });
 
-  it('ignores trailing seconds / timezone', () => {
+  it('ignores trailing seconds', () => {
     expect(parseLocal('2026-06-20T08:05:30')).toEqual({ y: 2026, m: 6, d: 20, hh: 8, mm: 5 });
   });
 
@@ -20,6 +21,13 @@ describe('parseLocal', () => {
     expect(parseLocal('')).toBeNull();
     expect(parseLocal('2026-06-20')).toBeNull();
     expect(parseLocal('not-a-date')).toBeNull();
+  });
+
+  it('rejects trailing garbage and TZ-suffixed ISO (anchored)', () => {
+    expect(parseLocal('2026-06-20T23:59GARBAGE')).toBeNull();
+    // TZ 付きはローカル誤解釈を避けるため null
+    expect(parseLocal('2026-06-20T23:59:00Z')).toBeNull();
+    expect(parseLocal('2026-06-20T23:59+09:00')).toBeNull();
   });
 
   it('rejects out-of-range month / hour / minute', () => {
@@ -54,6 +62,19 @@ describe('formatDisplay', () => {
   it('renders the Japanese weekday and zero-padded time', () => {
     // 2026-06-20 は土曜日
     expect(formatDisplay({ y: 2026, m: 6, d: 20, hh: 23, mm: 59 })).toBe('2026年6月20日 (土) 23:59');
+  });
+});
+
+describe('isoToLocalInput', () => {
+  it('round-trips a picker value through ISO and back', () => {
+    // ローカル文字列 → ISO (board が保存する形) → ローカル文字列 が一致する
+    const local = '2026-06-20T23:59';
+    const iso = new Date(local).toISOString();
+    expect(isoToLocalInput(iso)).toBe(local);
+  });
+
+  it('returns empty string for an invalid ISO', () => {
+    expect(isoToLocalInput('garbage')).toBe('');
   });
 });
 

--- a/apps/web/src/lib/datetime.test.ts
+++ b/apps/web/src/lib/datetime.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseLocal,
+  formatLocal,
+  formatDisplay,
+  daysInMonth,
+  minuteOptions,
+} from './datetime';
+
+describe('parseLocal', () => {
+  it('parses a valid local datetime string', () => {
+    expect(parseLocal('2026-06-20T23:59')).toEqual({ y: 2026, m: 6, d: 20, hh: 23, mm: 59 });
+  });
+
+  it('ignores trailing seconds / timezone', () => {
+    expect(parseLocal('2026-06-20T08:05:30')).toEqual({ y: 2026, m: 6, d: 20, hh: 8, mm: 5 });
+  });
+
+  it('returns null for empty / malformed input', () => {
+    expect(parseLocal('')).toBeNull();
+    expect(parseLocal('2026-06-20')).toBeNull();
+    expect(parseLocal('not-a-date')).toBeNull();
+  });
+
+  it('rejects out-of-range month / hour / minute', () => {
+    expect(parseLocal('2026-13-01T00:00')).toBeNull();
+    expect(parseLocal('2026-06-20T24:00')).toBeNull();
+    expect(parseLocal('2026-06-20T23:60')).toBeNull();
+  });
+
+  it('rejects non-existent calendar dates', () => {
+    expect(parseLocal('2026-02-31T12:00')).toBeNull();
+    expect(parseLocal('2026-04-31T12:00')).toBeNull();
+  });
+
+  it('accepts a valid leap day', () => {
+    expect(parseLocal('2028-02-29T12:00')).toEqual({ y: 2028, m: 2, d: 29, hh: 12, mm: 0 });
+  });
+});
+
+describe('formatLocal', () => {
+  it('zero-pads month / day / hour / minute', () => {
+    expect(formatLocal(2026, 6, 7, 9, 5)).toBe('2026-06-07T09:05');
+  });
+
+  it('round-trips through parseLocal', () => {
+    const s = '2026-12-31T00:00';
+    const p = parseLocal(s)!;
+    expect(formatLocal(p.y, p.m, p.d, p.hh, p.mm)).toBe(s);
+  });
+});
+
+describe('formatDisplay', () => {
+  it('renders the Japanese weekday and zero-padded time', () => {
+    // 2026-06-20 は土曜日
+    expect(formatDisplay({ y: 2026, m: 6, d: 20, hh: 23, mm: 59 })).toBe('2026年6月20日 (土) 23:59');
+  });
+});
+
+describe('daysInMonth', () => {
+  it('returns the correct length for each month', () => {
+    expect(daysInMonth(2026, 1)).toBe(31);
+    expect(daysInMonth(2026, 2)).toBe(28);
+    expect(daysInMonth(2028, 2)).toBe(29); // 閏年
+    expect(daysInMonth(2026, 4)).toBe(30);
+  });
+});
+
+describe('minuteOptions', () => {
+  it('returns 5-minute increments by default', () => {
+    expect(minuteOptions()).toEqual([0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
+  });
+
+  it('inserts an off-grid current value in order', () => {
+    expect(minuteOptions(59)).toContain(59);
+    const opts = minuteOptions(59);
+    expect(opts[opts.length - 1]).toBe(59);
+    expect([...opts].sort((a, b) => a - b)).toEqual(opts);
+  });
+
+  it('does not duplicate an on-grid current value', () => {
+    expect(minuteOptions(30)).toEqual([0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
+  });
+});

--- a/apps/web/src/lib/datetime.ts
+++ b/apps/web/src/lib/datetime.ts
@@ -1,0 +1,66 @@
+/**
+ * ローカル日時文字列 (`YYYY-MM-DDTHH:mm`) のパース / 整形ヘルパー。
+ *
+ * このフォーマットは `<input type="datetime-local">` の value と同形で、
+ * `new Date(value)` がローカルタイムとして解釈する。DateTimePicker は
+ * これを emit するので、既存の `new Date(deadline).toISOString()` 系の
+ * 呼び出しを一切変えずに置き換えられる。
+ */
+
+export const WEEKDAYS_JA = ['日', '月', '火', '水', '木', '金', '土'] as const;
+
+export interface LocalDateTime {
+  y: number;
+  m: number; // 1-12
+  d: number;
+  hh: number;
+  mm: number;
+}
+
+const pad2 = (n: number) => String(n).padStart(2, '0');
+
+/** `YYYY-MM-DDTHH:mm` をパース。空文字 / 不正 / 実在しない日付なら null。 */
+export function parseLocal(v: string): LocalDateTime | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})/.exec(v);
+  if (!match) return null;
+  const parsed: LocalDateTime = {
+    y: Number(match[1]),
+    m: Number(match[2]),
+    d: Number(match[3]),
+    hh: Number(match[4]),
+    mm: Number(match[5]),
+  };
+  if (parsed.m < 1 || parsed.m > 12) return null;
+  if (parsed.hh > 23 || parsed.mm > 59) return null;
+  // 実在日付か検証 (2026-02-31 のような壊れ値を弾く)
+  const probe = new Date(parsed.y, parsed.m - 1, parsed.d, parsed.hh, parsed.mm);
+  if (probe.getMonth() !== parsed.m - 1 || probe.getDate() !== parsed.d) return null;
+  return parsed;
+}
+
+/** `YYYY-MM-DDTHH:mm` を組み立てる。 */
+export function formatLocal(y: number, m: number, d: number, hh: number, mm: number): string {
+  return `${y}-${pad2(m)}-${pad2(d)}T${pad2(hh)}:${pad2(mm)}`;
+}
+
+/** 「2026年6月20日 (土) 23:59」のような表示用文字列。 */
+export function formatDisplay(p: LocalDateTime): string {
+  const w = WEEKDAYS_JA[new Date(p.y, p.m - 1, p.d).getDay()];
+  return `${p.y}年${p.m}月${p.d}日 (${w}) ${pad2(p.hh)}:${pad2(p.mm)}`;
+}
+
+/** その月の日数 (month1 は 1-12)。 */
+export function daysInMonth(year: number, month1: number): number {
+  return new Date(year, month1, 0).getDate();
+}
+
+/** 5 分刻みの分の選択肢。current が刻み外 (例 59) なら昇順で混ぜる。 */
+export function minuteOptions(current?: number): number[] {
+  const base: number[] = [];
+  for (let m = 0; m < 60; m += 5) base.push(m);
+  if (current !== undefined && current >= 0 && current <= 59 && !base.includes(current)) {
+    base.push(current);
+    base.sort((a, b) => a - b);
+  }
+  return base;
+}

--- a/apps/web/src/lib/datetime.ts
+++ b/apps/web/src/lib/datetime.ts
@@ -21,7 +21,9 @@ const pad2 = (n: number) => String(n).padStart(2, '0');
 
 /** `YYYY-MM-DDTHH:mm` をパース。空文字 / 不正 / 実在しない日付なら null。 */
 export function parseLocal(v: string): LocalDateTime | null {
-  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})/.exec(v);
+  // 秒は許容して切り捨てるが、末尾の無関係な文字列や TZ 指定は弾く
+  // (TZ 付き ISO はローカルとして誤解釈しないよう null にする。value は常にローカル形式)
+  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::\d{2})?$/.exec(v);
   if (!match) return null;
   const parsed: LocalDateTime = {
     y: Number(match[1]),
@@ -52,6 +54,23 @@ export function formatDisplay(p: LocalDateTime): string {
 /** その月の日数 (month1 は 1-12)。 */
 export function daysInMonth(year: number, month1: number): number {
   return new Date(year, month1, 0).getDate();
+}
+
+/**
+ * ISO 文字列 (PDS 保存値) を datetime-local 形式のローカル文字列
+ * `YYYY-MM-DDTHH:mm` に変換する。DateTimePicker / datetime-local の
+ * value としてそのまま使える (ローカルタイムで表示・編集)。
+ */
+export function isoToLocalInput(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  return formatLocal(
+    d.getFullYear(),
+    d.getMonth() + 1,
+    d.getDate(),
+    d.getHours(),
+    d.getMinutes(),
+  );
 }
 
 /** 5 分刻みの分の選択肢。current が刻み外 (例 59) なら昇順で混ぜる。 */

--- a/apps/web/src/routes/board-detail.tsx
+++ b/apps/web/src/routes/board-detail.tsx
@@ -28,6 +28,7 @@ import { getPostQuestNotifications } from '@/lib/prefs';
 import { refreshQuestIndex } from '@/lib/quest-index-cache';
 import { Handle } from '@/components/handle';
 import { DateTimePicker } from '@/components/date-time-picker';
+import { isoToLocalInput } from '@/lib/datetime';
 import { resolveHandle } from '@/lib/handle-cache';
 import {
   isExpired,
@@ -293,7 +294,7 @@ export function BoardDetail() {
         <div style={{ marginTop: '1em' }}>
           <div style={{ display: 'flex', gap: '0.6em' }}>
             <button onClick={() => {
-              setDeadlineInput(quest.deadline ? toLocalInput(quest.deadline) : '');
+              setDeadlineInput(quest.deadline ? isoToLocalInput(quest.deadline) : '');
               setEditingDeadline(true);
             }} disabled={busy}>募集期限を変更</button>
             <button onClick={cancelQuest} disabled={busy}>キャンセル</button>
@@ -519,10 +520,4 @@ function roleLabel(role: string): string {
   if (role === 'requesterApproval') return '承認';
   if (role === 'requesterRevision') return 'やり直し依頼';
   return role;
-}
-
-function toLocalInput(iso: string): string {
-  const d = new Date(iso);
-  const pad = (n: number) => String(n).padStart(2, '0');
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }

--- a/apps/web/src/routes/board-detail.tsx
+++ b/apps/web/src/routes/board-detail.tsx
@@ -27,6 +27,7 @@ import { createPost } from '@/lib/atproto';
 import { getPostQuestNotifications } from '@/lib/prefs';
 import { refreshQuestIndex } from '@/lib/quest-index-cache';
 import { Handle } from '@/components/handle';
+import { DateTimePicker } from '@/components/date-time-picker';
 import { resolveHandle } from '@/lib/handle-cache';
 import {
   isExpired,
@@ -303,13 +304,11 @@ export function BoardDetail() {
               <label htmlFor="deadline-input" style={{ display: 'block', fontSize: '0.8em', color: 'var(--color-muted)', marginBottom: '0.3em' }}>
                 新しい期限 (空欄で削除)
               </label>
-              <input
+              <DateTimePicker
                 id="deadline-input"
-                type="datetime-local"
                 value={deadlineInput}
-                onChange={(e) => setDeadlineInput(e.target.value)}
-                autoFocus
-                style={{ width: '100%' }}
+                onChange={setDeadlineInput}
+                ariaLabel="新しい募集期限を選択"
               />
               <div style={{ display: 'flex', gap: '0.5em', marginTop: '0.5em' }}>
                 <button onClick={async () => { await extendDeadline(deadlineInput); setEditingDeadline(false); }} disabled={busy}>適用</button>

--- a/apps/web/src/routes/board-new.tsx
+++ b/apps/web/src/routes/board-new.tsx
@@ -13,6 +13,7 @@ import { createQuest, listIssuedQuests } from '@/lib/quest-api';
 import { refreshQuestIndex } from '@/lib/quest-index-cache';
 import { createTaggedPost } from '@/lib/atproto';
 import { getPostQuestNotifications, getPostQuestNotificationsDefault } from '@/lib/prefs';
+import { DateTimePicker } from '@/components/date-time-picker';
 
 const MAX_TITLE = 80;
 const MAX_BODY = 1500;
@@ -174,10 +175,10 @@ export function BoardNew() {
       </Field>
 
       <Field label="募集期限 (任意)">
-        <input
-          type="datetime-local"
+        <DateTimePicker
           value={deadline}
-          onChange={(e) => setDeadline(e.target.value)}
+          onChange={setDeadline}
+          ariaLabel="募集期限を選択"
         />
         <p style={{ fontSize: '0.75em', color: 'var(--color-muted)', margin: '0.2em 0 0' }}>
           期限内のみ応募可。後から延長 / 短縮できます。期限切れでも自動キャンセルされません。

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1255,3 +1255,118 @@ p { margin: 0.4em 0; }
 @media (prefers-reduced-motion: reduce) {
   .card-stage { animation: none; }
 }
+
+/* ─── DateTimePicker (カレンダー日時ピッカー) ─────────────
+   DQ ウィンドウ様式の月グリッド + 時刻選択。
+   `<input type="datetime-local">` を世界観に揃えた置き換え。 */
+.dtp { position: relative; }
+
+/* trigger は input 様式に寄せた押せるフィールド */
+.dtp-trigger {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  width: 100%;
+  text-align: left;
+  background: var(--color-window-bg-alt);
+  border: 2px solid var(--color-border);
+  border-radius: 2px;
+  padding: 0.35em 0.6em;
+  box-shadow: none;
+  font-size: 0.95em;
+}
+.dtp-trigger:hover:not(:disabled) { background: var(--color-window-bg-alt); }
+.dtp-icon { flex: 0 0 auto; opacity: 0.85; }
+.dtp-trigger-text { flex: 1; }
+.dtp-trigger-text.is-empty { color: rgba(201, 212, 224, 0.55); }
+.dtp-caret { flex: 0 0 auto; opacity: 0.7; font-size: 0.8em; }
+
+/* パネルはインライン展開 (スクロールコンテナでクリップされない) */
+.dtp-panel {
+  margin-top: 0.4em;
+  margin-bottom: 0;
+  max-width: 19em;
+}
+
+.dtp-cal-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.4em;
+}
+.dtp-cal-title { font-size: 0.92em; font-weight: bold; }
+.dtp-nav {
+  padding: 0.1em 0.55em;
+  font-size: 1.1em;
+  line-height: 1;
+}
+
+.dtp-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 2px;
+}
+.dtp-weekrow { margin-bottom: 2px; }
+.dtp-weekday {
+  text-align: center;
+  font-size: 0.7em;
+  color: var(--color-muted);
+  padding: 0.2em 0;
+}
+.dtp-weekday.sun { color: var(--color-luk); }
+.dtp-weekday.sat { color: var(--color-accent); }
+
+.dtp-day {
+  aspect-ratio: 1 / 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.82em;
+  padding: 0;
+  border: 2px solid transparent;
+  background: transparent;
+  box-shadow: none;
+  border-radius: 2px;
+}
+.dtp-day:hover:not(:disabled):not(.empty) {
+  background: var(--color-window-bg-alt);
+  border-color: var(--color-window-inner-border);
+}
+.dtp-day.sun { color: var(--color-luk); }
+.dtp-day.sat { color: var(--color-accent); }
+.dtp-day.today {
+  border-color: var(--color-window-inner-border);
+}
+.dtp-day.selected {
+  background: var(--color-accent);
+  border-color: var(--color-primary);
+  color: #06223a;
+  font-weight: bold;
+}
+.dtp-day.selected.sun, .dtp-day.selected.sat { color: #06223a; }
+.dtp-day.empty {
+  cursor: default;
+  pointer-events: none;
+}
+
+.dtp-time {
+  display: flex;
+  align-items: center;
+  gap: 0.4em;
+  margin-top: 0.6em;
+}
+.dtp-time-label {
+  font-size: 0.78em;
+  color: var(--color-muted);
+  margin-right: 0.2em;
+}
+.dtp-time select { padding: 0.2em 0.4em; }
+.dtp-colon { opacity: 0.8; }
+
+.dtp-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5em;
+  margin-top: 0.6em;
+}
+.dtp-actions button { font-size: 0.85em; padding: 0.25em 0.8em; }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -19,6 +19,13 @@
   --color-window-inner-border: rgba(255, 255, 255, 0.35);
   --color-danger: #ff7272;
 
+  /* カレンダーの週末色。ステータス色 (atk/def/agi/int/luk) や accent の
+     意味と干渉しないよう専用に持つ (DESIGN.md: ステータス色は流用しない)。 */
+  --color-cal-sun: #ff9a9a;
+  --color-cal-sat: #8fc2ef;
+  /* accent 背景の上に乗せる文字色 (選択日セルなど)。濃紺で十分なコントラスト。 */
+  --color-on-accent: #06223a;
+
   --font-main: 'Hiragino Maru Gothic ProN', 'Hiragino Maru Gothic Pro', 'Noto Sans JP', sans-serif;
 }
 
@@ -1278,15 +1285,19 @@ p { margin: 0.4em 0; }
 .dtp-trigger:hover:not(:disabled) { background: var(--color-window-bg-alt); }
 .dtp-icon { flex: 0 0 auto; opacity: 0.85; }
 .dtp-trigger-text { flex: 1; }
-.dtp-trigger-text.is-empty { color: rgba(201, 212, 224, 0.55); }
+.dtp-trigger-text.is-empty { color: var(--color-muted); }
 .dtp-caret { flex: 0 0 auto; opacity: 0.7; font-size: 0.8em; }
 
 /* パネルはインライン展開 (スクロールコンテナでクリップされない) */
 .dtp-panel {
   margin-top: 0.4em;
   margin-bottom: 0;
-  max-width: 19em;
+  max-width: min(19em, 100%);
 }
+/* board-detail の dq-window の中に入れ子になると四隅装飾が
+   三重に出てうるさい。ネスト時は装飾を消して枠だけにする。 */
+.dtp-panel.dq-window::before,
+.dtp-panel.dq-window::after { display: none; }
 
 .dtp-cal-head {
   display: flex;
@@ -1313,8 +1324,8 @@ p { margin: 0.4em 0; }
   color: var(--color-muted);
   padding: 0.2em 0;
 }
-.dtp-weekday.sun { color: var(--color-luk); }
-.dtp-weekday.sat { color: var(--color-accent); }
+.dtp-weekday.sun { color: var(--color-cal-sun); }
+.dtp-weekday.sat { color: var(--color-cal-sat); }
 
 .dtp-day {
   aspect-ratio: 1 / 1;
@@ -1332,18 +1343,22 @@ p { margin: 0.4em 0; }
   background: var(--color-window-bg-alt);
   border-color: var(--color-window-inner-border);
 }
-.dtp-day.sun { color: var(--color-luk); }
-.dtp-day.sat { color: var(--color-accent); }
+.dtp-day.sun { color: var(--color-cal-sun); }
+.dtp-day.sat { color: var(--color-cal-sat); }
 .dtp-day.today {
   border-color: var(--color-window-inner-border);
 }
 .dtp-day.selected {
   background: var(--color-accent);
   border-color: var(--color-primary);
-  color: #06223a;
+  color: var(--color-on-accent);
   font-weight: bold;
 }
-.dtp-day.selected.sun, .dtp-day.selected.sat { color: #06223a; }
+.dtp-day.selected.sun, .dtp-day.selected.sat { color: var(--color-on-accent); }
+.dtp-day:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
 .dtp-day.empty {
   cursor: default;
   pointer-events: none;
@@ -1362,6 +1377,11 @@ p { margin: 0.4em 0; }
 }
 .dtp-time select { padding: 0.2em 0.4em; }
 .dtp-colon { opacity: 0.8; }
+.dtp-time-hint {
+  font-size: 0.72em;
+  color: var(--color-muted);
+  margin-left: 0.2em;
+}
 
 .dtp-actions {
   display: flex;


### PR DESCRIPTION
## Summary

募集期限などの日時入力を、OS 依存で世界観から浮く `<input type="datetime-local">` から **DQ ウィンドウ様式のカレンダーピッカー (DateTimePicker)** に置き換え。

- **新設**: `apps/web/src/components/date-time-picker.tsx` — 月グリッド (‹ 月 › ナビ、曜日行、本日マーク、選択日ハイライト) + 時刻選択 (時/分 select、分は 5 分刻み + 現在値補完) + 「未設定に戻す」/決定。曜日色は専用トークン、SVG カレンダーアイコン (絵文字不使用)
- **切り出し**: `apps/web/src/lib/datetime.ts` — `parseLocal` / `formatLocal` / `formatDisplay` / `daysInMonth` / `minuteOptions` / `isoToLocalInput` のピュア関数。ユニットテスト 16 件
- **置換**: board-new (クエスト発行の募集期限)、board-detail (発注者の期限変更)。board-detail の重複実装 `toLocalInput` を `isoToLocalInput` に集約
- パネルは **インライン展開** (絶対配置でない) → workspace のカラムスクローラや dq-window 内でクリップされない
- 値は datetime-local と同形の `YYYY-MM-DDTHH:mm` を emit → 既存の `new Date(deadline).toISOString()` 系は無変更

## Test plan
- [x] typecheck 緑
- [x] vitest 137 緑 (datetime.test.ts 16 件)
- [x] build 緑
- [ ] **dev 実機**: 発行画面で期限をカレンダー選択 → 投稿 → 詳細で正しい日時表示、期限変更も動くか。**特にモバイルで時刻 select を操作してもパネルが閉じないか** (★★★ 2 の実機検証ポイント、board-new はサインイン必須で headless 不可)

## Review

§1.5 に基づき 3 並列 subagent (設計 / 実装 / UX) で第三者レビューを実施。検出指摘と対応:

### ★★★ (PR 内で必修・対応済み)
- **(実装) 日付未選択で時刻 select を触ると deadline が誤確定** → 日付を選ぶまで時刻 select / 「未設定に戻す」を disabled に。日付選択で初めて値が確定 (commit e24392c)
- **(実装) ネイティブ select 操作中にパネルが閉じる懸念** → 外側クリック判定で focus がパネル内にある間は閉じないようガード追加。※モバイル実機検証は Test plan に明記 (commit e24392c)
- **(UX) 日曜=`--color-luk` / 土曜=`--color-accent` のステータス色・accent 流用が DESIGN.md 禁則違反** → 専用トークン `--color-cal-sun` / `--color-cal-sat` / `--color-on-accent` を新設して是正 (commit e24392c)

### ★★ (PR 内で対応)
- **過去日が締切に選べる** → `disablePast` (既定 true) で過去日を disabled に
- **board-detail で dq-window 三重ネスト + パネル幅オーバーフロー** → 入れ子時に四隅装飾を抑制、`max-width: min(19em, 100%)`
- **「未設定」表示のコントラスト不足** → `--color-muted` 実色に
- **時刻だけ変更で表示月が巻き戻る** → value の「月」が変わったときのみ表示月を追従
- **parseLocal の regex に末尾アンカーなし** → 末尾アンカー追加 + ISO↔ローカル変換を `isoToLocalInput` に集約 (DRY、★★ 設計指摘#3)

### ★★ → issue 化 (PR スコープ外)
- **コンポーネントのインタラクション層テスト (RTL 導入)** → #41

### ★ → issue 化
- 日時ショートカット/年送り → #42 / role=grid セマンティクス → #43 / モバイルタップ領域 44px → #44 / 期限編集パネルのフォーカス移動 → #45

### 対応しない (記録のみ)
- 告知プレビューと実投稿の deadline 文字列系の差 → **本 PR 由来でなく回帰でない** (datetime-local 時代から存在、value 契約は不変)。表示は `M/D` で一致するため実害なし