### PR TITLE
fix(board): ログアウト掲示板 UX (詳細が開く/自分用カラム除外) + 報酬表記 kojira.io P

### DIFF
--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -26,6 +26,13 @@ const nav: Array<{
   { to: '/settings', label: '設定', icon: SettingsIcon, key: 'settings' },
 ];
 
+/** 未ログイン時の footer-nav。ホーム/通知/検索などログイン必須の項目は出さず、
+ *  閲覧できるクエスト掲示板とログイン導線だけにする。 */
+const navLoggedOut: typeof nav = [
+  { to: '/board', label: 'クエスト掲示板', icon: ScrollIcon, key: 'quests' },
+  { to: '/onboarding', label: 'ログイン', icon: PersonIcon, key: 'login' },
+];
+
 export function AppShell() {
   const session = useSession();
   const location = useLocation();
@@ -116,7 +123,7 @@ export function AppShell() {
         <Outlet />
       </main>
       <nav className="footer-nav" ref={footerRef}>
-        {nav.map(({ to, label, icon: Icon, end, key, columnKind }) => (
+        {(session.status === 'signed-in' ? nav : navLoggedOut).map(({ to, label, icon: Icon, end, key, columnKind }) => (
           <NavLink
             key={to}
             to={to}

--- a/apps/web/src/components/column-content/board-shared.tsx
+++ b/apps/web/src/components/column-content/board-shared.tsx
@@ -12,7 +12,7 @@ import { getQuestIndexCached } from '@/lib/quest-index-cache';
 import type { UserQuest } from '@aozoraquest/core';
 import { useSession } from '@/lib/session';
 import { useRuntimeConfig } from '@/components/config-provider';
-import { Handle } from '@/components/handle';
+import { RewardPoints } from '@/components/handle';
 
 export interface BoardFilter {
   kind: 'open' | 'mine' | 'applied' | 'tag' | 'job' | 'issuer';
@@ -137,7 +137,7 @@ export function QuestCard({ summary, expired }: { summary: QuestIndexSummary; ex
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: '0.5em' }}>
           <div style={{ fontWeight: 700, fontSize: '0.92em', color: 'var(--color-fg)' }}>{summary.title}</div>
           <div style={{ fontFamily: 'ui-monospace, monospace', fontSize: '0.78em', color: 'var(--color-accent)', whiteSpace: 'nowrap' }}>
-            <Handle did={summary.did} suffix="P" /> {summary.rewardPoints.toLocaleString()}
+            <RewardPoints did={summary.did} points={summary.rewardPoints} />
           </div>
         </div>
         <div style={{ display: 'flex', gap: '0.5em', flexWrap: 'wrap', fontSize: '0.72em', color: 'var(--color-muted)', marginTop: '0.3em' }}>

--- a/apps/web/src/components/handle.tsx
+++ b/apps/web/src/components/handle.tsx
@@ -39,3 +39,18 @@ export function Handle({ did, prefix, suffix }: Props) {
   }
   return <>{prefix}{handle}{suffix}</>;
 }
+
+/**
+ * 報酬ポイント表記。「kojira.ioP777」だと読みづらいので
+ * 「kojira.io P 777」と区切り、「P」を太字の白で浮かせる
+ * (DESIGN.md: 強調は白)。handle 部分は親の色を踏襲する。
+ */
+export function RewardPoints({ did, points }: { did: string; points: number }) {
+  return (
+    <>
+      <Handle did={did} />{' '}
+      <span style={{ color: 'var(--color-primary)', fontWeight: 700 }}>P</span>{' '}
+      {points.toLocaleString()}
+    </>
+  );
+}

--- a/apps/web/src/lib/quest-api.ts
+++ b/apps/web/src/lib/quest-api.ts
@@ -88,7 +88,7 @@ export async function updateQuest(
 
 /** クエストを取得する (URI 指定)。発行者の PDS から公開 read する
  *  (自分の agent で他人 repo を読むと別ホスト時に「Could not find repo」になる)。 */
-export async function getQuest(_agent: Agent, uri: AtUri): Promise<UserQuest | null> {
+export async function getQuest(_agent: Agent | undefined, uri: AtUri): Promise<UserQuest | null> {
   const { repo, rkey } = parseAtUri(uri);
   const value = await getRecordForDid<Omit<UserQuest, 'uri' | 'did'>>(repo, COL.userQuest, rkey);
   if (!value) return null;
@@ -409,7 +409,7 @@ export async function withdrawApplication(
 
 /** 特定 quest への応募一覧を、index で発見した応募者 PDS から fetch する */
 export async function listApplicationsFor(
-  agent: Agent,
+  _agent: Agent | undefined,
   questUri: AtUri,
 ): Promise<QuestApplication[]> {
   const idx = await fetchQuestIndex();
@@ -539,7 +539,7 @@ export async function requestRevision(
 
 /** quest に紐付く completion レコードを発注者・受託者の PDS から fetch して時系列で返す */
 export async function listCompletionsFor(
-  agent: Agent,
+  _agent: Agent | undefined,
   quest: UserQuest,
 ): Promise<QuestCompletion[]> {
   const dids = new Set<Did>();

--- a/apps/web/src/routes/board-detail.tsx
+++ b/apps/web/src/routes/board-detail.tsx
@@ -82,12 +82,13 @@ export function BoardDetail() {
     // board 一覧 (募集中カラム等) に反映されるようにする
     void refreshQuestIndex();
     try {
-      const q = await getQuest(session.agent, uri);
+      // 読み取りは PDS 経由の公開 read なので agent 不要 (undefined を渡す)
+      const q = await getQuest(undefined, uri);
       setQuest(q);
       if (q) {
         const [apps, comps] = await Promise.all([
-          listApplicationsFor(session.agent, uri),
-          listCompletionsFor(session.agent, q),
+          listApplicationsFor(undefined, uri),
+          listCompletionsFor(undefined, q),
         ]);
         setApplications(apps);
         setCompletions(comps);
@@ -95,7 +96,8 @@ export function BoardDetail() {
     } catch (e) {
       setErr(String((e as Error)?.message ?? e));
     }
-  }, [uri, session.agent]);
+    // agent を使わないので deps は uri のみ (session 解決での二重 fetch を回避)
+  }, [uri]);
 
   useEffect(() => { void refresh(); }, [refresh]);
 

--- a/apps/web/src/routes/board-detail.tsx
+++ b/apps/web/src/routes/board-detail.tsx
@@ -26,7 +26,7 @@ import {
 import { createPost } from '@/lib/atproto';
 import { getPostQuestNotifications } from '@/lib/prefs';
 import { refreshQuestIndex } from '@/lib/quest-index-cache';
-import { Handle } from '@/components/handle';
+import { Handle, RewardPoints } from '@/components/handle';
 import { DateTimePicker } from '@/components/date-time-picker';
 import { isoToLocalInput } from '@/lib/datetime';
 import { resolveHandle } from '@/lib/handle-cache';
@@ -74,7 +74,10 @@ export function BoardDetail() {
   }, [uri]);
 
   const refresh = useCallback(async () => {
-    if (!uri || !session.agent) return;
+    // クエスト読み取りは公開 read (PDS 経由) で agent 不要。未ログインでも
+    // 詳細を表示できるよう session.agent はガードしない (操作系は個別に
+    // session.agent をチェック済み)。
+    if (!uri) return;
     // 状態を変える操作の後に呼ばれるので、共有 index キャッシュも破棄して
     // board 一覧 (募集中カラム等) に反映されるようにする
     void refreshQuestIndex();
@@ -272,7 +275,7 @@ export function BoardDetail() {
       <div style={{ display: 'flex', gap: '0.6em', flexWrap: 'wrap', fontSize: '0.85em', color: 'var(--color-muted)' }}>
         <span>発注者: <Handle did={quest.did} /></span>
         <span style={{ color: 'var(--color-accent)' }}>
-          <Handle did={quest.did} suffix="P" /> {quest.rewardPoints.toLocaleString()}
+          <RewardPoints did={quest.did} points={quest.rewardPoints} />
         </span>
         <span style={{ marginLeft: 'auto' }}>{statusLabel(quest.status, expired, completedByApproval)}</span>
       </div>
@@ -477,7 +480,7 @@ export function BoardDetail() {
           <p style={{ margin: 0, fontSize: '0.9em' }}>
             完了! 受託者 <strong>{quest.assignee ? <Handle did={quest.assignee} /> : '—'}</strong> に{' '}
             <span style={{ color: 'var(--color-accent)' }}>
-              <Handle did={quest.did} suffix="P" /> {quest.rewardPoints.toLocaleString()}
+              <RewardPoints did={quest.did} points={quest.rewardPoints} />
             </span>{' '}
             が発行されました。
           </p>

--- a/apps/web/src/routes/board.tsx
+++ b/apps/web/src/routes/board.tsx
@@ -31,8 +31,15 @@ import { useSession } from '@/lib/session';
 
 export function Board() {
   const session = useSession();
+  const signedIn = session.status === 'signed-in';
   const [columns, setColumns] = useState<Column[]>(() => loadColumns());
   const { index, myQuests, myApplicationQuestUris, err } = useBoardData();
+
+  // 未ログイン時は「自分が出した / 応募」など自分前提のカラムを描画しない
+  // (保存設定は壊さず描画だけ除外。ログインで復活する)。
+  const visibleColumns = signedIn
+    ? columns
+    : columns.filter((c) => c.kind !== 'mine' && c.kind !== 'applied');
 
   function persistColumns(next: Column[]) {
     setColumns(next);
@@ -72,12 +79,13 @@ export function Board() {
         </ActionLink>
       </p>
 
-      <ColumnControls onAdd={addColumn} onReset={reset} />
+      {/* カラム管理はログイン時のみ (未ログインは閲覧専用) */}
+      {signedIn && <ColumnControls onAdd={addColumn} onReset={reset} />}
 
       {err && <p style={{ color: 'var(--color-danger)' }}>取得に失敗: {err}</p>}
 
       <div className="board-columns">
-        {columns.map((col) => (
+        {visibleColumns.map((col) => (
           <BoardInnerColumnView
             key={col.id}
             column={col}

--- a/apps/web/src/routes/portfolio.tsx
+++ b/apps/web/src/routes/portfolio.tsx
@@ -25,7 +25,7 @@ import {
   listMyApplications,
   getQuest,
 } from '@/lib/quest-api';
-import { Handle } from '@/components/handle';
+import { Handle, RewardPoints } from '@/components/handle';
 
 const PUBLIC_APPVIEW = 'https://api.bsky.app';
 
@@ -244,7 +244,7 @@ function QuestHistoryList({ quests }: { quests: UserQuest[] }) {
             <div className="dq-window compact" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
               <span style={{ color: 'var(--color-fg)', fontSize: '0.9em' }}>{q.title}</span>
               <span style={{ fontSize: '0.75em', fontFamily: 'ui-monospace, monospace', color: 'var(--color-accent)' }}>
-                <Handle did={q.did} suffix="P" /> {q.rewardPoints.toLocaleString()}
+                <RewardPoints did={q.did} points={q.rewardPoints} />
               </span>
             </div>
           </Link>

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -160,6 +160,19 @@ export function Settings() {
     ? (profile.targetJob as Archetype)
     : null;
 
+  // 設定はログイン必須 (未ログインで設定項目・ログアウトボタンを出さない)
+  if (session.status !== 'signed-in') {
+    return (
+      <div>
+        <h2>設定</h2>
+        <p style={{ color: 'var(--color-muted)' }}>設定を使うにはログインしてください。</p>
+        <button style={{ marginTop: '0.5em' }} onClick={() => navigate('/onboarding')}>
+          ログインして始める
+        </button>
+      </div>
+    );
+  }
+
   return (
     <div>
       <h2>設定</h2>


### PR DESCRIPTION
## 報告(本番・実ユーザー)のログアウト UX 不具合をまとめて修正
1. ログアウトでクエスト詳細が「読み込み中」のまま進まない
2. ログアウトなのにカラム設定 UI・自分用カラムが出る
3. 設定がログイン必須でなく、設定項目/ログアウトボタンが出る
4. footer-nav にホーム/通知/検索が出る
5. 報酬「kojira.ioP777」が読みにくい

## 修正
1. board-detail: refresh の `session.agent` ガードを外す(読み取りは PDS 経由・公開 read)。deps を `[uri]` に絞り二重 fetch も解消
2. /board: ColumnControls をログイン時のみ、未ログインは mine/applied カラムを描画除外
3. settings: 未ログインは「ログインして始める」のみ表示
4. footer-nav: 未ログインは「クエスト掲示板」+「ログイン」のみ
5. RewardPoints: 「kojira.io P 777」、P を太字白(DESIGN: 強調は白)

## Review
§1.5 レビュー実施。★★★ ゼロ・write 系の回帰なし。★★(board-detail の deps 二重 fetch)は PR 内修正済み(deps `[uri]` + undefined agent)。★(削除済みハンドルで P 白浮き等)は仕様/既存挙動として許容。

## Test plan
- [x] typecheck / vitest 144 / build 緑
- [ ] 本番: ログアウトで①詳細が開く ②カラム設定/自分用カラム出ない ③設定がログイン要求 ④footer は掲示板+ログインのみ ⑤報酬が「kojira.io P 777」