### PR TITLE
release: 共鳴TL→BARブルスコ 文言統一 + CI flaky 根治 (#49, #50)

### DIFF
--- a/apps/web/e2e/model-urls.spec.ts
+++ b/apps/web/e2e/model-urls.spec.ts
@@ -13,13 +13,38 @@ function hfUrl(repo: string, path: string): string {
   return `https://huggingface.co/${repo}/resolve/main/${path}`;
 }
 
+/**
+ * HF への HEAD を確認する。このテストの目的は「ファイルの実在確認」
+ * (404 → SPA fallback HTML → クラッシュ の事前検知) であって、HF の
+ * 可用性監視ではない。
+ *
+ * 429 (レート制限) や 5xx (一時的なサーバ側エラー) は「URL が間違って
+ * いる/消えた」を意味しないので、これで CI を落とすのは誤検知。
+ * CI の IP が HF にまとめてレート制限される (429) のは恒常的に起きるため、
+ * transient 系は警告ログのみで skip し、404/401/403 等の本物の URL 不備
+ * だけを失敗させる。
+ */
+async function expectReachable(
+  api: Awaited<ReturnType<typeof request.newContext>>,
+  url: string,
+  label: string,
+): Promise<void> {
+  const res = await api.head(url, { maxRedirects: 5 });
+  const status = res.status();
+  if (status === 429 || status >= 500) {
+    // eslint-disable-next-line no-console
+    console.warn(`[model-urls] ${label}: HF が ${status} を返したため検証を skip (rate-limit/transient)`);
+    return;
+  }
+  expect(status, label).toBeLessThan(400);
+}
+
 test.describe('HuggingFace model URLs are reachable', () => {
   for (const repo of [COGNITIVE_REPO, COGNITIVE_SMALL_REPO]) {
     test(`${repo}: config + tokenizer + onnx exist`, async () => {
       const api = await request.newContext();
       for (const f of ['config.json', 'tokenizer.json', 'onnx/model_quantized.onnx']) {
-        const res = await api.head(hfUrl(repo, f), { maxRedirects: 5 });
-        expect(res.status(), `${repo}/${f}`).toBeLessThan(400);
+        await expectReachable(api, hfUrl(repo, f), `${repo}/${f}`);
       }
       await api.dispose();
     });
@@ -28,8 +53,7 @@ test.describe('HuggingFace model URLs are reachable', () => {
   test(`${GENERATOR_REPO}: tokenizer + model (q4) exist`, async () => {
     const api = await request.newContext();
     for (const f of ['tokenizer.json', 'onnx/model_q4f16.onnx']) {
-      const res = await api.head(hfUrl(GENERATOR_REPO, f), { maxRedirects: 5 });
-      expect(res.status(), `${GENERATOR_REPO}/${f}`).toBeLessThan(400);
+      await expectReachable(api, hfUrl(GENERATOR_REPO, f), `${GENERATOR_REPO}/${f}`);
     }
     await api.dispose();
   });

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -18,7 +18,7 @@ const OPTIN_TAG = 'aozoraquest';
 function statsOf(id: Archetype): StatVector {
   return statArrayToVector(JOBS_BY_ID[id].stats);
 }
-const DEFAULT_OPTIN_POST = `#${OPTIN_TAG} の気質診断に参加しました。共鳴 TL に自分の投稿が表示されても構いません。`;
+const DEFAULT_OPTIN_POST = `#${OPTIN_TAG} の気質診断に参加しました。BAR ブルスコ (aozoraquest 利用者が集う TL) に自分の投稿が表示されても構いません。`;
 
 interface Profile {
   targetJob?: string;
@@ -255,9 +255,9 @@ export function Settings() {
       </section>
 
       <section style={{ marginTop: '2em' }}>
-        <h3 style={{ fontSize: '0.95em' }}>共鳴タイムラインへの参加 (オプトイン)</h3>
+        <h3 style={{ fontSize: '0.95em' }}>BAR ブルスコへの参加 (オプトイン)</h3>
         <p style={{ fontSize: '0.8em', color: 'var(--color-muted)' }}>
-          参加すると、他のユーザーの共鳴 TL にあなたの投稿が表示される可能性があります。
+          参加すると、ほかの利用者の BAR ブルスコにあなたの投稿が表示される可能性があります。
           参加の合図として <code>#{OPTIN_TAG}</code> 付きの投稿をあなたのアカウントから 1 本作成します
           (これで検索 API で発見可能になる)。
         </p>
@@ -265,16 +265,16 @@ export function Settings() {
           <p>読み込み中...</p>
         ) : profile?.discoverable ? (
           <div style={{ marginTop: '0.5em' }}>
-            <p style={{ fontSize: '0.85em', color: '#1a6230' }}>✓ 共鳴 TL に参加しています。</p>
+            <p style={{ fontSize: '0.85em', color: '#1a6230' }}>✓ BAR ブルスコに参加しています。</p>
             <p style={{ fontSize: '0.75em', color: 'var(--color-muted)' }}>
               完全に離脱するには、このボタンで discoverable を false に戻し、かつ先ほどの <code>#{OPTIN_TAG}</code> 投稿を Bluesky から削除してください。
             </p>
-            <button onClick={optOut} disabled={optInBusy}>共鳴 TL から外す</button>
+            <button onClick={optOut} disabled={optInBusy}>BAR ブルスコから外す</button>
           </div>
         ) : (
           <div style={{ marginTop: '0.5em' }}>
             {!optInDialog ? (
-              <button onClick={() => setOptInDialog(true)}>共鳴 TL に参加する</button>
+              <button onClick={() => setOptInDialog(true)}>BAR ブルスコに参加する</button>
             ) : (
               <div style={{ border: '1px solid var(--color-border)', padding: '0.8em', borderRadius: 4 }}>
                 <p style={{ fontSize: '0.85em' }}>以下の投稿をあなたのアカウントから作成します。本文は自由に編集できます:</p>

--- a/apps/web/src/routes/tos.tsx
+++ b/apps/web/src/routes/tos.tsx
@@ -6,7 +6,7 @@ export function Tos() {
       <ul>
         <li>本アプリは無料で、商用化しません。</li>
         <li>LLM 推論はブラウザ内で完結します (Chrome の Gemini Nano)。生成系機能を使うブラウザに対応していない場合、その機能は自動的に無効化されます。</li>
-        <li>共鳴タイムラインのために主管理者 DID の PDS から公開コンフィグを読み取ります。</li>
+        <li>BAR ブルスコ (利用者が集う TL) のために主管理者 DID の PDS から公開コンフィグを読み取ります。</li>
         <li>気質診断は Bluesky 公開投稿のみを対象とし、ブラウザ内で完結します。</li>
       </ul>
       <p style={{ fontSize: '0.8em', color: 'var(--color-muted)' }}>最終更新: 2026-05-27</p>


### PR DESCRIPTION
## Summary
- **#49**: 設定オプトイン節・告知文・利用規約に残っていた「共鳴TL」を **BAR ブルスコ** に統一
- **#50**: モデル URL 確認 E2E が HF の 429 (レート制限) で落ちる flaky を根治 (429/5xx は transient skip、404 等のみ失敗)

両 PR とも §1.5 レビュー済み・CI 緑で dev にマージ済み。本番反映用リリース。