### PR TITLE
feat(compose): 添付画像(最大4枚)の並べ替え (← →)

### DIFF
--- a/apps/web/src/components/compose-modal.tsx
+++ b/apps/web/src/components/compose-modal.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useEffect, useRef, useState, type ReactNode } from 'react';
+import { createContext, useCallback, useContext, useEffect, useRef, useState, type CSSProperties, type ReactNode } from 'react';
 import { useSession } from '@/lib/session';
 import { createPost, createPostWithImages, MAX_POST_IMAGES, type ReplyRef } from '@/lib/atproto';
 import { compressImage } from '@/lib/image-compress';
@@ -140,6 +140,16 @@ function isAttachableImage(file: File): boolean {
 }
 /** Bluesky uploadBlob の上限は約 1MB。少しマージン取って 950KB を上限警告ラインに。 */
 const MAX_IMAGE_BYTES = 950_000;
+
+/** 画像プレビュー行の操作ボタン (← → 削除)。親が 0.75em と小さいので rem 基準で
+ *  独立に大きさを決め、モバイルのタップ領域 (≈40px) を確保する。 */
+const IMG_CTRL_BTN: CSSProperties = {
+  fontSize: '0.95rem',
+  minHeight: '2.6em',
+  minWidth: '2.6em',
+  padding: '0.2em 0.6em',
+  lineHeight: 1,
+};
 
 function ComposeDialog({
   replyTo,
@@ -447,6 +457,13 @@ function ComposeDialog({
 
         {showImageUi && (
           <div style={{ marginTop: '0.5em', display: 'flex', flexDirection: 'column', gap: '0.4em' }}>
+            {images.length > 1 && (
+              <p style={{ fontSize: '0.75em', color: 'var(--color-muted)', margin: 0 }}>
+                上から順に表示されます (1 枚目が代表)。← → で並べ替え。
+              </p>
+            )}
+            {/* key は previewUrl (blob ごとに一意・生存中不変)。並べ替えでも安定なので
+                index ベース操作でも img/alt の状態が混ざらない reorder-safe key になる。 */}
             {images.map((im, i) => (
               <div
                 key={im.previewUrl}
@@ -478,9 +495,9 @@ function ComposeDialog({
                     maxLength={1000}
                     disabled={loading}
                   />
-                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', fontSize: '0.75em', color: 'var(--color-muted)', marginTop: '0.2em', gap: '0.4em' }}>
-                    <span style={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{(im.blob.size / 1024).toFixed(0)} KB · {im.blob.type || '?'}</span>
-                    <span style={{ display: 'inline-flex', gap: '0.3em', flexShrink: 0 }}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', fontSize: '0.75em', color: 'var(--color-muted)', marginTop: '0.3em', gap: '0.5em', flexWrap: 'wrap' }}>
+                    <span style={{ flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{(im.blob.size / 1024).toFixed(0)} KB · {im.blob.type || '?'}</span>
+                    <span style={{ display: 'inline-flex', gap: '0.4em', flexShrink: 0, alignItems: 'center' }}>
                       {images.length > 1 && (
                         <>
                           <button
@@ -489,7 +506,7 @@ function ComposeDialog({
                             disabled={loading || i === 0}
                             aria-label={`画像 ${i + 1} を前へ`}
                             title="前へ"
-                            style={{ fontSize: '0.8em', padding: '0.1em 0.5em' }}
+                            style={IMG_CTRL_BTN}
                           >
                             ←
                           </button>
@@ -499,18 +516,19 @@ function ComposeDialog({
                             disabled={loading || i === images.length - 1}
                             aria-label={`画像 ${i + 1} を後ろへ`}
                             title="後ろへ"
-                            style={{ fontSize: '0.8em', padding: '0.1em 0.5em' }}
+                            style={IMG_CTRL_BTN}
                           >
                             →
                           </button>
                         </>
                       )}
+                      {/* 破壊的アクションなので移動ボタンと間隔を空けて誤タップを防ぐ */}
                       <button
                         className="secondary"
                         onClick={() => removeImage(i)}
                         disabled={loading}
                         aria-label={`画像 ${i + 1} を削除`}
-                        style={{ fontSize: '0.8em', padding: '0.1em 0.5em' }}
+                        style={{ ...IMG_CTRL_BTN, marginLeft: images.length > 1 ? '0.7em' : 0 }}
                       >
                         削除
                       </button>

--- a/apps/web/src/components/compose-modal.tsx
+++ b/apps/web/src/components/compose-modal.tsx
@@ -271,6 +271,22 @@ function ComposeDialog({
     });
   }
 
+  // 隣の画像と入れ替え (Bluesky は embed.images の配列順で表示するので順序に意味がある)。
+  // objectURL は不変なので revoke しない。
+  function moveImage(index: number, dir: -1 | 1) {
+    setImages((prev) => {
+      const to = index + dir;
+      if (to < 0 || to >= prev.length) return prev;
+      const next = [...prev];
+      const a = next[index];
+      const b = next[to];
+      if (!a || !b) return prev;
+      next[index] = b;
+      next[to] = a;
+      return next;
+    });
+  }
+
   async function submit() {
     const body = text.trim();
     if (loading || !agent) return;
@@ -462,17 +478,43 @@ function ComposeDialog({
                     maxLength={1000}
                     disabled={loading}
                   />
-                  <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '0.75em', color: 'var(--color-muted)', marginTop: '0.2em' }}>
-                    <span>{(im.blob.size / 1024).toFixed(0)} KB · {im.blob.type || '?'}</span>
-                    <button
-                      className="secondary"
-                      onClick={() => removeImage(i)}
-                      disabled={loading}
-                      aria-label={`画像 ${i + 1} を削除`}
-                      style={{ fontSize: '0.8em', padding: '0.1em 0.5em' }}
-                    >
-                      削除
-                    </button>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', fontSize: '0.75em', color: 'var(--color-muted)', marginTop: '0.2em', gap: '0.4em' }}>
+                    <span style={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{(im.blob.size / 1024).toFixed(0)} KB · {im.blob.type || '?'}</span>
+                    <span style={{ display: 'inline-flex', gap: '0.3em', flexShrink: 0 }}>
+                      {images.length > 1 && (
+                        <>
+                          <button
+                            className="secondary"
+                            onClick={() => moveImage(i, -1)}
+                            disabled={loading || i === 0}
+                            aria-label={`画像 ${i + 1} を前へ`}
+                            title="前へ"
+                            style={{ fontSize: '0.8em', padding: '0.1em 0.5em' }}
+                          >
+                            ←
+                          </button>
+                          <button
+                            className="secondary"
+                            onClick={() => moveImage(i, 1)}
+                            disabled={loading || i === images.length - 1}
+                            aria-label={`画像 ${i + 1} を後ろへ`}
+                            title="後ろへ"
+                            style={{ fontSize: '0.8em', padding: '0.1em 0.5em' }}
+                          >
+                            →
+                          </button>
+                        </>
+                      )}
+                      <button
+                        className="secondary"
+                        onClick={() => removeImage(i)}
+                        disabled={loading}
+                        aria-label={`画像 ${i + 1} を削除`}
+                        style={{ fontSize: '0.8em', padding: '0.1em 0.5em' }}
+                      >
+                        削除
+                      </button>
+                    </span>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
Closes #97。

## 変更
PR #91 の4枚添付に**並べ替え**を追加。Bluesky は `app.bsky.embed.images` の配列順で1枚目を大きく表示するので順序に意味がある。
- 各画像プレビューのメタ行に ← / → ボタン (2枚以上のときだけ表示)
- 先頭で ←、末尾で → を `disabled`
- `moveImage(i, dir)` は隣とスワップのみ。objectURL は不変 (revoke しない、`key={previewUrl}` も安定で DOM 再利用)

## 動作確認
- [x] typecheck / web test 167 / build 緑
- [ ] dev でログインして 2〜4枚添付 → ←→ で並べ替え → 投稿後 TL の並び順が一致 (compose は要ログインのためローカル目視不可)

## Review
§1.5 3並列レビュー実施予定。

---
## Review 結果
§1.5 設計/実装/UX 3並列レビュー実施。
### ★★★ (PR内で対応済み — commit e4f5764)
- **タップターゲットが小さすぎ (実効~9.6px/高さ~24px、iOS 44px 未満) + 破壊的「削除」が移動ボタンと無差別並びで誤タップ危険**: IMG_CTRL_BTN を rem基準(0.95rem)+minHeight/minWidth 2.6em で ≈40px に拡大、削除を marginLeft 0.7em で分離
### ★★ (対応 or issue化)
- 移動後のフォーカス追従 (a11y、キーボード/SR) → issue #105 に切り出し (mobile touch 主用途のため優先度低)
- 「1枚目が代表表示」の含意が不明 → 順序ヒント「上から順に表示 (1枚目が代表)」を追加
- previewUrl が reorder-safe key である前提 → コメントで明文化
### ★ 据え置き
- 2枚時に ←→ 両方表示で片方 disabled (3-4枚との一貫性優先)、disabled の視覚差 (テーマCSS依存、実機確認)

実装の正しさ (スワップ/objectURL不変/配列順保持/alt追従) は3観点とも確認済み。