### PR TITLE
fix(settings,tos): 残存する「共鳴TL」文言を BAR ブルスコ に統一

### DIFF
--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -18,7 +18,7 @@ const OPTIN_TAG = 'aozoraquest';
 function statsOf(id: Archetype): StatVector {
   return statArrayToVector(JOBS_BY_ID[id].stats);
 }
-const DEFAULT_OPTIN_POST = `#${OPTIN_TAG} の気質診断に参加しました。共鳴 TL に自分の投稿が表示されても構いません。`;
+const DEFAULT_OPTIN_POST = `#${OPTIN_TAG} の気質診断に参加しました。BAR ブルスコ (aozoraquest 利用者が集う TL) に自分の投稿が表示されても構いません。`;
 
 interface Profile {
   targetJob?: string;
@@ -255,9 +255,9 @@ export function Settings() {
       </section>
 
       <section style={{ marginTop: '2em' }}>
-        <h3 style={{ fontSize: '0.95em' }}>共鳴タイムラインへの参加 (オプトイン)</h3>
+        <h3 style={{ fontSize: '0.95em' }}>BAR ブルスコへの参加 (オプトイン)</h3>
         <p style={{ fontSize: '0.8em', color: 'var(--color-muted)' }}>
-          参加すると、他のユーザーの共鳴 TL にあなたの投稿が表示される可能性があります。
+          参加すると、ほかの利用者の BAR ブルスコにあなたの投稿が表示される可能性があります。
           参加の合図として <code>#{OPTIN_TAG}</code> 付きの投稿をあなたのアカウントから 1 本作成します
           (これで検索 API で発見可能になる)。
         </p>
@@ -265,16 +265,16 @@ export function Settings() {
           <p>読み込み中...</p>
         ) : profile?.discoverable ? (
           <div style={{ marginTop: '0.5em' }}>
-            <p style={{ fontSize: '0.85em', color: '#1a6230' }}>✓ 共鳴 TL に参加しています。</p>
+            <p style={{ fontSize: '0.85em', color: '#1a6230' }}>✓ BAR ブルスコに参加しています。</p>
             <p style={{ fontSize: '0.75em', color: 'var(--color-muted)' }}>
               完全に離脱するには、このボタンで discoverable を false に戻し、かつ先ほどの <code>#{OPTIN_TAG}</code> 投稿を Bluesky から削除してください。
             </p>
-            <button onClick={optOut} disabled={optInBusy}>共鳴 TL から外す</button>
+            <button onClick={optOut} disabled={optInBusy}>BAR ブルスコから外す</button>
           </div>
         ) : (
           <div style={{ marginTop: '0.5em' }}>
             {!optInDialog ? (
-              <button onClick={() => setOptInDialog(true)}>共鳴 TL に参加する</button>
+              <button onClick={() => setOptInDialog(true)}>BAR ブルスコに参加する</button>
             ) : (
               <div style={{ border: '1px solid var(--color-border)', padding: '0.8em', borderRadius: 4 }}>
                 <p style={{ fontSize: '0.85em' }}>以下の投稿をあなたのアカウントから作成します。本文は自由に編集できます:</p>

--- a/apps/web/src/routes/tos.tsx
+++ b/apps/web/src/routes/tos.tsx
@@ -6,7 +6,7 @@ export function Tos() {
       <ul>
         <li>本アプリは無料で、商用化しません。</li>
         <li>LLM 推論はブラウザ内で完結します (Chrome の Gemini Nano)。生成系機能を使うブラウザに対応していない場合、その機能は自動的に無効化されます。</li>
-        <li>共鳴タイムラインのために主管理者 DID の PDS から公開コンフィグを読み取ります。</li>
+        <li>BAR ブルスコ (利用者が集う TL) のために主管理者 DID の PDS から公開コンフィグを読み取ります。</li>
         <li>気質診断は Bluesky 公開投稿のみを対象とし、ブラウザ内で完結します。</li>
       </ul>
       <p style={{ fontSize: '0.8em', color: 'var(--color-muted)' }}>最終更新: 2026-05-27</p>


### PR DESCRIPTION
## Summary

マルチカラム化で共鳴 TL は「BAR ブルスコ」(利用者が集う酒場 TL) に名称統一したが、設定のオプトイン節・告知 post 文・利用規約に旧称が残っていた。ユーザー向け文言を BAR ブルスコ に揃える。

- settings.tsx: 見出し「共鳴タイムラインへの参加」→「BAR ブルスコへの参加」、本文・参加中表示・参加/外すボタン、告知 post デフォルト文
- tos.tsx: 「共鳴タイムラインのために…」→「BAR ブルスコ (利用者が集う TL) のために…」
- プロフィールの相性ステータス「共鳴」は**別概念 (similarity 指標)** なので据え置き

## Test plan
- [x] typecheck / build 緑
- [ ] dev: 設定ページのオプトイン節が BAR ブルスコ表記になっているか

## Review
文言のみの変更。第三者レビューを実施し記録。