### PR TITLE
feat(version): アプリの公開バージョンを設定画面の隅に表示 (YYYY.MM.DD-N)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,9 @@ dev に複数の feature PR が積まれた後、リリース単位で `dev → 
 3. CI 緑 + **第三者レビュー (§1.5) で指摘ゼロ or 全対応済み**
 4. オーナー承認
 5. squash merge (= 複数 feature が main に 1 コミットで反映、リリースノート的)
-6. **`APP_VERSION` と同じ値で git tag を打つ**: `git tag v2026.06.14-1 && git push origin v2026.06.14-1`
+6. **`APP_VERSION` と同じ値で git tag を打つ** (リリースされた main のコミットに付くよう、先に main を最新化してから打つ):
+   `git checkout main && git pull origin main && git tag v2026.06.14-1 && git push origin v2026.06.14-1`
+   (タグを打ったら忘れず `git checkout dev` で dev に戻る)
 7. dev ブランチは残す (= 次の機能開発用)
 
 `APP_VERSION` は設定画面の隅に表示され、ユーザー/サポートが「どのリリースを見ているか」を特定するのに使う。package.json の version は semver 制約でこの日付表記を表せないため、表示用バージョンは app-version.ts を単一の出所とする。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,11 +49,15 @@ gh pr create --base dev --head feature/<topic>
 ### dev → main の本番リリース
 
 dev に複数の feature PR が積まれた後、リリース単位で `dev → main` の PR を作成:
-1. `gh pr create --base main --head dev`
-2. CI 緑 + **第三者レビュー (§1.5) で指摘ゼロ or 全対応済み**
-3. オーナー承認
-4. squash merge (= 複数 feature が main に 1 コミットで反映、リリースノート的)
-5. dev ブランチは残す (= 次の機能開発用)
+1. **`apps/web/src/lib/app-version.ts` の `APP_VERSION` をリリース日 + 枝番に更新** (形式 `YYYY.MM.DD-N`、その日最初は `-1`、同日追加リリースは `-2`, `-3` …)。feature ブランチでコミットして dev に入れておく
+2. `gh pr create --base main --head dev`
+3. CI 緑 + **第三者レビュー (§1.5) で指摘ゼロ or 全対応済み**
+4. オーナー承認
+5. squash merge (= 複数 feature が main に 1 コミットで反映、リリースノート的)
+6. **`APP_VERSION` と同じ値で git tag を打つ**: `git tag v2026.06.14-1 && git push origin v2026.06.14-1`
+7. dev ブランチは残す (= 次の機能開発用)
+
+`APP_VERSION` は設定画面の隅に表示され、ユーザー/サポートが「どのリリースを見ているか」を特定するのに使う。package.json の version は semver 制約でこの日付表記を表せないため、表示用バージョンは app-version.ts を単一の出所とする。
 
 `main` / `dev` は GitHub の branch protection rule で守る:
 - Require pull request before merging

--- a/apps/web/src/lib/app-version.test.ts
+++ b/apps/web/src/lib/app-version.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { APP_VERSION, APP_VERSION_PATTERN } from './app-version';
+
+describe('APP_VERSION', () => {
+  it('は YYYY.MM.DD-N 形式 (リリース日 + 枝番) である', () => {
+    // 形式崩れ (semver を書いてしまった等) を CI で検出する
+    expect(APP_VERSION).toMatch(APP_VERSION_PATTERN);
+  });
+
+  it('月・日はゼロ詰め 2 桁、枝番は 1 以上', () => {
+    const m = APP_VERSION.match(/^(\d{4})\.(\d{2})\.(\d{2})-(\d+)$/);
+    expect(m).not.toBeNull();
+    const [, , mm, dd, n] = m!;
+    expect(Number(mm)).toBeGreaterThanOrEqual(1);
+    expect(Number(mm)).toBeLessThanOrEqual(12);
+    expect(Number(dd)).toBeGreaterThanOrEqual(1);
+    expect(Number(dd)).toBeLessThanOrEqual(31);
+    expect(Number(n)).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/apps/web/src/lib/app-version.test.ts
+++ b/apps/web/src/lib/app-version.test.ts
@@ -18,3 +18,26 @@ describe('APP_VERSION', () => {
     expect(Number(n)).toBeGreaterThanOrEqual(1);
   });
 });
+
+describe('APP_VERSION_PATTERN', () => {
+  it('正しい日付 + 枝番を受理する', () => {
+    for (const v of ['2026.06.14-1', '2026.01.01-1', '2026.12.31-2', '2026.10.09-12']) {
+      expect(APP_VERSION_PATTERN.test(v)).toBe(true);
+    }
+  });
+  it('不正な月/日/枝番/ゼロ詰め無しを弾く', () => {
+    for (const v of [
+      '2026.13.45-0', // 月13・日45・枝番0
+      '2026.13.01-1', // 月13
+      '2026.00.10-1', // 月00
+      '2026.06.32-1', // 日32
+      '2026.6.14-1', //  月ゼロ詰めなし
+      '2026.06.14-0', // 枝番0
+      '2026.06.14', //   枝番なし
+      '0.1.0', //        semver 誤記
+      'v2026.06.14-1', // v 付き
+    ]) {
+      expect(APP_VERSION_PATTERN.test(v)).toBe(false);
+    }
+  });
+});

--- a/apps/web/src/lib/app-version.ts
+++ b/apps/web/src/lib/app-version.ts
@@ -14,5 +14,6 @@
  */
 export const APP_VERSION = '2026.06.14-1';
 
-/** APP_VERSION が `YYYY.MM.DD-N` 形式かを検証する (テスト/CI で形式崩れを検出)。 */
-export const APP_VERSION_PATTERN = /^\d{4}\.\d{2}\.\d{2}-\d+$/;
+/** APP_VERSION が `YYYY.MM.DD-N` 形式かを検証する (テスト/CI で形式崩れを検出)。
+ *  月 01-12 / 日 01-31 のゼロ詰め 2 桁、枝番は先頭ゼロ不可の 1 以上まで一本でガードする。 */
+export const APP_VERSION_PATTERN = /^\d{4}\.(0[1-9]|1[0-2])\.(0[1-9]|[12]\d|3[01])-[1-9]\d*$/;

--- a/apps/web/src/lib/app-version.ts
+++ b/apps/web/src/lib/app-version.ts
@@ -1,0 +1,18 @@
+/**
+ * アプリの公開バージョン。形式は `YYYY.MM.DD-N` (例 `2026.06.14-1`)。
+ * - `YYYY.MM.DD`: 本番 (main) へ反映したリリース日
+ * - `-N`: 同日内のリリース枝番。その日最初は `-1`、追加リリースごとに `-2`, `-3` …
+ *
+ * package.json の `version` は semver 制約 (先頭ゼロ不可・3 セグメント) でこの表記を
+ * 表現できないため、表示用バージョンはこのファイルを唯一の出所 (single source) とする。
+ *
+ * リリース手順 (dev → main):
+ *   1. この APP_VERSION を「リリース日 + 枝番」に更新してコミット (feature ブランチで)
+ *   2. dev → main の PR をマージ (オーナーのリリース判断)
+ *   3. 同じ値で git tag を打つ:
+ *        git tag v2026.06.14-1 && git push origin v2026.06.14-1
+ */
+export const APP_VERSION = '2026.06.14-1';
+
+/** APP_VERSION が `YYYY.MM.DD-N` 形式かを検証する (テスト/CI で形式崩れを検出)。 */
+export const APP_VERSION_PATTERN = /^\d{4}\.\d{2}\.\d{2}-\d+$/;

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -9,6 +9,7 @@ import { createTaggedPost, getRecord, putRecord } from '@/lib/atproto';
 import { COL } from '@/lib/collections';
 import { getAutoTranslate, setAutoTranslate, getAnalyzePosts, setAnalyzePosts, getHideReposts, setHideReposts, getFontScale, setFontScale, FONT_SCALE_MIN, FONT_SCALE_MAX, FONT_SCALE_DEFAULT, clampFontScale, getPostQuestNotifications, setPostQuestNotifications, getPostQuestNotificationsDefault } from '@/lib/prefs';
 import { applyFontScale } from '@/lib/font-scale';
+import { APP_VERSION } from '@/lib/app-version';
 import { TextField } from '@/components/text-field';
 import { RadarChart } from '@/components/radar-chart';
 import { Avatar } from '@/components/avatar';
@@ -340,6 +341,18 @@ export function Settings() {
         )}
         <button onClick={onSignOut}>ログアウト</button>
       </section>
+
+      <p
+        style={{
+          marginTop: '2.5em',
+          textAlign: 'right',
+          fontSize: '0.7em',
+          color: 'var(--color-muted)',
+          fontFamily: 'ui-monospace, monospace',
+        }}
+      >
+        aozoraquest v{APP_VERSION}
+      </p>
     </div>
   );
 }

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -342,17 +342,42 @@ export function Settings() {
         <button onClick={onSignOut}>ログアウト</button>
       </section>
 
-      <p
+      <AppVersionFooter />
+    </div>
+  );
+}
+
+/** 設定画面の隅にバージョンを表示。タップでクリップボードにコピー (サポート連絡時に伝えやすく)。 */
+function AppVersionFooter() {
+  const label = `aozoraquest v${APP_VERSION}`;
+  const [copied, setCopied] = useState(false);
+  async function copy() {
+    try {
+      await navigator.clipboard?.writeText(label);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch (e) {
+      console.warn('version copy failed', e);
+    }
+  }
+  return (
+    <div style={{ marginTop: '2.5em', textAlign: 'right' }}>
+      <button
+        type="button"
+        onClick={copy}
+        title="タップでバージョンをコピー"
         style={{
-          marginTop: '2.5em',
-          textAlign: 'right',
-          fontSize: '0.7em',
+          background: 'none',
+          border: 'none',
+          padding: '0.3em 0',
+          fontSize: '0.75em',
           color: 'var(--color-muted)',
           fontFamily: 'ui-monospace, monospace',
+          cursor: 'pointer',
         }}
       >
-        aozoraquest v{APP_VERSION}
-      </p>
+        {copied ? 'コピーしました' : label}
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## 何を追加するか
リリースを **日付 + 枝番** (`YYYY.MM.DD-N`、例 `2026.06.14-1`) で識別できるようにし、**設定画面の隅**に `aozoraquest v2026.06.14-1` を表示。**タップでクリップボードにコピー**でき、サポート連絡時に伝えやすい。

## 設計
- `apps/web/src/lib/app-version.ts` を **唯一の出所 (single source)**。`package.json` の `version` は semver 制約で日付表記を表せないため別管理。
- 設定画面末尾に muted・右寄せ・等幅・`0.75em` で控えめに表示。
- 形式崩れを **CI で検出**する正規表現テスト (`app-version.test.ts`)。pattern は月 01-12 / 日 01-31 / 枝番 (先頭ゼロ不可) を厳格にガード。
- **git tag** をリリース手順に組み込み (`CLAUDE.md`): `APP_VERSION` 更新 → マージ → `main` 最新化 → 同値で `git tag v2026.06.14-1` を push。

## 検証
`typecheck` / **175 unit tests** / `build` 緑。

## Review
§1.5 レビュー (設計実装 + UX の 2 観点、変更が軽量なため観点を絞って実施)。**★★★ なし**。

### ★★ (PR 内で対応済み)
- **コピー導線がない** (UX): バージョンをタップでクリップボードコピー可に。→ commit 6519342。
- **`0.7em` が小さすぎ** (UX): 既存補助テキスト下限の `0.75em` に統一。→ 6519342。
- **git tag が実行時 HEAD に誤って付くリスク** (実装): 手順を「先に main を最新化してから打つ」に明確化。→ 6519342。
- **bump 忘れを防ぐ仕組みが無い** (実装): 日付完全一致の CI は誤検知 (TZ/同日複数/マージ日ズレ) コストが高いため**入れない判断**。CLAUDE.md リリース手順1 + §9 チェックリストで担保。→ 記録のみ。

### ★ (PR 内で対応)
- **正規表現が緩い** (実装): 月/日/枝番を厳格化し、不正日付を弾く回帰テスト追加。→ 6519342。
- 文言の `v` プレフィックス / 余白 / アプリ名直書き: 現状維持で妥当 (両レビューとも「現状維持を推奨」)。