### PR TITLE
release: 報酬ポイントを 1 刻みで入力可能に (#47)

### DIFF
--- a/apps/web/src/routes/board-new.tsx
+++ b/apps/web/src/routes/board-new.tsx
@@ -191,7 +191,7 @@ export function BoardNew() {
           value={rewardPoints}
           onChange={(e) => setRewardPoints(Math.max(0, parseInt(e.target.value, 10) || 0))}
           min={0}
-          step={100}
+          step={1}
           style={{ width: '12em' }}
         />
         <p style={{ fontSize: '0.75em', color: 'var(--color-muted)', margin: '0.2em 0 0' }}>


### PR DESCRIPTION
## Summary
発行画面の報酬ポイント input が step=100 で 777 等を弾いていた問題を修正 (PR #47、step 100→1)。本番ですぐ使えるようにリリース。

## Review
PR #47 で §1.5 レビュー実施済み (★★★/★★ なし、マージ可)。