### PR TITLE
fix(posts): 投稿内の URL をリンク化 (生成=facet自動検出 / 表示=facet隙間も自動リンク)

### DIFF
--- a/apps/web/src/components/post-text.test.ts
+++ b/apps/web/src/components/post-text.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { segmentPost, type Facet, type FacetFeature } from './post-text';
+
+// byte index は UTF-8。テスト用に文字列の byte offset を測るヘルパ。
+const enc = new TextEncoder();
+const byteLen = (s: string) => enc.encode(s).length;
+
+/** text 内の marker の byte 範囲で facet を作る。 */
+function facetAt(text: string, marker: string, feature: FacetFeature): Facet {
+  const idx = text.indexOf(marker);
+  return {
+    index: { byteStart: byteLen(text.slice(0, idx)), byteEnd: byteLen(text.slice(0, idx + marker.length)) },
+    features: [feature],
+  };
+}
+
+describe('segmentPost', () => {
+  it('facet が無い投稿の URL を自動リンクする', () => {
+    const segs = segmentPost('見て https://example.com/x すごい');
+    expect(segs).toEqual([
+      { kind: 'text', text: '見て ' },
+      { kind: 'link', text: 'https://example.com/x', uri: 'https://example.com/x' },
+      { kind: 'text', text: ' すごい' },
+    ]);
+  });
+
+  it('【本丸】#tag facet だけ付いた投稿でも、facet の隙間の URL を自動リンクする', () => {
+    // クエスト発行投稿の再現: tag facet は付くが URL は facet 化されていない
+    const text = '【クエスト】完了報告 https://aozoraquest.app/board/at%3A%2F#aozoraquest';
+    const facets = [facetAt(text, '#aozoraquest', { $type: 'app.bsky.richtext.facet#tag', tag: 'aozoraquest' })];
+    const segs = segmentPost(text, facets);
+    // URL が link セグメントになっていること (= 以前は text のままだった不具合)
+    expect(segs.some((s) => s.kind === 'link' && s.uri === 'https://aozoraquest.app/board/at%3A%2F')).toBe(true);
+    // #aozoraquest は tag セグメント
+    expect(segs.some((s) => s.kind === 'tag' && s.tag === 'aozoraquest')).toBe(true);
+    // 全セグメントを連結すると原文に戻る (欠落しない)
+    expect(segs.map((s) => s.text).join('')).toBe(text);
+  });
+
+  it('link facet をそのままリンク化する', () => {
+    const text = 'aaa link bbb';
+    const facets = [facetAt(text, 'link', { $type: 'app.bsky.richtext.facet#link', uri: 'https://t.co/abc' })];
+    const segs = segmentPost(text, facets);
+    expect(segs).toContainEqual({ kind: 'link', text: 'link', uri: 'https://t.co/abc' });
+  });
+
+  it('mention facet を handle 付き mention にする', () => {
+    const text = 'hi @alice.bsky.social !';
+    const facets = [facetAt(text, '@alice.bsky.social', { $type: 'app.bsky.richtext.facet#mention', did: 'did:plc:xxx' })];
+    const segs = segmentPost(text, facets);
+    expect(segs).toContainEqual({ kind: 'mention', text: '@alice.bsky.social', handle: 'alice.bsky.social' });
+  });
+
+  it('複数 facet の前後と隙間をすべて埋め、原文が復元できる', () => {
+    const text = 'a #tagA b https://x.io c #tagB';
+    const facets = [
+      facetAt(text, '#tagA', { $type: 'app.bsky.richtext.facet#tag', tag: 'tagA' }),
+      facetAt(text, '#tagB', { $type: 'app.bsky.richtext.facet#tag', tag: 'tagB' }),
+    ];
+    const segs = segmentPost(text, facets);
+    expect(segs.map((s) => s.text).join('')).toBe(text);
+    expect(segs.some((s) => s.kind === 'link' && s.uri === 'https://x.io')).toBe(true);
+    expect(segs.filter((s) => s.kind === 'tag')).toHaveLength(2);
+  });
+
+  it('壊れた facet (範囲外) は無視しつつ本文を欠落させない', () => {
+    const text = 'hello world';
+    const facets: Facet[] = [{ index: { byteStart: 100, byteEnd: 200 }, features: [] }];
+    const segs = segmentPost(text, facets);
+    expect(segs.map((s) => s.text).join('')).toBe(text);
+  });
+
+  it('@mention と #tag を facet 無しで自動リンク', () => {
+    const segs = segmentPost('@bob.test と #ねこ');
+    expect(segs).toContainEqual({ kind: 'mention', text: '@bob.test', handle: 'bob.test' });
+    expect(segs).toContainEqual({ kind: 'tag', text: '#ねこ', tag: 'ねこ' });
+  });
+});

