### PR TITLE
feat(board,settings): オプトイン導線を明確化 (空表示の誘導 + 連動の明記)

### DIFF
--- a/apps/web/src/components/column-content/board-column.tsx
+++ b/apps/web/src/components/column-content/board-column.tsx
@@ -73,7 +73,7 @@ export function BoardColumn({ inner }: { inner?: BoardInner[] | undefined }) {
       {items == null ? (
         <p style={{ fontSize: '0.8em', color: 'var(--color-muted)' }}>読み込み中...</p>
       ) : items.length === 0 ? (
-        <p style={{ fontSize: '0.8em', color: 'var(--color-muted)' }}>{emptyMessageForBoard(active)}</p>
+        <BoardEmpty filter={active} />
       ) : (
         <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
           {items.map((q) => (
@@ -82,6 +82,27 @@ export function BoardColumn({ inner }: { inner?: BoardInner[] | undefined }) {
             </li>
           ))}
         </ul>
+      )}
+    </div>
+  );
+}
+
+/** 空表示。クエストの発見はオプトイン (BAR ブルスコ参加) で広がるので、
+ *  open / mine が空のときは「出す」「参加して見つけてもらう」導線を出す。 */
+function BoardEmpty({ filter }: { filter: BoardFilter }) {
+  const showGuide = filter.kind === 'open' || filter.kind === 'mine';
+  return (
+    <div style={{ fontSize: '0.8em', color: 'var(--color-muted)', lineHeight: 1.6 }}>
+      <p style={{ margin: 0 }}>{emptyMessageForBoard(filter)}</p>
+      {showGuide && (
+        <div style={{ marginTop: '0.6em', display: 'flex', flexDirection: 'column', gap: '0.3em' }}>
+          <Link to="/board/new">＋ クエストを出す</Link>
+          <span>
+            自分のクエストや投稿を見つけてもらうには{' '}
+            <Link to="/settings">BAR ブルスコに参加 (オプトイン)</Link>
+            。<code>#aozoraquest</code> を 1 件投稿して掲示板の発見元に載ります。
+          </span>
+        </div>
       )}
     </div>
   );

--- a/apps/web/src/components/column-content/board-column.tsx
+++ b/apps/web/src/components/column-content/board-column.tsx
@@ -9,6 +9,7 @@
 import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import type { BoardInner } from '@/lib/app-columns';
+import { DISCOVERY_TAG } from '@/lib/quest-api';
 import {
   useBoardData,
   filterForBoard,
@@ -88,21 +89,19 @@ export function BoardColumn({ inner }: { inner?: BoardInner[] | undefined }) {
 }
 
 /** 空表示。クエストの発見はオプトイン (BAR ブルスコ参加) で広がるので、
- *  open / mine が空のときは「出す」「参加して見つけてもらう」導線を出す。 */
+ *  open / mine が空のときはオプトイン誘導を出す。
+ *  (「クエストを出す」リンクはカラムヘッダに常設なので空表示では重複させない) */
 function BoardEmpty({ filter }: { filter: BoardFilter }) {
   const showGuide = filter.kind === 'open' || filter.kind === 'mine';
   return (
     <div style={{ fontSize: '0.8em', color: 'var(--color-muted)', lineHeight: 1.6 }}>
       <p style={{ margin: 0 }}>{emptyMessageForBoard(filter)}</p>
       {showGuide && (
-        <div style={{ marginTop: '0.6em', display: 'flex', flexDirection: 'column', gap: '0.3em' }}>
-          <Link to="/board/new">＋ クエストを出す</Link>
-          <span>
-            自分のクエストや投稿を見つけてもらうには{' '}
-            <Link to="/settings">BAR ブルスコに参加 (オプトイン)</Link>
-            。<code>#aozoraquest</code> を 1 件投稿して掲示板の発見元に載ります。
-          </span>
-        </div>
+        <p style={{ marginTop: '0.6em' }}>
+          自分のクエストや投稿を見つけてもらうには{' '}
+          <Link to="/settings">BAR ブルスコに参加 (オプトイン)</Link>
+          。<code>#{DISCOVERY_TAG}</code> を 1 件投稿して掲示板の発見元に載ります。
+        </p>
       )}
     </div>
   );

--- a/apps/web/src/lib/quest-api.ts
+++ b/apps/web/src/lib/quest-api.ts
@@ -226,7 +226,7 @@ export async function buildQuestIndexFromDirectory(
   return { quests, applications, updatedAt: new Date().toISOString() };
 }
 
-const DISCOVERY_TAG = 'aozoraquest';
+export const DISCOVERY_TAG = 'aozoraquest';
 /** 集約対象 DID 数の上限 (1 DID = 2 listRecords なので過大にしない) */
 const MAX_DISCOVERY_DIDS = 60;
 

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -261,6 +261,11 @@ export function Settings() {
           参加の合図として <code>#{OPTIN_TAG}</code> 付きの投稿をあなたのアカウントから 1 本作成します
           (これで検索 API で発見可能になる)。
         </p>
+        <p style={{ fontSize: '0.78em', color: 'var(--color-muted)' }}>
+          この <code>#{OPTIN_TAG}</code> 投稿で <strong>クエスト掲示板の発見元 (ディレクトリ)</strong> にも載るため、
+          あなたが出したクエストが他の人の「募集中」に表示されやすくなります
+          (クエスト発行時の告知でも同じタグが付きます)。
+        </p>
         {!profileLoaded ? (
           <p>読み込み中...</p>
         ) : profile?.discoverable ? (


### PR DESCRIPTION
## Summary
「オプトインってどうやるん? BAR ブルスコ参加と連動してるなら書いて。空カラムにオプトイン誘導を」要望。

- **board 空表示 (open/mine)**: `BoardEmpty` で「BAR ブルスコに参加 (オプトイン) → 設定」リンク + `#aozoraquest` で掲示板の発見元に載る説明
- **設定オプトイン節**: この `#aozoraquest` 投稿で**クエスト掲示板の発見元 (ディレクトリ)** にも載り、自分のクエストが他人の「募集中」に出やすくなることを明記

## 正確性
閲覧側は自分のオプトイン有無に関わらず他人のクエストを集約表示(directory + #aozoraquest 検索 + 自分)。オプトインは「自分が見つけてもらう」ための導線。文言はこの実装に沿って誇張しない。

## Review
§1.5 レビュー実施。★★★ ゼロ、文言の正確性 OK。

### ★★ → PR 内で対応
- 空表示の「＋ クエストを出す」がヘッダと重複 → 空表示から削除しオプトイン誘導に集中
- `#aozoraquest` ハードコード → `DISCOVERY_TAG` 定数参照 (quest-api から export)

### ★ → 許容/記録
- mine 空での opt-in 誘導の文脈薄め(出してから告知される)→ 実害なし許容。`＋`(全角)は既存パターン、絵文字でない

## Test plan
- [x] typecheck / build 緑
- [ ] dev 実機: 空の募集中カラムに誘導が出る / リンク先が適切か