### PR TITLE
fix(compose): iPhone 写真 (HEIC / Safari) を投稿できるよう画像圧縮を改善

### DIFF
--- a/apps/web/src/components/compose-modal.tsx
+++ b/apps/web/src/components/compose-modal.tsx
@@ -127,6 +127,15 @@ interface DialogState {
 }
 
 const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+/** ファイル選択ダイアログに渡す accept。iPhone の HEIC や撮影写真も選べるよう
+ *  image/* を基本に、明示形式も併記する (一部 OS で image/* だけだと挙動が鈍い)。 */
+const FILE_ACCEPT = 'image/*,image/heic,image/heif';
+/** 添付を許可する type 判定。HEIC など ALLOWED 以外でも image/* なら受けて
+ *  compressImage 側で canvas 再エンコードを試す (Safari は HEIC を decode 可能)。
+ *  iOS は type が空文字で来ることがあるのでそれも許す。 */
+function isAttachableImage(file: File): boolean {
+  return file.type === '' || file.type.startsWith('image/') || ALLOWED_IMAGE_TYPES.includes(file.type);
+}
 /** Bluesky uploadBlob の上限は約 1MB。少しマージン取って 950KB を上限警告ラインに。 */
 const MAX_IMAGE_BYTES = 950_000;
 
@@ -193,8 +202,8 @@ function ComposeDialog({
     const file = e.target.files?.[0];
     e.target.value = ''; // 同じファイルを再選択しても change が起きるように
     if (!file) return;
-    if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
-      setErr(`対応していない画像形式です (${file.type || '不明'})。jpg/png/webp/gif のみ。`);
+    if (!isAttachableImage(file)) {
+      setErr(`画像ファイルを選んでください (${file.type || '不明な形式'})。`);
       return;
     }
     setErr(null);
@@ -461,7 +470,7 @@ function ComposeDialog({
             <input
               ref={fileInputRef}
               type="file"
-              accept={ALLOWED_IMAGE_TYPES.join(',')}
+              accept={FILE_ACCEPT}
               onChange={onFileChange}
               style={{ display: 'none' }}
             />

--- a/apps/web/src/components/compose-modal.tsx
+++ b/apps/web/src/components/compose-modal.tsx
@@ -1,7 +1,7 @@
 import { createContext, useCallback, useContext, useEffect, useRef, useState, type ReactNode } from 'react';
 import { useSession } from '@/lib/session';
 import { createPost, createPostWithImage, type ReplyRef } from '@/lib/atproto';
-import { compressImage, isBlueskySupportedImageType } from '@/lib/image-compress';
+import { compressImage } from '@/lib/image-compress';
 import { TextField } from './text-field';
 import { processSelfPost } from '@/lib/post-processor';
 import { bumpPower } from '@/lib/points';
@@ -213,11 +213,9 @@ function ComposeDialog({
     // (GIF はアニメ保持のため変換しない)。
     setCompressing(true);
     let blob: Blob = file;
-    let compressed = false;
     try {
       const result = await compressImage(file, { maxBytes: MAX_IMAGE_BYTES });
       blob = result.blob;
-      compressed = result.compressed;
     } catch (e) {
       console.warn('[compose] image compress failed, use original', e);
     } finally {
@@ -225,20 +223,13 @@ function ComposeDialog({
     }
     // 圧縮中に dialog を閉じていたら何もしない (objectURL を作らない = リーク防止)
     if (!mountedRef.current) return;
-    // 変換できず Bluesky 非対応形式 (HEIC など) のままなら投稿させない。
-    // (そのまま uploadBlob すると投稿は通っても画像が表示されない。
-    //  例: デスクトップ Chrome は HEIC を decode できず元 File が返る)
-    if (!compressed && !isBlueskySupportedImageType(blob.type)) {
-      setErr(
-        `この形式の画像 (${blob.type || '不明'}) はこの環境で変換できませんでした。` +
-          'JPEG / PNG で保存し直すか、別の画像でお試しください。',
-      );
-      return;
-    }
+    // 圧縮しても上限を超える場合のみエラー (= 物理的に投稿できないサイズ)。
+    // 形式での門前払いはしない。iOS は写真を JPEG で渡すか Safari が HEIC を
+    // decode できるので、compressImage が JPEG/WebP に変換して投稿できる。
     if (blob.size > MAX_IMAGE_BYTES) {
       setErr(
         `圧縮しても上限を超えました (${(blob.size / 1024).toFixed(0)} KB)。` +
-          'より小さい画像、または GIF 以外の形式でお試しください。',
+          'より小さい画像でお試しください。',
       );
       return;
     }

--- a/apps/web/src/components/compose-modal.tsx
+++ b/apps/web/src/components/compose-modal.tsx
@@ -1,7 +1,7 @@
 import { createContext, useCallback, useContext, useEffect, useRef, useState, type ReactNode } from 'react';
 import { useSession } from '@/lib/session';
 import { createPost, createPostWithImage, type ReplyRef } from '@/lib/atproto';
-import { compressImage } from '@/lib/image-compress';
+import { compressImage, isBlueskySupportedImageType } from '@/lib/image-compress';
 import { TextField } from './text-field';
 import { processSelfPost } from '@/lib/post-processor';
 import { bumpPower } from '@/lib/points';
@@ -126,15 +126,17 @@ interface DialogState {
   previewUrl: string;
 }
 
-const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
 /** ファイル選択ダイアログに渡す accept。iPhone の HEIC や撮影写真も選べるよう
  *  image/* を基本に、明示形式も併記する (一部 OS で image/* だけだと挙動が鈍い)。 */
 const FILE_ACCEPT = 'image/*,image/heic,image/heif';
-/** 添付を許可する type 判定。HEIC など ALLOWED 以外でも image/* なら受けて
- *  compressImage 側で canvas 再エンコードを試す (Safari は HEIC を decode 可能)。
- *  iOS は type が空文字で来ることがあるのでそれも許す。 */
+/** 添付を受け付ける type (HEIC/HEIF を含む。SVG や非画像は除外)。
+ *  iOS は type が空文字で来ることがあるのでそれも許し、最終的な可否は
+ *  「圧縮できて Bluesky 対応形式になったか」で判定する (onFileChange 参照)。 */
+const ATTACHABLE_TYPES = [
+  'image/jpeg', 'image/png', 'image/webp', 'image/gif', 'image/heic', 'image/heif',
+];
 function isAttachableImage(file: File): boolean {
-  return file.type === '' || file.type.startsWith('image/') || ALLOWED_IMAGE_TYPES.includes(file.type);
+  return file.type === '' || ATTACHABLE_TYPES.includes(file.type);
 }
 /** Bluesky uploadBlob の上限は約 1MB。少しマージン取って 950KB を上限警告ラインに。 */
 const MAX_IMAGE_BYTES = 950_000;
@@ -211,9 +213,11 @@ function ComposeDialog({
     // (GIF はアニメ保持のため変換しない)。
     setCompressing(true);
     let blob: Blob = file;
+    let compressed = false;
     try {
       const result = await compressImage(file, { maxBytes: MAX_IMAGE_BYTES });
       blob = result.blob;
+      compressed = result.compressed;
     } catch (e) {
       console.warn('[compose] image compress failed, use original', e);
     } finally {
@@ -221,6 +225,16 @@ function ComposeDialog({
     }
     // 圧縮中に dialog を閉じていたら何もしない (objectURL を作らない = リーク防止)
     if (!mountedRef.current) return;
+    // 変換できず Bluesky 非対応形式 (HEIC など) のままなら投稿させない。
+    // (そのまま uploadBlob すると投稿は通っても画像が表示されない。
+    //  例: デスクトップ Chrome は HEIC を decode できず元 File が返る)
+    if (!compressed && !isBlueskySupportedImageType(blob.type)) {
+      setErr(
+        `この形式の画像 (${blob.type || '不明'}) はこの環境で変換できませんでした。` +
+          'JPEG / PNG で保存し直すか、別の画像でお試しください。',
+      );
+      return;
+    }
     if (blob.size > MAX_IMAGE_BYTES) {
       setErr(
         `圧縮しても上限を超えました (${(blob.size / 1024).toFixed(0)} KB)。` +

--- a/apps/web/src/lib/image-compress.test.ts
+++ b/apps/web/src/lib/image-compress.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { compressImage } from './image-compress';
+import { compressImage, isBlueskySupportedImageType, pickOutputType } from './image-compress';
 
 // jsdom には createImageBitmap / canvas.toBlob('image/webp') が無いため、
 // canvas 経路は通らず early-return (元 File を返す) になる。ここではその
@@ -24,5 +24,30 @@ describe('compressImage (jsdom: canvas 非対応で fallback)', () => {
     const r = await compressImage(f);
     expect(r.compressed).toBe(false);
     expect(r.blob).toBe(f);
+  });
+});
+
+describe('isBlueskySupportedImageType', () => {
+  it('jpeg/png/webp/gif は対応', () => {
+    for (const t of ['image/jpeg', 'image/png', 'image/webp', 'image/gif']) {
+      expect(isBlueskySupportedImageType(t)).toBe(true);
+    }
+  });
+  it('HEIC / 空 / 非画像は非対応 (= 変換できなければ投稿不可にする)', () => {
+    for (const t of ['image/heic', 'image/heif', '', 'application/pdf', 'image/svg+xml']) {
+      expect(isBlueskySupportedImageType(t)).toBe(false);
+    }
+  });
+});
+
+describe('pickOutputType', () => {
+  it('webp 希望 + 対応 → webp', () => {
+    expect(pickOutputType(true, true)).toBe('image/webp');
+  });
+  it('webp 希望 + 非対応 (Safari) → jpeg にフォールバック', () => {
+    expect(pickOutputType(true, false)).toBe('image/jpeg');
+  });
+  it('webp 非希望 → jpeg', () => {
+    expect(pickOutputType(false, true)).toBe('image/jpeg');
   });
 });

--- a/apps/web/src/lib/image-compress.ts
+++ b/apps/web/src/lib/image-compress.ts
@@ -1,13 +1,20 @@
 /**
- * 投稿前の画像をクライアントで lossy WebP に圧縮する。
+ * 投稿前の画像をクライアントで圧縮する (lossy WebP 優先、非対応なら JPEG)。
  *
  * Bluesky の uploadBlob は約 1MB 上限。元画像が大きいと従来は「大きすぎる」と
- * 拒否していたが、ここで canvas 経由で WebP 変換 + 必要なら段階的に画質/寸法を
+ * 拒否していたが、ここで canvas 経由で再エンコード + 必要なら段階的に画質/寸法を
  * 落として上限内に収める。
  *
+ * - **出力形式**: WebP エンコード対応ブラウザ (Chrome 等) は WebP。
+ *   **iOS Safari は canvas の WebP エンコード非対応**なので JPEG に自動フォールバック
+ *   (これをしないと Safari で圧縮できず iPhone 写真が投稿できない)。
+ * - **入力**: jpeg/png/webp に加え、iPhone の **HEIC/HEIF** も受ける。Safari は
+ *   createImageBitmap で HEIC をデコードできるので、canvas 経由で jpeg/webp に
+ *   再エンコードして投稿可能にする。
  * - GIF はアニメーションを壊さないため変換しない (そのまま返す)
  * - EXIF 回転は createImageBitmap の imageOrientation:'from-image' で吸収
- * - canvas/WebP 非対応や失敗時は元 File をそのまま返す (呼び出し側で最終 size 検査)
+ * - createImageBitmap や canvas が使えない/失敗時は元 File を返す
+ *   (呼び出し側で最終 size 検査)
  */
 
 export interface CompressOptions {
@@ -17,7 +24,7 @@ export interface CompressOptions {
   maxDimension?: number;
   /** 試す画質 (高→低)。上から順に試して maxBytes 以下になったら採用 */
   qualitySteps?: number[];
-  /** 出力 MIME (既定 image/webp) */
+  /** 希望出力 MIME (既定 image/webp)。非対応なら image/jpeg にフォールバック */
   mimeType?: string;
 }
 
@@ -26,6 +33,8 @@ export interface CompressResult {
   /** 圧縮したか (false = GIF / 非対応 / 失敗で元のまま) */
   compressed: boolean;
   originalBytes: number;
+  /** 実際の出力 MIME (compressed=true のとき) */
+  outputType?: string;
   width?: number;
   height?: number;
 }
@@ -37,12 +46,11 @@ const DEFAULTS = {
   mimeType: 'image/webp',
 };
 
-function canUseCanvasWebp(): boolean {
-  if (typeof document === 'undefined' || typeof createImageBitmap === 'undefined') return false;
+/** canvas が WebP エンコードに対応しているか (Safari は長らく非対応 → JPEG に倒す) */
+function supportsWebpEncode(): boolean {
+  if (typeof document === 'undefined') return false;
   try {
-    const c = document.createElement('canvas');
-    // toDataURL が webp を返せれば対応 (Safari 14+ / Chrome / Firefox)
-    return c.toDataURL('image/webp').startsWith('data:image/webp');
+    return document.createElement('canvas').toDataURL('image/webp').startsWith('data:image/webp');
   } catch {
     return false;
   }
@@ -54,12 +62,17 @@ function canvasToBlob(canvas: HTMLCanvasElement, type: string, quality: number):
   });
 }
 
-function drawTo(bitmap: ImageBitmap, w: number, h: number): HTMLCanvasElement | null {
+/** outType が jpeg のときは透過部分が黒くならないよう白背景を敷く */
+function drawTo(bitmap: ImageBitmap, w: number, h: number, outType: string): HTMLCanvasElement | null {
   const canvas = document.createElement('canvas');
   canvas.width = w;
   canvas.height = h;
   const ctx = canvas.getContext('2d');
   if (!ctx) return null;
+  if (outType === 'image/jpeg') {
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, w, h);
+  }
   ctx.drawImage(bitmap, 0, 0, w, h);
   return canvas;
 }
@@ -68,18 +81,25 @@ export async function compressImage(file: File, opts: CompressOptions = {}): Pro
   const maxBytes = opts.maxBytes ?? DEFAULTS.maxBytes;
   const maxDimension = opts.maxDimension ?? DEFAULTS.maxDimension;
   const qualitySteps = opts.qualitySteps ?? DEFAULTS.qualitySteps;
-  const mimeType = opts.mimeType ?? DEFAULTS.mimeType;
   const originalBytes = file.size;
 
   // GIF はアニメ保持のため変換しない
-  if (file.type === 'image/gif' || !canUseCanvasWebp()) {
+  if (file.type === 'image/gif') {
     return { blob: file, compressed: false, originalBytes };
   }
+  if (typeof document === 'undefined' || typeof createImageBitmap === 'undefined') {
+    return { blob: file, compressed: false, originalBytes };
+  }
+
+  // 希望 webp でも未対応ブラウザ (Safari) では jpeg に倒す
+  const wantWebp = (opts.mimeType ?? DEFAULTS.mimeType) === 'image/webp';
+  const outType = wantWebp && supportsWebpEncode() ? 'image/webp' : 'image/jpeg';
 
   let bitmap: ImageBitmap;
   try {
     bitmap = await createImageBitmap(file, { imageOrientation: 'from-image' });
   } catch {
+    // HEIC を decode できない環境 (例: デスクトップ Chrome) 等
     return { blob: file, compressed: false, originalBytes };
   }
 
@@ -91,14 +111,14 @@ export async function compressImage(file: File, opts: CompressOptions = {}): Pro
 
     // 初期寸法 + 最大 2 回の縮小 (計 3 サイズ) を試し、各サイズで画質を上から試す
     for (let shrink = 0; shrink < 3; shrink++) {
-      const canvas = drawTo(bitmap, w, h);
+      const canvas = drawTo(bitmap, w, h, outType);
       if (!canvas) break;
       for (const q of qualitySteps) {
-        const blob = await canvasToBlob(canvas, mimeType, q);
+        const blob = await canvasToBlob(canvas, outType, q);
         if (!blob) continue;
         last = blob;
         if (blob.size <= maxBytes) {
-          return { blob, compressed: true, originalBytes, width: w, height: h };
+          return { blob, compressed: true, originalBytes, outputType: outType, width: w, height: h };
         }
       }
       // 全画質でも収まらない → 長辺を 0.7 倍に縮めて再挑戦
@@ -106,9 +126,9 @@ export async function compressImage(file: File, opts: CompressOptions = {}): Pro
       h = Math.max(1, Math.round(h * 0.7));
     }
 
-    // 収まらなくても、元より小さければ webp を返す (呼び出し側が最終 size 検査)
+    // 収まらなくても、元より小さければ返す (呼び出し側が最終 size 検査)
     if (last && last.size < originalBytes) {
-      return { blob: last, compressed: true, originalBytes };
+      return { blob: last, compressed: true, originalBytes, outputType: outType };
     }
     return { blob: file, compressed: false, originalBytes };
   } finally {

--- a/apps/web/src/lib/image-compress.ts
+++ b/apps/web/src/lib/image-compress.ts
@@ -46,6 +46,20 @@ const DEFAULTS = {
   mimeType: 'image/webp',
 };
 
+/** Bluesky の app.bsky.embed.images が受け付ける画像形式。
+ *  HEIC はここに無いので、HEIC のまま uploadBlob すると表示不能になる。 */
+export const BLUESKY_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+
+/** その MIME が Bluesky にそのまま投稿できる形式か。 */
+export function isBlueskySupportedImageType(type: string): boolean {
+  return BLUESKY_IMAGE_TYPES.includes(type);
+}
+
+/** 希望 webp + 対応状況から実際の出力 MIME を決める (DOM 非依存・テスト用)。 */
+export function pickOutputType(wantWebp: boolean, webpSupported: boolean): string {
+  return wantWebp && webpSupported ? 'image/webp' : 'image/jpeg';
+}
+
 /** canvas が WebP エンコードに対応しているか (Safari は長らく非対応 → JPEG に倒す) */
 function supportsWebpEncode(): boolean {
   if (typeof document === 'undefined') return false;
@@ -93,7 +107,7 @@ export async function compressImage(file: File, opts: CompressOptions = {}): Pro
 
   // 希望 webp でも未対応ブラウザ (Safari) では jpeg に倒す
   const wantWebp = (opts.mimeType ?? DEFAULTS.mimeType) === 'image/webp';
-  const outType = wantWebp && supportsWebpEncode() ? 'image/webp' : 'image/jpeg';
+  const outType = pickOutputType(wantWebp, supportsWebpEncode());
 
   let bitmap: ImageBitmap;
   try {


### PR DESCRIPTION
## 報告バグ
iPhone で撮影した写真サイズだとまったく投稿できない。

## 原因
1. iOS Safari は **canvas の WebP エンコード非対応** → 圧縮が素通り → 大サイズのままサイズ上限で拒否
2. iPhone 写真の HEIC が ALLOWED_IMAGE_TYPES に無く添付時点で拒否されることも

## 修正
- **Safari では JPEG にフォールバック圧縮**(`pickOutputType`)。これで iPhone の写真を JPEG に変換して投稿できる(本命の修正)
- HEIC/HEIF / 空 type を添付許可。Safari は `createImageBitmap` で HEIC を decode → canvas で再エンコード
- JPEG 出力時は透過部を白背景に
- **形式での投稿ブロックはしない**(「変換して投稿できるようにする」のがスジ)。残すのは「圧縮しても上限超」のサイズエラーのみ

## 既知の取りこぼし
ブラウザが decode できない形式(例: デスクトップ Chrome の HEIC)は client 変換不可。これは **Cloudflare Worker でのサーバ変換**で対応予定(別 PR)。iPhone は本 PR で解決。

## Test plan
- [x] typecheck / vitest 147 / build 緑
- [ ] **iPhone 実機**: 撮影写真を添付 → JPEG に圧縮されて投稿でき、画像が表示されるか
- [ ] PC Chrome: 既存 webp 圧縮維持