### PR TITLE
release: 他人のクエスト/ポートフォリオが見えない本番バグ修正 (#81)

### DIFF
--- a/apps/web/src/lib/quest-api.test.ts
+++ b/apps/web/src/lib/quest-api.test.ts
@@ -1,7 +1,15 @@
-import { describe, it, expect, beforeEach, beforeAll } from 'vitest';
+import { describe, it, expect, beforeEach, beforeAll, vi } from 'vitest';
 import { parseAtUri, questUrlOf } from './quest-api';
 import { mockIndex } from './quest-mock';
 import type { UserQuest } from '@aozoraquest/core';
+
+// 他人 repo 読み取りは repo-read 経由 (対象 DID の PDS を解決して読む)。
+// テストではモックして「どの DID が何を返すか」を制御する。
+vi.mock('./repo-read', () => ({
+  listRecordsForDid: vi.fn(),
+  getRecordForDid: vi.fn(),
+}));
+import { listRecordsForDid } from './repo-read';
 
 // in-memory localStorage polyfill (node 環境では存在しないので)
 beforeAll(() => {
@@ -110,27 +118,22 @@ describe('mockIndex', () => {
 });
 
 describe('buildQuestIndexFromDirectory', () => {
-  // listRecords をコレクション種別で出し分ける fake agent を作る
-  function fakeAgent(byDid: Record<string, { quests?: any[]; apps?: any[] }>) {
-    return {
-      com: {
-        atproto: {
-          repo: {
-            listRecords: async ({ repo, collection }: { repo: string; collection: string }) => {
-              const data = byDid[repo] ?? {};
-              const isQuest = collection.endsWith('userQuest');
-              const recs = (isQuest ? data.quests : data.apps) ?? [];
-              return { data: { records: recs } };
-            },
-          },
-        },
-      },
-    } as any;
+  const anyAgent = {} as any; // agent は読み取りに使わない (PDS 解決経由)
+
+  // listRecordsForDid を「DID×コレクション種別」で出し分ける
+  function mockReads(byDid: Record<string, { quests?: any[]; apps?: any[] }>) {
+    vi.mocked(listRecordsForDid).mockImplementation(async (did: string, collection: string) => {
+      const data = byDid[did] ?? {};
+      const isQuest = collection.endsWith('userQuest');
+      return { records: (isQuest ? data.quests : data.apps) ?? [] };
+    });
   }
+
+  beforeEach(() => { vi.mocked(listRecordsForDid).mockReset(); });
 
   it('集約: 複数 DID の quest を summary 化してまとめる', async () => {
     const { buildQuestIndexFromDirectory } = await import('./quest-api');
-    const agent = fakeAgent({
+    mockReads({
       'did:plc:a': {
         quests: [{
           uri: 'at://did:plc:a/c/1',
@@ -145,10 +148,9 @@ describe('buildQuestIndexFromDirectory', () => {
         apps: [{ uri: 'at://did:plc:b/ca/1', value: { questUri: 'at://did:plc:a/c/1', createdAt: '2026-06-03T00:00:00Z' } }],
       },
     });
-    const idx = await buildQuestIndexFromDirectory(agent, ['did:plc:a', 'did:plc:b']);
+    const idx = await buildQuestIndexFromDirectory(anyAgent, ['did:plc:a', 'did:plc:b']);
     expect(idx.quests).toHaveLength(2);
-    // createdAt 降順
-    expect(idx.quests[0]!.uri).toBe('at://did:plc:b/c/2');
+    expect(idx.quests[0]!.uri).toBe('at://did:plc:b/c/2'); // createdAt 降順
     expect(idx.quests[0]!.did).toBe('did:plc:b');
     expect(idx.applications).toHaveLength(1);
     expect(idx.applications[0]!.questUri).toBe('at://did:plc:a/c/1');
@@ -156,23 +158,20 @@ describe('buildQuestIndexFromDirectory', () => {
 
   it('重複 DID を 1 回だけ読む (dedup)', async () => {
     const { buildQuestIndexFromDirectory } = await import('./quest-api');
-    const agent = fakeAgent({
+    mockReads({
       'did:plc:a': { quests: [{ uri: 'at://did:plc:a/c/1', value: { title: 't', tags: [], rewardPoints: 0, status: 'open', createdAt: '2026-06-01T00:00:00Z' } }] },
     });
-    const idx = await buildQuestIndexFromDirectory(agent, ['did:plc:a', 'did:plc:a']);
+    const idx = await buildQuestIndexFromDirectory(anyAgent, ['did:plc:a', 'did:plc:a']);
     expect(idx.quests).toHaveLength(1);
   });
 
   it('一部 DID の読み取り失敗を無視して続行する', async () => {
     const { buildQuestIndexFromDirectory } = await import('./quest-api');
-    const agent = {
-      com: { atproto: { repo: { listRecords: async ({ repo }: { repo: string }) => {
-        if (repo === 'did:plc:bad') throw new Error('boom');
-        return { data: { records: [{ uri: 'at://did:plc:ok/c/1', value: { title: 'ok', tags: [], rewardPoints: 0, status: 'open', createdAt: 't' } }] } };
-      } } } },
-    } as any;
-    const idx = await buildQuestIndexFromDirectory(agent, ['did:plc:bad', 'did:plc:ok']);
-    // bad は失敗、ok の quest だけ残る (userQuest/questApplication 両方 ok を返すが questUri 無し app は除外)
+    vi.mocked(listRecordsForDid).mockImplementation(async (did: string) => {
+      if (did === 'did:plc:bad') throw new Error('boom');
+      return { records: [{ uri: 'at://did:plc:ok/c/1', value: { title: 'ok', tags: [], rewardPoints: 0, status: 'open', createdAt: 't' } }] };
+    });
+    const idx = await buildQuestIndexFromDirectory(anyAgent, ['did:plc:bad', 'did:plc:ok']);
     expect(idx.quests.some((q) => q.did === 'did:plc:ok')).toBe(true);
   });
 });

--- a/apps/web/src/lib/quest-api.ts
+++ b/apps/web/src/lib/quest-api.ts
@@ -18,6 +18,7 @@ import type {
 } from '@aozoraquest/core';
 import { isValidCompletion } from '@aozoraquest/core';
 import { putRecord, getRecord } from './atproto';
+import { listRecordsForDid, getRecordForDid } from './repo-read';
 import { COL } from './collections';
 import { mockIndex } from './quest-mock';
 
@@ -85,10 +86,11 @@ export async function updateQuest(
   return next;
 }
 
-/** クエストを取得する (URI 指定、公開 read で OK) */
-export async function getQuest(agent: Agent, uri: AtUri): Promise<UserQuest | null> {
+/** クエストを取得する (URI 指定)。発行者の PDS から公開 read する
+ *  (自分の agent で他人 repo を読むと別ホスト時に「Could not find repo」になる)。 */
+export async function getQuest(_agent: Agent, uri: AtUri): Promise<UserQuest | null> {
   const { repo, rkey } = parseAtUri(uri);
-  const value = await getRecord<Omit<UserQuest, 'uri' | 'did'>>(agent, repo, COL.userQuest, rkey);
+  const value = await getRecordForDid<Omit<UserQuest, 'uri' | 'did'>>(repo, COL.userQuest, rkey);
   if (!value) return null;
   return {
     ...value,
@@ -99,14 +101,11 @@ export async function getQuest(agent: Agent, uri: AtUri): Promise<UserQuest | nu
   };
 }
 
-/** 発行者 (= 任意の did) の userQuest を時系列で list */
-export async function listIssuedQuests(agent: Agent, issuerDid: Did, limit = 100): Promise<UserQuest[]> {
-  const res = await agent.com.atproto.repo.listRecords({
-    repo: issuerDid,
-    collection: COL.userQuest,
-    limit,
-  });
-  return res.data.records.map(r => {
+/** 発行者 (= 任意の did) の userQuest を時系列で list。
+ *  対象 DID の PDS から公開 read する (他人 repo を自分の PDS 経由で読まない)。 */
+export async function listIssuedQuests(_agent: Agent, issuerDid: Did, limit = 100): Promise<UserQuest[]> {
+  const res = await listRecordsForDid(issuerDid, COL.userQuest, limit);
+  return res.records.map(r => {
     const v = r.value as Omit<UserQuest, 'uri' | 'did'>;
     return {
       ...v,
@@ -166,29 +165,45 @@ function questToSummary(q: UserQuest): QuestIndexSummary {
  * 各 DID の userQuest / questApplication を listRecords で読み、
  * 公開 quest 一覧と応募 index を作る。一部 DID の失敗は無視して続行する。
  */
+/** items を最大 limit 並列で fn にかけ、Promise.allSettled 相当の結果を返す。 */
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<PromiseSettledResult<R>[]> {
+  const results: PromiseSettledResult<R>[] = [];
+  for (let i = 0; i < items.length; i += limit) {
+    const settled = await Promise.allSettled(items.slice(i, i + limit).map(fn));
+    results.push(...settled);
+  }
+  return results;
+}
+
 export async function buildQuestIndexFromDirectory(
-  agent: Agent,
+  _agent: Agent,
   dids: Did[],
   limitPerRepo = 100,
 ): Promise<QuestIndex> {
   // 重複 DID を除去 (自分 + directory の和集合などで重なりうる)
   const unique = Array.from(new Set(dids));
-  const results = await Promise.allSettled(
-    unique.map(async (did) => {
+  // plc.directory / 各 PDS への過大な同時リクエストを避けるため並列数を絞る
+  // (最大 60 DID を一気に叩くと plc.directory に 429 を食らい欠落しうる)
+  const results = await mapWithConcurrency(unique, 8, async (did) => {
+      // 各 DID の PDS から公開 read する (自分の PDS 経由だと別ホストの repo を読めない)
       const [questsRes, appsRes] = await Promise.allSettled([
-        agent.com.atproto.repo.listRecords({ repo: did, collection: COL.userQuest, limit: limitPerRepo }),
-        agent.com.atproto.repo.listRecords({ repo: did, collection: COL.questApplication, limit: limitPerRepo }),
+        listRecordsForDid(did, COL.userQuest, limitPerRepo),
+        listRecordsForDid(did, COL.questApplication, limitPerRepo),
       ]);
       const quests: QuestIndexSummary[] = [];
       const applications: ApplicationIndexEntry[] = [];
       if (questsRes.status === 'fulfilled') {
-        for (const r of questsRes.value.data.records) {
+        for (const r of questsRes.value.records) {
           const v = r.value as Omit<UserQuest, 'uri' | 'did'>;
           quests.push(questToSummary({ ...v, uri: r.uri, did, updatedAt: v.updatedAt ?? v.createdAt }));
         }
       }
       if (appsRes.status === 'fulfilled') {
-        for (const r of appsRes.value.data.records) {
+        for (const r of appsRes.value.records) {
           const v = r.value as { questUri?: AtUri; createdAt?: string };
           if (typeof v.questUri === 'string') {
             applications.push({
@@ -201,8 +216,7 @@ export async function buildQuestIndexFromDirectory(
         }
       }
       return { quests, applications };
-    }),
-  );
+    });
 
   const quests: QuestIndexSummary[] = [];
   const applications: ApplicationIndexEntry[] = [];
@@ -404,8 +418,8 @@ export async function listApplicationsFor(
   for (const e of entries) {
     try {
       const { rkey } = parseAtUri(e.uri);
-      const v = await getRecord<Omit<QuestApplication, 'uri' | 'did'>>(
-        agent, e.did, COL.questApplication, rkey,
+      const v = await getRecordForDid<Omit<QuestApplication, 'uri' | 'did'>>(
+        e.did, COL.questApplication, rkey,
       );
       if (v) {
         // withdrawn も含めて返す (= UI 側で「取り下げ済み」表示するため)
@@ -419,18 +433,14 @@ export async function listApplicationsFor(
   return out.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
 }
 
-/** 自分が出した応募一覧 (withdrawn も含めて返す。フィルタは UI 側で) */
-export async function listMyApplications(agent: Agent, myDid: Did, limit = 100): Promise<QuestApplication[]> {
-  const res = await agent.com.atproto.repo.listRecords({
-    repo: myDid,
-    collection: COL.questApplication,
-    limit,
+/** ある DID が出した応募一覧 (withdrawn 含む。フィルタは UI 側で)。
+ *  対象 DID の PDS から公開 read する (ポートフォリオで他人の did も渡るため)。 */
+export async function listMyApplications(_agent: Agent, did: Did, limit = 100): Promise<QuestApplication[]> {
+  const res = await listRecordsForDid(did, COL.questApplication, limit);
+  return res.records.map(r => {
+    const v = r.value as Omit<QuestApplication, 'uri' | 'did'>;
+    return { ...v, uri: r.uri, did };
   });
-  return res.data.records
-    .map(r => {
-      const v = r.value as Omit<QuestApplication, 'uri' | 'did'>;
-      return { ...v, uri: r.uri, did: myDid };
-    });
 }
 
 // ─── Phase 2: 受託者指定 (発注者が quest record を更新) ───
@@ -539,12 +549,9 @@ export async function listCompletionsFor(
   const out: QuestCompletion[] = [];
   for (const did of dids) {
     try {
-      const res = await agent.com.atproto.repo.listRecords({
-        repo: did,
-        collection: COL.questCompletion,
-        limit: 100,
-      });
-      for (const r of res.data.records) {
+      // 各 DID の PDS から公開 read (自分の PDS 経由だと別ホストの repo を読めない)
+      const res = await listRecordsForDid(did, COL.questCompletion, 100);
+      for (const r of res.records) {
         const v = r.value as Omit<QuestCompletion, 'uri' | 'did'>;
         if (v.questUri !== quest.uri) continue;
         const c: QuestCompletion = { ...v, uri: r.uri, did };

--- a/apps/web/src/lib/repo-read.ts
+++ b/apps/web/src/lib/repo-read.ts
@@ -1,0 +1,78 @@
+/**
+ * 他人の repo の公開レコードを「その人の PDS から直接」読むためのヘルパー。
+ *
+ * Bluesky はユーザーごとに PDS が分散している (puffball / enoki / 自前 PDS …)。
+ * 他人の repo を**自分のログイン中 agent (= 自分の PDS)** で
+ * com.atproto.repo.listRecords / getRecord すると、相手が別ホストにいる場合
+ * 「Could not find repo」や空が返り、クエスト掲示板やポートフォリオが
+ * 表示できない (= 本番バグ)。
+ *
+ * userQuest / questApplication / questCompletion / directory は public record
+ * なので、**対象 DID の PDS を解決して無認証で読む**のが正しい。
+ *
+ * PDS エンドポイントは DID document (did:plc は plc.directory、did:web は
+ * .well-known/did.json) から解決し、DID 単位・PDS 単位でキャッシュする。
+ */
+import { AtpAgent } from '@atproto/api';
+import { resolveDidToPds } from './runtime-config';
+
+const pdsByDid = new Map<string, Promise<string>>();
+const agentByPds = new Map<string, AtpAgent>();
+
+/** DID → PDS を DID/PDS 単位でキャッシュしつつ解決する
+ *  (解決ロジックは runtime-config の resolveDidToPds に一本化)。 */
+async function resolvePds(did: string): Promise<string> {
+  let p = pdsByDid.get(did);
+  if (!p) {
+    p = resolveDidToPds(did);
+    // 失敗した promise はキャッシュに残さない (一過性失敗で永久に詰まらないよう)
+    p.catch(() => pdsByDid.delete(did));
+    pdsByDid.set(did, p);
+  }
+  return p;
+}
+
+async function agentForDid(did: string): Promise<AtpAgent> {
+  const pds = await resolvePds(did);
+  let a = agentByPds.get(pds);
+  if (!a) {
+    a = new AtpAgent({ service: pds });
+    agentByPds.set(pds, a);
+  }
+  return a;
+}
+
+/** 対象 DID の PDS から listRecords する (公開レコード、無認証)。 */
+export async function listRecordsForDid(
+  did: string,
+  collection: string,
+  limit = 100,
+): Promise<{ records: { uri: string; value: unknown }[] }> {
+  const agent = await agentForDid(did);
+  const res = await agent.com.atproto.repo.listRecords({ repo: did, collection, limit });
+  return { records: res.data.records.map((r) => ({ uri: r.uri, value: r.value })) };
+}
+
+/** 対象 DID の PDS から getRecord する。RecordNotFound 系は null。 */
+export async function getRecordForDid<T = unknown>(
+  did: string,
+  collection: string,
+  rkey: string,
+): Promise<T | null> {
+  const agent = await agentForDid(did);
+  try {
+    const res = await agent.com.atproto.repo.getRecord({ repo: did, collection, rkey });
+    return res.data.value as T;
+  } catch (e) {
+    const err = e as { name?: string; message?: string };
+    if (err?.name === 'RecordNotFoundError') return null;
+    if (/RecordNotFound|not found|could not locate|InvalidRequest/i.test(err?.message ?? '')) return null;
+    throw e;
+  }
+}
+
+/** テスト用 */
+export function clearRepoReadCache(): void {
+  pdsByDid.clear();
+  agentByPds.clear();
+}

--- a/apps/web/src/lib/runtime-config.ts
+++ b/apps/web/src/lib/runtime-config.ts
@@ -23,28 +23,27 @@ function getPrimaryAdminDid(): string | null {
   return first ?? null;
 }
 
-async function resolveDidToPds(did: string): Promise<string> {
-  // did:plc:* は plc.directory を経由、did:web:* はドメイン直 .well-known/did.json
-  if (did.startsWith('did:plc:')) {
-    const res = await fetch(`${PLC_DIRECTORY}/${did}`);
-    if (!res.ok) throw new Error(`plc.directory ${res.status}`);
-    const doc = await res.json();
-    const service = (doc.service ?? []).find(
-      (s: { type: string }) => s.type === 'AtprotoPersonalDataServer',
+/** DID を PDS エンドポイントに解決する (公開 read の宛先決定に使う唯一の実装)。
+ *  did:plc:* は plc.directory、did:web:* はドメイン直 .well-known/did.json。 */
+export async function resolveDidToPds(did: string): Promise<string> {
+  const pickPds = (doc: { service?: { id?: string; type?: string; serviceEndpoint?: string }[] }) => {
+    const svc = (doc.service ?? []).find(
+      (s) => s.id === '#atproto_pds' || s.type === 'AtprotoPersonalDataServer',
     );
-    if (!service) throw new Error(`no PDS in DID doc for ${did}`);
-    return service.serviceEndpoint as string;
+    if (!svc?.serviceEndpoint) throw new Error(`no PDS in DID doc for ${did}`);
+    return svc.serviceEndpoint;
+  };
+  if (did.startsWith('did:plc:')) {
+    const res = await fetch(`${PLC_DIRECTORY}/${encodeURIComponent(did)}`);
+    if (!res.ok) throw new Error(`plc.directory ${res.status}`);
+    return pickPds(await res.json());
   }
   if (did.startsWith('did:web:')) {
+    // host-only did:web のみ対応 (path 付きは未対応 = Bluesky では稀)
     const host = did.slice('did:web:'.length);
     const res = await fetch(`https://${host}/.well-known/did.json`);
     if (!res.ok) throw new Error(`did:web ${res.status}`);
-    const doc = await res.json();
-    const service = (doc.service ?? []).find(
-      (s: { type: string }) => s.type === 'AtprotoPersonalDataServer',
-    );
-    if (!service) throw new Error(`no PDS in did:web doc for ${did}`);
-    return service.serviceEndpoint as string;
+    return pickPds(await res.json());
   }
   throw new Error(`unsupported DID method: ${did}`);
 }


### PR DESCRIPTION
## Summary
本番障害の修正。他人の repo (公開レコード) を自分の PDS 経由で読んでいたため、PDS が分散する Bluesky で「クエストが他人に見えない」「ポートフォリオが Could not find repo」になっていた (#81)。

対象 DID の PDS を解決して読むよう全箇所修正。実 API 検証 + §1.5 レビュー (★★★ ゼロ、★★ PR 内対応) + CI 緑。

> 本番反映後、別アカウントで board「募集中」と他人ポートフォリオが見えるか要確認。