### PR TITLE
fix(compose): 画像 decode を createImageBitmap→<img> 2段フォールバックに (Android 高解像度 reject 対策)

### DIFF
--- a/apps/web/src/components/compose-modal.tsx
+++ b/apps/web/src/components/compose-modal.tsx
@@ -233,6 +233,7 @@ function ComposeDialog({
     setCompressing(true);
     const added: DialogState[] = [];
     let sizeSkipped = 0;
+    let worstSkippedBytes = 0; // 超過した中で最大の「圧縮後」サイズ (文言で原因を可視化)
     try {
       for (const file of files) {
         // 大きい画像は弾かず、lossy WebP に圧縮して上限内に収める (GIF は変換しない)。
@@ -245,6 +246,7 @@ function ComposeDialog({
         }
         if (blob.size > MAX_IMAGE_BYTES) {
           sizeSkipped += 1;
+          worstSkippedBytes = Math.max(worstSkippedBytes, blob.size);
           continue;
         }
         added.push({ blob, alt: '', source: 'user', previewUrl: URL.createObjectURL(blob) });
@@ -269,7 +271,11 @@ function ComposeDialog({
     const notes: string[] = [];
     if (overLimit > 0) notes.push(`${overLimit} 枚は上限 (${MAX_POST_IMAGES} 枚) 超過`);
     if (unsupported > 0) notes.push(`${unsupported} 枚は非対応形式`);
-    if (sizeSkipped > 0) notes.push(`${sizeSkipped} 枚はサイズ超過`);
+    if (sizeSkipped > 0) {
+      // 圧縮後サイズを併記。これが原寸近いなら「圧縮が効いていない」と切り分けできる。
+      const mb = (worstSkippedBytes / 1_000_000).toFixed(1);
+      notes.push(`${sizeSkipped} 枚はサイズ超過 (圧縮後 約${mb}MB)`);
+    }
     setErr(notes.length > 0 ? `一部スキップ: ${notes.join(' / ')}` : null);
   }
 

--- a/apps/web/src/components/compose-modal.tsx
+++ b/apps/web/src/components/compose-modal.tsx
@@ -175,6 +175,8 @@ function ComposeDialog({
   });
   const [loading, setLoading] = useState(false);
   const [compressing, setCompressing] = useState(false);
+  // 複数枚を逐次処理する間「進んでいる」ことを見せる (高解像度 4 枚は数秒かかり、固まったと誤解されるため)
+  const [compressProgress, setCompressProgress] = useState<{ done: number; total: number } | null>(null);
   const [err, setErr] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const imagesRef = useRef<DialogState[]>(images);
@@ -231,10 +233,11 @@ function ComposeDialog({
     }
 
     setCompressing(true);
+    setCompressProgress({ done: 0, total: files.length });
     const added: DialogState[] = [];
     let sizeSkipped = 0;
-    let worstSkippedBytes = 0; // 超過した中で最大の「圧縮後」サイズ (文言で原因を可視化)
     try {
+      let done = 0;
       for (const file of files) {
         // 大きい画像は弾かず、lossy WebP に圧縮して上限内に収める (GIF は変換しない)。
         let blob: Blob = file;
@@ -244,15 +247,20 @@ function ComposeDialog({
         } catch (err) {
           console.warn('[compose] image compress failed, use original', err);
         }
+        if (mountedRef.current) setCompressProgress({ done: ++done, total: files.length });
         if (blob.size > MAX_IMAGE_BYTES) {
           sizeSkipped += 1;
-          worstSkippedBytes = Math.max(worstSkippedBytes, blob.size);
+          // 原因切り分け (圧縮が効いていない / 効いても収まらない) は開発者向け。文言には出さない。
+          console.warn(`[compose] 添付不可: 圧縮後も ${(blob.size / 1000).toFixed(0)}KB で上限 ${(MAX_IMAGE_BYTES / 1000).toFixed(0)}KB 超過`);
           continue;
         }
         added.push({ blob, alt: '', source: 'user', previewUrl: URL.createObjectURL(blob) });
       }
     } finally {
-      if (mountedRef.current) setCompressing(false);
+      if (mountedRef.current) {
+        setCompressing(false);
+        setCompressProgress(null);
+      }
     }
     // 圧縮中に dialog を閉じていたら何もしない (objectURL を破棄してリーク防止)
     if (!mountedRef.current) {
@@ -269,14 +277,13 @@ function ComposeDialog({
     }
     // スキップ内訳をまとめて 1 つの文言に
     const notes: string[] = [];
-    if (overLimit > 0) notes.push(`${overLimit} 枚は上限 (${MAX_POST_IMAGES} 枚) 超過`);
-    if (unsupported > 0) notes.push(`${unsupported} 枚は非対応形式`);
+    if (overLimit > 0) notes.push(`${overLimit} 枚は上限 (${MAX_POST_IMAGES} 枚) を超えました`);
+    if (unsupported > 0) notes.push(`${unsupported} 枚は対応していない形式でした`);
     if (sizeSkipped > 0) {
-      // 圧縮後サイズを併記。これが原寸近いなら「圧縮が効いていない」と切り分けできる。
-      const mb = (worstSkippedBytes / 1_000_000).toFixed(1);
-      notes.push(`${sizeSkipped} 枚はサイズ超過 (圧縮後 約${mb}MB)`);
+      // ユーザーには行動 (撮り直し/縮小) を促す。サイズ等の技術詳細は console 側に出す。
+      notes.push(`${sizeSkipped} 枚は容量が大きく添付できませんでした。小さくして添付し直してください`);
     }
-    setErr(notes.length > 0 ? `一部スキップ: ${notes.join(' / ')}` : null);
+    setErr(notes.length > 0 ? `一部添付できませんでした: ${notes.join(' / ')}` : null);
   }
 
   function removeImage(index: number) {
@@ -552,14 +559,16 @@ function ComposeDialog({
                 style={{ fontSize: '0.85em' }}
               >
                 {compressing
-                  ? '画像を圧縮中...'
+                  ? compressProgress && compressProgress.total > 1
+                    ? `画像を準備中... (${compressProgress.done}/${compressProgress.total})`
+                    : '画像を準備中...'
                   : images.length === 0
                     ? '画像を添付'
                     : `画像を追加 (${images.length}/${MAX_POST_IMAGES})`}
               </button>
               {compressing && (
                 <span style={{ fontSize: '0.75em', color: 'var(--color-muted)', marginLeft: '0.5em' }}>
-                  WebP に圧縮しています…
+                  投稿用に画像を準備しています…
                 </span>
               )}
             </div>

--- a/apps/web/src/lib/image-compress.test.ts
+++ b/apps/web/src/lib/image-compress.test.ts
@@ -1,16 +1,21 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { compressImage, isBlueskySupportedImageType } from './image-compress';
 
-// jsdom には createImageBitmap / canvas.toBlob('image/webp') が無いため、
-// canvas 経路は通らず early-return (元 File を返す) になる。ここではその
-// 「壊さない」分岐 (GIF スキップ / 非対応フォールバック) を検証する。
-// 実際の WebP 変換は browser 専用なので実機 / e2e 側で確認する。
+// vitest は node 環境 (DOM 無し)。createImageBitmap / canvas.toBlob が無い素の状態では
+// canvas 経路は通らず early-return (元 File を返す) になる。まずその「壊さない」分岐を検証。
+// canvas / createImageBitmap / Image をスタブした分岐 (= 実ブラウザ相当の制御フロー) は後段で検証する。
+// 実際の WebP 変換品質は browser 専用なので実機 / Playwright 側で確認する。
 
 function fakeFile(type: string, bytes = 2_000_000): File {
   return new File([new Uint8Array(bytes)], 'x', { type });
 }
 
-describe('compressImage (jsdom: canvas 非対応で fallback)', () => {
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('compressImage (DOM 非対応で fallback)', () => {
   it('GIF はアニメ保持のため変換せず元 File を返す', async () => {
     const f = fakeFile('image/gif');
     const r = await compressImage(f);
@@ -22,6 +27,112 @@ describe('compressImage (jsdom: canvas 非対応で fallback)', () => {
   it('canvas/WebP 非対応環境では元 File をそのまま返す (壊さない)', async () => {
     const f = fakeFile('image/png');
     const r = await compressImage(f);
+    expect(r.compressed).toBe(false);
+    expect(r.blob).toBe(f);
+  });
+});
+
+// fit する小さい blob を必ず返す fake canvas (toBlob は ~100KB を返す)
+function installCanvasStub() {
+  const FIT_BYTES = 100_000;
+  const fakeCtx = {
+    fillStyle: '',
+    fillRect: vi.fn(),
+    drawImage: vi.fn(),
+    getImageData: vi.fn(() => ({ data: new Uint8ClampedArray(4), width: 1, height: 1 })),
+  };
+  const createElement = vi.fn((tag: string) => {
+    if (tag !== 'canvas') throw new Error(`unexpected createElement(${tag})`);
+    return {
+      width: 0,
+      height: 0,
+      getContext: () => fakeCtx,
+      // supportsWebpEncode() が true を返すよう webp を申告 → ネイティブ WebP 経路
+      toDataURL: (type: string) => `data:${type};base64,xxx`,
+      toBlob: (cb: (b: Blob | null) => void, type: string) => {
+        cb(new Blob([new Uint8Array(FIT_BYTES)], { type }));
+      },
+    };
+  });
+  vi.stubGlobal('document', { createElement });
+}
+
+function stubUrl() {
+  vi.stubGlobal('URL', { createObjectURL: () => 'blob:fake', revokeObjectURL: vi.fn() });
+}
+
+/**
+ * 本丸: Android Chrome は端末メモリ次第で高解像度カメラ JPEG (12〜64MP) の
+ * createImageBitmap が reject することがある。その時に元 File を返すと「圧縮されず
+ * 素のサイズで上限超過 → 投稿弾かれ」になるため、<img> 経路に退避して必ず圧縮まで
+ * 到達させる。ここではその制御フローをスタブで検証する。
+ */
+describe('compressImage decode fallback', () => {
+  it('createImageBitmap が reject しても <img> 経路で圧縮まで到達する', async () => {
+    installCanvasStub();
+    stubUrl();
+    vi.stubGlobal('createImageBitmap', vi.fn(() => Promise.reject(new Error('forced reject'))));
+
+    const imgInstances: Array<{ src: string }> = [];
+    class FakeImage {
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      naturalWidth = 4080;
+      naturalHeight = 3072;
+      _src = '';
+      set src(v: string) {
+        this._src = v;
+        imgInstances.push(this);
+        queueMicrotask(() => this.onload?.()); // 実ブラウザの decode 同様に非同期で発火
+      }
+      get src() {
+        return this._src;
+      }
+    }
+    vi.stubGlobal('Image', FakeImage as unknown as typeof Image);
+
+    const r = await compressImage(fakeFile('image/jpeg', 4_000_000), { maxBytes: 950_000 });
+
+    expect(r.compressed).toBe(true); // 元 File にフォールバックしていない
+    expect(r.blob.size).toBeLessThanOrEqual(950_000);
+    expect(imgInstances.length).toBeGreaterThan(0); // <img> 経路を実際に通った
+  });
+
+  it('createImageBitmap 成功時は <img> を使わず bitmap を後始末する', async () => {
+    installCanvasStub();
+    stubUrl();
+    const close = vi.fn();
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn(() => Promise.resolve({ width: 4080, height: 3072, close })),
+    );
+    const ImageCtor = vi.fn();
+    vi.stubGlobal('Image', ImageCtor as unknown as typeof Image);
+
+    const r = await compressImage(fakeFile('image/jpeg', 4_000_000), { maxBytes: 950_000 });
+
+    expect(r.compressed).toBe(true);
+    expect(r.blob.size).toBeLessThanOrEqual(950_000);
+    expect(ImageCtor).not.toHaveBeenCalled(); // 成功時は <img> を使わない
+    expect(close).toHaveBeenCalled(); // bitmap を後始末している
+  });
+
+  it('両方の decode 経路が失敗したら元 File を返す (壊さない)', async () => {
+    installCanvasStub();
+    stubUrl();
+    vi.stubGlobal('createImageBitmap', vi.fn(() => Promise.reject(new Error('reject'))));
+    class FailImage {
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      set src(_v: string) {
+        queueMicrotask(() => this.onerror?.());
+      }
+    }
+    vi.stubGlobal('Image', FailImage as unknown as typeof Image);
+
+    const f = fakeFile('image/jpeg', 4_000_000);
+    const r = await compressImage(f, { maxBytes: 950_000 });
+
     expect(r.compressed).toBe(false);
     expect(r.blob).toBe(f);
   });
@@ -39,4 +150,3 @@ describe('isBlueskySupportedImageType', () => {
     }
   });
 });
-

--- a/apps/web/src/lib/image-compress.test.ts
+++ b/apps/web/src/lib/image-compress.test.ts
@@ -98,6 +98,32 @@ describe('compressImage decode fallback', () => {
     expect(imgInstances.length).toBeGreaterThan(0); // <img> 経路を実際に通った
   });
 
+  it('createImageBitmap が存在しない環境でも <img> 経路で圧縮する (早期 return しない)', async () => {
+    installCanvasStub();
+    stubUrl();
+    // createImageBitmap 自体が未定義 (古い WebView 等)。早期 return せず <img> に退避する想定。
+    vi.stubGlobal('createImageBitmap', undefined);
+    let used = false;
+    class FakeImage {
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      naturalWidth = 4080;
+      naturalHeight = 3072;
+      decode = () => Promise.resolve();
+      set src(_v: string) {
+        used = true;
+        queueMicrotask(() => this.onload?.());
+      }
+    }
+    vi.stubGlobal('Image', FakeImage as unknown as typeof Image);
+
+    const r = await compressImage(fakeFile('image/jpeg', 4_000_000), { maxBytes: 950_000 });
+
+    expect(r.compressed).toBe(true);
+    expect(r.blob.size).toBeLessThanOrEqual(950_000);
+    expect(used).toBe(true);
+  });
+
   it('createImageBitmap 成功時は <img> を使わず bitmap を後始末する', async () => {
     installCanvasStub();
     stubUrl();

--- a/apps/web/src/lib/image-compress.ts
+++ b/apps/web/src/lib/image-compress.ts
@@ -99,29 +99,52 @@ interface DecodedImage {
   cleanup: () => void;
 }
 
-/** <img> + decode() でデコードする (createImageBitmap が使えない/失敗した時の退避)。
+/** decode に時間がかかっても固まらないよう上限を設ける (壊れた環境で onload/onerror が
+ *  どちらも来ないと添付処理ごと hang するのを防ぐ)。実機の大画像 decode を吸収できる長さ。 */
+const IMG_DECODE_TIMEOUT_MS = 15_000;
+
+/** <img> で file をデコードする (createImageBitmap が使えない/失敗した時の退避)。
  *  Android Chrome で高解像度 JPEG の createImageBitmap が reject するケースを救う。
- *  EXIF 回転はブラウザ既定の image-orientation:from-image が効く。 */
+ *  - onload だけだと稀に内部デコード未完で drawImage が失敗するため、可能なら
+ *    img.decode() の解決も待つ (未対応/失敗時は onload にフォールバック)。
+ *  - EXIF 回転はブラウザ既定の image-orientation:from-image が効く (明示制御は不可)。 */
 function decodeViaImgElement(file: File): Promise<DecodedImage | null> {
   if (typeof Image === 'undefined' || typeof URL === 'undefined') return Promise.resolve(null);
   return new Promise((resolve) => {
     const url = URL.createObjectURL(file);
     const img = new Image();
-    const cleanup = () => URL.revokeObjectURL(url);
-    img.onload = () => {
+    let settled = false; // onload/onerror/timeout の二重解決を防ぐ
+    const cleanupUrl = () => URL.revokeObjectURL(url);
+    const fail = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      cleanupUrl();
+      resolve(null);
+    };
+    const succeed = () => {
+      if (settled) return;
       const width = img.naturalWidth;
       const height = img.naturalHeight;
       if (!width || !height) {
-        cleanup();
-        resolve(null);
+        fail();
         return;
       }
-      resolve({ source: img, width, height, cleanup });
+      settled = true;
+      clearTimeout(timer);
+      // cleanup: objectURL 解放 + デコード済みバッファ解放のヒント (close() 相当の後始末)
+      resolve({ source: img, width, height, cleanup: () => { cleanupUrl(); img.src = ''; } });
     };
-    img.onerror = () => {
-      cleanup();
-      resolve(null);
+    const timer = setTimeout(fail, IMG_DECODE_TIMEOUT_MS);
+    img.onload = () => {
+      // decode() があれば内部デコード完了まで待ってから採用 (drawImage 失敗を防ぐ)
+      if (typeof img.decode === 'function') {
+        img.decode().then(succeed, succeed);
+      } else {
+        succeed();
+      }
     };
+    img.onerror = fail;
     img.src = url;
   });
 }
@@ -242,7 +265,9 @@ export async function compressImage(file: File, opts: CompressOptions = {}): Pro
   if (file.type === 'image/gif') {
     return { blob: file, compressed: false, originalBytes };
   }
-  if (typeof document === 'undefined' || typeof createImageBitmap === 'undefined') {
+  // canvas が無ければ再エンコードできないので元 File を返す。createImageBitmap の
+  // 有無はここで判定しない (無ければ decodeImage が <img> 経路に退避する)。
+  if (typeof document === 'undefined') {
     return { blob: file, compressed: false, originalBytes };
   }
 

--- a/apps/web/src/lib/image-compress.ts
+++ b/apps/web/src/lib/image-compress.ts
@@ -12,9 +12,14 @@
  *   createImageBitmap で HEIC をデコードできるので、canvas 経由で jpeg/webp に
  *   再エンコードして投稿可能にする。
  * - GIF はアニメーションを壊さないため変換しない (そのまま返す)
- * - EXIF 回転は createImageBitmap の imageOrientation:'from-image' で吸収
- * - createImageBitmap や canvas が使えない/失敗時は元 File を返す
- *   (呼び出し側で最終 size 検査)
+ * - EXIF 回転は createImageBitmap の imageOrientation:'from-image' で吸収。
+ *   img フォールバック時はブラウザ既定の image-orientation:from-image で吸収。
+ * - **デコードは createImageBitmap → 失敗時 <img> の 2 段**。Android Chrome は
+ *   端末メモリ次第で高解像度カメラ JPEG (12〜64MP) の createImageBitmap が
+ *   reject することがある (= 4 枚連続添付すると後半が落ちる)。その時に元 File を
+ *   返すと「圧縮されず素のサイズで上限超過 → 投稿弾かれ」になるため、<img> +
+ *   decode() の別経路でデコードし、必ず再エンコードまで到達させる。
+ * - 両経路とも失敗 / canvas 非対応時のみ元 File を返す (呼び出し側で最終 size 検査)
  */
 
 export interface CompressOptions {
@@ -72,7 +77,7 @@ function canvasToBlob(canvas: HTMLCanvasElement, type: string, quality: number):
 }
 
 /** outType が jpeg のときは透過部分が黒くならないよう白背景を敷く */
-function drawTo(bitmap: ImageBitmap, w: number, h: number, outType: string): HTMLCanvasElement | null {
+function drawTo(source: CanvasImageSource, w: number, h: number, outType: string): HTMLCanvasElement | null {
   const canvas = document.createElement('canvas');
   canvas.width = w;
   canvas.height = h;
@@ -82,8 +87,57 @@ function drawTo(bitmap: ImageBitmap, w: number, h: number, outType: string): HTM
     ctx.fillStyle = '#ffffff';
     ctx.fillRect(0, 0, w, h);
   }
-  ctx.drawImage(bitmap, 0, 0, w, h);
+  ctx.drawImage(source, 0, 0, w, h);
   return canvas;
+}
+
+/** デコード結果 (createImageBitmap か <img>)。再エンコードの draw に使う共通形。 */
+interface DecodedImage {
+  source: CanvasImageSource;
+  width: number;
+  height: number;
+  cleanup: () => void;
+}
+
+/** <img> + decode() でデコードする (createImageBitmap が使えない/失敗した時の退避)。
+ *  Android Chrome で高解像度 JPEG の createImageBitmap が reject するケースを救う。
+ *  EXIF 回転はブラウザ既定の image-orientation:from-image が効く。 */
+function decodeViaImgElement(file: File): Promise<DecodedImage | null> {
+  if (typeof Image === 'undefined' || typeof URL === 'undefined') return Promise.resolve(null);
+  return new Promise((resolve) => {
+    const url = URL.createObjectURL(file);
+    const img = new Image();
+    const cleanup = () => URL.revokeObjectURL(url);
+    img.onload = () => {
+      const width = img.naturalWidth;
+      const height = img.naturalHeight;
+      if (!width || !height) {
+        cleanup();
+        resolve(null);
+        return;
+      }
+      resolve({ source: img, width, height, cleanup });
+    };
+    img.onerror = () => {
+      cleanup();
+      resolve(null);
+    };
+    img.src = url;
+  });
+}
+
+/** createImageBitmap (EXIF 吸収・HEIC 対応) を優先し、失敗したら <img> に退避する。 */
+async function decodeImage(file: File): Promise<DecodedImage | null> {
+  if (typeof createImageBitmap !== 'undefined') {
+    try {
+      const bitmap = await createImageBitmap(file, { imageOrientation: 'from-image' });
+      return { source: bitmap, width: bitmap.width, height: bitmap.height, cleanup: () => bitmap.close() };
+    } catch (e) {
+      // Android Chrome のメモリ起因 reject 等。<img> 経路に退避する。
+      console.warn('[image-compress] createImageBitmap 失敗、<img> 経路に退避', e);
+    }
+  }
+  return decodeViaImgElement(file);
 }
 
 /** canvas を quality (0-1) で Blob にエンコードする関数。 */
@@ -142,21 +196,23 @@ async function chooseEncoder(wantWebp: boolean): Promise<{ outType: string; enco
  *  encode が throw しても握りつぶして null 扱いにする (堅牢性)。
  *  fit する blob が無ければ「最小だが超過」の best を返し、1 枚も作れなければ null。 */
 async function encodeBestFit(
-  bitmap: ImageBitmap,
+  source: CanvasImageSource,
+  srcWidth: number,
+  srcHeight: number,
   outType: string,
   encode: Encoder,
   maxBytes: number,
   maxDimension: number,
   qualitySteps: number[],
 ): Promise<{ blob: Blob; w: number; h: number; fit: boolean } | null> {
-  const scale = Math.min(1, maxDimension / Math.max(bitmap.width, bitmap.height));
-  let w = Math.max(1, Math.round(bitmap.width * scale));
-  let h = Math.max(1, Math.round(bitmap.height * scale));
+  const scale = Math.min(1, maxDimension / Math.max(srcWidth, srcHeight));
+  let w = Math.max(1, Math.round(srcWidth * scale));
+  let h = Math.max(1, Math.round(srcHeight * scale));
   let best: { blob: Blob; w: number; h: number; fit: boolean } | null = null;
 
   // 初期寸法 + 最大 2 回の縮小 (計 3 サイズ) を試し、各サイズで画質を上から試す
   for (let shrink = 0; shrink < 3; shrink++) {
-    const canvas = drawTo(bitmap, w, h, outType);
+    const canvas = drawTo(source, w, h, outType);
     if (!canvas) break;
     for (const q of qualitySteps) {
       let blob: Blob | null = null;
@@ -196,24 +252,25 @@ export async function compressImage(file: File, opts: CompressOptions = {}): Pro
   // WASM 経路 (heavy) はメインスレッド負荷が高いので試行回数を減らす
   const primarySteps = heavy && !opts.qualitySteps ? WASM_QUALITY_STEPS : qualitySteps;
 
-  let bitmap: ImageBitmap;
-  try {
-    bitmap = await createImageBitmap(file, { imageOrientation: 'from-image' });
-  } catch {
-    // HEIC を decode できない環境 (例: デスクトップ Chrome) 等
+  // createImageBitmap (EXIF/HEIC) 優先、ダメなら <img> に退避してでもデコードする。
+  // ここで null = どの経路でもデコードできなかった (= 元 File を返すしかない)。
+  const decoded = await decodeImage(file);
+  if (!decoded) {
+    // HEIC を <img> でも decode できない環境 (例: デスクトップ Chrome) 等
     return { blob: file, compressed: false, originalBytes };
   }
+  const { source, width: srcW, height: srcH } = decoded;
 
   try {
     let usedType = outType;
-    let result = await encodeBestFit(bitmap, outType, encode, maxBytes, maxDimension, primarySteps);
+    let result = await encodeBestFit(source, srcW, srcH, outType, encode, maxBytes, maxDimension, primarySteps);
 
     // WebP エンコーダが 1 枚も作れなかった (WASM ロード/実行失敗等) 場合は
     // JPEG に退避する。これで「これまで動いていた JPEG 圧縮」を絶対に壊さない。
     if (!result && outType !== 'image/jpeg') {
       usedType = 'image/jpeg';
       result = await encodeBestFit(
-        bitmap, 'image/jpeg', (c, q) => canvasToBlob(c, 'image/jpeg', q), maxBytes, maxDimension, qualitySteps,
+        source, srcW, srcH, 'image/jpeg', (c, q) => canvasToBlob(c, 'image/jpeg', q), maxBytes, maxDimension, qualitySteps,
       );
     }
 
@@ -222,10 +279,10 @@ export async function compressImage(file: File, opts: CompressOptions = {}): Pro
     }
     // 収まらなくても、元より小さければ返す (呼び出し側が最終 size 検査)
     if (result && result.blob.size < originalBytes) {
-      return { blob: result.blob, compressed: true, originalBytes, outputType: usedType };
+      return { blob: result.blob, compressed: true, originalBytes, outputType: usedType, width: result.w, height: result.h };
     }
     return { blob: file, compressed: false, originalBytes };
   } finally {
-    bitmap.close();
+    decoded.cleanup();
   }
 }


### PR DESCRIPTION
## 何を直すか

実機 Pixel 7a (Android Chrome) で写真 4 枚添付時、**2 枚 (5.4MB / 1.2MB) が「サイズ超過」で弾かれ**、上限未満の 2 枚 (876KB / 793KB) だけ通る症状。

原因は **圧縮が大きい写真に到達していない**こと。Android Chrome は端末メモリ次第で高解像度カメラ JPEG (12〜64MP) の `createImageBitmap` が reject することがあり、その場合 `compressImage` が**元 File をそのまま返していた** → 素のサイズが Bluesky の ~1MB 上限を超え skip。desktop Chromium (同 Blink) では同寸の 12MP/64MP も 186KB/215KB へ問題なく圧縮できるため、**端末固有の `createImageBitmap` reject** と切り分けた。

## 修正
- `decodeImage()` を新設し、`createImageBitmap` 失敗/不在時は **`<img>` + `decode()` 経路に退避**。どちらでも `CanvasImageSource` を得て必ず再エンコードまで到達。15s タイムアウト・二重解決防止・cleanup で `img.src=''` 解放。
- `drawTo` / `encodeBestFit` を `CanvasImageSource` + 明示寸法に一般化。
- compose: スキップ文言をリカバリ導線付きに、逐次圧縮の進捗 (done/total) 表示、実装詳細語の除去。

## 検証
- **Playwright (実 Chromium)**: `createImageBitmap` を強制 reject させても `<img>` 経路で 12MP/64MP が **~172KB** へ圧縮されることを確認 (= Android 症状の再現と修正確認)。通常経路も無変更。
- **vitest**: 2 段 decode の制御フロー (reject 退避 / undefined 退避 / 成功時は不使用 / 両方失敗で原本返却) を回帰化。
- `typecheck` / **171 unit tests** / `build` 緑。

## 実機確認のお願い
Android-only の症状で desktop では再現しないため、**マージ後 dev デプロイ → Pixel 7a で 4 枚添付**を再確認してほしいです。まだ skip されるなら、開発者コンソールに `[compose] 添付不可: 圧縮後も XXXKb で上限 950KB 超過` が出るので、その数値で次の手を打てます。

## Review
§1.5 必須レビュー (3 並列 subagent: 設計 / 実装 / UX) 実施。

### ★★★ (PR 内で必須対応 → 対応済み)
- **早期 return が `<img>` フォールバックを無効化** (設計・実装が一致して検出): `compressImage` 冒頭の `createImageBitmap === undefined` 判定を外し `document` 非対応のみで弾くよう緩和。createImageBitmap 不在環境でも `<img>` 退避が効くようにした。→ commit c52f82d + 回帰テスト追加。

### ★★ (PR 内で対応 or issue 化)
- **decodeViaImgElement の堅牢化** (実装): `img.decode()` の解決待ち + 15s タイムアウト + 二重解決防止 + 解放ヒント。→ PR 内対応 (c52f82d)。
- **「圧縮後 約X.XMB」がユーザーに不適切 / 圧縮 throw 時に原寸で誤認** (実装・UX): ユーザー文言から数値を撤去しリカバリ導線へ。技術詳細は `console.warn` に集約。→ PR 内対応 (c52f82d)。
- **逐次圧縮中の進捗が見えず固まったと誤解** (UX): `画像を準備中... (N/total)` を表示。→ PR 内対応 (c52f82d)。
- **decode の省メモリ化 (resizeWidth/Height) が根本対処** (設計): `<img>` 退避は対症療法。→ issue #108。
- **エラー表示枠のトーン/色設計の整理** (UX): 部分成功/失敗/枚数超過の視覚区別、投稿失敗の生メッセージのラップ。→ issue #109。

### ★ (対応 or issue、柔軟)
- 単位表記 (MB↔KB) の不統一 → 上記文言修正で KB に統一 (PR 内)。
- EXIF orientation の `<img>` 既定依存 → コメント明記済 (PR 内)。
- 非 fit 分岐 / naturalWidth=0 等の追加テスト → 主要ケースは追加済、残りは #109 で。
- ドラクエ世界観トーン / 「WebP」語の掃除 → #109 に集約。