### PR TITLE
feat(quest): core effectiveState (唯一の真実) + questXpEarned + approve冪等化 (PR-2)

### DIFF
--- a/apps/web/src/lib/quest-api.ts
+++ b/apps/web/src/lib/quest-api.ts
@@ -16,7 +16,7 @@ import type {
   AtUri,
   Did,
 } from '@aozoraquest/core';
-import { isValidCompletion } from '@aozoraquest/core';
+import { isValidCompletion, isCompleted } from '@aozoraquest/core';
 import { putRecord, getRecord } from './atproto';
 import { listRecordsForDid, getRecordForDid } from './repo-read';
 import { COL } from './collections';
@@ -538,6 +538,18 @@ export async function approveCompletion(
   quest: UserQuest,
   comment?: string,
 ): Promise<{ completion: QuestCompletion; updatedQuest: UserQuest }> {
+  // 冪等性: 既に承認済みなら二重 approval record を書かない (= 二重発行防止)。
+  // 報酬 (ポイント/XP) は完了集合からの派生なので record が 1 つでも複数でも結果は同じだが、
+  // 余計な record を増やさないため既存 approval を返して no-op にする。
+  const existing = await listCompletionsFor(undefined, quest);
+  if (isCompleted(quest, existing)) {
+    const approval = existing.find(c => c.role === 'requesterApproval' && c.did === quest.did);
+    const updated: UserQuest = quest.status === 'completed'
+      ? quest
+      : { ...quest, status: 'completed', updatedAt: new Date().toISOString() };
+    if (approval) return { completion: approval, updatedQuest: updated };
+    // status は completed だが approval record が見当たらない稀ケースは通常経路で書く
+  }
   // 順序: (A) approval record → (B) quest status → (C) index 同期。
   // (A) が真実、B-C は派生 (docs/15-user-quest.md §耐故障性)。
   const completion = await writeCompletion(agent, requesterDid, quest.uri, 'requesterApproval', comment);

--- a/packages/core/src/__tests__/user-quest.test.ts
+++ b/packages/core/src/__tests__/user-quest.test.ts
@@ -172,6 +172,12 @@ describe('effectiveState (唯一の真実)', () => {
     expect(effectiveState(q, [report('2026-06-15T01:00:00Z'), revision('2026-06-15T02:00:00Z')])).toBe('REVISION_REQUESTED');
     expect(effectiveState(q, [report('2026-06-15T01:00:00Z'), revision('2026-06-15T02:00:00Z'), report('2026-06-15T03:00:00Z')])).toBe('AWAITING_APPROVAL');
   });
+  it('報告と差し戻しが同時刻のタイブレークは AWAITING (docs §2.3: v>r のみ REVISION)', () => {
+    // 別 PDS への別 record なので現実の衝突確率はほぼ無いが、挙動を固定して回帰を防ぐ。
+    const q = mk({ status: 'assigned', assignee, did: owner });
+    const t = '2026-06-15T01:00:00Z';
+    expect(effectiveState(q, [report(t), revision(t)])).toBe('AWAITING_APPROVAL');
+  });
   it('needsRequesterApproval は effectiveState===AWAITING_APPROVAL のラッパ', () => {
     const q = mk({ status: 'assigned', assignee, did: owner });
     expect(needsRequesterApproval(q, [report('2026-06-15T01:00:00Z')])).toBe(true);

--- a/packages/core/src/__tests__/user-quest.test.ts
+++ b/packages/core/src/__tests__/user-quest.test.ts
@@ -4,6 +4,8 @@ import {
   isCompleted,
   isValidCompletion,
   needsRequesterApproval,
+  effectiveState,
+  questXpEarned,
   outcomeOf,
   holdings,
   totalIssued,
@@ -140,6 +142,60 @@ describe('needsRequesterApproval (status ではなく completion record から�
   it('assignee 以外が書いた偽の報告は無視する', () => {
     const fake: QuestCompletion = { uri: 'r', did: 'did:plc:attacker', questUri: q.uri, role: 'assigneeReport', createdAt: '2026-06-15T01:00:00Z' };
     expect(needsRequesterApproval(q, [fake])).toBe(false);
+  });
+});
+
+describe('effectiveState (唯一の真実)', () => {
+  const owner = 'did:plc:owner';
+  const assignee = 'did:plc:assignee';
+  const report = (at: string): QuestCompletion => ({ uri: `r-${at}`, did: assignee, questUri: 'at://did:plc:owner/app.aozoraquest.userQuest/abc', role: 'assigneeReport', createdAt: at });
+  const approval = (at: string): QuestCompletion => ({ uri: `a-${at}`, did: owner, questUri: 'at://did:plc:owner/app.aozoraquest.userQuest/abc', role: 'requesterApproval', createdAt: at });
+  const revision = (at: string): QuestCompletion => ({ uri: `v-${at}`, did: owner, questUri: 'at://did:plc:owner/app.aozoraquest.userQuest/abc', role: 'requesterRevision', createdAt: at });
+
+  it('cancelled / completed を最優先', () => {
+    expect(effectiveState(mk({ status: 'cancelled' }), [])).toBe('CANCELLED');
+    expect(effectiveState(mk({ status: 'completed' }), [])).toBe('COMPLETED');
+    expect(effectiveState(mk({ status: 'assigned', assignee, did: owner }), [approval('2026-06-15T02:00:00Z')])).toBe('COMPLETED');
+  });
+  it('assignee 無し: open=OPEN / 期限切れ=EXPIRED', () => {
+    expect(effectiveState(mk({ status: 'open' }), [], NOW)).toBe('OPEN');
+    const expired = mk({ status: 'open', deadline: '2026-06-01T00:00:00Z' });
+    expect(effectiveState(expired, [], NOW)).toBe('EXPIRED');
+  });
+  it('assignee あり: 報告前=IN_PROGRESS / 報告後=AWAITING_APPROVAL', () => {
+    const q = mk({ status: 'assigned', assignee, did: owner });
+    expect(effectiveState(q, [])).toBe('IN_PROGRESS');
+    expect(effectiveState(q, [report('2026-06-15T01:00:00Z')])).toBe('AWAITING_APPROVAL');
+  });
+  it('差し戻しが最新=REVISION_REQUESTED / 再報告で AWAITING に戻る', () => {
+    const q = mk({ status: 'assigned', assignee, did: owner });
+    expect(effectiveState(q, [report('2026-06-15T01:00:00Z'), revision('2026-06-15T02:00:00Z')])).toBe('REVISION_REQUESTED');
+    expect(effectiveState(q, [report('2026-06-15T01:00:00Z'), revision('2026-06-15T02:00:00Z'), report('2026-06-15T03:00:00Z')])).toBe('AWAITING_APPROVAL');
+  });
+  it('needsRequesterApproval は effectiveState===AWAITING_APPROVAL のラッパ', () => {
+    const q = mk({ status: 'assigned', assignee, did: owner });
+    expect(needsRequesterApproval(q, [report('2026-06-15T01:00:00Z')])).toBe(true);
+    expect(needsRequesterApproval(q, [])).toBe(false);
+  });
+});
+
+describe('questXpEarned (完了集合からの派生 XP)', () => {
+  const me = 'did:plc:me';
+  it('自分が受託して完了したクエストの statXpDistribution を合算', () => {
+    const quests = [
+      mk({ uri: 'at://x/1', status: 'completed', assignee: me, tags: ['code'] }),    // 100 を code 配分
+      mk({ uri: 'at://x/2', status: 'completed', assignee: me, tags: ['illust'] }),  // 100 を illust 配分
+      mk({ uri: 'at://x/3', status: 'assigned', assignee: me, tags: ['code'] }),     // 未完了 → 除外
+      mk({ uri: 'at://x/4', status: 'completed', assignee: 'did:plc:other', tags: ['code'] }), // 他人 → 除外
+    ];
+    const xp = questXpEarned(quests, me);
+    const total = xp.atk + xp.def + xp.agi + xp.int + xp.luk;
+    expect(total).toBe(200); // 完了 2 件 × 100
+    expect(xp.int).toBeGreaterThan(0); // code は int 寄り
+  });
+  it('完了が無ければ全 0', () => {
+    const xp = questXpEarned([mk({ status: 'open', assignee: me, tags: ['code'] })], me);
+    expect(xp).toEqual({ atk: 0, def: 0, agi: 0, int: 0, luk: 0 });
   });
 });
 

--- a/packages/core/src/user-quest.ts
+++ b/packages/core/src/user-quest.ts
@@ -124,13 +124,47 @@ function latestCreatedAt(items: QuestCompletion[]): string | null {
  *  - 最後の報告 (assigneeReport) が最後の差し戻し (requesterRevision) より新しければ「承認待ち」。
  *    差し戻しの方が新しければ受託者の再報告待ちなので false。 */
 export function needsRequesterApproval(q: UserQuest, completions: QuestCompletion[]): boolean {
-  if (q.status === 'completed' || q.status === 'cancelled') return false;
+  return effectiveState(q, completions) === 'AWAITING_APPROVAL';
+}
+
+/**
+ * クエストの **実効状態 (effective state)** — 全ての表示・操作可否の唯一の真実。
+ *
+ * record 上の `status` は発注者しか書けないので素朴に信じてはいけない (受託者の完了報告は
+ * 発注者 record に乗らず status は `assigned` のまま)。`isCompleted` / `needsRequesterApproval`
+ * と同じく **completion record から導出** する (docs/17 §2.3)。
+ *
+ * | state | 意味 |
+ * |---|---|
+ * | OPEN | 募集中 (応募受付) |
+ * | IN_PROGRESS | 受託確定、受託者が作業中 (未報告) |
+ * | AWAITING_APPROVAL | 受託者が完了報告済み、発注者の承認待ち |
+ * | REVISION_REQUESTED | 発注者がやり直し依頼、受託者の再報告待ち |
+ * | COMPLETED | 承認済み = 達成 (報酬確定) |
+ * | CANCELLED | 発注者が中止 |
+ * | EXPIRED | 募集期限切れ (open のまま期限超過) |
+ */
+export type EffectiveState =
+  | 'OPEN' | 'IN_PROGRESS' | 'AWAITING_APPROVAL' | 'REVISION_REQUESTED'
+  | 'COMPLETED' | 'CANCELLED' | 'EXPIRED';
+
+export function effectiveState(
+  q: UserQuest,
+  completions: QuestCompletion[],
+  now: Date = new Date(),
+): EffectiveState {
+  if (q.status === 'cancelled') return 'CANCELLED';
+  if (isCompleted(q, completions)) return 'COMPLETED';
+  if (!q.assignee) {
+    return isExpired(q, now) ? 'EXPIRED' : 'OPEN';
+  }
+  // 受託確定済み (assignee あり)。completion record から進行を判定する。
   const valid = completions.filter(c => isValidCompletion(c, q));
-  if (valid.some(c => c.role === 'requesterApproval')) return false;
   const lastReport = latestCreatedAt(valid.filter(c => c.role === 'assigneeReport'));
-  if (lastReport === null) return false;
+  if (lastReport === null) return 'IN_PROGRESS';
   const lastRevision = latestCreatedAt(valid.filter(c => c.role === 'requesterRevision'));
-  return lastRevision === null || lastReport > lastRevision;
+  if (lastRevision !== null && lastRevision > lastReport) return 'REVISION_REQUESTED';
+  return 'AWAITING_APPROVAL';
 }
 
 // ─── 発注者視点: 成功 / 失敗 / キャンセル / 進行中 ─────────
@@ -272,6 +306,24 @@ export function statXpDistribution(tags: string[]): StatVector {
     result[maxStat] += 100 - final;
   }
   return result;
+}
+
+/**
+ * 受託者が **完了したクエストから得た累計ステータス XP** (`holdings` と同じく完了集合からの
+ * 派生 = 二重加算が原理的に起きない)。
+ *
+ * 完了 1 件あたり `statXpDistribution(tags)` (合計 100) を配分加算する。`me` が受託者で、かつ
+ * 承認済み (`status==='completed'`) のクエストのみ対象。承認の真実は発注者 record の
+ * `status='completed'` (= 承認時に発注者が書く) で、受託者はそれを公開 read できる。
+ */
+export function questXpEarned(receivedQuests: UserQuest[], me: Did): StatVector {
+  const acc: StatVector = v(0, 0, 0, 0, 0);
+  for (const q of receivedQuests) {
+    if (q.status !== 'completed' || q.assignee !== me) continue;
+    const dist = statXpDistribution(q.tags);
+    for (const stat of STATS) acc[stat] += dist[stat];
+  }
+  return acc;
 }
 
 // ─── 発行スパム上限 (docs/15-user-quest.md §モデレーション) ─


### PR DESCRIPTION
## 何を追加するか
依頼クエストの全状態の唯一の真実を **`effectiveState(quest, completions)`** に集約 (docs/17 §2.3)。status は発注者しか書けず素朴に信じられないため completion record から導出。

- `effectiveState()`: OPEN/IN_PROGRESS/AWAITING_APPROVAL/REVISION_REQUESTED/COMPLETED/CANCELLED/EXPIRED。`needsRequesterApproval` はこのラッパに整理。
- `questXpEarned(receivedQuests, me)`: 完了集合からの派生 XP(二重加算不能)。
- `approveCompletion`: `isCompleted` で承認済みなら no-op(二重発行防止)。

UI 非変更(PR-3 で gate に使う)。

## 検証
core 164 + web 188 / typecheck / build 緑。

## Review
§1.5 実施。**マージ可・★★★ なし**。
- **★★ → PR 内対応**: `needsRequesterApproval` ラッパ化で「報告と差し戻しが**完全同時刻**」のタイブレークが旧(REVISION)→新(AWAITING)に変わる。新挙動は docs §2.3(`v>r` のみ REVISION)に忠実で意図的。回帰テストで固定 (commit 追加)。他の全入力は旧と等価(differential check 済)。
- **★ → 記録**: `questXpEarned` は本 PR では呼び出し側なし(PR-4 で portfolio に配線する core 先行)。冪等性主張は `holdings` 同様の純粋関数で妥当。`approveCompletion` の listCompletionsFor 追加 read は承認押下時 1 回のみ。