--- a/apps/web/src/components/post-text.tsx
+++ b/apps/web/src/components/post-text.tsx
@@ -30,19 +30,98 @@ interface PostTextProps {
 const AUTO_LINK_RE =
   /(https?:\/\/[^\s\u3000]+)|((?:www\.)[a-zA-Z0-9][-a-zA-Z0-9]*(?:\.[a-zA-Z0-9][-a-zA-Z0-9]*)*\.[a-zA-Z]{2,8}(?:\/[^\s\u3000]*)?)|([#＃][\w\u3040-\u30ff\u4e00-\u9fff_ー\-]+)|(@[A-Za-z0-9_.\-]+)/g;
 
+/** 描画に依存しない投稿セグメント (テスト可能な純粋表現)。 */
+export type PostSegment =
+  | { kind: 'text'; text: string }
+  | { kind: 'link'; text: string; uri: string }
+  | { kind: 'mention'; text: string; handle: string }
+  | { kind: 'tag'; text: string; tag: string };
+
+/** facet を持たないテキスト片を URL / #tag / @mention で分割する (自動リンク)。 */
+function autoLinkSegments(text: string): PostSegment[] {
+  const out: PostSegment[] = [];
+  let last = 0;
+  for (const m of text.matchAll(AUTO_LINK_RE)) {
+    const start = m.index ?? 0;
+    if (start > last) out.push({ kind: 'text', text: text.slice(last, start) });
+    const matched = m[0];
+    if (m[1]) {
+      out.push({ kind: 'link', text: matched, uri: matched }); // http(s)://
+    } else if (m[2]) {
+      out.push({ kind: 'link', text: matched, uri: `https://${matched}` }); // www. → https 補完
+    } else if (m[3]) {
+      out.push({ kind: 'tag', text: matched, tag: matched.replace(/^[#＃]/, '') });
+    } else if (m[4]) {
+      out.push({ kind: 'mention', text: matched, handle: matched.slice(1) });
+    }
+    last = start + matched.length;
+  }
+  if (last < text.length) out.push({ kind: 'text', text: text.slice(last) });
+  return out;
+}
+
+/** facet 1 つ分のセグメント化。未知 feature は素のテキストとして返す。 */
+function featureSegment(segment: string, feature: FacetFeature | undefined): PostSegment {
+  const t = feature?.$type;
+  if (t === 'app.bsky.richtext.facet#link' && feature?.uri) {
+    return { kind: 'link', text: segment, uri: feature.uri };
+  }
+  if (t === 'app.bsky.richtext.facet#mention' && feature?.did) {
+    return { kind: 'mention', text: segment, handle: segment.replace(/^@/, '') };
+  }
+  if (t === 'app.bsky.richtext.facet#tag' && feature?.tag) {
+    return { kind: 'tag', text: segment, tag: feature.tag };
+  }
+  return { kind: 'text', text: segment };
+}
+
+/**
+ * 投稿本文をセグメント列に変換する純粋関数 (描画非依存・テスト可能)。
+ * - facets があればその範囲を feature 通りにリンク化し、**facet の隙間 (URL 等が
+ *   facet 化されていない部分) は自動リンク**する。これがないと「#tag だけ facet が
+ *   付いた投稿の URL が素のテキストになる」不具合が起きる (クエスト発行投稿など)。
+ * - facets が無ければ全文を自動リンク。
+ */
+export function segmentPost(text: string, facets?: Facet[]): PostSegment[] {
+  if (!facets || facets.length === 0) return autoLinkSegments(text);
+
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+  const bytes = encoder.encode(text);
+  const sorted = [...facets]
+    .filter((f) => f.index && typeof f.index.byteStart === 'number' && typeof f.index.byteEnd === 'number')
+    .sort((a, b) => a.index.byteStart - b.index.byteStart);
+
+  const out: PostSegment[] = [];
+  let cursor = 0;
+  for (const f of sorted) {
+    const { byteStart, byteEnd } = f.index;
+    // 範囲外 / 重複 / 逆順は無視 (壊れた facet で本文が欠落しないよう gap 処理は続行)
+    if (byteStart < cursor || byteEnd > bytes.length || byteStart >= byteEnd) continue;
+    if (byteStart > cursor) {
+      // facet と facet の隙間は自動リンク (素の URL を拾う)
+      out.push(...autoLinkSegments(decoder.decode(bytes.slice(cursor, byteStart))));
+    }
+    const segment = decoder.decode(bytes.slice(byteStart, byteEnd));
+    out.push(featureSegment(segment, (f.features ?? [])[0]));
+    cursor = byteEnd;
+  }
+  if (cursor < bytes.length) {
+    out.push(...autoLinkSegments(decoder.decode(bytes.slice(cursor))));
+  }
+  return out;
+}
+
 /**
  * 投稿本文の描画。
  * - AT Protocol の facets があればそれに従ってリンク / メンション / タグを描画
- * - facets が無ければ URL を自動検出してリンク化
+ * - facet の隙間や facets が無い投稿は URL / #tag / @mention を自動リンク
  * - 長い URL も word-break でカードからはみ出さない
  * - 外部リンクは別タブ、rel=noopener noreferrer
  */
 export function PostText({ text, facets, style, override }: PostTextProps) {
-  const effective = override ?? text;
-  const parts =
-    override === undefined && facets && facets.length > 0
-      ? renderWithFacets(text, facets)
-      : renderAutoLink(effective);
+  const segments =
+    override === undefined ? segmentPost(text, facets) : autoLinkSegments(override);
 
   return (
     <div
@@ -54,99 +133,30 @@ export function PostText({ text, facets, style, override }: PostTextProps) {
         ...style,
       }}
     >
-      {parts}
+      {segments.map((seg, i) => renderSegment(seg, i))}
     </div>
   );
 }
 
-function renderWithFacets(text: string, facets: Facet[]): ReactNode[] {
-  const encoder = new TextEncoder();
-  const decoder = new TextDecoder();
-  const bytes = encoder.encode(text);
-  const sorted = [...facets]
-    .filter((f) => f.index && typeof f.index.byteStart === 'number' && typeof f.index.byteEnd === 'number')
-    .sort((a, b) => a.index.byteStart - b.index.byteStart);
-
-  const out: ReactNode[] = [];
-  let cursor = 0;
-  let key = 0;
-
-  for (const f of sorted) {
-    const { byteStart, byteEnd } = f.index;
-    if (byteStart < cursor || byteEnd > bytes.length || byteStart >= byteEnd) continue;
-    if (byteStart > cursor) {
-      out.push(<span key={key++}>{decoder.decode(bytes.slice(cursor, byteStart))}</span>);
-    }
-    const segment = decoder.decode(bytes.slice(byteStart, byteEnd));
-    const feature = (f.features ?? [])[0];
-    out.push(renderFeature(segment, feature, key++));
-    cursor = byteEnd;
-  }
-  if (cursor < bytes.length) {
-    out.push(<span key={key++}>{decoder.decode(bytes.slice(cursor))}</span>);
-  }
-  return out;
-}
-
-function renderFeature(segment: string, feature: FacetFeature | undefined, key: number): ReactNode {
-  if (!feature) return <span key={key}>{segment}</span>;
-  const t = feature.$type;
-  if (t === 'app.bsky.richtext.facet#link' && feature.uri) {
-    return <ExternalLink key={key} href={feature.uri} label={segment} />;
-  }
-  if (t === 'app.bsky.richtext.facet#mention' && feature.did) {
-    const handle = segment.replace(/^@/, '');
-    return (
-      <Link key={key} to={`/profile/${handle}`}>
-        {segment}
-      </Link>
-    );
-  }
-  if (t === 'app.bsky.richtext.facet#tag' && feature.tag) {
-    return (
-      <Link key={key} to={`/search?q=${encodeURIComponent('#' + feature.tag)}`}>
-        {segment}
-      </Link>
-    );
-  }
-  return <span key={key}>{segment}</span>;
-}
-
-function renderAutoLink(text: string): ReactNode[] {
-  const out: ReactNode[] = [];
-  let key = 0;
-  let last = 0;
-  for (const m of text.matchAll(AUTO_LINK_RE)) {
-    const start = m.index ?? 0;
-    if (start > last) out.push(<span key={key++}>{text.slice(last, start)}</span>);
-    const matched = m[0];
-    if (m[1]) {
-      // http(s)://
-      out.push(<ExternalLink key={key++} href={matched} label={matched} />);
-    } else if (m[2]) {
-      // www.xxx (no scheme) → https を補う
-      out.push(<ExternalLink key={key++} href={`https://${matched}`} label={matched} />);
-    } else if (m[3]) {
-      // #hashtag
-      const tag = matched.replace(/^[#＃]/, '');
-      out.push(
-        <Link key={key++} to={`/search?q=${encodeURIComponent('#' + tag)}`} onClick={(e) => e.stopPropagation()}>
-          {matched}
-        </Link>,
+function renderSegment(seg: PostSegment, key: number): ReactNode {
+  switch (seg.kind) {
+    case 'link':
+      return <ExternalLink key={key} href={seg.uri} label={seg.text} />;
+    case 'mention':
+      return (
+        <Link key={key} to={`/profile/${seg.handle}`} onClick={(e) => e.stopPropagation()}>
+          {seg.text}
+        </Link>
       );
-    } else if (m[4]) {
-      // @mention
-      const handle = matched.slice(1);
-      out.push(
-        <Link key={key++} to={`/profile/${handle}`} onClick={(e) => e.stopPropagation()}>
-          {matched}
-        </Link>,
+    case 'tag':
+      return (
+        <Link key={key} to={`/search?q=${encodeURIComponent('#' + seg.tag)}`} onClick={(e) => e.stopPropagation()}>
+          {seg.text}
+        </Link>
       );
-    }
-    last = start + matched.length;
+    default:
+      return <span key={key}>{seg.text}</span>;
   }
-  if (last < text.length) out.push(<span key={key++}>{text.slice(last)}</span>);
-  return out;
 }
 
 function ExternalLink({ href, label }: { href: string; label: string }) {

--- a/apps/web/src/lib/atproto.ts
+++ b/apps/web/src/lib/atproto.ts
@@ -1,4 +1,4 @@
-import type { Agent } from '@atproto/api';
+import { RichText, type Agent } from '@atproto/api';
 import { BLUESKY_API_PAGE_LIMIT, DIAGNOSIS_MIN_POST_TEXT_LENGTH, DIAGNOSIS_POST_LIMIT, TIMELINE_PAGE_LIMIT } from '@aozoraquest/core';
 
 /** クライアント識別子。TOKIMEKI 方式で post record 最上位に書き込む。 */
@@ -247,12 +247,14 @@ export async function fetchPostThread(
  * クライアント識別のため `via: VIA` を record top-level に付加 (TOKIMEKI 互換)。
  */
 export async function createPost(agent: Agent, text: string, reply?: ReplyRef) {
-  const base: { text: string; createdAt: string; via: string; reply?: ReplyRef } = {
+  const base: { text: string; createdAt: string; via: string; reply?: ReplyRef; facets?: unknown[] } = {
     text,
     createdAt: new Date().toISOString(),
     via: VIA,
   };
   if (reply) base.reply = reply;
+  const facets = await detectPostFacets(agent, text);
+  if (facets) base.facets = facets;
   return agent.post(base as unknown as Parameters<Agent['post']>[0]);
 }
 
@@ -283,22 +285,23 @@ export async function getRecord<T = unknown>(agent: Agent, repo: string, collect
 }
 
 /**
- * text 内のハッシュタグ `#tag` を richtext facet (tag) に変換する。
- * 見つからなければ undefined。
+ * 投稿本文から richtext facet (URL リンク / @メンション / #ハッシュタグ) を自動検出する。
+ * - URL → `facet#link` (他クライアントでもクリック可能になる)
+ * - @handle → `facet#mention` (handle を DID に解決。要ネットワーク)
+ * - #tag → `facet#tag` (検索 API で拾える)
+ * detectFacets は内部で正しい byte index を計算するので、手組みより堅牢。
+ * 失敗しても投稿自体は止めない (facet 無しで投稿)。
  */
-function buildTagFacets(text: string, tag?: string): unknown[] | undefined {
-  if (!tag) return undefined;
-  const marker = `#${tag}`;
-  const idx = text.indexOf(marker);
-  if (idx < 0) return undefined;
-  const encoder = new TextEncoder();
-  return [{
-    index: {
-      byteStart: encoder.encode(text.slice(0, idx)).length,
-      byteEnd: encoder.encode(text.slice(0, idx + marker.length)).length,
-    },
-    features: [{ $type: 'app.bsky.richtext.facet#tag', tag }],
-  }];
+async function detectPostFacets(agent: Agent, text: string): Promise<unknown[] | undefined> {
+  if (!text) return undefined;
+  const rt = new RichText({ text });
+  try {
+    await rt.detectFacets(agent);
+  } catch (e) {
+    console.warn('[atproto] facet 検出に失敗 (facet 無しで投稿)', e);
+    return undefined;
+  }
+  return rt.facets && rt.facets.length > 0 ? rt.facets : undefined;
 }
 
 /** Bluesky の 1 投稿あたり画像添付上限。 */
@@ -308,7 +311,8 @@ export const MAX_POST_IMAGES = 4;
  * 画像付き投稿を作成する。最大 {@link MAX_POST_IMAGES} 枚を uploadBlob して
  * `app.bsky.embed.images` embed として post に紐付ける (画像は配列順で表示)。
  * @param images 各 {blob, alt}。alt は a11y 用 (空でも可)
- * @param tag    付与したいハッシュタグ (指定時 text 内から facet を抽出)
+ * @param tag    互換のため残置。facet (リンク/メンション/#tag) は detectPostFacets が
+ *               text から自動検出するので、ハッシュタグもこの引数なしで facet 化される。
  */
 export async function createPostWithImages(
   agent: Agent,
@@ -316,6 +320,7 @@ export async function createPostWithImages(
   images: Array<{ blob: Blob; alt: string }>,
   tag?: string,
 ): Promise<void> {
+  void tag; // facet 検出は自動化済み。引数は呼び出し側互換のため受けるだけ。
   // 呼び出し側 (UI) を信頼せず lib 側でも 4 枚に切り詰める最終ガード。
   const picked = images.slice(0, MAX_POST_IMAGES);
   const record: Record<string, unknown> = {
@@ -334,28 +339,21 @@ export async function createPostWithImages(
     record['embed'] = { $type: 'app.bsky.embed.images', images: uploaded };
   }
   // picked が空なら embed を付けない (空 images embed は不正なので作らない)。
-  const facets = buildTagFacets(text, tag);
+  const facets = await detectPostFacets(agent, text);
   if (facets) record['facets'] = facets;
   await agent.post(record as unknown as Parameters<Agent['post']>[0]);
 }
 
-/** ハッシュタグ facet 付き投稿 (検索 API で拾えるようにする) */
+/** ハッシュタグ facet 付き投稿 (検索 API で拾えるようにする)。
+ *  text に含まれる #tag / URL / @mention をまとめて facet 化する。 */
 export async function createTaggedPost(agent: Agent, text: string, tag: string): Promise<void> {
-  const marker = `#${tag}`;
-  const idx = text.indexOf(marker);
-  const encoder = new TextEncoder();
-  const facets = idx >= 0 ? [{
-    index: {
-      byteStart: encoder.encode(text.slice(0, idx)).length,
-      byteEnd: encoder.encode(text.slice(0, idx + marker.length)).length,
-    },
-    features: [{ $type: 'app.bsky.richtext.facet#tag', tag }],
-  }] : [];
+  void tag; // #tag は text に含まれている前提。facet 化は detectPostFacets が自動で行う。
+  const facets = await detectPostFacets(agent, text);
   const record = {
     text,
     createdAt: new Date().toISOString(),
     via: VIA,
-    ...(facets.length > 0 ? { facets } : {}),
+    ...(facets ? { facets } : {}),
   };
   await agent.post(record as unknown as Parameters<Agent['post']>[0]);
 }

--- a/apps/web/src/lib/atproto.ts
+++ b/apps/web/src/lib/atproto.ts
@@ -301,7 +301,18 @@ async function detectPostFacets(agent: Agent, text: string): Promise<unknown[] |
     console.warn('[atproto] facet 検出に失敗 (facet 無しで投稿)', e);
     return undefined;
   }
-  return rt.facets && rt.facets.length > 0 ? rt.facets : undefined;
+  if (!rt.facets || rt.facets.length === 0) return undefined;
+  // detectFacets は handle を解決できなかった mention に did:'' を残す。
+  // 空 did の mention facet をそのまま post すると壊れた facet が PDS に書かれる
+  // (通知投稿は必ず @handle を含むので、相手が離脱/改名/解決失敗だと発生する) ため除外する。
+  const MENTION = 'app.bsky.richtext.facet#mention';
+  const clean = rt.facets.filter((f) =>
+    f.features.every((ft) => {
+      const feat = ft as { $type?: string; did?: string };
+      return feat.$type !== MENTION || (typeof feat.did === 'string' && feat.did.length > 0);
+    }),
+  );
+  return clean.length > 0 ? clean : undefined;
 }
 
 /** Bluesky の 1 投稿あたり画像添付上限。 */

--- a/apps/web/src/lib/create-post-images.test.ts
+++ b/apps/web/src/lib/create-post-images.test.ts
@@ -5,7 +5,7 @@ import type { Agent } from '@atproto/api';
 interface PostRecord {
   text: string;
   embed?: { $type: string; images: { alt: string }[] };
-  facets?: { features: { tag?: string }[] }[];
+  facets?: { features?: { $type?: string; tag?: string; uri?: string }[] }[];
 }
 
 function mockAgent() {
@@ -50,6 +50,16 @@ describe('createPostWithImages', () => {
     const m = mockAgent();
     await createPostWithImages(m.agent, 'タグなし本文', [img('image/webp', '')], 'AozoraQuest');
     expect(m.posted()?.facets).toBeUndefined();
+  });
+
+  it('detects a URL in text as a link facet (他クライアントでもクリック可能に)', async () => {
+    const m = mockAgent();
+    await createPostWithImages(m.agent, 'みて https://aozoraquest.app/board/x', [img('image/webp', '')]);
+    const facets = m.posted()?.facets;
+    expect(facets).toBeDefined();
+    expect(
+      facets?.some((f) => f.features?.some((ft) => ft.$type === 'app.bsky.richtext.facet#link' && ft.uri === 'https://aozoraquest.app/board/x')),
+    ).toBe(true);
   });
 
   it('posts a single image correctly', async () => {

--- a/apps/web/src/lib/create-post-images.test.ts
+++ b/apps/web/src/lib/create-post-images.test.ts
@@ -1,12 +1,31 @@
 import { describe, it, expect, vi } from 'vitest';
-import { createPostWithImages, MAX_POST_IMAGES } from './atproto';
+import { createPost, createPostWithImages, MAX_POST_IMAGES } from './atproto';
 import type { Agent } from '@atproto/api';
 
 interface PostRecord {
   text: string;
   embed?: { $type: string; images: { alt: string }[] };
-  facets?: { features?: { $type?: string; tag?: string; uri?: string }[] }[];
+  facets?: { features?: { $type?: string; tag?: string; uri?: string; did?: string }[] }[];
 }
+
+/** mention 解決 (resolveHandle) も持つ mock agent。resolve が null を返すと解決失敗。 */
+function mockAgentWithResolve(resolve: (handle: string) => string | null) {
+  let posted: PostRecord | undefined;
+  const post = vi.fn(async (record: unknown) => {
+    posted = record as PostRecord;
+    return { uri: 'at://x/app.bsky.feed.post/1', cid: 'cid' };
+  });
+  const resolveHandle = vi.fn(async ({ handle }: { handle: string }) => {
+    const did = resolve(handle);
+    if (!did) throw new Error('unresolved');
+    return { data: { did } };
+  });
+  const agent = { post, com: { atproto: { identity: { resolveHandle } } } } as unknown as Agent;
+  return { agent, post, posted: () => posted };
+}
+
+const hasFeature = (rec: PostRecord | undefined, type: string) =>
+  rec?.facets?.some((f) => f.features?.some((ft) => ft.$type === type)) ?? false;
 
 function mockAgent() {
   let posted: PostRecord | undefined;
@@ -75,5 +94,25 @@ describe('createPostWithImages', () => {
     expect(m.uploadBlob).not.toHaveBeenCalled();
     expect(m.posted()?.embed).toBeUndefined();
     expect(m.posted()?.text).toBe('text only');
+  });
+});
+
+describe('createPost facets (mention 解決)', () => {
+  it('mention を DID に解決して mention + link facet を付ける', async () => {
+    const m = mockAgentWithResolve(() => 'did:plc:abc');
+    await createPost(m.agent, '@alice.test みて https://x.io/y');
+    expect(
+      m.posted()?.facets?.some((f) => f.features?.some((ft) => ft.$type === 'app.bsky.richtext.facet#mention' && ft.did === 'did:plc:abc')),
+    ).toBe(true);
+    expect(hasFeature(m.posted(), 'app.bsky.richtext.facet#link')).toBe(true);
+  });
+
+  it('解決できない handle の mention facet は捨てる (空 did facet を漏らさない)', async () => {
+    const m = mockAgentWithResolve(() => null); // 解決失敗 → did:''
+    await createPost(m.agent, '@ghost.test みて https://x.io/y');
+    // 空 did の壊れた mention facet は record に載らない
+    expect(hasFeature(m.posted(), 'app.bsky.richtext.facet#mention')).toBe(false);
+    // URL の link facet は残る
+    expect(hasFeature(m.posted(), 'app.bsky.richtext.facet#link')).toBe(true);
   });
 });


### PR DESCRIPTION
## 何を直すか
クエスト発行投稿・通常投稿で **URL がクリックできない**(スクショ: クエスト完了報告の URL が素のテキスト)。生成側・表示側の両方に原因があった。

| | 症状 | 原因 |
|---|---|---|
| **表示** | #タグ付き投稿の URL が素テキスト | facets があると `renderWithFacets` が facet 範囲しかリンク化せず隙間の URL を素通り |
| **生成** | aozoraquest 発の投稿が他クライアントでもリンクにならない | 手組み `buildTagFacets` が `#tag` しか facet 化せず URL を無視 |

## 修正
1. **表示 (`post-text.tsx`)**: facet と facet の**隙間テキストも自動リンク**(URL/#tag/@mention)。描画非依存の純粋関数 **`segmentPost`** に切り出してテスト可能化。
2. **生成 (`atproto.ts`)**: `RichText.detectFacets` に置換し URL(link)/@mention/#tag をまとめて検出。`createPost` / `createPostWithImages` / `createTaggedPost` 全適用。
3. **(レビュー対応)** 解決できない mention の **空 did facet を post しない**フィルタを追加。

## 検証
- `segmentPost`: #tag facet 付き投稿の隙間 URL が link になる(本丸)/ link・mention facet / 壊れた facet でも本文非欠落。
- `createPost`/`createPostWithImages`: URL→link facet 検出、mention 解決成功で mention+link、**解決失敗で空 did facet を漏らさない**。
- `typecheck` / **185 unit tests** / `build` 緑。

## 実機確認のお願い
デプロイ後、(1) クエスト発行投稿の URL がリンクになるか、(2) 通常投稿の URL が本家 Bluesky アプリでもクリックできるか。

## Review
§1.5 3 並列レビュー (設計/実装/UX) 実施。

### ★★★ (PR 内で必須対応 → 対応済み)
- **解決できない mention の空 did facet がそのまま post される** (設計・実装が一致して検出): `formatNotificationPost` (通知投稿) は必ず @handle を含むため、相手の離脱/改名/解決失敗で壊れた facet が PDS に書かれる。→ `detectPostFacets` で空 did mention facet を除外 + 回帰テスト (commit f406b00)。

### ★★ (対応 or issue 化)
- **detectFacets のネットワーク遅延が投稿を直列ブロック** (設計): 投稿は元々 async。mention 解決の round-trip が乗るトレードオフは許容(facet 無しでも投稿は止めない設計)。timeout 検討は #114 に併記可。
- **`void tag` dead 引数 / `createTaggedPost` の収束** (設計・実装): → issue #114。
- **AUTO_LINK_RE 過検出 (@/tag)** (UX): 既存正規表現の精度問題、発火面が広がった。→ issue #115。
- **ExternalLink の break-all** (UX): ラベルが任意テキストの facet#link で過剰改行の可能性。軽微、#115 に併記。

### ★ (確認済み・対応柔軟)
- 二重リンク化なし / `rt.text` 不使用で byte ズレなし / override(翻訳)経路は既存等価 / リンクのスタイルは DESIGN.md 準拠 / React index key 問題なし — いずれもレビューで健全と確認。
- 副次効果: facet 経由 mention/tag に `stopPropagation` が付き、カード遷移との二重発火(既存バグ)も解消。