### PR TITLE
fix(board): 報酬ポイントを 1 刻みで入力できるように

### DIFF
--- a/apps/web/src/routes/board-new.tsx
+++ b/apps/web/src/routes/board-new.tsx
@@ -191,7 +191,7 @@ export function BoardNew() {
           value={rewardPoints}
           onChange={(e) => setRewardPoints(Math.max(0, parseInt(e.target.value, 10) || 0))}
           min={0}
-          step={100}
+          step={1}
           style={{ width: '12em' }}
         />
         <p style={{ fontSize: '0.75em', color: 'var(--color-muted)', margin: '0.2em 0 0' }}>


### PR DESCRIPTION
## Summary

報酬ポイント input の `step={100}` のせいで、777 など 100 の倍数でない値が HTML5 検証で弾かれていた (`Please enter a valid value. The two nearest valid values are 700 and 800.`)。`step={1}` にして任意の整数ポイントを設定できるようにする。`parseInt` で整数化しているので小数は元々入らない。設定画面の input も既に step={1} で一貫。

## Test plan
- [x] typecheck / build 緑
- [ ] dev: 発行画面で 777 等の半端な値が入力・送信できるか

## Review

§1.5 レビュー実施 (変更が 1 行=HTML `step` 属性のため観点を集約した第三者レビュー)。

- **★★★ / ★★ なし、マージ可**
- 値確定は `Math.max(0, parseInt(...) || 0)` で行われ、`step` は HTML5 スピナー刻みと stepMismatch 検証にしか影響しない。100 倍数前提のロジック (`%100` 等) はコード全体に存在せず、副作用なし
- ★ (既存挙動・本変更で改善 or 不変): 小数/負/空文字は parseInt+clamp で吸収、上限なしは仕様、上下矢印が 1 刻みになる UX は任意値入力では改善 (劣化は許容範囲)