### PR TITLE
refactor(datetime): 日時の生成関数を format-datetime.ts に集約

### DIFF
--- a/apps/web/src/components/home-summary.tsx
+++ b/apps/web/src/components/home-summary.tsx
@@ -8,6 +8,7 @@ import { PersonIcon, ScrollIcon } from './icons';
 import { SpiritBubble } from './spirit-bubble';
 import { useOnPosted } from './compose-modal';
 import { ensureTodayQuestLog, loadTodayQuestLog, type ActivityEntry, type QuestLogRecord } from '@/lib/post-processor';
+import { formatTime } from '@/lib/format-datetime';
 
 interface HomeSummaryProps {
   agent: Agent | null;
@@ -406,9 +407,7 @@ function ActivityRow({ entry }: { entry: ActivityEntry }) {
     const t = DEFAULT_QUEST_TEMPLATES.find((t) => t.id === id);
     return t ? t.descriptionTemplate.replace('{N}', '—') : id;
   };
-  const time = (() => {
-    try { return new Date(entry.at).toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' }); } catch { return ''; }
-  })();
+  const time = formatTime(entry.at);
   const actionText = actionLabel(entry.action);
   return (
     <div

--- a/apps/web/src/lib/format-datetime.test.ts
+++ b/apps/web/src/lib/format-datetime.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatDateTime } from './format-datetime';
+import { formatDateTime, formatTime } from './format-datetime';
 
 describe('formatDateTime', () => {
   it('formats an ISO string to YYYY/MM/DD HH:MM:SS in local time', () => {
@@ -23,5 +23,23 @@ describe('formatDateTime', () => {
     expect(formatDateTime(undefined)).toBe('');
     expect(formatDateTime('')).toBe('');
     expect(formatDateTime('not-a-date')).toBe('');
+  });
+});
+
+describe('formatTime', () => {
+  it('formats HH:MM in local time, zero-padded', () => {
+    const d = new Date(2026, 5, 14, 9, 5, 30);
+    expect(formatTime(d.toISOString())).toBe('09:05');
+  });
+
+  it('drops seconds and date', () => {
+    const d = new Date(2026, 11, 31, 23, 59, 59);
+    expect(formatTime(d.toISOString())).toBe('23:59');
+  });
+
+  it('returns empty string for null / undefined / invalid', () => {
+    expect(formatTime(null)).toBe('');
+    expect(formatTime(undefined)).toBe('');
+    expect(formatTime('nope')).toBe('');
   });
 });

--- a/apps/web/src/lib/format-datetime.ts
+++ b/apps/web/src/lib/format-datetime.ts
@@ -1,11 +1,31 @@
+/**
+ * 日時表記はこのモジュールに集約する (アプリ全体で生成関数を統一)。
+ *
+ * 方針:
+ * - 投稿カード (post-metrics) / 通知 (notification-item): いつの投稿か特定できるよう
+ *   `formatDateTime` のフル表記 (年月日 + 秒まで)。秒は残す (オーナー方針)。
+ * - 当日の行動ログ (home-summary の監査ログ) のように日付が自明な文脈: `formatTime`
+ *   の時刻のみ (HH:MM)。
+ * 表示サイズは配置の都合でレイアウト側が決める (投稿=小さく右端 / 通知=1 行に収める)。
+ */
+
+const pad = (n: number) => String(n).padStart(2, '0');
+
 /** ISO 文字列を "YYYY/MM/DD HH:MM:SS" (ローカルタイムゾーン) に整形。 */
 export function formatDateTime(iso: string | undefined | null): string {
   if (!iso) return '';
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return '';
-  const pad = (n: number) => String(n).padStart(2, '0');
   return (
     `${d.getFullYear()}/${pad(d.getMonth() + 1)}/${pad(d.getDate())} ` +
     `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
   );
+}
+
+/** ISO 文字列を "HH:MM" (ローカルタイムゾーン) に整形。日付が自明な文脈用。 */
+export function formatTime(iso: string | undefined | null): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }

--- a/apps/web/src/routes/quests.tsx
+++ b/apps/web/src/routes/quests.tsx
@@ -10,6 +10,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { BoardIcon } from '@/components/icons';
 import { ActionLink } from '@/components/action-link';
+import { formatTime } from '@/lib/format-datetime';
 import type { Agent } from '@atproto/api';
 import type { DiagnosisResult, Quest, StatVector } from '@aozoraquest/core';
 import {
@@ -425,13 +426,7 @@ function QuestRow({ quest }: { quest: Quest }) {
 }
 
 function ActivityRow({ entry }: { entry: ActivityEntry }) {
-  const time = (() => {
-    try {
-      return new Date(entry.at).toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' });
-    } catch {
-      return '';
-    }
-  })();
+  const time = formatTime(entry.at);
   const actionText = actionLabel(entry.action);
   const types = entry.actionTypes ?? (entry.action ? [entry.action] : []);
   return (


### PR DESCRIPTION
Closes #98。

## 変更
- format-datetime.ts に formatTime(iso) → "HH:MM" を追加 + 日時表記の方針コメント (post/通知=フル+秒、当日ログ=時刻のみ)
- home-summary 監査ログの inline toLocaleTimeString を formatTime に置換 (出力 HH:MM で従来と同一)
- formatTime ユニットテスト追加 (web 164→167)

## 判断記録
- **サイズ** (post 0.68em / 通知 0.8em): 配置都合 (投稿=小さく右端 / 通知=1行に収める) でレイアウト側が決める。サイズ強制統一はオーナーの既存要望 (投稿はさらに小さく / 通知は1行) と矛盾するため**しない**。
- **フォーマット**: post/通知=フル(秒あり)、当日ログ=時刻のみ、を文脈別に維持。生成関数だけ集約。

## 動作確認
- [x] typecheck / web test 167 / build 緑、監査ログの時刻出力は従来と同一(HH:MM)

## Review
小さな集約のため実装観点1本でレビュー。

---
## Review 結果
実装レビュー: ★★★ ゼロ。旧 toLocaleTimeString と formatTime の出力同一 (00:00/09:05/23:59 等) を検証済み・回帰なし。
- ★★ 集約の取りこぼし (quests.tsx の ActivityRow に同一 inline が残存) → commit 8f455a2 で formatTime に置換。**toLocaleTimeString はアプリから全廃**。