### PR TITLE
feat(home): 行動監査ログを分類アイコン+件数に集約

### DIFF
--- a/apps/web/src/components/home-summary.tsx
+++ b/apps/web/src/components/home-summary.tsx
@@ -258,8 +258,19 @@ function QuestRow({ quest, showIcon }: { quest: Quest; showIcon: boolean }) {
 /**
  * 今日の投稿が何と分類され、どのクエストを +1 したかの監査ログ。
  * 「なぜ感謝の返信 3 件が進まないのか」「この投稿はどの行動扱いなのか」を
- * 自分で確認できる透明性 UI。折り畳み式で最新 3 件をデフォルト表示。
+ * 自分で確認できる透明性 UI。
+ *
+ * 結果カテゴリ (クエスト達成 / カウント対象外 / 分類不能) ごとに
+ * アイコン + 件数のチップへ畳み、チップをタップしたときだけ本文を出す。
  */
+type AuditCatKey = 'quest' | 'other' | 'none';
+
+/** entry を結果カテゴリへ振り分ける単一の分類基準 (チップと展開本文でズレないよう一元化)。 */
+function auditCategory(e: ActivityEntry): AuditCatKey {
+  if (e.incremented.length > 0) return 'quest';
+  return e.action ? 'other' : 'none';
+}
+
 /** 分類不能 (?) アイコン */
 function UnclassifiedIcon({ size = 15 }: { size?: number }) {
   return (
@@ -281,31 +292,31 @@ function NoMatchIcon({ size = 15 }: { size?: number }) {
 }
 
 function ActivityAudit({ activity }: { activity: ActivityEntry[] }) {
-  const [openKey, setOpenKey] = useState<string | null>(null);
+  const [openKey, setOpenKey] = useState<AuditCatKey | null>(null);
   // 新しい順 (activity は古い順に追記)
   const sorted = useMemo(() => [...activity].reverse(), [activity]);
-  if (sorted.length === 0) return null;
 
   // 結果カテゴリに振り分け (本文は出さず、アイコン+件数だけ畳む)
-  const cats = [
-    {
-      key: 'quest', label: 'クエスト達成', accent: true,
-      icon: <ScrollIcon size={15} />,
-      entries: sorted.filter((e) => e.incremented.length > 0),
-    },
-    {
-      key: 'other', label: 'カウント対象外', accent: false,
-      icon: <NoMatchIcon />,
-      entries: sorted.filter((e) => e.incremented.length === 0 && !!e.action),
-    },
-    {
-      key: 'none', label: '分類不能', accent: false,
-      icon: <UnclassifiedIcon />,
-      entries: sorted.filter((e) => e.incremented.length === 0 && !e.action),
-    },
-  ].filter((c) => c.entries.length > 0);
+  const cats = useMemo(() => {
+    const defs: { key: AuditCatKey; label: string; accent: boolean; icon: React.ReactNode }[] = [
+      { key: 'quest', label: 'クエスト達成', accent: true, icon: <ScrollIcon size={15} /> },
+      { key: 'other', label: 'カウント対象外', accent: false, icon: <NoMatchIcon size={15} /> },
+      { key: 'none', label: '分類不能', accent: false, icon: <UnclassifiedIcon size={15} /> },
+    ];
+    return defs
+      .map((d) => ({ ...d, entries: sorted.filter((e) => auditCategory(e) === d.key) }))
+      .filter((c) => c.entries.length > 0);
+  }, [sorted]);
+
+  // 開いていたカテゴリが再集計 (投稿後の再 fetch 等) で 0 件化したら閉じる (ゴースト state 防止)
+  useEffect(() => {
+    if (openKey && !cats.some((c) => c.key === openKey)) setOpenKey(null);
+  }, [cats, openKey]);
+
+  if (sorted.length === 0) return null;
 
   const openCat = cats.find((c) => c.key === openKey) ?? null;
+  const panelId = 'activity-audit-panel';
 
   return (
     <div style={{ borderTop: '1px solid rgba(255,255,255,0.15)', paddingTop: '0.5em' }}>
@@ -322,13 +333,15 @@ function ActivityAudit({ activity }: { activity: ActivityEntry[] }) {
               type="button"
               onClick={() => setOpenKey(active ? null : c.key)}
               aria-expanded={active}
+              aria-controls={active ? panelId : undefined}
               aria-label={`${c.label} ${c.entries.length}件`}
               title={`${c.label} ${c.entries.length}件`}
               style={{
                 display: 'inline-flex',
                 alignItems: 'center',
                 gap: '0.3em',
-                padding: '0.2em 0.6em',
+                minHeight: '1.9em',
+                padding: '0.3em 0.7em',
                 fontSize: '0.82em',
                 borderRadius: 999,
                 background: active ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.35)',
@@ -345,13 +358,19 @@ function ActivityAudit({ activity }: { activity: ActivityEntry[] }) {
         })}
       </div>
       {openCat && (
-        <ul style={{ listStyle: 'none', padding: 0, margin: '0.45em 0 0', display: 'flex', flexDirection: 'column', gap: '0.3em' }}>
-          {openCat.entries.map((e, i) => (
-            <li key={i}>
-              <ActivityRow entry={e} />
-            </li>
-          ))}
-        </ul>
+        <div id={panelId} style={{ marginTop: '0.45em' }}>
+          {/* タップ時のみ、どの分類を開いているかをラベルで明示 (普段はアイコンのみ) */}
+          <div style={{ fontSize: '0.78em', fontWeight: 700, marginBottom: '0.3em', color: openCat.accent ? 'var(--color-accent)' : 'var(--color-muted)' }}>
+            {openCat.label} ({openCat.entries.length})
+          </div>
+          <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: '0.3em' }}>
+            {openCat.entries.map((e) => (
+              <li key={e.at}>
+                <ActivityRow entry={e} />
+              </li>
+            ))}
+          </ul>
+        </div>
       )}
     </div>
   );

--- a/apps/web/src/components/home-summary.tsx
+++ b/apps/web/src/components/home-summary.tsx
@@ -4,6 +4,7 @@ import type { Agent } from '@atproto/api';
 import type { DiagnosisResult, Quest, StatVector } from '@aozoraquest/core';
 import { DEFAULT_QUEST_TEMPLATES, actionLabel, generateDailyQuests, jobDisplayName, jobLevelFromXp, jobTagline, playerLevelFromXp } from '@aozoraquest/core';
 import { RadarChart } from './radar-chart';
+import { ScrollIcon } from './icons';
 import { SpiritBubble } from './spirit-bubble';
 import { useOnPosted } from './compose-modal';
 import { ensureTodayQuestLog, loadTodayQuestLog, type ActivityEntry, type QuestLogRecord } from '@/lib/post-processor';
@@ -259,49 +260,98 @@ function QuestRow({ quest, showIcon }: { quest: Quest; showIcon: boolean }) {
  * 「なぜ感謝の返信 3 件が進まないのか」「この投稿はどの行動扱いなのか」を
  * 自分で確認できる透明性 UI。折り畳み式で最新 3 件をデフォルト表示。
  */
+/** 分類不能 (?) アイコン */
+function UnclassifiedIcon({ size = 15 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" aria-hidden focusable="false">
+      <circle cx="8" cy="8" r="6.4" stroke="currentColor" strokeWidth="1.3" />
+      <path d="M6.3 6.2c0-1 .8-1.7 1.8-1.7s1.7.7 1.7 1.6c0 .8-.5 1.2-1.1 1.6-.5.3-.7.6-.7 1.1v.3" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" fill="none" />
+      <circle cx="8" cy="11.6" r="0.85" fill="currentColor" />
+    </svg>
+  );
+}
+/** カウント対象外 (横線) アイコン */
+function NoMatchIcon({ size = 15 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" aria-hidden focusable="false">
+      <circle cx="8" cy="8" r="6.4" stroke="currentColor" strokeWidth="1.3" />
+      <path d="M4.8 8H11.2" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+    </svg>
+  );
+}
+
 function ActivityAudit({ activity }: { activity: ActivityEntry[] }) {
-  const [open, setOpen] = useState(false);
-  // 新しい順に並べ替え (activity は古い順に追記されている)
-  const sorted = [...activity].reverse();
-  const visible = open ? sorted : sorted.slice(0, 3);
-  const hidden = sorted.length - visible.length;
+  const [openKey, setOpenKey] = useState<string | null>(null);
+  // 新しい順 (activity は古い順に追記)
+  const sorted = useMemo(() => [...activity].reverse(), [activity]);
+  if (sorted.length === 0) return null;
+
+  // 結果カテゴリに振り分け (本文は出さず、アイコン+件数だけ畳む)
+  const cats = [
+    {
+      key: 'quest', label: 'クエスト達成', accent: true,
+      icon: <ScrollIcon size={15} />,
+      entries: sorted.filter((e) => e.incremented.length > 0),
+    },
+    {
+      key: 'other', label: 'カウント対象外', accent: false,
+      icon: <NoMatchIcon />,
+      entries: sorted.filter((e) => e.incremented.length === 0 && !!e.action),
+    },
+    {
+      key: 'none', label: '分類不能', accent: false,
+      icon: <UnclassifiedIcon />,
+      entries: sorted.filter((e) => e.incremented.length === 0 && !e.action),
+    },
+  ].filter((c) => c.entries.length > 0);
+
+  const openCat = cats.find((c) => c.key === openKey) ?? null;
 
   return (
     <div style={{ borderTop: '1px solid rgba(255,255,255,0.15)', paddingTop: '0.5em' }}>
-      <button
-        onClick={() => setOpen((v) => !v)}
-        aria-expanded={open}
-        style={{
-          width: '100%',
-          background: 'transparent',
-          border: 'none',
-          padding: '0.2em 0',
-          color: 'var(--color-fg)',
-          font: 'inherit',
-          textAlign: 'left',
-          display: 'flex',
-          alignItems: 'center',
-          gap: '0.5em',
-          cursor: 'pointer',
-          boxShadow: 'none',
-        }}
-      >
-        <span style={{ fontSize: '0.8em', color: 'var(--color-muted)' }}>
-          今日カウントされた行動 ({sorted.length})
-        </span>
-        <span style={{ marginLeft: 'auto', color: 'var(--color-muted)' }}>{open ? '▾' : '▸'}</span>
-      </button>
-      <ul style={{ listStyle: 'none', padding: 0, margin: '0.3em 0 0', display: 'flex', flexDirection: 'column', gap: '0.3em' }}>
-        {visible.map((e, i) => (
-          <li key={i}>
-            <ActivityRow entry={e} />
-          </li>
-        ))}
-      </ul>
-      {!open && hidden > 0 && (
-        <div style={{ fontSize: '0.75em', color: 'var(--color-muted)', marginTop: '0.2em' }}>
-          他 {hidden} 件
-        </div>
+      <div style={{ fontSize: '0.78em', color: 'var(--color-muted)', marginBottom: '0.35em' }}>
+        今日カウントされた行動 ({sorted.length})
+      </div>
+      {/* 分類ごとにアイコン + 件数。押すまで本文は 1 行も出さない */}
+      <div style={{ display: 'flex', gap: '0.45em', flexWrap: 'wrap' }}>
+        {cats.map((c) => {
+          const active = openKey === c.key;
+          return (
+            <button
+              key={c.key}
+              type="button"
+              onClick={() => setOpenKey(active ? null : c.key)}
+              aria-expanded={active}
+              aria-label={`${c.label} ${c.entries.length}件`}
+              title={`${c.label} ${c.entries.length}件`}
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: '0.3em',
+                padding: '0.2em 0.6em',
+                fontSize: '0.82em',
+                borderRadius: 999,
+                background: active ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.35)',
+                border: '1px solid',
+                borderColor: active ? 'var(--color-primary)' : 'rgba(255,255,255,0.15)',
+                color: c.accent ? 'var(--color-accent)' : 'var(--color-muted)',
+                boxShadow: 'none',
+              }}
+            >
+              {c.icon}
+              <span style={{ fontWeight: 700 }}>{c.entries.length}</span>
+            </button>
+          );
+        })}
+      </div>
+      {openCat && (
+        <ul style={{ listStyle: 'none', padding: 0, margin: '0.45em 0 0', display: 'flex', flexDirection: 'column', gap: '0.3em' }}>
+          {openCat.entries.map((e, i) => (
+            <li key={i}>
+              <ActivityRow entry={e} />
+            </li>
+          ))}
+        </ul>
       )}
     </div>
   );


### PR DESCRIPTION
## 概要

ホーム上部「今日カウントされた行動」の監査ログを、長い文字列+常時展開のリストから、**結果カテゴリごとの SVG アイコン + 件数ピル**に集約した。チップをタップしたときだけ該当カテゴリの本文行を展開する。

### 変更点
- カテゴリは 3 種: **クエスト達成** (`ScrollIcon`, アクセント色) / **カウント対象外** (横線アイコン) / **分類不能** (? アイコン)
- 各カテゴリは「アイコン + 件数」のピルチップで表示 (絵文字ではなく SVG)
- チップ未タップ時は本文を **1 行も出さない**。タップ時にカテゴリ名ラベル + 本文行を展開
- 件数が 0 のカテゴリはチップ自体を出さない

### Why
ファーストビューを行動ログが占有してクエストを押し下げていた。普段は俯瞰だけ見せ、詳細は明示タップ時のみ展開して認知負荷と縦長を抑える。絵文字は使わず SVG アイコン (DESIGN.md 準拠)。

## 動作確認
- [x] typecheck 緑
- [x] test 緑 (144 passed)
- [x] build 緑

## Review

§1.5 必須レビュー (設計 / 実装 / UX の 3 並列 subagent) 実施。**★★★ = 0 件**。

### ★★ (PR 内で対応済み — commit f502865)
- **openKey ゴースト state**: 開いたカテゴリが投稿後の再 fetch で 0 件化すると state が死んだキーを保持 → `useEffect` で閉じるよう修正
- **リスト key が index**: `key={i}` → `key={e.at}` で再描画の取り違えを防止
- **分類基準の二重定義**: チップ振り分けと展開本文の分類を `auditCategory()` に一元化
- **アイコンのみで意味が伝わらない**: 展開時にカテゴリ名ラベルを表示 (普段はアイコンのみ、押すと分かる)
- **達成チップの accent 色 (DESIGN「強調は白」との緊張)**: 直上の既存「達成 N/M」カウンタと同じ accent で統一する**設計判断**として維持 (色は装飾でなく達成の意味付け)

### ★ (対応 or 据え置き)
- `cats` を `useMemo` 化 / `aria-controls` 付与 / `minHeight` でタップターゲット拡大 / 新 SVG の `size` 明示 / 旧 doc コメント更新 — **PR 内で対応済み**
- 新 SVG の viewBox が `icons.tsx` (24×24) と不一致 — ローカルヘルパとして許容、据え置き
- コンポーネント単体テスト追加 — e2e 中心方針のため据え置き