### PR TITLE
release: 投稿前の画像 lossy WebP 圧縮 (#73)

### DIFF
--- a/apps/web/src/components/compose-modal.tsx
+++ b/apps/web/src/components/compose-modal.tsx
@@ -1,6 +1,7 @@
 import { createContext, useCallback, useContext, useEffect, useRef, useState, type ReactNode } from 'react';
 import { useSession } from '@/lib/session';
 import { createPost, createPostWithImage, type ReplyRef } from '@/lib/atproto';
+import { compressImage } from '@/lib/image-compress';
 import { TextField } from './text-field';
 import { processSelfPost } from '@/lib/post-processor';
 import { bumpPower } from '@/lib/points';
@@ -152,10 +153,13 @@ function ComposeDialog({
     };
   });
   const [loading, setLoading] = useState(false);
+  const [compressing, setCompressing] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const imageRef = useRef<DialogState | null>(image);
   imageRef.current = image;
+  // 圧縮中に dialog が閉じたら、完了後の setState / objectURL 生成を抑止する
+  const mountedRef = useRef(true);
 
   // ESC で閉じる、背面スクロールをロック、画像 objectURL を unmount で revoke
   useEffect(() => {
@@ -166,6 +170,7 @@ function ComposeDialog({
     };
     window.addEventListener('keydown', onKey);
     return () => {
+      mountedRef.current = false;
       document.body.style.overflow = prevOverflow;
       window.removeEventListener('keydown', onKey);
       // 最後にセットされてた image の url を revoke
@@ -184,7 +189,7 @@ function ComposeDialog({
     fileInputRef.current?.click();
   }
 
-  function onFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+  async function onFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
     e.target.value = ''; // 同じファイルを再選択しても change が起きるように
     if (!file) return;
@@ -192,18 +197,34 @@ function ComposeDialog({
       setErr(`対応していない画像形式です (${file.type || '不明'})。jpg/png/webp/gif のみ。`);
       return;
     }
-    if (file.size > MAX_IMAGE_BYTES) {
-      setErr(`画像サイズが大きすぎます (${(file.size / 1024).toFixed(0)} KB)。950KB 以下にしてください。`);
+    setErr(null);
+    // 大きい画像は弾かず、lossy WebP に圧縮して上限内に収める
+    // (GIF はアニメ保持のため変換しない)。
+    setCompressing(true);
+    let blob: Blob = file;
+    try {
+      const result = await compressImage(file, { maxBytes: MAX_IMAGE_BYTES });
+      blob = result.blob;
+    } catch (e) {
+      console.warn('[compose] image compress failed, use original', e);
+    } finally {
+      if (mountedRef.current) setCompressing(false);
+    }
+    // 圧縮中に dialog を閉じていたら何もしない (objectURL を作らない = リーク防止)
+    if (!mountedRef.current) return;
+    if (blob.size > MAX_IMAGE_BYTES) {
+      setErr(
+        `圧縮しても上限を超えました (${(blob.size / 1024).toFixed(0)} KB)。` +
+          'より小さい画像、または GIF 以外の形式でお試しください。',
+      );
       return;
     }
-    setErr(null);
-    // 既存があれば revoke
     if (image) URL.revokeObjectURL(image.previewUrl);
     setImage({
-      blob: file,
+      blob,
       alt: '',
       source: 'user',
-      previewUrl: URL.createObjectURL(file),
+      previewUrl: URL.createObjectURL(blob),
     });
   }
 
@@ -288,6 +309,7 @@ function ComposeDialog({
   const showImageUi = !replyTo;
   const submitDisabled =
     loading
+    || compressing
     || (!text.trim() && !image)
     || text.length > POST_MAX_LENGTH;
 
@@ -425,11 +447,16 @@ function ComposeDialog({
               <button
                 className="secondary"
                 onClick={pickImage}
-                disabled={loading}
+                disabled={loading || compressing}
                 style={{ fontSize: '0.85em' }}
               >
-                📷 画像を添付
+                {compressing ? '画像を圧縮中...' : '📷 画像を添付'}
               </button>
+            )}
+            {compressing && (
+              <span style={{ fontSize: '0.75em', color: 'var(--color-muted)', marginLeft: '0.5em' }}>
+                WebP に圧縮しています…
+              </span>
             )}
             <input
               ref={fileInputRef}

--- a/apps/web/src/lib/image-compress.test.ts
+++ b/apps/web/src/lib/image-compress.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { compressImage } from './image-compress';
+
+// jsdom には createImageBitmap / canvas.toBlob('image/webp') が無いため、
+// canvas 経路は通らず early-return (元 File を返す) になる。ここではその
+// 「壊さない」分岐 (GIF スキップ / 非対応フォールバック) を検証する。
+// 実際の WebP 変換は browser 専用なので実機 / e2e 側で確認する。
+
+function fakeFile(type: string, bytes = 2_000_000): File {
+  return new File([new Uint8Array(bytes)], 'x', { type });
+}
+
+describe('compressImage (jsdom: canvas 非対応で fallback)', () => {
+  it('GIF はアニメ保持のため変換せず元 File を返す', async () => {
+    const f = fakeFile('image/gif');
+    const r = await compressImage(f);
+    expect(r.compressed).toBe(false);
+    expect(r.blob).toBe(f);
+    expect(r.originalBytes).toBe(f.size);
+  });
+
+  it('canvas/WebP 非対応環境では元 File をそのまま返す (壊さない)', async () => {
+    const f = fakeFile('image/png');
+    const r = await compressImage(f);
+    expect(r.compressed).toBe(false);
+    expect(r.blob).toBe(f);
+  });
+});

--- a/apps/web/src/lib/image-compress.ts
+++ b/apps/web/src/lib/image-compress.ts
@@ -1,0 +1,117 @@
+/**
+ * 投稿前の画像をクライアントで lossy WebP に圧縮する。
+ *
+ * Bluesky の uploadBlob は約 1MB 上限。元画像が大きいと従来は「大きすぎる」と
+ * 拒否していたが、ここで canvas 経由で WebP 変換 + 必要なら段階的に画質/寸法を
+ * 落として上限内に収める。
+ *
+ * - GIF はアニメーションを壊さないため変換しない (そのまま返す)
+ * - EXIF 回転は createImageBitmap の imageOrientation:'from-image' で吸収
+ * - canvas/WebP 非対応や失敗時は元 File をそのまま返す (呼び出し側で最終 size 検査)
+ */
+
+export interface CompressOptions {
+  /** 目標の最大バイト数 (これ以下に収める) */
+  maxBytes?: number;
+  /** 長辺の最大ピクセル */
+  maxDimension?: number;
+  /** 試す画質 (高→低)。上から順に試して maxBytes 以下になったら採用 */
+  qualitySteps?: number[];
+  /** 出力 MIME (既定 image/webp) */
+  mimeType?: string;
+}
+
+export interface CompressResult {
+  blob: Blob;
+  /** 圧縮したか (false = GIF / 非対応 / 失敗で元のまま) */
+  compressed: boolean;
+  originalBytes: number;
+  width?: number;
+  height?: number;
+}
+
+const DEFAULTS = {
+  maxBytes: 950_000,
+  maxDimension: 1920,
+  qualitySteps: [0.85, 0.72, 0.6, 0.48, 0.38],
+  mimeType: 'image/webp',
+};
+
+function canUseCanvasWebp(): boolean {
+  if (typeof document === 'undefined' || typeof createImageBitmap === 'undefined') return false;
+  try {
+    const c = document.createElement('canvas');
+    // toDataURL が webp を返せれば対応 (Safari 14+ / Chrome / Firefox)
+    return c.toDataURL('image/webp').startsWith('data:image/webp');
+  } catch {
+    return false;
+  }
+}
+
+function canvasToBlob(canvas: HTMLCanvasElement, type: string, quality: number): Promise<Blob | null> {
+  return new Promise((resolve) => {
+    canvas.toBlob((b) => resolve(b), type, quality);
+  });
+}
+
+function drawTo(bitmap: ImageBitmap, w: number, h: number): HTMLCanvasElement | null {
+  const canvas = document.createElement('canvas');
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return null;
+  ctx.drawImage(bitmap, 0, 0, w, h);
+  return canvas;
+}
+
+export async function compressImage(file: File, opts: CompressOptions = {}): Promise<CompressResult> {
+  const maxBytes = opts.maxBytes ?? DEFAULTS.maxBytes;
+  const maxDimension = opts.maxDimension ?? DEFAULTS.maxDimension;
+  const qualitySteps = opts.qualitySteps ?? DEFAULTS.qualitySteps;
+  const mimeType = opts.mimeType ?? DEFAULTS.mimeType;
+  const originalBytes = file.size;
+
+  // GIF はアニメ保持のため変換しない
+  if (file.type === 'image/gif' || !canUseCanvasWebp()) {
+    return { blob: file, compressed: false, originalBytes };
+  }
+
+  let bitmap: ImageBitmap;
+  try {
+    bitmap = await createImageBitmap(file, { imageOrientation: 'from-image' });
+  } catch {
+    return { blob: file, compressed: false, originalBytes };
+  }
+
+  try {
+    const scale = Math.min(1, maxDimension / Math.max(bitmap.width, bitmap.height));
+    let w = Math.max(1, Math.round(bitmap.width * scale));
+    let h = Math.max(1, Math.round(bitmap.height * scale));
+    let last: Blob | null = null;
+
+    // 初期寸法 + 最大 2 回の縮小 (計 3 サイズ) を試し、各サイズで画質を上から試す
+    for (let shrink = 0; shrink < 3; shrink++) {
+      const canvas = drawTo(bitmap, w, h);
+      if (!canvas) break;
+      for (const q of qualitySteps) {
+        const blob = await canvasToBlob(canvas, mimeType, q);
+        if (!blob) continue;
+        last = blob;
+        if (blob.size <= maxBytes) {
+          return { blob, compressed: true, originalBytes, width: w, height: h };
+        }
+      }
+      // 全画質でも収まらない → 長辺を 0.7 倍に縮めて再挑戦
+      w = Math.max(1, Math.round(w * 0.7));
+      h = Math.max(1, Math.round(h * 0.7));
+    }
+
+    // 収まらなくても、元より小さければ webp を返す (呼び出し側が最終 size 検査)
+    if (last && last.size < originalBytes) {
+      return { blob: last, compressed: true, originalBytes };
+    }
+    return { blob: file, compressed: false, originalBytes };
+  } finally {
+    bitmap.close();
+  }
+}


### PR DESCRIPTION
画像投稿前にクライアントで lossy WebP 圧縮し uploadBlob 上限内に自動で収める (#73)。§1.5 レビュー済み (★★★ ゼロ、★★ 対応 or #74)、CI 緑。