### PR TITLE
release: クエスト可視化修正 + カラム更新機能 (#56, #58)

### DIFF
--- a/apps/web/src/components/column-content/board-shared.tsx
+++ b/apps/web/src/components/column-content/board-shared.tsx
@@ -7,10 +7,11 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import type { QuestIndex, QuestIndexSummary } from '@/lib/quest-api';
-import { listIssuedQuests, listMyApplications } from '@/lib/quest-api';
+import { listIssuedQuests, listMyApplications, buildQuestIndexViaDiscovery } from '@/lib/quest-api';
 import { getQuestIndexCached } from '@/lib/quest-index-cache';
 import type { UserQuest } from '@aozoraquest/core';
 import { useSession } from '@/lib/session';
+import { useRuntimeConfig } from '@/components/config-provider';
 import { Handle } from '@/components/handle';
 
 export interface BoardFilter {
@@ -22,18 +23,32 @@ export interface BoardFilter {
  *  (index は quest-index-cache で重複防止)。 */
 export function useBoardData() {
   const session = useSession();
+  const config = useRuntimeConfig();
   const [index, setIndex] = useState<QuestIndex | null>(null);
   const [myQuests, setMyQuests] = useState<UserQuest[] | null>(null);
   const [myApplicationQuestUris, setMyApplicationQuestUris] = useState<Set<string> | null>(null);
   const [err, setErr] = useState<string | null>(null);
 
+  // 集約 Worker が未デプロイの間は、発見ディレクトリの DID 群 (+ 自分) から
+  // クライアント集約して quest を全員に見えるようにする。サインインしている
+  // ときだけ実 agent で各 PDS を読める (未サインインは従来 fallback)。
+  const directoryDids = config.directory.map((u) => u.did);
+  const agent = session.agent;
+  const selfDid = session.did;
+  // 依存値を文字列化して effect の不要再実行を防ぐ
+  const aggregationKey = `${selfDid ?? ''}|${directoryDids.join(',')}`;
+
   useEffect(() => {
     let cancelled = false;
-    getQuestIndexCached()
+    const builder = agent
+      ? () => buildQuestIndexViaDiscovery(agent, directoryDids, selfDid)
+      : undefined;
+    getQuestIndexCached(builder)
       .then((idx) => { if (!cancelled) setIndex(idx); })
       .catch((e) => { if (!cancelled) setErr(String((e as Error)?.message ?? e)); });
     return () => { cancelled = true; };
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agent, aggregationKey]);
 
   useEffect(() => {
     if (session.status !== 'signed-in' || !session.agent || !session.did) return;

--- a/apps/web/src/components/workspace.tsx
+++ b/apps/web/src/components/workspace.tsx
@@ -30,6 +30,8 @@ import { publishVisibleColumn } from '@/lib/visible-column';
 import { ColumnScrollContext } from '@/components/column-scroll-context';
 import { ColumnContent } from '@/components/column-content';
 import { ColumnPicker } from '@/components/column-picker';
+import { refreshQuestIndex } from '@/lib/quest-index-cache';
+import { invalidateProfile } from '@/lib/profile-cache';
 
 /** picker の表示位置: 'end' = 末尾タイル、数値 = そのカラムの直右 */
 type PickerAnchor = number | 'end' | null;
@@ -49,6 +51,34 @@ export function Workspace() {
 
   const [pickerAnchor, setPickerAnchor] = useState<PickerAnchor>(null);
   const scrollerRef = useRef<HTMLDivElement>(null);
+
+  // 各カラムの「更新世代」。bump すると ColumnContent の key が変わり remount
+  // → mount 時に各カラムがネットワークから取り直す (= リフレッシュ)。
+  // 明示更新なので先頭に戻る挙動は自然 (pull-to-refresh / ↻ ボタンとして妥当)。
+  const [refreshNonce, setRefreshNonce] = useState<Record<string, number>>({});
+
+  /** kind ごとのモジュールキャッシュを無効化する (remount だけでは
+   *  取り直さない quest index / profile を真に fresh にするため)。 */
+  function bustColumnCache(col: AppColumn) {
+    if (col.kind === 'board') void refreshQuestIndex();
+    if (col.kind === 'profile' && col.param) invalidateProfile(col.param);
+  }
+
+  /** 1 カラムをリフレッシュする */
+  function refreshColumn(col: AppColumn) {
+    bustColumnCache(col);
+    setRefreshNonce((m) => ({ ...m, [col.id]: (m[col.id] ?? 0) + 1 }));
+  }
+
+  /** 全カラムをまとめてリフレッシュする */
+  function refreshAll(cols: AppColumn[]) {
+    for (const c of cols) bustColumnCache(c);
+    setRefreshNonce((m) => {
+      const next = { ...m };
+      for (const c of cols) next[c.id] = (next[c.id] ?? 0) + 1;
+      return next;
+    });
+  }
 
   // いま主に見えているカラムの kind を footer-nav に伝える
   // (モバイル横スワイプで現在位置が分かるように)。
@@ -162,6 +192,17 @@ export function Workspace() {
 
   return (
     <div data-workspace="1">
+      {(columns?.length ?? 0) > 0 && (
+        <button
+          type="button"
+          className="workspace-refresh-all"
+          aria-label="すべてのカラムを更新"
+          title="すべてのカラムを更新"
+          onClick={() => refreshAll(columns ?? [])}
+        >
+          <RefreshIcon /> すべて更新
+        </button>
+      )}
       <div className="workspace-columns" ref={scrollerRef}>
         {(columns ?? []).map((col, i) => (
           <Fragment key={col.id}>
@@ -173,8 +214,10 @@ export function Workspace() {
               onMoveRight={() => edit((cols) => moveColumnRight(cols, col.id))}
               onRemove={() => edit((cols) => removeColumn(cols, col.id))}
               onAddRight={() => setPickerAnchor(i)}
+              onRefresh={() => refreshColumn(col)}
             >
               <ColumnContent
+                key={refreshNonce[col.id] ?? 0}
                 column={col}
                 onPatch={(patch) => patchColumn(col.id, patch)}
               />
@@ -221,15 +264,25 @@ interface ColumnViewProps {
   onMoveRight: () => void;
   onRemove: () => void;
   onAddRight: () => void;
+  onRefresh: () => void;
   children: ReactNode;
 }
 
-function ColumnView({ column, canMoveLeft, canMoveRight, onMoveLeft, onMoveRight, onRemove, onAddRight, children }: ColumnViewProps) {
+function ColumnView({ column, canMoveLeft, canMoveRight, onMoveLeft, onMoveRight, onRemove, onAddRight, onRefresh, children }: ColumnViewProps) {
   // body 要素を state で持つ (callback ref)。要素の出現が props 変化として
   // 子に伝わり、VirtualFeed がカラム内スクロールへ自然に切り替わる。
   const [bodyEl, setBodyEl] = useState<HTMLElement | null>(null);
   const [menuOpen, setMenuOpen] = useState(false);
   const [copied, setCopied] = useState(false);
+  // 押下フィードバック (↻ を一瞬回す) 用
+  const [spinning, setSpinning] = useState(false);
+  function triggerRefresh() {
+    onRefresh();
+    setSpinning(true);
+    setTimeout(() => setSpinning(false), 600);
+  }
+  // モバイル pull-to-refresh (カラム body を最上部から下に引くと更新)
+  const pull = usePullToRefresh(bodyEl, triggerRefresh);
 
   // home / bar は専用 URL を持たない (urlForColumn が '/' を返す) ので
   // 直リンク項目を出さない
@@ -261,6 +314,15 @@ function ColumnView({ column, canMoveLeft, canMoveRight, onMoveLeft, onMoveRight
         <span className="workspace-column-title">{appColumnTitle(column)}</span>
         <button
           type="button"
+          className={`workspace-column-refresh-btn${spinning ? ' is-spinning' : ''}`}
+          aria-label={`${appColumnTitle(column)}を更新`}
+          title="このカラムを更新"
+          onClick={triggerRefresh}
+        >
+          <RefreshIcon />
+        </button>
+        <button
+          type="button"
           className="workspace-column-menu-btn"
           aria-label="カラム操作メニュー"
           aria-expanded={menuOpen}
@@ -284,10 +346,118 @@ function ColumnView({ column, canMoveLeft, canMoveRight, onMoveLeft, onMoveRight
         </div>
       )}
       <div className="workspace-column-body" ref={setBodyEl}>
+        {pull.offset > 0 && (
+          <div className="workspace-pull-indicator" style={{ height: pull.offset }}>
+            <span className={pull.armed ? 'armed' : ''}>
+              {pull.armed ? '離して更新' : '引いて更新'}
+            </span>
+          </div>
+        )}
         <ColumnScrollContext.Provider value={bodyEl}>
           {children}
         </ColumnScrollContext.Provider>
       </div>
     </section>
   );
+}
+
+/** カレンダーの ↻ / すべて更新ボタンで使う回転矢印アイコン (絵文字不使用)。 */
+function RefreshIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden focusable="false">
+      <path
+        d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        fill="none"
+      />
+      <path d="M13.7 1.8V5h-3.2" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" fill="none" />
+    </svg>
+  );
+}
+
+interface PullState {
+  offset: number;
+  armed: boolean;
+}
+
+/**
+ * モバイル pull-to-refresh。スクロール最上部 (scrollTop===0) から下に引いた
+ * ときだけ反応し、閾値を超えて指を離したら onRefresh を呼ぶ。
+ * 通常の縦スクロールを邪魔しないよう、最上部かつ下方向のときだけ engage する。
+ */
+function usePullToRefresh(el: HTMLElement | null, onRefresh: () => void): PullState {
+  const [state, setState] = useState<PullState>({ offset: 0, armed: false });
+  const startY = useRef<number | null>(null);
+  const startX = useRef<number>(0);
+  const lockedAxis = useRef<'none' | 'vertical' | 'horizontal'>('none');
+  const pulling = useRef(false);
+  const armedRef = useRef(false);
+  // onRefresh は毎 render で identity が変わるので ref 越しに最新を読む
+  // (effect を毎回貼り直さないため)。
+  const onRefreshRef = useRef(onRefresh);
+  onRefreshRef.current = onRefresh;
+  const THRESHOLD = 64;
+  const MAX = 96;
+
+  useEffect(() => {
+    if (!el) return;
+
+    const onTouchStart = (e: TouchEvent) => {
+      if (el.scrollTop <= 0 && e.touches.length === 1) {
+        startY.current = e.touches[0]!.clientY;
+        startX.current = e.touches[0]!.clientX;
+        lockedAxis.current = 'none';
+        pulling.current = false;
+      } else {
+        startY.current = null;
+      }
+    };
+    const onTouchMove = (e: TouchEvent) => {
+      if (startY.current === null) return;
+      const dy = e.touches[0]!.clientY - startY.current;
+      const dx = e.touches[0]!.clientX - startX.current;
+      // 軸ロック: 最初に優勢な方向を決め、横優勢ならカラム間スワイプとして
+      // pull を一切発火させない (scroll-snap の横送りを妨げない)。
+      if (lockedAxis.current === 'none' && (Math.abs(dx) > 6 || Math.abs(dy) > 6)) {
+        lockedAxis.current = Math.abs(dx) > Math.abs(dy) ? 'horizontal' : 'vertical';
+      }
+      if (lockedAxis.current === 'horizontal') return;
+      if (dy <= 0) {
+        if (pulling.current) {
+          pulling.current = false;
+          armedRef.current = false;
+          setState({ offset: 0, armed: false });
+        }
+        return;
+      }
+      pulling.current = true;
+      const offset = Math.min(MAX, dy * 0.5); // ゴム的に減衰
+      const armed = offset >= THRESHOLD;
+      armedRef.current = armed;
+      setState({ offset, armed });
+      if (e.cancelable) e.preventDefault(); // pull 中はネイティブスクロール抑止
+    };
+    const end = () => {
+      if (pulling.current && armedRef.current) onRefreshRef.current();
+      pulling.current = false;
+      armedRef.current = false;
+      startY.current = null;
+      setState({ offset: 0, armed: false });
+    };
+
+    el.addEventListener('touchstart', onTouchStart, { passive: true });
+    el.addEventListener('touchmove', onTouchMove, { passive: false });
+    el.addEventListener('touchend', end);
+    el.addEventListener('touchcancel', end);
+    return () => {
+      el.removeEventListener('touchstart', onTouchStart);
+      el.removeEventListener('touchmove', onTouchMove);
+      el.removeEventListener('touchend', end);
+      el.removeEventListener('touchcancel', end);
+    };
+  }, [el]);
+
+  return state;
 }

--- a/apps/web/src/lib/quest-api.test.ts
+++ b/apps/web/src/lib/quest-api.test.ts
@@ -108,3 +108,71 @@ describe('mockIndex', () => {
     expect(mockIndex().applications).toHaveLength(1);
   });
 });
+
+describe('buildQuestIndexFromDirectory', () => {
+  // listRecords をコレクション種別で出し分ける fake agent を作る
+  function fakeAgent(byDid: Record<string, { quests?: any[]; apps?: any[] }>) {
+    return {
+      com: {
+        atproto: {
+          repo: {
+            listRecords: async ({ repo, collection }: { repo: string; collection: string }) => {
+              const data = byDid[repo] ?? {};
+              const isQuest = collection.endsWith('userQuest');
+              const recs = (isQuest ? data.quests : data.apps) ?? [];
+              return { data: { records: recs } };
+            },
+          },
+        },
+      },
+    } as any;
+  }
+
+  it('集約: 複数 DID の quest を summary 化してまとめる', async () => {
+    const { buildQuestIndexFromDirectory } = await import('./quest-api');
+    const agent = fakeAgent({
+      'did:plc:a': {
+        quests: [{
+          uri: 'at://did:plc:a/c/1',
+          value: { title: 'A の依頼', tags: ['x'], rewardPoints: 100, status: 'open', createdAt: '2026-06-01T00:00:00Z' },
+        }],
+      },
+      'did:plc:b': {
+        quests: [{
+          uri: 'at://did:plc:b/c/2',
+          value: { title: 'B の依頼', tags: [], rewardPoints: 50, status: 'open', createdAt: '2026-06-02T00:00:00Z' },
+        }],
+        apps: [{ uri: 'at://did:plc:b/ca/1', value: { questUri: 'at://did:plc:a/c/1', createdAt: '2026-06-03T00:00:00Z' } }],
+      },
+    });
+    const idx = await buildQuestIndexFromDirectory(agent, ['did:plc:a', 'did:plc:b']);
+    expect(idx.quests).toHaveLength(2);
+    // createdAt 降順
+    expect(idx.quests[0]!.uri).toBe('at://did:plc:b/c/2');
+    expect(idx.quests[0]!.did).toBe('did:plc:b');
+    expect(idx.applications).toHaveLength(1);
+    expect(idx.applications[0]!.questUri).toBe('at://did:plc:a/c/1');
+  });
+
+  it('重複 DID を 1 回だけ読む (dedup)', async () => {
+    const { buildQuestIndexFromDirectory } = await import('./quest-api');
+    const agent = fakeAgent({
+      'did:plc:a': { quests: [{ uri: 'at://did:plc:a/c/1', value: { title: 't', tags: [], rewardPoints: 0, status: 'open', createdAt: '2026-06-01T00:00:00Z' } }] },
+    });
+    const idx = await buildQuestIndexFromDirectory(agent, ['did:plc:a', 'did:plc:a']);
+    expect(idx.quests).toHaveLength(1);
+  });
+
+  it('一部 DID の読み取り失敗を無視して続行する', async () => {
+    const { buildQuestIndexFromDirectory } = await import('./quest-api');
+    const agent = {
+      com: { atproto: { repo: { listRecords: async ({ repo }: { repo: string }) => {
+        if (repo === 'did:plc:bad') throw new Error('boom');
+        return { data: { records: [{ uri: 'at://did:plc:ok/c/1', value: { title: 'ok', tags: [], rewardPoints: 0, status: 'open', createdAt: 't' } }] } };
+      } } } },
+    } as any;
+    const idx = await buildQuestIndexFromDirectory(agent, ['did:plc:bad', 'did:plc:ok']);
+    // bad は失敗、ok の quest だけ残る (userQuest/questApplication 両方 ok を返すが questUri 無し app は除外)
+    expect(idx.quests.some((q) => q.did === 'did:plc:ok')).toBe(true);
+  });
+});

--- a/apps/web/src/lib/quest-api.ts
+++ b/apps/web/src/lib/quest-api.ts
@@ -143,6 +143,133 @@ export interface QuestIndex {
   updatedAt: string;
 }
 
+/** クエストを questIndex の summary 形に落とす */
+function questToSummary(q: UserQuest): QuestIndexSummary {
+  return {
+    uri: q.uri,
+    did: q.did,
+    title: q.title,
+    tags: q.tags ?? [],
+    rewardPoints: q.rewardPoints,
+    ...(q.deadline ? { deadline: q.deadline } : {}),
+    status: q.status,
+    createdAt: q.createdAt,
+  };
+}
+
+/**
+ * 集約 Worker が未デプロイのとき、**発見ディレクトリの DID 群から直接**
+ * questIndex を組み立てる (共鳴 TL と同じく各 PDS を読むクライアント集約)。
+ *
+ * これがないと fetchQuestIndex は localStorage モックに落ち、quest が
+ * 「発行者本人の端末でしか見えない」状態になる (= 他人に見えないバグ)。
+ * 各 DID の userQuest / questApplication を listRecords で読み、
+ * 公開 quest 一覧と応募 index を作る。一部 DID の失敗は無視して続行する。
+ */
+export async function buildQuestIndexFromDirectory(
+  agent: Agent,
+  dids: Did[],
+  limitPerRepo = 100,
+): Promise<QuestIndex> {
+  // 重複 DID を除去 (自分 + directory の和集合などで重なりうる)
+  const unique = Array.from(new Set(dids));
+  const results = await Promise.allSettled(
+    unique.map(async (did) => {
+      const [questsRes, appsRes] = await Promise.allSettled([
+        agent.com.atproto.repo.listRecords({ repo: did, collection: COL.userQuest, limit: limitPerRepo }),
+        agent.com.atproto.repo.listRecords({ repo: did, collection: COL.questApplication, limit: limitPerRepo }),
+      ]);
+      const quests: QuestIndexSummary[] = [];
+      const applications: ApplicationIndexEntry[] = [];
+      if (questsRes.status === 'fulfilled') {
+        for (const r of questsRes.value.data.records) {
+          const v = r.value as Omit<UserQuest, 'uri' | 'did'>;
+          quests.push(questToSummary({ ...v, uri: r.uri, did, updatedAt: v.updatedAt ?? v.createdAt }));
+        }
+      }
+      if (appsRes.status === 'fulfilled') {
+        for (const r of appsRes.value.data.records) {
+          const v = r.value as { questUri?: AtUri; createdAt?: string };
+          if (typeof v.questUri === 'string') {
+            applications.push({
+              uri: r.uri,
+              did,
+              questUri: v.questUri,
+              createdAt: v.createdAt ?? '',
+            });
+          }
+        }
+      }
+      return { quests, applications };
+    }),
+  );
+
+  const quests: QuestIndexSummary[] = [];
+  const applications: ApplicationIndexEntry[] = [];
+  const seenQ = new Set<string>();
+  const seenA = new Set<string>();
+  for (const res of results) {
+    if (res.status !== 'fulfilled') continue;
+    for (const q of res.value.quests) {
+      if (seenQ.has(q.uri)) continue;
+      seenQ.add(q.uri);
+      quests.push(q);
+    }
+    for (const a of res.value.applications) {
+      if (seenA.has(a.uri)) continue;
+      seenA.add(a.uri);
+      applications.push(a);
+    }
+  }
+  // 新しい順 (createdAt 降順) に並べる
+  quests.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  return { quests, applications, updatedAt: new Date().toISOString() };
+}
+
+const DISCOVERY_TAG = 'aozoraquest';
+/** 集約対象 DID 数の上限 (1 DID = 2 listRecords なので過大にしない) */
+const MAX_DISCOVERY_DIDS = 60;
+
+/**
+ * questIndex を「発見ディレクトリ + #aozoraquest 投稿者 + 自分」の和集合から
+ * 集約する。集約 Worker 未デプロイ時の board の正規ルート。
+ *
+ * directory は admin キュレーションなので、**まだ directory 未登録でも告知
+ * (#aozoraquest 投稿) した発行者をその場の検索で拾う** ことで、登録待ち
+ * (毎時 cron) を待たずに quest が他人へ見えるようにする。過去の quest も
+ * その発行者の userQuest を listRecords で全件読むので一緒に出る。
+ */
+export async function buildQuestIndexViaDiscovery(
+  agent: Agent,
+  directoryDids: Did[],
+  selfDid?: Did | null,
+): Promise<QuestIndex> {
+  const dids = new Set<string>(directoryDids);
+  if (selfDid) dids.add(selfDid);
+  // #aozoraquest 投稿者を拾う (告知した発行者を即 discovery)。検索失敗は無視。
+  try {
+    let cursor: string | undefined;
+    for (let page = 0; page < 2 && dids.size < MAX_DISCOVERY_DIDS; page++) {
+      const res = await agent.app.bsky.feed.searchPosts({
+        q: `#${DISCOVERY_TAG}`,
+        limit: 100,
+        ...(cursor !== undefined ? { cursor } : {}),
+      });
+      for (const post of res.data.posts) {
+        const d = post.author?.did;
+        if (d) dids.add(d);
+        if (dids.size >= MAX_DISCOVERY_DIDS) break;
+      }
+      const next = res.data.cursor;
+      if (!next || next === cursor) break;
+      cursor = next;
+    }
+  } catch (e) {
+    console.warn('[quest-api] discovery search failed, directory のみで集約', e);
+  }
+  return buildQuestIndexFromDirectory(agent, Array.from(dids).slice(0, MAX_DISCOVERY_DIDS));
+}
+
 /** 公開クエスト一覧を取得 (Worker → admin PDS の questIndex)。
  *  Worker 未デプロイなら mock-index に fallback。 */
 export async function fetchQuestIndex(): Promise<QuestIndex> {

--- a/apps/web/src/lib/quest-index-cache.ts
+++ b/apps/web/src/lib/quest-index-cache.ts
@@ -10,13 +10,26 @@ const TTL_MS = 30_000;
 
 let cached: { index: QuestIndex; ts: number } | null = null;
 let inflight: Promise<QuestIndex> | null = null;
+/** 直近に使った builder を覚え、refresh 時に同じ経路で取り直す。 */
+let lastBuilder: (() => Promise<QuestIndex>) | null = null;
 
-export async function getQuestIndexCached(): Promise<QuestIndex> {
+/**
+ * questIndex を取得 (TTL 30s キャッシュ + inflight 共有)。
+ *
+ * builder を渡すとそれで取得する。集約 Worker が未デプロイのとき、
+ * board が「発見ディレクトリからのクライアント集約」
+ * (buildQuestIndexFromDirectory) を builder として注入することで、
+ * quest が発行者以外にも見えるようにする。未指定なら直近 builder か
+ * fetchQuestIndex (Worker or mock) に落ちる。
+ */
+export async function getQuestIndexCached(builder?: () => Promise<QuestIndex>): Promise<QuestIndex> {
+  if (builder) lastBuilder = builder;
   if (cached && Date.now() - cached.ts < TTL_MS) return cached.index;
   if (inflight) return inflight;
+  const fetcher = builder ?? lastBuilder ?? fetchQuestIndex;
   inflight = (async () => {
     try {
-      const index = await fetchQuestIndex();
+      const index = await fetcher();
       cached = { index, ts: Date.now() };
       return index;
     } finally {
@@ -26,7 +39,7 @@ export async function getQuestIndexCached(): Promise<QuestIndex> {
   return inflight;
 }
 
-/** リフレッシュ操作用: キャッシュを捨てて取り直す */
+/** リフレッシュ操作用: キャッシュを捨てて取り直す (直近の builder を踏襲) */
 export async function refreshQuestIndex(): Promise<QuestIndex> {
   cached = null;
   return getQuestIndexCached();
@@ -36,4 +49,5 @@ export async function refreshQuestIndex(): Promise<QuestIndex> {
 export function clearQuestIndexCache(): void {
   cached = null;
   inflight = null;
+  lastBuilder = null;
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -284,7 +284,9 @@ p { margin: 0.4em 0; }
   flex: 0 0 auto;
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  /* タイトル左、ボタン群 (↻ / ⋯) は refresh-btn の margin-left:auto で右へ。
+     space-between だと 3 子が等間隔に散るので flex-start にする。 */
+  justify-content: flex-start;
   gap: 0.5em;
   padding: 0.45em 0.5em 0.45em 0.8em;
   font-size: 0.92em;
@@ -302,6 +304,67 @@ p { margin: 0.4em 0; }
 }
 .workspace-column-menu-btn:hover:not(:disabled) {
   background: rgba(255, 255, 255, 0.1);
+}
+
+/* カラムヘッダーの更新ボタン (↻)。タイトルの右、⋯ の左に置く。 */
+.workspace-column-refresh-btn {
+  margin-left: auto; /* タイトルを左、ボタン群を右へ寄せる */
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15em 0.4em;
+  background: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  color: var(--color-fg);
+}
+.workspace-column-refresh-btn:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.1);
+}
+.workspace-column-refresh-btn.is-spinning svg {
+  animation: dtp-spin 0.6s linear;
+}
+@keyframes dtp-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .workspace-column-refresh-btn.is-spinning svg { animation: none; }
+}
+
+/* 全カラム一括更新ボタン (右下のフローティング FAB)。
+   PC は各カラムヘッダーの ↻ で足りる + カラムが右端まで埋まって被るため、
+   モバイル (単一カラム表示) 限定で出す。pull-to-refresh と機能は冗長なので
+   PC で消しても損失は小さい。 */
+.workspace-refresh-all { display: none; }
+@media (max-width: 767px) {
+  .workspace-refresh-all {
+    display: inline-flex;
+    position: fixed;
+    right: 0.8em;
+    bottom: calc(var(--shell-chrome-height, 9.5em) * 0.5 + 0.8em);
+    z-index: 20;
+    align-items: center;
+    gap: 0.4em;
+    font-size: 0.82em;
+    padding: 0.45em 0.85em;
+    border-radius: 999px;
+    box-shadow: inset 0 0 0 1px var(--color-window-inner-border), 0 3px 8px rgba(0, 0, 0, 0.4);
+  }
+}
+
+/* pull-to-refresh のインジケータ (カラム body 先頭に出る) */
+.workspace-pull-indicator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  font-size: 0.78em;
+  color: var(--color-muted);
+  transition: height 0.12s ease;
+}
+.workspace-pull-indicator .armed {
+  color: var(--color-accent);
+  font-weight: 700;
 }
 
 .workspace-column-menu {


### PR DESCRIPTION
## Summary
本番に急ぎ反映するリリース。

- **#58 クエスト可視化修正**: 集約 Worker 未デプロイで quest が発行者の端末でしか見えなかったバグを修正。「発見ディレクトリ ∪ #aozoraquest 告知者 ∪ 自分」から各 PDS を listRecords でクライアント集約。過去 quest も発行者の userQuest 全件読むので一緒に出る
- **#56 カラム更新機能**: 各カラム ↻ ボタン + モバイル pull-to-refresh + すべて更新 FAB

両 PR とも §1.5 レビュー済み(★★★ は PR 内対応、★★ は対応 or issue 化)、CI 緑で dev にマージ済み。

### 既知の制約 (#58)
告知 OFF かつ directory 未登録の発行者の quest は他人に見えない(Worker 実装で根治予定)。未サインイン閲覧は集約が効かない(#61)。