### PR TITLE
fix(compose): 添付画像の並べ替えを ↑↓ に (縦並びに合わせる)

### DIFF
--- a/apps/web/src/components/compose-modal.tsx
+++ b/apps/web/src/components/compose-modal.tsx
@@ -472,7 +472,7 @@ function ComposeDialog({
           <div style={{ marginTop: '0.5em', display: 'flex', flexDirection: 'column', gap: '0.4em' }}>
             {images.length > 1 && (
               <p style={{ fontSize: '0.75em', color: 'var(--color-muted)', margin: 0 }}>
-                上から順に表示されます (1 枚目が代表)。← → で並べ替え。
+                上から順に表示されます (1 枚目が代表)。↑ ↓ で並べ替え。
               </p>
             )}
             {/* key は previewUrl (blob ごとに一意・生存中不変)。並べ替えでも安定なので
@@ -517,21 +517,21 @@ function ComposeDialog({
                             className="secondary"
                             onClick={() => moveImage(i, -1)}
                             disabled={loading || i === 0}
-                            aria-label={`画像 ${i + 1} を前へ`}
-                            title="前へ"
+                            aria-label={`画像 ${i + 1} を上へ`}
+                            title="上へ"
                             style={IMG_CTRL_BTN}
                           >
-                            ←
+                            ↑
                           </button>
                           <button
                             className="secondary"
                             onClick={() => moveImage(i, 1)}
                             disabled={loading || i === images.length - 1}
-                            aria-label={`画像 ${i + 1} を後ろへ`}
-                            title="後ろへ"
+                            aria-label={`画像 ${i + 1} を下へ`}
+                            title="下へ"
                             style={IMG_CTRL_BTN}
                           >
-                            →
+                            ↓
                           </button>
                         </>
                       )}

--- a/apps/web/src/components/compose-modal.tsx
+++ b/apps/web/src/components/compose-modal.tsx
@@ -141,7 +141,7 @@ function isAttachableImage(file: File): boolean {
 /** Bluesky uploadBlob の上限は約 1MB。少しマージン取って 950KB を上限警告ラインに。 */
 const MAX_IMAGE_BYTES = 950_000;
 
-/** 画像プレビュー行の操作ボタン (← → 削除)。親が 0.75em と小さいので rem 基準で
+/** 画像プレビュー行の操作ボタン (↑ ↓ 削除)。親が 0.75em と小さいので rem 基準で
  *  独立に大きさを決め、モバイルのタップ領域 (≈40px) を確保する。 */
 const IMG_CTRL_BTN: CSSProperties = {
   fontSize: '0.95rem',


### PR DESCRIPTION
## 何を直すか
添付画像リストは常に **縦 1 列**(上が代表)で表示されるのに、並べ替えボタンが `← →` だったため「右へ = 実際は下へ」と方向がねじれ、特にスマホで直感に反していた(実機 Pixel 7a で確認)。リストの向きに合わせて **`↑`(上へ)/ `↓`(下へ)** に変更。

## 変更
- ボタンの字形 `←/→` → `↑/↓`、補助文「← → で並べ替え」→「↑ ↓ で並べ替え」。
- `aria-label`/`title` を「前へ/後ろへ」→「上へ/下へ」に統一。
- ロジック (`moveImage(i, -1|1)`) は不変。字形と文言のみ。

## なぜ D&D ではないか
ドラッグ&ドロップも候補だが、モバイル誤発火リスク + 依存追加があるため、まず ↑↓ で直感性を回復する最小修正。D&D は要望次第で別 issue。

## 検証
`typecheck` / **175 unit tests** / `build` 緑。

## Review
§1.5 を観点を絞って実施 (字形 + a11y ラベル変更のため UX/a11y 観点 1 名)。**★★★ なし**。
- **★★ コメント残骸**: `IMG_CTRL_BTN` の doc コメントが `← →` のままだった → `↑ ↓` に修正 (PR 内対応)。
- レビューで aria-label↔挙動の一致 / 端の disabled / タップターゲット維持 / 他ファイルの ←→ は別機能で対象外、を確認済み。
- ★ グリフ視認性 (将来 ▲▼/SVG も可) は対応不要。