### PR TITLE
release: オプトイン導線の明確化 (#71)

### DIFF
--- a/apps/web/src/components/column-content/board-column.tsx
+++ b/apps/web/src/components/column-content/board-column.tsx
@@ -9,6 +9,7 @@
 import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import type { BoardInner } from '@/lib/app-columns';
+import { DISCOVERY_TAG } from '@/lib/quest-api';
 import {
   useBoardData,
   filterForBoard,
@@ -73,7 +74,7 @@ export function BoardColumn({ inner }: { inner?: BoardInner[] | undefined }) {
       {items == null ? (
         <p style={{ fontSize: '0.8em', color: 'var(--color-muted)' }}>読み込み中...</p>
       ) : items.length === 0 ? (
-        <p style={{ fontSize: '0.8em', color: 'var(--color-muted)' }}>{emptyMessageForBoard(active)}</p>
+        <BoardEmpty filter={active} />
       ) : (
         <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
           {items.map((q) => (
@@ -82,6 +83,25 @@ export function BoardColumn({ inner }: { inner?: BoardInner[] | undefined }) {
             </li>
           ))}
         </ul>
+      )}
+    </div>
+  );
+}
+
+/** 空表示。クエストの発見はオプトイン (BAR ブルスコ参加) で広がるので、
+ *  open / mine が空のときはオプトイン誘導を出す。
+ *  (「クエストを出す」リンクはカラムヘッダに常設なので空表示では重複させない) */
+function BoardEmpty({ filter }: { filter: BoardFilter }) {
+  const showGuide = filter.kind === 'open' || filter.kind === 'mine';
+  return (
+    <div style={{ fontSize: '0.8em', color: 'var(--color-muted)', lineHeight: 1.6 }}>
+      <p style={{ margin: 0 }}>{emptyMessageForBoard(filter)}</p>
+      {showGuide && (
+        <p style={{ marginTop: '0.6em' }}>
+          自分のクエストや投稿を見つけてもらうには{' '}
+          <Link to="/settings">BAR ブルスコに参加 (オプトイン)</Link>
+          。<code>#{DISCOVERY_TAG}</code> を 1 件投稿して掲示板の発見元に載ります。
+        </p>
       )}
     </div>
   );

--- a/apps/web/src/lib/quest-api.ts
+++ b/apps/web/src/lib/quest-api.ts
@@ -226,7 +226,7 @@ export async function buildQuestIndexFromDirectory(
   return { quests, applications, updatedAt: new Date().toISOString() };
 }
 
-const DISCOVERY_TAG = 'aozoraquest';
+export const DISCOVERY_TAG = 'aozoraquest';
 /** 集約対象 DID 数の上限 (1 DID = 2 listRecords なので過大にしない) */
 const MAX_DISCOVERY_DIDS = 60;
 

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -261,6 +261,11 @@ export function Settings() {
           参加の合図として <code>#{OPTIN_TAG}</code> 付きの投稿をあなたのアカウントから 1 本作成します
           (これで検索 API で発見可能になる)。
         </p>
+        <p style={{ fontSize: '0.78em', color: 'var(--color-muted)' }}>
+          この <code>#{OPTIN_TAG}</code> 投稿で <strong>クエスト掲示板の発見元 (ディレクトリ)</strong> にも載るため、
+          あなたが出したクエストが他の人の「募集中」に表示されやすくなります
+          (クエスト発行時の告知でも同じタグが付きます)。
+        </p>
         {!profileLoaded ? (
           <p>読み込み中...</p>
         ) : profile?.discoverable ? (


### PR DESCRIPTION
クエスト空表示にオプトイン誘導 + 設定にディレクトリ連動を明記 (#71)。§1.5 レビュー済み (★★★ ゼロ、文言正確)、CI 緑。