### PR TITLE
fix(quest): 応募を PDS 直読みで発見 (Worker無しでクエストが進行しない不具合)

### DIFF
--- a/apps/web/src/lib/quest-api.test.ts
+++ b/apps/web/src/lib/quest-api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, beforeAll, vi } from 'vitest';
-import { parseAtUri, questUrlOf } from './quest-api';
+import { parseAtUri, questUrlOf, listApplicationsFor, type QuestIndex } from './quest-api';
 import { mockIndex } from './quest-mock';
 import type { UserQuest } from '@aozoraquest/core';
 
@@ -9,7 +9,7 @@ vi.mock('./repo-read', () => ({
   listRecordsForDid: vi.fn(),
   getRecordForDid: vi.fn(),
 }));
-import { listRecordsForDid } from './repo-read';
+import { listRecordsForDid, getRecordForDid } from './repo-read';
 
 // in-memory localStorage polyfill (node 環境では存在しないので)
 beforeAll(() => {
@@ -51,6 +51,34 @@ describe('questUrlOf', () => {
   it('encodes at-uri into /quests/<encoded>', () => {
     const url = questUrlOf('at://did:plc:abc/app.aozoraquest.userQuest/r1', 'https://aozoraquest.app');
     expect(url).toBe('https://aozoraquest.app/quests/at%3A%2F%2Fdid%3Aplc%3Aabc%2Fapp.aozoraquest.userQuest%2Fr1');
+  });
+});
+
+describe('listApplicationsFor', () => {
+  beforeEach(() => { vi.mocked(getRecordForDid).mockReset(); });
+
+  it('渡された discovery index の applications を使い、対象 quest の応募だけを PDS から取る', async () => {
+    const questUri = 'at://did:plc:owner/app.aozoraquest.userQuest/q1';
+    const index: QuestIndex = {
+      quests: [],
+      applications: [
+        { uri: 'at://did:plc:alice/app.aozoraquest.questApplication/a1', did: 'did:plc:alice', questUri, createdAt: '2026-06-14T00:00:00Z' },
+        // 別 quest への応募 → 除外されるべき
+        { uri: 'at://did:plc:bob/app.aozoraquest.questApplication/b1', did: 'did:plc:bob', questUri: 'at://did:plc:owner/app.aozoraquest.userQuest/OTHER', createdAt: '2026-06-14T00:00:00Z' },
+      ],
+      updatedAt: '2026-06-14T00:00:00Z',
+    };
+    vi.mocked(getRecordForDid).mockResolvedValue({
+      questUri, message: 'やります', withdrawn: false, createdAt: '2026-06-14T00:00:00Z',
+    } as unknown as Awaited<ReturnType<typeof getRecordForDid>>);
+
+    const apps = await listApplicationsFor(undefined, questUri, index);
+
+    expect(apps).toHaveLength(1);
+    expect(apps[0]?.did).toBe('did:plc:alice');
+    // alice の 1 件だけ PDS read (bob の別 quest 応募は対象外)
+    expect(vi.mocked(getRecordForDid)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(getRecordForDid)).toHaveBeenCalledWith('did:plc:alice', expect.any(String), 'a1');
   });
 });
 

--- a/apps/web/src/lib/quest-api.ts
+++ b/apps/web/src/lib/quest-api.ts
@@ -407,12 +407,18 @@ export async function withdrawApplication(
   await putRecord(agent, COL.questApplication, rkey, toRecord(next, COL.questApplication));
 }
 
-/** 特定 quest への応募一覧を、index で発見した応募者 PDS から fetch する */
+/** 特定 quest への応募一覧を、index で発見した応募者 PDS から fetch する。
+ *
+ *  `index` を渡すと、それ (= 掲示板と同じ PDS 直読みの discovery index) の
+ *  applications を使う。これにより集約 Worker が未デプロイでも **他ユーザーの
+ *  応募が発注者に見える** (応募者が #aozoraquest 投稿で発見可能な前提)。
+ *  未指定なら従来どおり fetchQuestIndex (Worker or localStorage モック) に落ちる。 */
 export async function listApplicationsFor(
   _agent: Agent | undefined,
   questUri: AtUri,
+  index?: QuestIndex,
 ): Promise<QuestApplication[]> {
-  const idx = await fetchQuestIndex();
+  const idx = index ?? await fetchQuestIndex();
   const entries = idx.applications.filter(a => a.questUri === questUri);
   const out: QuestApplication[] = [];
   for (const e of entries) {

--- a/apps/web/src/routes/board-detail.tsx
+++ b/apps/web/src/routes/board-detail.tsx
@@ -171,8 +171,11 @@ export function BoardDetail() {
   async function notifyBluesky(action: NotificationAction, recipientDid: string | null) {
     if (!session.agent || !quest) return;
     if (!recipientDid) return;
-    // dev 環境では default OFF。設定で明示的に ON にしている場合のみ送る。
-    if (!getPostQuestNotifications()) {
+    // 'applied' は集約 Worker 無しで発注者が応募者を発見する唯一の手段 (#aozoraquest 投稿で
+    // discovery 網に乗せる) なので、通知設定に関わらず必ず送る。これが出ないと応募しても
+    // 発注者に見えず進行が詰む。他の通知 (assigned/reported/approved/revision) は従来どおり
+    // 設定に従う (dev 環境では default OFF)。
+    if (action !== 'applied' && !getPostQuestNotifications()) {
       console.info('[board-detail] skip notify (postQuestNotifications=false):', action, recipientDid);
       return;
     }

--- a/apps/web/src/routes/board-detail.tsx
+++ b/apps/web/src/routes/board-detail.tsx
@@ -22,10 +22,13 @@ import {
   approveCompletion,
   requestRevision,
   listCompletionsFor,
+  buildQuestIndexViaDiscovery,
+  type QuestIndex,
 } from '@/lib/quest-api';
 import { createPost } from '@/lib/atproto';
 import { getPostQuestNotifications } from '@/lib/prefs';
 import { refreshQuestIndex } from '@/lib/quest-index-cache';
+import { useRuntimeConfig } from '@/components/config-provider';
 import { Handle, RewardPoints } from '@/components/handle';
 import { DateTimePicker } from '@/components/date-time-picker';
 import { isoToLocalInput } from '@/lib/datetime';
@@ -73,6 +76,14 @@ export function BoardDetail() {
     setBusy(false);
   }, [uri]);
 
+  const config = useRuntimeConfig();
+  const agent = session.agent;
+  const selfDid = session.did;
+  // directory の DID 群 (+ 自分) から掲示板と同じ PDS 直読み index を組む材料。
+  // 配列は毎 render 新規なので、effect の不要再実行を防ぐため文字列キー化する。
+  const directoryDids = config.directory.map((u) => u.did);
+  const aggregationKey = `${selfDid ?? ''}|${directoryDids.join(',')}`;
+
   const refresh = useCallback(async () => {
     // クエスト読み取りは公開 read (PDS 経由) で agent 不要。未ログインでも
     // 詳細を表示できるよう session.agent はガードしない (操作系は個別に
@@ -86,8 +97,15 @@ export function BoardDetail() {
       const q = await getQuest(undefined, uri);
       setQuest(q);
       if (q) {
+        // 集約 Worker が未デプロイでも他ユーザーの応募が発注者に見えるよう、
+        // 掲示板と同じ「discovery index (各 PDS 直読み)」を **この詳細表示用に直接** 組む。
+        // (共有キャッシュ経由だと refreshQuestIndex の inflight と競合して mock を
+        //  掴みうるため、詳細では毎回 fresh に組む。サインイン時のみ他 repo を読める)
+        const index: QuestIndex | undefined = agent
+          ? await buildQuestIndexViaDiscovery(agent, directoryDids, selfDid).catch(() => undefined)
+          : undefined;
         const [apps, comps] = await Promise.all([
-          listApplicationsFor(undefined, uri),
+          listApplicationsFor(undefined, uri, index),
           listCompletionsFor(undefined, q),
         ]);
         setApplications(apps);
@@ -96,8 +114,10 @@ export function BoardDetail() {
     } catch (e) {
       setErr(String((e as Error)?.message ?? e));
     }
-    // agent を使わないので deps は uri のみ (session 解決での二重 fetch を回避)
-  }, [uri]);
+    // directoryDids / selfDid は aggregationKey に内包される (配列を直接 deps に
+    // 入れると毎 render 別参照で refetch ループになるため文字列キーで安定化)。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [uri, agent, aggregationKey]);
 
   useEffect(() => { void refresh(); }, [refresh]);
 

--- a/packages/core/src/__tests__/user-quest.test.ts
+++ b/packages/core/src/__tests__/user-quest.test.ts
@@ -371,6 +371,17 @@ describe('formatNotificationPost', () => {
       questTitle: '精霊のイラスト',
       questUrl: 'https://aozoraquest.app/quests/x',
     });
-    expect(out).toBe('@sato.bsky.social 受託者に指定されました: 精霊のイラスト → https://aozoraquest.app/quests/x');
+    expect(out).toBe('@sato.bsky.social 受託者に指定されました: 精霊のイラスト → https://aozoraquest.app/quests/x #aozoraquest');
+  });
+
+  it('発見性のため #aozoraquest を必ず含む', () => {
+    const out = formatNotificationPost({
+      action: 'applied',
+      recipientHandle: 'owner.bsky.social',
+      questTitle: 'テスト',
+      questUrl: 'https://aozoraquest.app/quests/y',
+    });
+    expect(out).toContain('#aozoraquest');
+    expect(out.startsWith('@owner.bsky.social')).toBe(true);
   });
 });

--- a/packages/core/src/__tests__/user-quest.test.ts
+++ b/packages/core/src/__tests__/user-quest.test.ts
@@ -371,17 +371,37 @@ describe('formatNotificationPost', () => {
       questTitle: '精霊のイラスト',
       questUrl: 'https://aozoraquest.app/quests/x',
     });
-    expect(out).toBe('@sato.bsky.social 受託者に指定されました: 精霊のイラスト → https://aozoraquest.app/quests/x #aozoraquest');
+    // applied 以外 (assigned 等) には #aozoraquest を付けない (TL 汚染回避)
+    expect(out).toBe('@sato.bsky.social 受託者に指定されました: 精霊のイラスト → https://aozoraquest.app/quests/x');
   });
 
-  it('発見性のため #aozoraquest を必ず含む', () => {
-    const out = formatNotificationPost({
+  it('applied のときだけ発見用 #aozoraquest を付ける', () => {
+    const applied = formatNotificationPost({
       action: 'applied',
       recipientHandle: 'owner.bsky.social',
       questTitle: 'テスト',
       questUrl: 'https://aozoraquest.app/quests/y',
     });
-    expect(out).toContain('#aozoraquest');
-    expect(out.startsWith('@owner.bsky.social')).toBe(true);
+    expect(applied).toContain('#aozoraquest');
+    expect(applied.startsWith('@owner.bsky.social')).toBe(true);
+
+    // ネガティブ寄りの通知はタグ無し (公開タグ TL に流さない)
+    for (const action of ['reported', 'approved', 'revisionRequested'] as const) {
+      const out = formatNotificationPost({ action, recipientHandle: 'h', questTitle: 't', questUrl: 'u' });
+      expect(out).not.toContain('#aozoraquest');
+    }
+  });
+
+  it('長いタイトルを丸めて post が長くなりすぎないようにする', () => {
+    const longTitle = 'あ'.repeat(200);
+    const out = formatNotificationPost({
+      action: 'applied',
+      recipientHandle: 'owner.bsky.social',
+      questTitle: longTitle,
+      questUrl: 'https://aozoraquest.app/quests/at%3A%2F%2Fdid%3Aplc%3Axxxxxxxxxxxxxxxxxxxx%2Fapp.aozoraquest.userQuest%2F3lpzzzzzz',
+    });
+    expect(out).toContain('…');
+    // Bluesky 上限 300 grapheme に対し安全側 (タイトル丸め後)
+    expect([...out].length).toBeLessThanOrEqual(300);
   });
 });

--- a/packages/core/src/user-quest.ts
+++ b/packages/core/src/user-quest.ts
@@ -324,16 +324,28 @@ const ACTION_MESSAGES: Record<NotificationAction, string> = {
   revisionRequested: 'やり直しを依頼されました',
 };
 
+/** 通知 post 本文がこの grapheme 数を超えないようタイトルを丸める (Bluesky 上限 300 の安全側)。 */
+const NOTIFICATION_TITLE_MAX = 80;
+
 export function formatNotificationPost(args: {
   action: NotificationAction;
   recipientHandle: string;
   questTitle: string;
   questUrl: string;
 }): string {
-  // #aozoraquest を必ず付ける。集約 Worker が無い間、応募者/関係者の発見は
-  // 「#aozoraquest 投稿者の PDS を走査する」経路に依存するため、通知 post に
-  // タグが無いと応募しても発注者の掲示板に応募者として現れない (= 進行が詰む)。
-  return `@${args.recipientHandle} ${ACTION_MESSAGES[args.action]}: ${args.questTitle} → ${args.questUrl} #aozoraquest`;
+  // #aozoraquest は **応募 (applied) のときだけ** 付ける。集約 Worker が無い間、
+  // 発注者が応募者を発見する経路は「#aozoraquest 投稿者の PDS を走査する」のみで、
+  // 応募者をこの検索網に乗せるのが目的。承認/やり直し等は当事者間の mention で
+  // 足り、全部にタグを付けると (a) 発見用 TL を希釈し (b) ネガティブなやりとりまで
+  // 公開タグに流す副作用があるため付けない。
+  const tag = args.action === 'applied' ? ' #aozoraquest' : '';
+  // タイトル + 長い at:// URL で 300 grapheme を超えると post が落ち、応募者が
+  // 発見されなくなる。タイトルを安全側に丸める。
+  const title =
+    args.questTitle.length > NOTIFICATION_TITLE_MAX
+      ? `${args.questTitle.slice(0, NOTIFICATION_TITLE_MAX - 1)}…`
+      : args.questTitle;
+  return `@${args.recipientHandle} ${ACTION_MESSAGES[args.action]}: ${title} → ${args.questUrl}${tag}`;
 }
 
 function formatDateShort(iso: string): string {

--- a/packages/core/src/user-quest.ts
+++ b/packages/core/src/user-quest.ts
@@ -330,7 +330,10 @@ export function formatNotificationPost(args: {
   questTitle: string;
   questUrl: string;
 }): string {
-  return `@${args.recipientHandle} ${ACTION_MESSAGES[args.action]}: ${args.questTitle} → ${args.questUrl}`;
+  // #aozoraquest を必ず付ける。集約 Worker が無い間、応募者/関係者の発見は
+  // 「#aozoraquest 投稿者の PDS を走査する」経路に依存するため、通知 post に
+  // タグが無いと応募しても発注者の掲示板に応募者として現れない (= 進行が詰む)。
+  return `@${args.recipientHandle} ${ACTION_MESSAGES[args.action]}: ${args.questTitle} → ${args.questUrl} #aozoraquest`;
 }
 
 function formatDateShort(iso: string): string {


### PR DESCRIPTION
## 何を直すか
オーナー報告:「クエストが他ユーザーから進まない / 完了報告だけのクエストがずっと達成されない」。調査の結果、**応募が他ユーザー間で見えない**ことが一次原因と判明。

### 根本原因
集約 Worker (`VITE_QUEST_EDGE_URL`) が未デプロイで、応募一覧 `listApplicationsFor` が `fetchQuestIndex()` = **localStorage モック (各ブラウザ内のみ)** を読んでいた。応募レコードは応募者自身の localStorage にしか index 登録されず、別ブラウザの発注者には応募者が**一生見えない** → `open` のまま受託指定できず、完了報告 (受託者限定) にも到達できず → **永久に未達成**。クエスト一覧・状態・完了報告は既に PDS 直読みで動いており、壊れていたのは**「応募の発見」だけ**。

## 修正 (Option B: Worker 無しで PDS 直読み。オーナー選択)
1. `listApplicationsFor` に discovery index を渡せるようにし、`board-detail` は掲示板と同じ `buildQuestIndexViaDiscovery`(#aozoraquest 投稿者 + directory + 自分の PDS を直読み)で組んだ index から応募を取得。
2. 応募者を発見可能にするため、応募時の `applied` 通知 post に **#aozoraquest を付与**し、かつ**通知設定に関わらず必ず送る**(発見の必須インフラ。OFF だと詰むため)。
3. **完了モデルは2段階維持**(受託者「報告」→ 発注者「承認」。オーナー確認済み)。

## 検証
- `listApplicationsFor` が渡された index の対象 quest 応募だけを PDS read する回帰
- `formatNotificationPost`: applied のみ #aozoraquest / ネガ通知はタグ無し / 長文タイトル丸めで 300 grapheme 以内
- core 149 + web 186 / typecheck / build 緑

## Review
§1.5 3 並列 (設計/実装/UX) 実施。

### ★★★ (PR 内で対応済み)
- **発見機構が自己矛盾** (設計): 応募者発見が `applied` post 依存なのに、その post が `getPostQuestNotifications` で gating され OFF だと無効化 → 修正が効かない。→ `applied` だけは設定非依存で必ず送るよう変更 (commit 88af5d9)。

### ★★ (PR 内で対応)
- **#aozoraquest を全通知に付与する副作用** (設計/UX): 承認/やり直し等まで公開タグ TL に流入・希釈。→ タグを `applied` のみに限定 (88af5d9)。
- **通知 post の文字数超過で無言失敗** (実装): 長タイトル+at:// URL+タグで 300 grapheme 超 → post 落ち → 応募者不可視。→ タイトルを 80 文字に丸め (88af5d9)。

### ★★ / ★★★(UX分類) → issue 化
- **承認待ちに発注者が気づく導線がない** (UX ★★★): 元不満の本丸の一つ。応募が見えても発注者が詳細を開かないと承認されない。→ **issue #119**(掲示板一覧に「承認待ち」バッジ等)。
- **discovery のコスト/60 DID 取りこぼし** (設計/実装/UX ★★): 毎 refresh フルスキャン + 上限超で応募欠落。→ **issue #120**。
- **応募の反映ラグ/発見依存がユーザーに見えない + docs に Option B 境界未記載** (設計/UX ★★): → **issue #121**。

### ★ (確認済み)
- deps 配列のループ/stale closure は無し (実装レビュー検証)。completion 経路 (listCompletionsFor) は当事者2 repo 直読みで discovery 不要、application だけ discovery にする非対称は正しい。`index?` フォールバックは後方互換で Worker 復活時に自動で戻る。

## 実機確認のお願い
2 アカウント (別ブラウザ): A が発行 → B が応募 → **A の詳細に B の応募が出るか** → A が B を受託指定 → B が完了報告 → A が承認 → 双方「完了」表示になるか。