### PR TITLE
release: Safari でも WebP 出力 (WASM エンコーダ) (#78)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
     "@atproto/api": "^0.17",
     "@atproto/oauth-client-browser": "^0.3.41",
     "@huggingface/transformers": "^4.1.0",
+    "@jsquash/webp": "^1.5.0",
     "@tanstack/react-virtual": "^3.13.0",
     "hls.js": "^1.6.16",
     "react": "^18",

--- a/apps/web/src/lib/image-compress.test.ts
+++ b/apps/web/src/lib/image-compress.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { compressImage, isBlueskySupportedImageType, pickOutputType } from './image-compress';
+import { compressImage, isBlueskySupportedImageType } from './image-compress';
 
 // jsdom には createImageBitmap / canvas.toBlob('image/webp') が無いため、
 // canvas 経路は通らず early-return (元 File を返す) になる。ここではその
@@ -40,14 +40,3 @@ describe('isBlueskySupportedImageType', () => {
   });
 });
 
-describe('pickOutputType', () => {
-  it('webp 希望 + 対応 → webp', () => {
-    expect(pickOutputType(true, true)).toBe('image/webp');
-  });
-  it('webp 希望 + 非対応 (Safari) → jpeg にフォールバック', () => {
-    expect(pickOutputType(true, false)).toBe('image/jpeg');
-  });
-  it('webp 非希望 → jpeg', () => {
-    expect(pickOutputType(false, true)).toBe('image/jpeg');
-  });
-});

--- a/apps/web/src/lib/image-compress.ts
+++ b/apps/web/src/lib/image-compress.ts
@@ -55,12 +55,7 @@ export function isBlueskySupportedImageType(type: string): boolean {
   return BLUESKY_IMAGE_TYPES.includes(type);
 }
 
