### PR TITLE
test(e2e): モデル URL 確認で HF の 429/5xx を transient 扱いに (CI flaky 根治)

### DIFF
--- a/apps/web/e2e/model-urls.spec.ts
+++ b/apps/web/e2e/model-urls.spec.ts
@@ -13,13 +13,38 @@ function hfUrl(repo: string, path: string): string {
   return `https://huggingface.co/${repo}/resolve/main/${path}`;
 }
 
+/**
+ * HF への HEAD を確認する。このテストの目的は「ファイルの実在確認」
+ * (404 → SPA fallback HTML → クラッシュ の事前検知) であって、HF の
+ * 可用性監視ではない。
+ *
+ * 429 (レート制限) や 5xx (一時的なサーバ側エラー) は「URL が間違って
+ * いる/消えた」を意味しないので、これで CI を落とすのは誤検知。
+ * CI の IP が HF にまとめてレート制限される (429) のは恒常的に起きるため、
+ * transient 系は警告ログのみで skip し、404/401/403 等の本物の URL 不備
+ * だけを失敗させる。
+ */
+async function expectReachable(
+  api: Awaited<ReturnType<typeof request.newContext>>,
+  url: string,
+  label: string,
+): Promise<void> {
+  const res = await api.head(url, { maxRedirects: 5 });
+  const status = res.status();
+  if (status === 429 || status >= 500) {
+    // eslint-disable-next-line no-console
+    console.warn(`[model-urls] ${label}: HF が ${status} を返したため検証を skip (rate-limit/transient)`);
+    return;
+  }
+  expect(status, label).toBeLessThan(400);
+}
+
 test.describe('HuggingFace model URLs are reachable', () => {
   for (const repo of [COGNITIVE_REPO, COGNITIVE_SMALL_REPO]) {
     test(`${repo}: config + tokenizer + onnx exist`, async () => {
       const api = await request.newContext();
       for (const f of ['config.json', 'tokenizer.json', 'onnx/model_quantized.onnx']) {
-        const res = await api.head(hfUrl(repo, f), { maxRedirects: 5 });
-        expect(res.status(), `${repo}/${f}`).toBeLessThan(400);
+        await expectReachable(api, hfUrl(repo, f), `${repo}/${f}`);
       }
       await api.dispose();
     });
@@ -28,8 +53,7 @@ test.describe('HuggingFace model URLs are reachable', () => {
   test(`${GENERATOR_REPO}: tokenizer + model (q4) exist`, async () => {
     const api = await request.newContext();
     for (const f of ['tokenizer.json', 'onnx/model_q4f16.onnx']) {
-      const res = await api.head(hfUrl(GENERATOR_REPO, f), { maxRedirects: 5 });
-      expect(res.status(), `${GENERATOR_REPO}/${f}`).toBeLessThan(400);
+      await expectReachable(api, hfUrl(GENERATOR_REPO, f), `${GENERATOR_REPO}/${f}`);
     }
     await api.dispose();
   });


### PR DESCRIPTION
## Summary

dev マージ後の `E2E (smoke + model URL sanity)` が **HuggingFace の 429 (レート制限)** で落ちていた (`Expected: < 400 / Received: 429`)。CI の IP が HF にまとめてレート制限されるのは恒常的に起きる。

`model-urls.spec.ts` の目的は「ファイルの実在確認 (404 → SPA fallback → クラッシュ の事前検知)」であって HF の可用性監視ではない。429 / 5xx は URL 不備を意味しないので **transient として警告ログのみで skip**、404/401/403 等の本物の不備だけを失敗させるようにした。

報酬ステップ修正 (#47) や文言統一 (#49) とは無関係の、既存の flaky 失敗の根治。

## Test plan
- [x] typecheck 緑
- [x] `playwright test e2e/model-urls.spec.ts` ローカル 3 passed (4.8s)

## Review
テスト堅牢化の限定変更。第三者レビューを実施し記録。