### PR TITLE
feat(board): クエスト告知を必須化 (告知 OFF 廃止)

### DIFF
--- a/apps/web/src/routes/board-new.tsx
+++ b/apps/web/src/routes/board-new.tsx
@@ -29,7 +29,6 @@ export function BoardNew() {
   const [targetJob, setTargetJob] = useState<string>('');
   const [deadline, setDeadline] = useState('');
   const [rewardPoints, setRewardPoints] = useState(100);
-  const [announce, setAnnounce] = useState(() => getPostQuestNotifications());
   const [announceText, setAnnounceText] = useState('');
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
@@ -85,8 +84,10 @@ export function BoardNew() {
         ...(deadline ? { deadline: new Date(deadline).toISOString() } : {}),
         rewardPoints,
       });
-      // Bluesky 告知 (default ON、ユーザー編集テキストを使う)
-      if (announce) {
+      // Bluesky 告知は常時 ON (= 掲示板で他人に見えるために必須。発行者が
+      // off にできる導線は廃止)。ただし dev 環境だけは本番 Bluesky への誤投稿
+      // 防止ゲート (getPostQuestNotifications) を残す。
+      if (getPostQuestNotifications()) {
         const questUrl = `${location.origin}/board/${encodeURIComponent(quest.uri)}`;
         // [QUEST_URL] マーカーが残っていれば置換。ユーザーが消してしまっていれば末尾に追加。
         let finalText = announceText.replace('[QUEST_URL]', questUrl);
@@ -199,30 +200,24 @@ export function BoardNew() {
         </p>
       </Field>
 
-      <Field label="Bluesky に告知する">
-        <label style={{ display: 'flex', alignItems: 'center', gap: '0.4em', fontSize: '0.9em' }}>
-          <input type="checkbox" checked={announce} onChange={(e) => setAnnounce(e.target.checked)} />
-          告知する
-        </label>
+      <Field label="Bluesky 告知文 (発行時に自動投稿)">
+        <p style={{ fontSize: '0.75em', color: 'var(--color-muted)', margin: '0 0 0.3em' }}>
+          クエストは発行と同時に <code>#aozoraquest</code> 付きで Bluesky に告知されます
+          (= 他の人の掲示板に載るために必須)。本文は編集できます。
+          <code>[QUEST_URL]</code> が発行後の URL に置き換わります (消した場合は末尾に自動追加)。
+        </p>
+        <textarea
+          aria-label="Bluesky 告知本文"
+          value={announceText}
+          onChange={(e) => setAnnounceText(e.target.value)}
+          rows={5}
+          style={{ width: '100%' }}
+        />
         {!getPostQuestNotificationsDefault() && (
-          <p style={{ fontSize: '0.75em', color: 'var(--color-muted)', margin: '0.3em 0 0' }}>
-            dev 環境では default OFF (本番 Bluesky に流さないため)。
-            設定ページの「クエスト告知を Bluesky に投稿する」で常時 ON にできます。
+          <p style={{ fontSize: '0.72em', color: 'var(--color-muted)', margin: '0.3em 0 0' }}>
+            ※ この環境 (dev) では本番 Bluesky への誤投稿を防ぐため告知を保留します。
+            設定ページの「クエスト告知を Bluesky に投稿する」を ON にすると告知されます。
           </p>
-        )}
-        {announce && (
-          <>
-            <p style={{ fontSize: '0.75em', color: 'var(--color-muted)', margin: '0.4em 0 0.2em' }}>
-              <code>[QUEST_URL]</code> が発行後の URL に置き換わります。消した場合は末尾に自動追加されます。
-            </p>
-            <textarea
-              aria-label="Bluesky 告知本文"
-              value={announceText}
-              onChange={(e) => setAnnounceText(e.target.value)}
-              rows={5}
-              style={{ width: '100%', marginTop: '0.2em' }}
-            />
-          </>
         )}
       </Field>
 

--- a/apps/web/src/routes/board-new.tsx
+++ b/apps/web/src/routes/board-new.tsx
@@ -92,6 +92,9 @@ export function BoardNew() {
         // [QUEST_URL] マーカーが残っていれば置換。ユーザーが消してしまっていれば末尾に追加。
         let finalText = announceText.replace('[QUEST_URL]', questUrl);
         if (!finalText.includes(questUrl)) finalText = `${finalText.trim()}\n${questUrl}`;
+        // 発見タグ #aozoraquest は掲示板掲載の必須条件。ユーザーが本文から
+        // 消していても必ず付ける (= これが無いと searchPosts で拾えない)。
+        if (!finalText.includes('#aozoraquest')) finalText = `#aozoraquest\n${finalText.trim()}`;
         try {
           await createTaggedPost(session.agent, finalText, 'aozoraquest');
         } catch (e) {

--- a/packages/core/src/__tests__/user-quest.test.ts
+++ b/packages/core/src/__tests__/user-quest.test.ts
@@ -279,6 +279,19 @@ describe('formatQuestAnnouncement', () => {
     expect(out).toContain('〆切: 6/15');
     expect(out).toContain('#illust');
     expect(out).toContain('https://aozoraquest.app/');
+    // 発見タグ #aozoraquest が必ず含まれる (これが無いと掲示板に載らない)
+    expect(out).toContain('#aozoraquest');
+  });
+
+  it('タグ無しでも #aozoraquest は付く', () => {
+    const out = formatQuestAnnouncement({
+      title: 't',
+      rewardPoints: 100,
+      handle: 'k',
+      tags: [],
+      questUrl: 'https://x',
+    });
+    expect(out).toContain('#aozoraquest');
   });
 
   it('〆切なしのときは行ごと省略', () => {

--- a/packages/core/src/user-quest.ts
+++ b/packages/core/src/user-quest.ts
@@ -301,8 +301,10 @@ export function formatQuestAnnouncement(args: {
   lines.push(`【クエスト】${args.title}`);
   lines.push(`報酬: ${args.handle}ポイント ${args.rewardPoints} pt`);
   if (args.deadline) lines.push(`〆切: ${formatDateShort(args.deadline)}`);
-  const tagLine = args.tags.map(t => t.startsWith('#') ? t : `#${t}`).join(' ');
-  if (tagLine) lines.push(tagLine);
+  // #aozoraquest は掲示板の発見タグ (= これが本文に無いと searchPosts で
+  // 拾えず他人の掲示板に載らない)。必ず先頭に入れ、ユーザータグを後続する。
+  const userTags = args.tags.map(t => t.startsWith('#') ? t : `#${t}`);
+  lines.push(['#aozoraquest', ...userTags].join(' '));
   lines.push(args.questUrl);
   return lines.join('\n');
 }


### PR DESCRIPTION
## Summary
「告知 OFF はなしにして」要望 + レビューで発覚した可視化の真の根因を修正。

- **告知 OFF 廃止**: 発行画面の「告知する」チェックボックス + `announce` state を削除。発行と同時に必ず告知。告知文 textarea は常時表示・編集可
- **🔑 #aozoraquest 必須化 (可視化の根因)**: `formatQuestAnnouncement` が `#aozoraquest` を含んでいなかったため、告知投稿にタグ facet が付かず `searchPosts` で拾えず、ディレクトリ集約も自動更新も発行者を発見できなかった。テンプレ先頭に `#aozoraquest` を必ず入れ、ユーザーが消しても送信時に付与する保険を追加
- 本番 Bluesky への誤投稿防止のため dev 環境だけ `getPostQuestNotifications` ゲートを残す

## Review
§1.5 レビュー実施。

### ★★ → PR 内で対応 (commit 6154a88)
- **`formatQuestAnnouncement` に `#aozoraquest` が無く、告知しても discovery で拾えない**(可視化機能の中核が崩れる致命的不整合)→ テンプレ + 送信時保険で必須化、core テスト追加

### ★★ / ★ → issue 化
- 告知失敗のサイレント化 → #65
- 告知文 空送信ガード → #66
- テンプレ追従が編集を上書き (dirty フラグ) → #67

## Test plan
- [x] core 146 / web typecheck / build 緑
- [ ] 本番実機: 発行 → 告知投稿に #aozoraquest が付く → 別アカウントの掲示板に出るか