### PR TITLE
feat(compose): 画像添付を最大4枚に対応

### DIFF
--- a/apps/web/src/components/compose-modal.tsx
+++ b/apps/web/src/components/compose-modal.tsx
@@ -1,6 +1,6 @@
 import { createContext, useCallback, useContext, useEffect, useRef, useState, type ReactNode } from 'react';
 import { useSession } from '@/lib/session';
-import { createPost, createPostWithImage, type ReplyRef } from '@/lib/atproto';
+import { createPost, createPostWithImages, MAX_POST_IMAGES, type ReplyRef } from '@/lib/atproto';
 import { compressImage } from '@/lib/image-compress';
 import { TextField } from './text-field';
 import { processSelfPost } from '@/lib/post-processor';
@@ -154,21 +154,21 @@ function ComposeDialog({
 }) {
   const session = useSession();
   const [text, setText] = useState(initialText);
-  const [image, setImage] = useState<DialogState | null>(() => {
-    if (!initialImage) return null;
-    return {
+  const [images, setImages] = useState<DialogState[]>(() => {
+    if (!initialImage) return [];
+    return [{
       blob: initialImage.blob,
       alt: initialImage.alt,
       source: initialImage.source,
       previewUrl: URL.createObjectURL(initialImage.blob),
-    };
+    }];
   });
   const [loading, setLoading] = useState(false);
   const [compressing, setCompressing] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const imageRef = useRef<DialogState | null>(image);
-  imageRef.current = image;
+  const imagesRef = useRef<DialogState[]>(images);
+  imagesRef.current = images;
   // 圧縮中に dialog が閉じたら、完了後の setState / objectURL 生成を抑止する
   const mountedRef = useRef(true);
 
@@ -184,9 +184,8 @@ function ComposeDialog({
       mountedRef.current = false;
       document.body.style.overflow = prevOverflow;
       window.removeEventListener('keydown', onKey);
-      // 最後にセットされてた image の url を revoke
-      const last = imageRef.current;
-      if (last) URL.revokeObjectURL(last.previewUrl);
+      // 最後にセットされてた image 群の url をすべて revoke
+      for (const im of imagesRef.current) URL.revokeObjectURL(im.previewUrl);
     };
   }, [loading, onClose]);
 
@@ -201,65 +200,75 @@ function ComposeDialog({
   }
 
   async function onFileChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const file = e.target.files?.[0];
+    const selected = Array.from(e.target.files ?? []);
     e.target.value = ''; // 同じファイルを再選択しても change が起きるように
-    if (!file) return;
-    if (!isAttachableImage(file)) {
-      setErr(`画像ファイルを選んでください (${file.type || '不明な形式'})。`);
+    if (selected.length === 0) return;
+
+    // 既存枚数 + 今回分が上限を超えるぶんは切り捨てて警告
+    const remaining = MAX_POST_IMAGES - imagesRef.current.length;
+    if (remaining <= 0) {
+      setErr(`画像は最大 ${MAX_POST_IMAGES} 枚までです。`);
       return;
     }
-    setErr(null);
-    // 大きい画像は弾かず、lossy WebP に圧縮して上限内に収める
-    // (GIF はアニメ保持のため変換しない)。
+    const files = selected.filter(isAttachableImage).slice(0, remaining);
+    const rejected = selected.length - files.length;
+    if (files.length === 0) {
+      setErr('画像ファイルを選んでください。');
+      return;
+    }
+    setErr(rejected > 0 ? `一部の画像は追加できませんでした (上限 ${MAX_POST_IMAGES} 枚 / 非対応形式)。` : null);
+
     setCompressing(true);
-    let blob: Blob = file;
+    const added: DialogState[] = [];
     try {
-      const result = await compressImage(file, { maxBytes: MAX_IMAGE_BYTES });
-      blob = result.blob;
-    } catch (e) {
-      console.warn('[compose] image compress failed, use original', e);
+      for (const file of files) {
+        // 大きい画像は弾かず、lossy WebP に圧縮して上限内に収める (GIF は変換しない)。
+        let blob: Blob = file;
+        try {
+          const result = await compressImage(file, { maxBytes: MAX_IMAGE_BYTES });
+          blob = result.blob;
+        } catch (err) {
+          console.warn('[compose] image compress failed, use original', err);
+        }
+        if (blob.size > MAX_IMAGE_BYTES) {
+          setErr(`圧縮しても上限を超える画像をスキップしました (${(blob.size / 1024).toFixed(0)} KB)。`);
+          continue;
+        }
+        added.push({ blob, alt: '', source: 'user', previewUrl: URL.createObjectURL(blob) });
+      }
     } finally {
       if (mountedRef.current) setCompressing(false);
     }
-    // 圧縮中に dialog を閉じていたら何もしない (objectURL を作らない = リーク防止)
-    if (!mountedRef.current) return;
-    // 圧縮しても上限を超える場合のみエラー (= 物理的に投稿できないサイズ)。
-    // 形式での門前払いはしない。iOS は写真を JPEG で渡すか Safari が HEIC を
-    // decode できるので、compressImage が JPEG/WebP に変換して投稿できる。
-    if (blob.size > MAX_IMAGE_BYTES) {
-      setErr(
-        `圧縮しても上限を超えました (${(blob.size / 1024).toFixed(0)} KB)。` +
-          'より小さい画像でお試しください。',
-      );
+    // 圧縮中に dialog を閉じていたら何もしない (objectURL を破棄してリーク防止)
+    if (!mountedRef.current) {
+      for (const im of added) URL.revokeObjectURL(im.previewUrl);
       return;
     }
-    if (image) URL.revokeObjectURL(image.previewUrl);
-    setImage({
-      blob,
-      alt: '',
-      source: 'user',
-      previewUrl: URL.createObjectURL(blob),
-    });
+    if (added.length > 0) setImages((prev) => [...prev, ...added].slice(0, MAX_POST_IMAGES));
   }
 
-  function removeImage() {
-    if (image) URL.revokeObjectURL(image.previewUrl);
-    setImage(null);
+  function removeImage(index: number) {
+    setImages((prev) => {
+      const target = prev[index];
+      if (target) URL.revokeObjectURL(target.previewUrl);
+      return prev.filter((_, i) => i !== index);
+    });
   }
 
   async function submit() {
     const body = text.trim();
     if (loading || !agent) return;
     // 画像なしの場合は空文字 NG。画像付きの場合は本文空でも投稿可。
-    if (!image && !body) return;
+    if (images.length === 0 && !body) return;
     if (body.length > POST_MAX_LENGTH) return;
 
     setLoading(true);
     setErr(null);
     try {
-      if (image) {
-        const tag = image.source === 'card' ? 'AozoraQuest' : undefined;
-        await createPostWithImage(agent, body, image.blob, image.alt, tag);
+      if (images.length > 0) {
+        // カード共有画像が含まれていれば #AozoraQuest facet を付ける。
+        const tag = images.some((im) => im.source === 'card') ? 'AozoraQuest' : undefined;
+        await createPostWithImages(agent, body, images.map((im) => ({ blob: im.blob, alt: im.alt })), tag);
       } else {
         const reply: ReplyRef | undefined = replyTo
           ? { root: replyTo.root, parent: replyTo.parent }
@@ -324,7 +333,7 @@ function ComposeDialog({
   const submitDisabled =
     loading
     || compressing
-    || (!text.trim() && !image)
+    || (!text.trim() && images.length === 0)
     || text.length > POST_MAX_LENGTH;
 
   return (
@@ -405,77 +414,74 @@ function ComposeDialog({
         />
 
         {showImageUi && (
-          <div style={{ marginTop: '0.5em' }}>
-            {image ? (
+          <div style={{ marginTop: '0.5em', display: 'flex', flexDirection: 'column', gap: '0.4em' }}>
+            {images.map((im, i) => (
               <div
+                key={im.previewUrl}
                 style={{
                   border: '1px solid rgba(255,255,255,0.18)',
                   borderRadius: 6,
                   padding: '0.5em',
                   display: 'flex',
-                  flexDirection: 'column',
-                  gap: '0.4em',
+                  gap: '0.6em',
+                  alignItems: 'flex-start',
                   background: 'rgba(0,0,0,0.25)',
                 }}
               >
-                <div style={{ display: 'flex', gap: '0.6em', alignItems: 'flex-start' }}>
-                  <img
-                    src={image.previewUrl}
-                    alt=""
-                    style={{
-                      maxWidth: 120,
-                      maxHeight: 160,
-                      objectFit: 'contain',
-                      borderRadius: 4,
-                      background: '#000',
-                    }}
+                <img
+                  src={im.previewUrl}
+                  alt=""
+                  style={{ maxWidth: 120, maxHeight: 160, objectFit: 'contain', borderRadius: 4, background: '#000' }}
+                />
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <label style={{ fontSize: '0.78em', color: 'var(--color-muted)' }}>
+                    alt (代替テキスト) — {i + 1}/{images.length}
+                  </label>
+                  <TextField
+                    multiline
+                    value={im.alt}
+                    onChange={(v) => setImages((prev) => prev.map((p, j) => (j === i ? { ...p, alt: v } : p)))}
+                    style={{ width: '100%', minHeight: '3em', padding: '0.3em', fontSize: '0.85em' }}
+                    placeholder="画像の説明 (a11y 用、空でも投稿可)"
+                    maxLength={1000}
+                    disabled={loading}
                   />
-                  <div style={{ flex: 1, minWidth: 0 }}>
-                    <label style={{ fontSize: '0.78em', color: 'var(--color-muted)' }}>
-                      alt (代替テキスト)
-                    </label>
-                    <TextField
-                      multiline
-                      value={image.alt}
-                      onChange={(v) => setImage((prev) => prev ? { ...prev, alt: v } : prev)}
-                      style={{ width: '100%', minHeight: '3em', padding: '0.3em', fontSize: '0.85em' }}
-                      placeholder="画像の説明 (a11y 用、空でも投稿可)"
-                      maxLength={1000}
+                  <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '0.75em', color: 'var(--color-muted)', marginTop: '0.2em' }}>
+                    <span>{(im.blob.size / 1024).toFixed(0)} KB · {im.blob.type || '?'}</span>
+                    <button
+                      className="secondary"
+                      onClick={() => removeImage(i)}
                       disabled={loading}
-                    />
-                    <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '0.75em', color: 'var(--color-muted)', marginTop: '0.2em' }}>
-                      <span>{(image.blob.size / 1024).toFixed(0)} KB · {image.blob.type || '?'}</span>
-                      <button
-                        className="secondary"
-                        onClick={removeImage}
-                        disabled={loading}
-                        style={{ fontSize: '0.8em', padding: '0.1em 0.5em' }}
-                      >
-                        画像を削除
-                      </button>
-                    </div>
+                      style={{ fontSize: '0.8em', padding: '0.1em 0.5em' }}
+                    >
+                      削除
+                    </button>
                   </div>
                 </div>
               </div>
-            ) : (
-              <button
-                className="secondary"
-                onClick={pickImage}
-                disabled={loading || compressing}
-                style={{ fontSize: '0.85em' }}
-              >
-                {compressing ? '画像を圧縮中...' : '📷 画像を添付'}
-              </button>
-            )}
-            {compressing && (
-              <span style={{ fontSize: '0.75em', color: 'var(--color-muted)', marginLeft: '0.5em' }}>
-                WebP に圧縮しています…
-              </span>
+            ))}
+            {images.length < MAX_POST_IMAGES && (
+              <div>
+                <button
+                  className="secondary"
+                  onClick={pickImage}
+                  disabled={loading || compressing}
+                  style={{ fontSize: '0.85em' }}
+                >
+                  {compressing ? '画像を圧縮中...' : images.length === 0 ? '画像を添付' : `画像を追加 (${images.length}/${MAX_POST_IMAGES})`}
+                </button>
+                {compressing && (
+                  <span style={{ fontSize: '0.75em', color: 'var(--color-muted)', marginLeft: '0.5em' }}>
+                    WebP に圧縮しています…
+                  </span>
+                )}
+              </div>
             )}
             <input
               ref={fileInputRef}
               type="file"
               accept={FILE_ACCEPT}
+              multiple
               onChange={onFileChange}
               style={{ display: 'none' }}
             />

--- a/apps/web/src/components/compose-modal.tsx
+++ b/apps/web/src/components/compose-modal.tsx
@@ -210,16 +210,19 @@ function ComposeDialog({
       setErr(`画像は最大 ${MAX_POST_IMAGES} 枚までです。`);
       return;
     }
-    const files = selected.filter(isAttachableImage).slice(0, remaining);
-    const rejected = selected.length - files.length;
+    const attachable = selected.filter(isAttachableImage);
+    const files = attachable.slice(0, remaining);
+    // スキップ理由を内訳で集計 (1 つの文言に上書きしない)
+    const unsupported = selected.length - attachable.length; // 非対応形式
+    const overLimit = attachable.length - files.length;       // 上限超過で入りきらない
     if (files.length === 0) {
       setErr('画像ファイルを選んでください。');
       return;
     }
-    setErr(rejected > 0 ? `一部の画像は追加できませんでした (上限 ${MAX_POST_IMAGES} 枚 / 非対応形式)。` : null);
 
     setCompressing(true);
     const added: DialogState[] = [];
+    let sizeSkipped = 0;
     try {
       for (const file of files) {
         // 大きい画像は弾かず、lossy WebP に圧縮して上限内に収める (GIF は変換しない)。
@@ -231,7 +234,7 @@ function ComposeDialog({
           console.warn('[compose] image compress failed, use original', err);
         }
         if (blob.size > MAX_IMAGE_BYTES) {
-          setErr(`圧縮しても上限を超える画像をスキップしました (${(blob.size / 1024).toFixed(0)} KB)。`);
+          sizeSkipped += 1;
           continue;
         }
         added.push({ blob, alt: '', source: 'user', previewUrl: URL.createObjectURL(blob) });
@@ -244,7 +247,20 @@ function ComposeDialog({
       for (const im of added) URL.revokeObjectURL(im.previewUrl);
       return;
     }
-    if (added.length > 0) setImages((prev) => [...prev, ...added].slice(0, MAX_POST_IMAGES));
+    if (added.length > 0) {
+      setImages((prev) => {
+        const merged = [...prev, ...added];
+        // 上限超過で落ちた分の objectURL を revoke (await を挟む間に prev が増えても漏らさない)
+        for (const dropped of merged.slice(MAX_POST_IMAGES)) URL.revokeObjectURL(dropped.previewUrl);
+        return merged.slice(0, MAX_POST_IMAGES);
+      });
+    }
+    // スキップ内訳をまとめて 1 つの文言に
+    const notes: string[] = [];
+    if (overLimit > 0) notes.push(`${overLimit} 枚は上限 (${MAX_POST_IMAGES} 枚) 超過`);
+    if (unsupported > 0) notes.push(`${unsupported} 枚は非対応形式`);
+    if (sizeSkipped > 0) notes.push(`${sizeSkipped} 枚はサイズ超過`);
+    setErr(notes.length > 0 ? `一部スキップ: ${notes.join(' / ')}` : null);
   }
 
   function removeImage(index: number) {
@@ -435,7 +451,7 @@ function ComposeDialog({
                 />
                 <div style={{ flex: 1, minWidth: 0 }}>
                   <label style={{ fontSize: '0.78em', color: 'var(--color-muted)' }}>
-                    alt (代替テキスト) — {i + 1}/{images.length}
+                    画像 {i + 1}/{images.length} の代替テキスト (alt)
                   </label>
                   <TextField
                     multiline
@@ -452,6 +468,7 @@ function ComposeDialog({
                       className="secondary"
                       onClick={() => removeImage(i)}
                       disabled={loading}
+                      aria-label={`画像 ${i + 1} を削除`}
                       style={{ fontSize: '0.8em', padding: '0.1em 0.5em' }}
                     >
                       削除
@@ -460,23 +477,26 @@ function ComposeDialog({
                 </div>
               </div>
             ))}
-            {images.length < MAX_POST_IMAGES && (
-              <div>
-                <button
-                  className="secondary"
-                  onClick={pickImage}
-                  disabled={loading || compressing}
-                  style={{ fontSize: '0.85em' }}
-                >
-                  {compressing ? '画像を圧縮中...' : images.length === 0 ? '画像を添付' : `画像を追加 (${images.length}/${MAX_POST_IMAGES})`}
-                </button>
-                {compressing && (
-                  <span style={{ fontSize: '0.75em', color: 'var(--color-muted)', marginLeft: '0.5em' }}>
-                    WebP に圧縮しています…
-                  </span>
-                )}
-              </div>
-            )}
+            {/* 上限到達時もボタンは残し disabled + (N/4) で「これ以上添付できない」を明示 */}
+            <div>
+              <button
+                className="secondary"
+                onClick={pickImage}
+                disabled={loading || compressing || images.length >= MAX_POST_IMAGES}
+                style={{ fontSize: '0.85em' }}
+              >
+                {compressing
+                  ? '画像を圧縮中...'
+                  : images.length === 0
+                    ? '画像を添付'
+                    : `画像を追加 (${images.length}/${MAX_POST_IMAGES})`}
+              </button>
+              {compressing && (
+                <span style={{ fontSize: '0.75em', color: 'var(--color-muted)', marginLeft: '0.5em' }}>
+                  WebP に圧縮しています…
+                </span>
+              )}
+            </div>
             <input
               ref={fileInputRef}
               type="file"

--- a/apps/web/src/lib/atproto.ts
+++ b/apps/web/src/lib/atproto.ts
@@ -316,37 +316,27 @@ export async function createPostWithImages(
   images: Array<{ blob: Blob; alt: string }>,
   tag?: string,
 ): Promise<void> {
+  // 呼び出し側 (UI) を信頼せず lib 側でも 4 枚に切り詰める最終ガード。
   const picked = images.slice(0, MAX_POST_IMAGES);
-  // 並列アップロード (map は順序を保持するので表示順は維持される)
-  const uploaded = await Promise.all(
-    picked.map(async ({ blob, alt }) => {
-      const res = await agent.uploadBlob(blob, { encoding: blob.type || 'image/png' });
-      return { alt, image: res.data.blob };
-    }),
-  );
   const record: Record<string, unknown> = {
     text,
     createdAt: new Date().toISOString(),
     via: VIA,
-    embed: {
-      $type: 'app.bsky.embed.images',
-      images: uploaded,
-    },
   };
+  if (picked.length > 0) {
+    // 並列アップロード (map は順序を保持するので表示順は維持される)
+    const uploaded = await Promise.all(
+      picked.map(async ({ blob, alt }) => {
+        const res = await agent.uploadBlob(blob, { encoding: blob.type || 'image/png' });
+        return { alt, image: res.data.blob };
+      }),
+    );
+    record['embed'] = { $type: 'app.bsky.embed.images', images: uploaded };
+  }
+  // picked が空なら embed を付けない (空 images embed は不正なので作らない)。
   const facets = buildTagFacets(text, tag);
   if (facets) record['facets'] = facets;
   await agent.post(record as unknown as Parameters<Agent['post']>[0]);
-}
-
-/** 単一画像版 (createPostWithImages の薄いラッパ。既存呼び出し互換)。 */
-export async function createPostWithImage(
-  agent: Agent,
-  text: string,
-  blob: Blob,
-  alt: string,
-  tag?: string,
-): Promise<void> {
-  return createPostWithImages(agent, text, [{ blob, alt }], tag);
 }
 
 /** ハッシュタグ facet 付き投稿 (検索 API で拾えるようにする) */

--- a/apps/web/src/lib/atproto.ts
+++ b/apps/web/src/lib/atproto.ts
@@ -283,11 +283,62 @@ export async function getRecord<T = unknown>(agent: Agent, repo: string, collect
 }
 
 /**
- * 画像付き投稿を作成する。画像を uploadBlob → `app.bsky.embed.images` embed
- * として post に紐付ける。
- * @param alt 画像の代替テキスト (アクセシビリティ)
- * @param tag  付与したいハッシュタグ (指定した場合 text 内から facet を抽出)
+ * text 内のハッシュタグ `#tag` を richtext facet (tag) に変換する。
+ * 見つからなければ undefined。
  */
+function buildTagFacets(text: string, tag?: string): unknown[] | undefined {
+  if (!tag) return undefined;
+  const marker = `#${tag}`;
+  const idx = text.indexOf(marker);
+  if (idx < 0) return undefined;
+  const encoder = new TextEncoder();
+  return [{
+    index: {
+      byteStart: encoder.encode(text.slice(0, idx)).length,
+      byteEnd: encoder.encode(text.slice(0, idx + marker.length)).length,
+    },
+    features: [{ $type: 'app.bsky.richtext.facet#tag', tag }],
+  }];
+}
+
+/** Bluesky の 1 投稿あたり画像添付上限。 */
+export const MAX_POST_IMAGES = 4;
+
+/**
+ * 画像付き投稿を作成する。最大 {@link MAX_POST_IMAGES} 枚を uploadBlob して
+ * `app.bsky.embed.images` embed として post に紐付ける (画像は配列順で表示)。
+ * @param images 各 {blob, alt}。alt は a11y 用 (空でも可)
+ * @param tag    付与したいハッシュタグ (指定時 text 内から facet を抽出)
+ */
+export async function createPostWithImages(
+  agent: Agent,
+  text: string,
+  images: Array<{ blob: Blob; alt: string }>,
+  tag?: string,
+): Promise<void> {
+  const picked = images.slice(0, MAX_POST_IMAGES);
+  // 並列アップロード (map は順序を保持するので表示順は維持される)
+  const uploaded = await Promise.all(
+    picked.map(async ({ blob, alt }) => {
+      const res = await agent.uploadBlob(blob, { encoding: blob.type || 'image/png' });
+      return { alt, image: res.data.blob };
+    }),
+  );
+  const record: Record<string, unknown> = {
+    text,
+    createdAt: new Date().toISOString(),
+    via: VIA,
+    embed: {
+      $type: 'app.bsky.embed.images',
+      images: uploaded,
+    },
+  };
+  const facets = buildTagFacets(text, tag);
+  if (facets) record['facets'] = facets;
+  await agent.post(record as unknown as Parameters<Agent['post']>[0]);
+}
+
+/** 単一画像版 (createPostWithImages の薄いラッパ。既存呼び出し互換)。 */
 export async function createPostWithImage(
   agent: Agent,
   text: string,
@@ -295,31 +346,7 @@ export async function createPostWithImage(
   alt: string,
   tag?: string,
 ): Promise<void> {
-  const res = await agent.uploadBlob(blob, { encoding: blob.type || 'image/png' });
-  const record: Record<string, unknown> = {
-    text,
-    createdAt: new Date().toISOString(),
-    via: VIA,
-    embed: {
-      $type: 'app.bsky.embed.images',
-      images: [{ alt, image: res.data.blob }],
-    },
-  };
-  if (tag) {
-    const marker = `#${tag}`;
-    const idx = text.indexOf(marker);
-    if (idx >= 0) {
-      const encoder = new TextEncoder();
-      record['facets'] = [{
-        index: {
-          byteStart: encoder.encode(text.slice(0, idx)).length,
-          byteEnd: encoder.encode(text.slice(0, idx + marker.length)).length,
-        },
-        features: [{ $type: 'app.bsky.richtext.facet#tag', tag }],
-      }];
-    }
-  }
-  await agent.post(record as unknown as Parameters<Agent['post']>[0]);
+  return createPostWithImages(agent, text, [{ blob, alt }], tag);
 }
 
 /** ハッシュタグ facet 付き投稿 (検索 API で拾えるようにする) */

--- a/apps/web/src/lib/create-post-images.test.ts
+++ b/apps/web/src/lib/create-post-images.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createPostWithImages, createPostWithImage, MAX_POST_IMAGES } from './atproto';
+import type { Agent } from '@atproto/api';
+
+function mockAgent() {
+  const uploadBlob = vi.fn(async (blob: Blob) => ({ data: { blob: { $type: 'blob', mimeType: blob.type } } }));
+  const post = vi.fn(async () => ({ uri: 'at://x/app.bsky.feed.post/1', cid: 'cid' }));
+  return { agent: { uploadBlob, post } as unknown as Agent, uploadBlob, post };
+}
+
+const img = (type: string, alt: string) => ({ blob: new Blob([alt], { type }), alt });
+
+describe('createPostWithImages', () => {
+  it('uploads each image and builds embed.images preserving order', async () => {
+    const { agent, uploadBlob, post } = mockAgent();
+    await createPostWithImages(agent, 'hello', [img('image/webp', 'A'), img('image/jpeg', 'B')]);
+    expect(uploadBlob).toHaveBeenCalledTimes(2);
+    const record = post.mock.calls[0][0] as { embed: { $type: string; images: { alt: string }[] } };
+    expect(record.embed.$type).toBe('app.bsky.embed.images');
+    expect(record.embed.images.map((i) => i.alt)).toEqual(['A', 'B']);
+  });
+
+  it('caps at MAX_POST_IMAGES (4)', async () => {
+    const { agent, uploadBlob, post } = mockAgent();
+    const many = Array.from({ length: 6 }, (_, i) => img('image/webp', String(i)));
+    await createPostWithImages(agent, '', many);
+    expect(uploadBlob).toHaveBeenCalledTimes(MAX_POST_IMAGES);
+    const record = post.mock.calls[0][0] as { embed: { images: unknown[] } };
+    expect(record.embed.images).toHaveLength(MAX_POST_IMAGES);
+  });
+
+  it('adds a tag facet when the tag appears in text', async () => {
+    const { agent, post } = mockAgent();
+    await createPostWithImages(agent, 'みて #AozoraQuest', [img('image/webp', '')], 'AozoraQuest');
+    const record = post.mock.calls[0][0] as { facets?: { features: { tag: string }[] }[] };
+    expect(record.facets).toBeDefined();
+    expect(record.facets?.[0].features[0].tag).toBe('AozoraQuest');
+  });
+
+  it('omits facets when the tag is not present in text', async () => {
+    const { agent, post } = mockAgent();
+    await createPostWithImages(agent, 'タグなし本文', [img('image/webp', '')], 'AozoraQuest');
+    const record = post.mock.calls[0][0] as { facets?: unknown };
+    expect(record.facets).toBeUndefined();
+  });
+
+  it('createPostWithImage delegates to the multi version (single image)', async () => {
+    const { agent, uploadBlob, post } = mockAgent();
+    await createPostWithImage(agent, 'hi', new Blob(['x'], { type: 'image/png' }), 'alt');
+    expect(uploadBlob).toHaveBeenCalledTimes(1);
+    const record = post.mock.calls[0][0] as { embed: { images: { alt: string }[] } };
+    expect(record.embed.images).toHaveLength(1);
+    expect(record.embed.images[0].alt).toBe('alt');
+  });
+});

--- a/apps/web/src/lib/create-post-images.test.ts
+++ b/apps/web/src/lib/create-post-images.test.ts
@@ -1,55 +1,69 @@
 import { describe, it, expect, vi } from 'vitest';
-import { createPostWithImages, createPostWithImage, MAX_POST_IMAGES } from './atproto';
+import { createPostWithImages, MAX_POST_IMAGES } from './atproto';
 import type { Agent } from '@atproto/api';
 
+interface PostRecord {
+  text: string;
+  embed?: { $type: string; images: { alt: string }[] };
+  facets?: { features: { tag?: string }[] }[];
+}
+
 function mockAgent() {
+  let posted: PostRecord | undefined;
   const uploadBlob = vi.fn(async (blob: Blob) => ({ data: { blob: { $type: 'blob', mimeType: blob.type } } }));
-  const post = vi.fn(async () => ({ uri: 'at://x/app.bsky.feed.post/1', cid: 'cid' }));
-  return { agent: { uploadBlob, post } as unknown as Agent, uploadBlob, post };
+  const post = vi.fn(async (record: unknown) => {
+    posted = record as PostRecord;
+    return { uri: 'at://x/app.bsky.feed.post/1', cid: 'cid' };
+  });
+  return { agent: { uploadBlob, post } as unknown as Agent, uploadBlob, post, posted: () => posted };
 }
 
 const img = (type: string, alt: string) => ({ blob: new Blob([alt], { type }), alt });
 
 describe('createPostWithImages', () => {
   it('uploads each image and builds embed.images preserving order', async () => {
-    const { agent, uploadBlob, post } = mockAgent();
-    await createPostWithImages(agent, 'hello', [img('image/webp', 'A'), img('image/jpeg', 'B')]);
-    expect(uploadBlob).toHaveBeenCalledTimes(2);
-    const record = post.mock.calls[0][0] as { embed: { $type: string; images: { alt: string }[] } };
-    expect(record.embed.$type).toBe('app.bsky.embed.images');
-    expect(record.embed.images.map((i) => i.alt)).toEqual(['A', 'B']);
+    const m = mockAgent();
+    await createPostWithImages(m.agent, 'hello', [img('image/webp', 'A'), img('image/jpeg', 'B')]);
+    expect(m.uploadBlob).toHaveBeenCalledTimes(2);
+    const rec = m.posted();
+    expect(rec?.embed?.$type).toBe('app.bsky.embed.images');
+    expect(rec?.embed?.images.map((i) => i.alt)).toEqual(['A', 'B']);
   });
 
   it('caps at MAX_POST_IMAGES (4)', async () => {
-    const { agent, uploadBlob, post } = mockAgent();
+    const m = mockAgent();
     const many = Array.from({ length: 6 }, (_, i) => img('image/webp', String(i)));
-    await createPostWithImages(agent, '', many);
-    expect(uploadBlob).toHaveBeenCalledTimes(MAX_POST_IMAGES);
-    const record = post.mock.calls[0][0] as { embed: { images: unknown[] } };
-    expect(record.embed.images).toHaveLength(MAX_POST_IMAGES);
+    await createPostWithImages(m.agent, '', many);
+    expect(m.uploadBlob).toHaveBeenCalledTimes(MAX_POST_IMAGES);
+    expect(m.posted()?.embed?.images).toHaveLength(MAX_POST_IMAGES);
   });
 
   it('adds a tag facet when the tag appears in text', async () => {
-    const { agent, post } = mockAgent();
-    await createPostWithImages(agent, 'みて #AozoraQuest', [img('image/webp', '')], 'AozoraQuest');
-    const record = post.mock.calls[0][0] as { facets?: { features: { tag: string }[] }[] };
-    expect(record.facets).toBeDefined();
-    expect(record.facets?.[0].features[0].tag).toBe('AozoraQuest');
+    const m = mockAgent();
+    await createPostWithImages(m.agent, 'みて #AozoraQuest', [img('image/webp', '')], 'AozoraQuest');
+    const facets = m.posted()?.facets;
+    expect(facets).toBeDefined();
+    expect(facets?.[0]?.features?.[0]?.tag).toBe('AozoraQuest');
   });
 
   it('omits facets when the tag is not present in text', async () => {
-    const { agent, post } = mockAgent();
-    await createPostWithImages(agent, 'タグなし本文', [img('image/webp', '')], 'AozoraQuest');
-    const record = post.mock.calls[0][0] as { facets?: unknown };
-    expect(record.facets).toBeUndefined();
+    const m = mockAgent();
+    await createPostWithImages(m.agent, 'タグなし本文', [img('image/webp', '')], 'AozoraQuest');
+    expect(m.posted()?.facets).toBeUndefined();
   });
 
-  it('createPostWithImage delegates to the multi version (single image)', async () => {
-    const { agent, uploadBlob, post } = mockAgent();
-    await createPostWithImage(agent, 'hi', new Blob(['x'], { type: 'image/png' }), 'alt');
-    expect(uploadBlob).toHaveBeenCalledTimes(1);
-    const record = post.mock.calls[0][0] as { embed: { images: { alt: string }[] } };
-    expect(record.embed.images).toHaveLength(1);
-    expect(record.embed.images[0].alt).toBe('alt');
+  it('posts a single image correctly', async () => {
+    const m = mockAgent();
+    await createPostWithImages(m.agent, 'hi', [img('image/png', 'alt')]);
+    expect(m.uploadBlob).toHaveBeenCalledTimes(1);
+    expect(m.posted()?.embed?.images.map((i) => i.alt)).toEqual(['alt']);
+  });
+
+  it('omits the embed entirely for an empty image list (text-only post)', async () => {
+    const m = mockAgent();
+    await createPostWithImages(m.agent, 'text only', []);
+    expect(m.uploadBlob).not.toHaveBeenCalled();
+    expect(m.posted()?.embed).toBeUndefined();
+    expect(m.posted()?.text).toBe('text only');
   });
 });

--- a/apps/web/src/routes/card.tsx
+++ b/apps/web/src/routes/card.tsx
@@ -385,7 +385,7 @@ export function Card() {
       const initialText = `${displayArchetype(result.archetype)} の気質が出ました。 #AozoraQuest`;
       const alt = `${profile.displayName} の診断カード。職業は${displayArchetype(result.archetype)}。`;
       // 既存の投稿モーダルに blob + 既定テキストを渡して、ユーザー編集 → 送信。
-      // モーダル送信時は createPostWithImage 経路を通るので tag (#AozoraQuest)
+      // モーダル送信時は createPostWithImages 経路を通るので tag (#AozoraQuest)
       // も automatic に facet 化される (compose-modal 側で source='card' を判定)。
       openCompose({
         initialText,


### PR DESCRIPTION
## 概要

画像が 1 枚しか添付できなかった問題を修正。Bluesky は 1 投稿あたり **4 枚**まで対応しているので合わせる。

### 変更
- **lib/atproto**: `createPostWithImages(images[])` を追加。最大 4 枚を**並列 uploadBlob** → `app.bsky.embed.images` に**配列順**で格納。0 枚なら embed 無しの text-only post。tag facet 抽出を `buildTagFacets` に共通化。`MAX_POST_IMAGES=4` を export。(旧 `createPostWithImage` は本番呼び出し元が無いため削除し一本化)
- **compose-modal**: 単一 `image` → `images` 配列 (最大4)。file input に `multiple`、複数選択をまとめて圧縮して追加。各画像にプレビュー + alt 入力 + 個別削除、4 枚到達でボタン disabled + (4/4) 表示。スキップ理由は内訳集計して 1 文言に
- 「画像を添付」の絵文字 (📷) を撤去 (DESIGN)
- **テスト**: `create-post-images.test.ts` — 順序保持 / 4枚上限 / tag facet 有無 / 単一 / 空配列 (vitest 158→164)

## 動作確認
- [x] typecheck / test (164) / build 緑
- [ ] dev でログインして複数選択 2〜4枚 → 投稿 → TL に並ぶことを確認 (compose は要ログインのため実機/dev で)

## Review

§1.5 必須レビュー (設計 / 実装 / UX 3 並列) 実施。**★★★ = 0**。

### ★★ (PR 内で対応済み — commit 59011d3)
- **createPostWithImage が dead code** (card も createPostWithImages を通る) → 削除して一本化、card.tsx の stale コメント修正
- **空配列で空 embed を作る** → 0 枚なら embed 無し text-only に
- **エラー文言が上書きされ複数原因が混ざる** → スキップ理由を内訳集計して 1 文言に
- **slice で落ちた objectURL リーク** → setImages 内で revoke
- **4枚到達でボタンが無言で消える** → disabled + (4/4) で上限明示
- **テストが typecheck 未通過** (test+build のみ確認していた) → noUncheckedIndexedAccess 配下で mock.calls 索引が型エラー → record を mock 側で捕捉する形に書き直し typecheck もクリーン

### ★ / 据え置き (issue 化候補)
- 画像の**並べ替え**不可 (順序は添付順固定) — 別 issue
- 4枚時に alt 欄が縦に伸びる (横サムネ + alt 折りたたみ案) — 別 issue
- `buildTagFacets` を `createTaggedPost` にも展開する DRY — 別 issue
- StrictMode 初回マウントでの card 共有プレビュー表示 — dev 実機確認