### PR TITLE
fix(board): クエストを発行者以外も見られるよう発見ディレクトリ集約

### DIFF
--- a/apps/web/src/components/column-content/board-shared.tsx
+++ b/apps/web/src/components/column-content/board-shared.tsx
@@ -7,7 +7,7 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import type { QuestIndex, QuestIndexSummary } from '@/lib/quest-api';
-import { listIssuedQuests, listMyApplications, buildQuestIndexFromDirectory } from '@/lib/quest-api';
+import { listIssuedQuests, listMyApplications, buildQuestIndexViaDiscovery } from '@/lib/quest-api';
 import { getQuestIndexCached } from '@/lib/quest-index-cache';
 import type { UserQuest } from '@aozoraquest/core';
 import { useSession } from '@/lib/session';
@@ -41,10 +41,7 @@ export function useBoardData() {
   useEffect(() => {
     let cancelled = false;
     const builder = agent
-      ? () => {
-          const dids = selfDid ? [selfDid, ...directoryDids] : directoryDids;
-          return buildQuestIndexFromDirectory(agent, dids);
-        }
+      ? () => buildQuestIndexViaDiscovery(agent, directoryDids, selfDid)
       : undefined;
     getQuestIndexCached(builder)
       .then((idx) => { if (!cancelled) setIndex(idx); })

--- a/apps/web/src/components/column-content/board-shared.tsx
+++ b/apps/web/src/components/column-content/board-shared.tsx
@@ -7,10 +7,11 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import type { QuestIndex, QuestIndexSummary } from '@/lib/quest-api';
-import { listIssuedQuests, listMyApplications } from '@/lib/quest-api';
+import { listIssuedQuests, listMyApplications, buildQuestIndexFromDirectory } from '@/lib/quest-api';
 import { getQuestIndexCached } from '@/lib/quest-index-cache';
 import type { UserQuest } from '@aozoraquest/core';
 import { useSession } from '@/lib/session';
+import { useRuntimeConfig } from '@/components/config-provider';
 import { Handle } from '@/components/handle';
 
 export interface BoardFilter {
@@ -22,18 +23,35 @@ export interface BoardFilter {
  *  (index は quest-index-cache で重複防止)。 */
 export function useBoardData() {
   const session = useSession();
+  const config = useRuntimeConfig();
   const [index, setIndex] = useState<QuestIndex | null>(null);
   const [myQuests, setMyQuests] = useState<UserQuest[] | null>(null);
   const [myApplicationQuestUris, setMyApplicationQuestUris] = useState<Set<string> | null>(null);
   const [err, setErr] = useState<string | null>(null);
 
+  // 集約 Worker が未デプロイの間は、発見ディレクトリの DID 群 (+ 自分) から
+  // クライアント集約して quest を全員に見えるようにする。サインインしている
+  // ときだけ実 agent で各 PDS を読める (未サインインは従来 fallback)。
+  const directoryDids = config.directory.map((u) => u.did);
+  const agent = session.agent;
+  const selfDid = session.did;
+  // 依存値を文字列化して effect の不要再実行を防ぐ
+  const aggregationKey = `${selfDid ?? ''}|${directoryDids.join(',')}`;
+
   useEffect(() => {
     let cancelled = false;
-    getQuestIndexCached()
+    const builder = agent
+      ? () => {
+          const dids = selfDid ? [selfDid, ...directoryDids] : directoryDids;
+          return buildQuestIndexFromDirectory(agent, dids);
+        }
+      : undefined;
+    getQuestIndexCached(builder)
       .then((idx) => { if (!cancelled) setIndex(idx); })
       .catch((e) => { if (!cancelled) setErr(String((e as Error)?.message ?? e)); });
     return () => { cancelled = true; };
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agent, aggregationKey]);
 
   useEffect(() => {
     if (session.status !== 'signed-in' || !session.agent || !session.did) return;

--- a/apps/web/src/lib/quest-api.test.ts
+++ b/apps/web/src/lib/quest-api.test.ts
@@ -108,3 +108,71 @@ describe('mockIndex', () => {
     expect(mockIndex().applications).toHaveLength(1);
   });
 });
+
+describe('buildQuestIndexFromDirectory', () => {
+  // listRecords をコレクション種別で出し分ける fake agent を作る
+  function fakeAgent(byDid: Record<string, { quests?: any[]; apps?: any[] }>) {
+    return {
+      com: {
+        atproto: {
+          repo: {
+            listRecords: async ({ repo, collection }: { repo: string; collection: string }) => {
+              const data = byDid[repo] ?? {};
+              const isQuest = collection.endsWith('userQuest');
+              const recs = (isQuest ? data.quests : data.apps) ?? [];
+              return { data: { records: recs } };
+            },
+          },
+        },
+      },
+    } as any;
+  }
+
+  it('集約: 複数 DID の quest を summary 化してまとめる', async () => {
+    const { buildQuestIndexFromDirectory } = await import('./quest-api');
+    const agent = fakeAgent({
+      'did:plc:a': {
+        quests: [{
+          uri: 'at://did:plc:a/c/1',
+          value: { title: 'A の依頼', tags: ['x'], rewardPoints: 100, status: 'open', createdAt: '2026-06-01T00:00:00Z' },
+        }],
+      },
+      'did:plc:b': {
+        quests: [{
+          uri: 'at://did:plc:b/c/2',
+          value: { title: 'B の依頼', tags: [], rewardPoints: 50, status: 'open', createdAt: '2026-06-02T00:00:00Z' },
+        }],
+        apps: [{ uri: 'at://did:plc:b/ca/1', value: { questUri: 'at://did:plc:a/c/1', createdAt: '2026-06-03T00:00:00Z' } }],
+      },
+    });
+    const idx = await buildQuestIndexFromDirectory(agent, ['did:plc:a', 'did:plc:b']);
+    expect(idx.quests).toHaveLength(2);
+    // createdAt 降順
+    expect(idx.quests[0]!.uri).toBe('at://did:plc:b/c/2');
+    expect(idx.quests[0]!.did).toBe('did:plc:b');
+    expect(idx.applications).toHaveLength(1);
+    expect(idx.applications[0]!.questUri).toBe('at://did:plc:a/c/1');
+  });
+
+  it('重複 DID を 1 回だけ読む (dedup)', async () => {
+    const { buildQuestIndexFromDirectory } = await import('./quest-api');
+    const agent = fakeAgent({
+      'did:plc:a': { quests: [{ uri: 'at://did:plc:a/c/1', value: { title: 't', tags: [], rewardPoints: 0, status: 'open', createdAt: '2026-06-01T00:00:00Z' } }] },
+    });
+    const idx = await buildQuestIndexFromDirectory(agent, ['did:plc:a', 'did:plc:a']);
+    expect(idx.quests).toHaveLength(1);
+  });
+
+  it('一部 DID の読み取り失敗を無視して続行する', async () => {
+    const { buildQuestIndexFromDirectory } = await import('./quest-api');
+    const agent = {
+      com: { atproto: { repo: { listRecords: async ({ repo }: { repo: string }) => {
+        if (repo === 'did:plc:bad') throw new Error('boom');
+        return { data: { records: [{ uri: 'at://did:plc:ok/c/1', value: { title: 'ok', tags: [], rewardPoints: 0, status: 'open', createdAt: 't' } }] } };
+      } } } },
+    } as any;
+    const idx = await buildQuestIndexFromDirectory(agent, ['did:plc:bad', 'did:plc:ok']);
+    // bad は失敗、ok の quest だけ残る (userQuest/questApplication 両方 ok を返すが questUri 無し app は除外)
+    expect(idx.quests.some((q) => q.did === 'did:plc:ok')).toBe(true);
+  });
+});

--- a/apps/web/src/lib/quest-api.ts
+++ b/apps/web/src/lib/quest-api.ts
@@ -226,6 +226,50 @@ export async function buildQuestIndexFromDirectory(
   return { quests, applications, updatedAt: new Date().toISOString() };
 }
 
+const DISCOVERY_TAG = 'aozoraquest';
+/** 集約対象 DID 数の上限 (1 DID = 2 listRecords なので過大にしない) */
+const MAX_DISCOVERY_DIDS = 60;
+
+/**
+ * questIndex を「発見ディレクトリ + #aozoraquest 投稿者 + 自分」の和集合から
+ * 集約する。集約 Worker 未デプロイ時の board の正規ルート。
+ *
+ * directory は admin キュレーションなので、**まだ directory 未登録でも告知
+ * (#aozoraquest 投稿) した発行者をその場の検索で拾う** ことで、登録待ち
+ * (毎時 cron) を待たずに quest が他人へ見えるようにする。過去の quest も
+ * その発行者の userQuest を listRecords で全件読むので一緒に出る。
+ */
+export async function buildQuestIndexViaDiscovery(
+  agent: Agent,
+  directoryDids: Did[],
+  selfDid?: Did | null,
+): Promise<QuestIndex> {
+  const dids = new Set<string>(directoryDids);
+  if (selfDid) dids.add(selfDid);
+  // #aozoraquest 投稿者を拾う (告知した発行者を即 discovery)。検索失敗は無視。
+  try {
+    let cursor: string | undefined;
+    for (let page = 0; page < 2 && dids.size < MAX_DISCOVERY_DIDS; page++) {
+      const res = await agent.app.bsky.feed.searchPosts({
+        q: `#${DISCOVERY_TAG}`,
+        limit: 100,
+        ...(cursor !== undefined ? { cursor } : {}),
+      });
+      for (const post of res.data.posts) {
+        const d = post.author?.did;
+        if (d) dids.add(d);
+        if (dids.size >= MAX_DISCOVERY_DIDS) break;
+      }
+      const next = res.data.cursor;
+      if (!next || next === cursor) break;
+      cursor = next;
+    }
+  } catch (e) {
+    console.warn('[quest-api] discovery search failed, directory のみで集約', e);
+  }
+  return buildQuestIndexFromDirectory(agent, Array.from(dids).slice(0, MAX_DISCOVERY_DIDS));
+}
+
 /** 公開クエスト一覧を取得 (Worker → admin PDS の questIndex)。
  *  Worker 未デプロイなら mock-index に fallback。 */
 export async function fetchQuestIndex(): Promise<QuestIndex> {

--- a/apps/web/src/lib/quest-api.ts
+++ b/apps/web/src/lib/quest-api.ts
@@ -143,6 +143,89 @@ export interface QuestIndex {
   updatedAt: string;
 }
 
+/** クエストを questIndex の summary 形に落とす */
+function questToSummary(q: UserQuest): QuestIndexSummary {
+  return {
+    uri: q.uri,
+    did: q.did,
+    title: q.title,
+    tags: q.tags ?? [],
+    rewardPoints: q.rewardPoints,
+    ...(q.deadline ? { deadline: q.deadline } : {}),
+    status: q.status,
+    createdAt: q.createdAt,
+  };
+}
+
+/**
+ * 集約 Worker が未デプロイのとき、**発見ディレクトリの DID 群から直接**
+ * questIndex を組み立てる (共鳴 TL と同じく各 PDS を読むクライアント集約)。
+ *
+ * これがないと fetchQuestIndex は localStorage モックに落ち、quest が
+ * 「発行者本人の端末でしか見えない」状態になる (= 他人に見えないバグ)。
+ * 各 DID の userQuest / questApplication を listRecords で読み、
+ * 公開 quest 一覧と応募 index を作る。一部 DID の失敗は無視して続行する。
+ */
+export async function buildQuestIndexFromDirectory(
+  agent: Agent,
+  dids: Did[],
+  limitPerRepo = 100,
+): Promise<QuestIndex> {
+  // 重複 DID を除去 (自分 + directory の和集合などで重なりうる)
+  const unique = Array.from(new Set(dids));
+  const results = await Promise.allSettled(
+    unique.map(async (did) => {
+      const [questsRes, appsRes] = await Promise.allSettled([
+        agent.com.atproto.repo.listRecords({ repo: did, collection: COL.userQuest, limit: limitPerRepo }),
+        agent.com.atproto.repo.listRecords({ repo: did, collection: COL.questApplication, limit: limitPerRepo }),
+      ]);
+      const quests: QuestIndexSummary[] = [];
+      const applications: ApplicationIndexEntry[] = [];
+      if (questsRes.status === 'fulfilled') {
+        for (const r of questsRes.value.data.records) {
+          const v = r.value as Omit<UserQuest, 'uri' | 'did'>;
+          quests.push(questToSummary({ ...v, uri: r.uri, did, updatedAt: v.updatedAt ?? v.createdAt }));
+        }
+      }
+      if (appsRes.status === 'fulfilled') {
+        for (const r of appsRes.value.data.records) {
+          const v = r.value as { questUri?: AtUri; createdAt?: string };
+          if (typeof v.questUri === 'string') {
+            applications.push({
+              uri: r.uri,
+              did,
+              questUri: v.questUri,
+              createdAt: v.createdAt ?? '',
+            });
+          }
+        }
+      }
+      return { quests, applications };
+    }),
+  );
+
+  const quests: QuestIndexSummary[] = [];
+  const applications: ApplicationIndexEntry[] = [];
+  const seenQ = new Set<string>();
+  const seenA = new Set<string>();
+  for (const res of results) {
+    if (res.status !== 'fulfilled') continue;
+    for (const q of res.value.quests) {
+      if (seenQ.has(q.uri)) continue;
+      seenQ.add(q.uri);
+      quests.push(q);
+    }
+    for (const a of res.value.applications) {
+      if (seenA.has(a.uri)) continue;
+      seenA.add(a.uri);
+      applications.push(a);
+    }
+  }
+  // 新しい順 (createdAt 降順) に並べる
+  quests.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  return { quests, applications, updatedAt: new Date().toISOString() };
+}
+
 /** 公開クエスト一覧を取得 (Worker → admin PDS の questIndex)。
  *  Worker 未デプロイなら mock-index に fallback。 */
 export async function fetchQuestIndex(): Promise<QuestIndex> {

--- a/apps/web/src/lib/quest-index-cache.ts
+++ b/apps/web/src/lib/quest-index-cache.ts
@@ -10,13 +10,26 @@ const TTL_MS = 30_000;
 
 let cached: { index: QuestIndex; ts: number } | null = null;
 let inflight: Promise<QuestIndex> | null = null;
+/** 直近に使った builder を覚え、refresh 時に同じ経路で取り直す。 */
+let lastBuilder: (() => Promise<QuestIndex>) | null = null;
 
-export async function getQuestIndexCached(): Promise<QuestIndex> {
+/**
+ * questIndex を取得 (TTL 30s キャッシュ + inflight 共有)。
+ *
+ * builder を渡すとそれで取得する。集約 Worker が未デプロイのとき、
+ * board が「発見ディレクトリからのクライアント集約」
+ * (buildQuestIndexFromDirectory) を builder として注入することで、
+ * quest が発行者以外にも見えるようにする。未指定なら直近 builder か
+ * fetchQuestIndex (Worker or mock) に落ちる。
+ */
+export async function getQuestIndexCached(builder?: () => Promise<QuestIndex>): Promise<QuestIndex> {
+  if (builder) lastBuilder = builder;
   if (cached && Date.now() - cached.ts < TTL_MS) return cached.index;
   if (inflight) return inflight;
+  const fetcher = builder ?? lastBuilder ?? fetchQuestIndex;
   inflight = (async () => {
     try {
-      const index = await fetchQuestIndex();
+      const index = await fetcher();
       cached = { index, ts: Date.now() };
       return index;
     } finally {
@@ -26,7 +39,7 @@ export async function getQuestIndexCached(): Promise<QuestIndex> {
   return inflight;
 }
 
-/** リフレッシュ操作用: キャッシュを捨てて取り直す */
+/** リフレッシュ操作用: キャッシュを捨てて取り直す (直近の builder を踏襲) */
 export async function refreshQuestIndex(): Promise<QuestIndex> {
   cached = null;
   return getQuestIndexCached();
@@ -36,4 +49,5 @@ export async function refreshQuestIndex(): Promise<QuestIndex> {
 export function clearQuestIndexCache(): void {
   cached = null;
   inflight = null;
+  lastBuilder = null;
 }


### PR DESCRIPTION
## 報告バグ
「クエストが発行者以外見れない」。

## 原因
集約 Worker (`VITE_QUEST_EDGE_URL`) 未デプロイ → `fetchQuestIndex` が **localStorage モックに fallback**。localStorage はブラウザごとなので発行者の端末でしか見えなかった。

## 修正
集約 Worker 不在時、**「発見ディレクトリ ∪ #aozoraquest 投稿者(searchPosts)∪ 自分」の各 PDS から `userQuest`/`questApplication` を `listRecords` で読み**、クライアントで questIndex を組み立てる。

- `buildQuestIndexFromDirectory`: DID 群から集約(allSettled で一部失敗無視・uri dedup・createdAt 降順)
- `buildQuestIndexViaDiscovery`: 上記 + **#aozoraquest 検索で告知済み発行者を即 discovery**(directory 登録の毎時 cron を待たない)。DID 60 cap
- `getQuestIndexCached(builder?)` で builder 注入、`useBoardData` が discovery builder を使う

### 過去クエストの扱い
データは各発行者 PDS に残存。集約は発行者の `userQuest` を全件(最新100)読むので、**過去 quest も自動的に再表示**(移行不要)。条件は「発行者が directory に居る or #aozoraquest で告知済み」。

## Review
§1.5 の 3 並列レビュー実施。

### ★★★(PR 内で対応・commit 96ca466)
- **directory 未登録の発行者の quest が他人に見えない**(directory は admin キュレーションで自動登録なし)→ `buildQuestIndexViaDiscovery` で #aozoraquest 投稿者を検索 union し、告知済み発行者を即可視化

### ★★ → issue 化
- `refreshQuestIndex` の `lastBuilder` が stale agent/directory を掴む → #59
- `index.applications` が全員の応募に変質した点の明記 → #60
- 集約 effect deps を bar-column と統一 → #62
- 応募者一覧の他人可視化 + 未サインイン公開閲覧(public agent)→ #61

### ★(記録のみ)
- DID 数上限は 60 で cap 済み(resonance は 30)、createdAt 欠損時の順序不定は実害小

## 既知の制約
- **告知 OFF かつ directory 未登録**の発行者の quest は他人に見えない(Worker 実装で根治予定)
- 未サインイン閲覧は集約が効かない(#61)

## Test plan
- [x] typecheck / vitest 140 / build 緑
- [ ] dev 実機: 別アカウントで board「募集中」に他人の(告知済み)クエストが過去分含め出るか