-/** 希望 webp + 対応状況から実際の出力 MIME を決める (DOM 非依存・テスト用)。 */
-export function pickOutputType(wantWebp: boolean, webpSupported: boolean): string {
-  return wantWebp && webpSupported ? 'image/webp' : 'image/jpeg';
-}
-
-/** canvas が WebP エンコードに対応しているか (Safari は長らく非対応 → JPEG に倒す) */
+/** canvas が WebP エンコードに対応しているか (Safari は非対応 → WASM か JPEG に倒す) */
 function supportsWebpEncode(): boolean {
   if (typeof document === 'undefined') return false;
   try {
@@ -91,6 +86,96 @@ function drawTo(bitmap: ImageBitmap, w: number, h: number, outType: string): HTM
   return canvas;
 }
 
+/** canvas を quality (0-1) で Blob にエンコードする関数。 */
+type Encoder = (canvas: HTMLCanvasElement, quality: number) => Promise<Blob | null>;
+
+// WASM WebP エンコーダ (@jsquash/webp) は添付時に 1 回だけ動的 import する。
+// canvas が WebP を吐けないブラウザ (iOS Safari) でも WebP を出すため。
+let wasmWebpPromise: Promise<((d: ImageData, q: number) => Promise<ArrayBuffer>) | null> | null = null;
+function loadWasmWebpEncode() {
+  if (!wasmWebpPromise) {
+    wasmWebpPromise = import('@jsquash/webp/encode')
+      .then((m) => {
+        const enc = m.default;
+        return (data: ImageData, q: number) => enc(data, { quality: q });
+      })
+      .catch((e) => {
+        console.warn('[image-compress] WASM WebP エンコーダのロードに失敗 (JPEG に倒す)', e);
+        return null;
+      });
+  }
+  return wasmWebpPromise;
+}
+
+/** WASM encode はメインスレッドで重い。試行回数を抑えるため画質ステップを
+ *  短くする (ネイティブ/JPEG の 5 段に対し 3 段)。 */
+const WASM_QUALITY_STEPS = [0.82, 0.6, 0.42];
+
+/** 出力形式とエンコーダを決める。heavy=true は WASM 経路 (encode が重い)。
+ *  - WebP 希望 + canvas ネイティブ対応 (Chrome) → ネイティブ WebP (高速)
+ *  - WebP 希望 + 非対応 (Safari) → WASM WebP。ロード失敗時のみ JPEG
+ *  - それ以外 → JPEG */
+async function chooseEncoder(wantWebp: boolean): Promise<{ outType: string; encode: Encoder; heavy: boolean }> {
+  if (wantWebp && supportsWebpEncode()) {
+    return { outType: 'image/webp', encode: (c, q) => canvasToBlob(c, 'image/webp', q), heavy: false };
+  }
+  if (wantWebp) {
+    const wasm = await loadWasmWebpEncode();
+    if (wasm) {
+      return {
+        outType: 'image/webp',
+        heavy: true,
+        encode: async (c, q) => {
+          const ctx = c.getContext('2d');
+          if (!ctx) return null;
+          const id = ctx.getImageData(0, 0, c.width, c.height);
+          const buf = await wasm(id, Math.round(q * 100));
+          return new Blob([buf], { type: 'image/webp' });
+        },
+      };
+    }
+  }
+  return { outType: 'image/jpeg', encode: (c, q) => canvasToBlob(c, 'image/jpeg', q), heavy: false };
+}
+
+/** 指定エンコーダで「寸法 × 画質」を試し、maxBytes 以下になる最良 (fit) を返す。
+ *  encode が throw しても握りつぶして null 扱いにする (堅牢性)。
+ *  fit する blob が無ければ「最小だが超過」の best を返し、1 枚も作れなければ null。 */
+async function encodeBestFit(
+  bitmap: ImageBitmap,
+  outType: string,
+  encode: Encoder,
+  maxBytes: number,
+  maxDimension: number,
+  qualitySteps: number[],
+): Promise<{ blob: Blob; w: number; h: number; fit: boolean } | null> {
+  const scale = Math.min(1, maxDimension / Math.max(bitmap.width, bitmap.height));
+  let w = Math.max(1, Math.round(bitmap.width * scale));
+  let h = Math.max(1, Math.round(bitmap.height * scale));
+  let best: { blob: Blob; w: number; h: number; fit: boolean } | null = null;
+
+  // 初期寸法 + 最大 2 回の縮小 (計 3 サイズ) を試し、各サイズで画質を上から試す
+  for (let shrink = 0; shrink < 3; shrink++) {
+    const canvas = drawTo(bitmap, w, h, outType);
+    if (!canvas) break;
+    for (const q of qualitySteps) {
+      let blob: Blob | null = null;
+      try {
+        blob = await encode(canvas, q);
+      } catch (e) {
+        console.warn('[image-compress] encode に失敗', e);
+      }
+      // size 0 (壊れた encode 結果) は採用しない
+      if (!blob || blob.size === 0) continue;
+      if (blob.size <= maxBytes) return { blob, w, h, fit: true };
+      if (!best || blob.size < best.blob.size) best = { blob, w, h, fit: false };
+    }
+    w = Math.max(1, Math.round(w * 0.7));
+    h = Math.max(1, Math.round(h * 0.7));
+  }
+  return best;
+}
+
 export async function compressImage(file: File, opts: CompressOptions = {}): Promise<CompressResult> {
   const maxBytes = opts.maxBytes ?? DEFAULTS.maxBytes;
   const maxDimension = opts.maxDimension ?? DEFAULTS.maxDimension;
@@ -105,9 +190,11 @@ export async function compressImage(file: File, opts: CompressOptions = {}): Pro
     return { blob: file, compressed: false, originalBytes };
   }
 
-  // 希望 webp でも未対応ブラウザ (Safari) では jpeg に倒す
+  // WebP 希望: ネイティブ(Chrome)→ WASM(Safari)→ JPEG の順でエンコーダを選ぶ
   const wantWebp = (opts.mimeType ?? DEFAULTS.mimeType) === 'image/webp';
-  const outType = pickOutputType(wantWebp, supportsWebpEncode());
+  const { outType, encode, heavy } = await chooseEncoder(wantWebp);
+  // WASM 経路 (heavy) はメインスレッド負荷が高いので試行回数を減らす
+  const primarySteps = heavy && !opts.qualitySteps ? WASM_QUALITY_STEPS : qualitySteps;
 
   let bitmap: ImageBitmap;
   try {
@@ -118,31 +205,24 @@ export async function compressImage(file: File, opts: CompressOptions = {}): Pro
   }
 
   try {
-    const scale = Math.min(1, maxDimension / Math.max(bitmap.width, bitmap.height));
-    let w = Math.max(1, Math.round(bitmap.width * scale));
-    let h = Math.max(1, Math.round(bitmap.height * scale));
-    let last: Blob | null = null;
+    let usedType = outType;
+    let result = await encodeBestFit(bitmap, outType, encode, maxBytes, maxDimension, primarySteps);
 
-    // 初期寸法 + 最大 2 回の縮小 (計 3 サイズ) を試し、各サイズで画質を上から試す
-    for (let shrink = 0; shrink < 3; shrink++) {
-      const canvas = drawTo(bitmap, w, h, outType);
-      if (!canvas) break;
-      for (const q of qualitySteps) {
-        const blob = await canvasToBlob(canvas, outType, q);
-        if (!blob) continue;
-        last = blob;
-        if (blob.size <= maxBytes) {
-          return { blob, compressed: true, originalBytes, outputType: outType, width: w, height: h };
-        }
-      }
-      // 全画質でも収まらない → 長辺を 0.7 倍に縮めて再挑戦
-      w = Math.max(1, Math.round(w * 0.7));
-      h = Math.max(1, Math.round(h * 0.7));
+    // WebP エンコーダが 1 枚も作れなかった (WASM ロード/実行失敗等) 場合は
+    // JPEG に退避する。これで「これまで動いていた JPEG 圧縮」を絶対に壊さない。
+    if (!result && outType !== 'image/jpeg') {
+      usedType = 'image/jpeg';
+      result = await encodeBestFit(
+        bitmap, 'image/jpeg', (c, q) => canvasToBlob(c, 'image/jpeg', q), maxBytes, maxDimension, qualitySteps,
+      );
     }
 
+    if (result && result.fit) {
+      return { blob: result.blob, compressed: true, originalBytes, outputType: usedType, width: result.w, height: result.h };
+    }
     // 収まらなくても、元より小さければ返す (呼び出し側が最終 size 検査)
-    if (last && last.size < originalBytes) {
-      return { blob: last, compressed: true, originalBytes, outputType: outType };
+    if (result && result.blob.size < originalBytes) {
+      return { blob: result.blob, compressed: true, originalBytes, outputType: usedType };
     }
     return { blob: file, compressed: false, originalBytes };
   } finally {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,6 +130,9 @@ importers:
       '@huggingface/transformers':
         specifier: ^4.1.0
         version: 4.1.0
+      '@jsquash/webp':
+        specifier: ^1.5.0
+        version: 1.5.0
       '@tanstack/react-virtual':
         specifier: ^3.13.0
         version: 3.13.24(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1207,6 +1210,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
+  '@jsquash/webp@1.5.0':
+    resolution: {integrity: sha512-KggLoj2MnRSfIqTeKe1EmbljTX2vuV7mh79k89PCL1pyqiDULcPM1L47twxXt0hkb68F70bXiL31MxsuoZtKFw==}
+
   '@playwright/test@1.59.1':
     resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
     engines: {node: '>=18'}
@@ -2246,6 +2252,9 @@ packages:
       jsdom:
         optional: true
 
+  wasm-feature-detect@1.8.0:
+    resolution: {integrity: sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==}
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
@@ -3184,6 +3193,10 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@jsquash/webp@1.5.0':
+    dependencies:
+      wasm-feature-detect: 1.8.0
 
   '@playwright/test@1.59.1':
     dependencies:
@@ -4273,6 +4286,8 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  wasm-feature-detect@1.8.0: {}
 
   web-streams-polyfill@3.3.3: {}
 


### PR DESCRIPTION
## Summary
画像投稿圧縮で iOS Safari でも WebP を出すため WASM エンコーダ (@jsquash/webp) を導入 (#78)。Chrome=ネイティブWebP / Safari=WASM WebP / 失敗時=JPEG。WASM は添付時のみ動的ロード(初期バンドル不変)。

§1.5 レビュー + **再レビュー済み**(★★★/★★ ゼロ、本番デグレ無し、JPEG 安全網で現状動作を壊さない)、CI 緑。Worker 化は #79。

> 本番反映後、iOS Safari 実機で「投稿でき、形式が image/webp になる」確認が必要。