### PR TITLE
fix(ui): compose FAB の角丸を DESIGN 準拠の 3px に

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -490,7 +490,7 @@ p { margin: 0.4em 0; }
   color: #ffffff;
   background: var(--color-window-bg);
   border: 3px solid var(--color-border);
-  border-radius: 8px;
+  border-radius: 3px;
   box-shadow:
     inset 0 0 0 1px var(--color-window-inner-border),
     0 4px 0 rgba(0, 0, 0, 0.35);


### PR DESCRIPTION
## 概要
dev→main リリースレビュー (PR #89) の §1.5 ★★★ 対応。`.compose-fab` の `border-radius` が 8px で DESIGN.md「角丸を 8px 以上に上げない」(L178/L215) に違反していたため、DQ ウィンドウ系 (`.dq-window` / `.footer-nav` = 3px) に揃える。

差分は 1 行 (`8px → 3px`)。`.footer-nav-item` の既存 8px は本 PR スコープ外として据え置き。

## Review
リリースレビュー (#89) で検出した ★★★ の直接対応。単一 CSS 定数 (DESIGN.md 準拠) のため再 3 並列レビューは割愛。typecheck/build 緑。