### PR TITLE
fix(quest): 受託者がクエストを見失う問題を解消 (assigned カラム + effectiveState gate) [PR-3]

### DIFF
--- a/apps/web/src/components/column-content/board-column.tsx
+++ b/apps/web/src/components/column-content/board-column.tsx
@@ -21,7 +21,7 @@ import {
   type BoardFilter,
 } from './board-shared';
 
-const DEFAULT_INNER: BoardInner[] = [{ kind: 'open' }, { kind: 'mine' }];
+const DEFAULT_INNER: BoardInner[] = [{ kind: 'open' }, { kind: 'assigned' }, { kind: 'mine' }, { kind: 'applied' }];
 
 /** タブ表示用ラベル。issuer は DID 全表示だと長く区別もできないため
  *  末尾を省略して識別子の頭を見せる。 */
@@ -41,10 +41,10 @@ export function BoardColumn({ inner }: { inner?: BoardInner[] | undefined }) {
   const activeIndex = Math.min(tabIndex, tabs.length - 1);
   const active = tabs[activeIndex]!;
 
-  const { index, myQuests, myApplicationQuestUris, pendingApproval, err } = useBoardData();
+  const { index, myQuests, myApplicationQuestUris, pendingApproval, err, sessionDid } = useBoardData();
   const items = useMemo(
-    () => filterForBoard(active, index, myQuests, myApplicationQuestUris),
-    [active, index, myQuests, myApplicationQuestUris],
+    () => filterForBoard(active, index, myQuests, myApplicationQuestUris, sessionDid),
+    [active, index, myQuests, myApplicationQuestUris, sessionDid],
   );
   const pendingUris = useMemo(() => new Set(pendingApproval.map((q) => q.uri)), [pendingApproval]);
 

--- a/apps/web/src/components/column-content/board-shared.test.ts
+++ b/apps/web/src/components/column-content/board-shared.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { filterForBoard } from './board-shared';
+import type { QuestIndex, QuestIndexSummary } from '@/lib/quest-api';
+
+function s(over: Partial<QuestIndexSummary>): QuestIndexSummary {
+  return {
+    uri: over.uri ?? 'at://x/1',
+    did: over.did ?? 'did:plc:owner',
+    title: 't',
+    tags: [],
+    rewardPoints: 0,
+    status: over.status ?? 'open',
+    createdAt: '2026-06-15T00:00:00Z',
+    ...over,
+  };
+}
+
+function idx(quests: QuestIndexSummary[]): QuestIndex {
+  return { quests, applications: [], updatedAt: '2026-06-15T00:00:00Z' };
+}
+
+describe('filterForBoard: assigned (受託中)', () => {
+  const me = 'did:plc:me';
+  const index = idx([
+    s({ uri: 'at://x/1', status: 'open' }),
+    s({ uri: 'at://x/2', status: 'assigned', assignee: me }),       // 自分が受託中 → 出る
+    s({ uri: 'at://x/3', status: 'assigned', assignee: 'did:plc:other' }), // 他人が受託 → 除外
+    s({ uri: 'at://x/4', status: 'completed', assignee: me }),       // 完了 → 受託中からは抜ける
+  ]);
+
+  it('自分が受託確定済みかつ未完了のクエストだけを返す', () => {
+    const r = filterForBoard({ kind: 'assigned' }, index, null, null, me);
+    expect(r?.map(q => q.uri)).toEqual(['at://x/2']);
+  });
+
+  it('未ログイン (selfDid=null) は空', () => {
+    expect(filterForBoard({ kind: 'assigned' }, index, null, null, null)).toEqual([]);
+  });
+
+  it('index 未ロードは null (読み込み中)', () => {
+    expect(filterForBoard({ kind: 'assigned' }, null, null, null, me)).toBeNull();
+  });
+});

--- a/apps/web/src/components/column-content/board-shared.tsx
+++ b/apps/web/src/components/column-content/board-shared.tsx
@@ -15,7 +15,7 @@ import { useRuntimeConfig } from '@/components/config-provider';
 import { RewardPoints } from '@/components/handle';
 
 export interface BoardFilter {
-  kind: 'open' | 'mine' | 'applied' | 'tag' | 'job' | 'issuer';
+  kind: 'open' | 'assigned' | 'mine' | 'applied' | 'tag' | 'job' | 'issuer';
   param?: string;
 }
 
@@ -95,10 +95,19 @@ export function filterForBoard(
   index: QuestIndex | null,
   myQuests: UserQuest[] | null,
   myApplicationQuestUris: Set<string> | null,
+  selfDid: string | null,
 ): QuestIndexSummary[] | null {
   if (c.kind === 'open') {
     if (!index) return null;
     return index.quests.filter(q => q.status === 'open');
+  }
+  if (c.kind === 'assigned') {
+    // 自分が受託したクエスト (受託確定〜完了前)。status==='assigned' は受託者の
+    // IN_PROGRESS / 承認待ち / 差し戻し をすべて含む (発注者が承認すると completed に
+    // 抜ける)。これが無いと受託者は受託後にクエストを見失い完了報告に到達できない。
+    if (!index) return null;
+    if (!selfDid) return [];
+    return index.quests.filter(q => q.assignee === selfDid && q.status === 'assigned');
   }
   if (c.kind === 'mine') {
     if (!myQuests) return null;
@@ -209,6 +218,7 @@ export function ApprovalPendingBanner({ pending }: { pending: UserQuest[] }) {
 export function emptyMessageForBoard(c: BoardFilter): string {
   switch (c.kind) {
     case 'open':    return 'まだ誰も募集していません。「クエストを出す」から始めてみましょう。';
+    case 'assigned': return '受託中のクエストはありません。募集中から応募してみましょう。';
     case 'mine':    return 'あなたが発行したクエストはまだありません。';
     case 'applied': return '応募中のクエストはありません。';
     case 'tag':     return `#${c.param ?? ''} のクエストは見つかりませんでした。`;
@@ -220,6 +230,7 @@ export function emptyMessageForBoard(c: BoardFilter): string {
 export function boardFilterTitle(c: BoardFilter): string {
   switch (c.kind) {
     case 'open':    return '募集中';
+    case 'assigned': return '受託中';
     case 'mine':    return '自分が出した';
     case 'applied': return '自分が応募した';
     case 'tag':     return `#${c.param ?? ''}`;

--- a/apps/web/src/lib/app-columns.ts
+++ b/apps/web/src/lib/app-columns.ts
@@ -29,7 +29,7 @@ export type AppColumnKind = 'home' | 'bar' | 'notifications' | 'search' | 'board
  *  board ColumnContent が React key 用の id を mount 時に付与して
  *  橋渡しする (削除・並べ替えは index ベースで書き戻す)。 */
 export interface BoardInner {
-  kind: 'open' | 'mine' | 'applied' | 'tag' | 'job' | 'issuer';
+  kind: 'open' | 'assigned' | 'mine' | 'applied' | 'tag' | 'job' | 'issuer';
   param?: string;
 }
 
@@ -171,7 +171,7 @@ export function appColumnTitle(c: AppColumn): string {
 // ─── validation ───────────────────────────────────────
 
 const APP_KINDS: AppColumnKind[] = ['home', 'bar', 'notifications', 'search', 'board', 'profile'];
-const BOARD_INNER_KINDS: BoardInner['kind'][] = ['open', 'mine', 'applied', 'tag', 'job', 'issuer'];
+const BOARD_INNER_KINDS: BoardInner['kind'][] = ['open', 'assigned', 'mine', 'applied', 'tag', 'job', 'issuer'];
 
 export function isValidAppColumn(c: unknown): c is AppColumn {
   if (!c || typeof c !== 'object') return false;

--- a/apps/web/src/lib/board-columns.test.ts
+++ b/apps/web/src/lib/board-columns.test.ts
@@ -21,8 +21,13 @@ beforeAll(() => {
   }
 });
 
+const ASSIGNED_MIGRATED_KEY = 'aozoraquest:boardColumns:assignedMigrated';
+
 beforeEach(() => {
   localStorage.clear();
+  // 既存テストは「受託中」移行と無関係なので、既定で移行済みにして干渉を避ける。
+  // 移行ロジック自体は専用 describe でフラグを外して検証する。
+  localStorage.setItem(ASSIGNED_MIGRATED_KEY, '1');
 });
 
 describe('loadColumns / saveColumns', () => {
@@ -78,6 +83,31 @@ describe('resetColumns', () => {
     expect(cols).toHaveLength(4);
     const loaded = loadColumns();
     expect(loaded).toHaveLength(4);
+  });
+});
+
+describe('既存ユーザーへの「受託中」マイグレーション', () => {
+  it('旧 [open, mine] に open 直後で assigned を、末尾に applied を 1 回だけ注入し保存する', () => {
+    localStorage.removeItem(ASSIGNED_MIGRATED_KEY); // 未移行の既存ユーザーを再現
+    localStorage.setItem('aozoraquest:boardColumns:v1', JSON.stringify([
+      { id: 'a', kind: 'open' }, { id: 'b', kind: 'mine' },
+    ]));
+    const cols = loadColumns();
+    expect(cols.map(c => c.kind)).toEqual(['open', 'assigned', 'mine', 'applied']);
+    // 保存もされる (= workspace の board inner にも効く)
+    expect((JSON.parse(localStorage.getItem('aozoraquest:boardColumns:v1')!) as { kind: string }[]).map(c => c.kind))
+      .toEqual(['open', 'assigned', 'mine', 'applied']);
+    // 2 回目はフラグ済みなので再注入しない (ユーザーが消しても戻らない)
+    saveColumns([{ id: 'a', kind: 'open' }]);
+    expect(loadColumns().map(c => c.kind)).toEqual(['open']);
+  });
+
+  it('既に assigned を持つ構成は変更しない', () => {
+    localStorage.removeItem(ASSIGNED_MIGRATED_KEY);
+    localStorage.setItem('aozoraquest:boardColumns:v1', JSON.stringify([
+      { id: 'a', kind: 'open' }, { id: 'x', kind: 'assigned' },
+    ]));
+    expect(loadColumns().map(c => c.kind)).toEqual(['open', 'assigned']);
   });
 });
 

--- a/apps/web/src/lib/board-columns.test.ts
+++ b/apps/web/src/lib/board-columns.test.ts
@@ -26,10 +26,10 @@ beforeEach(() => {
 });
 
 describe('loadColumns / saveColumns', () => {
-  it('初期状態で default 2 カラム (募集中 + 自分が出した)', () => {
+  it('初期状態で default 4 カラム (募集中 + 受託中 + 自分が出した + 自分が応募)', () => {
     const cols = loadColumns();
-    expect(cols).toHaveLength(2);
-    expect(cols.map(c => c.kind)).toEqual(['open', 'mine']);
+    expect(cols).toHaveLength(4);
+    expect(cols.map(c => c.kind)).toEqual(['open', 'assigned', 'mine', 'applied']);
   });
 
   it('save → load で同じ内容が戻る', () => {
@@ -50,13 +50,13 @@ describe('loadColumns / saveColumns', () => {
   it('壊れた JSON は default に fallback', () => {
     localStorage.setItem('aozoraquest:boardColumns:v1', 'not json {');
     const cols = loadColumns();
-    expect(cols).toHaveLength(2);
+    expect(cols).toHaveLength(4);
   });
 
   it('空配列は default に fallback (= UI 上「全消し」を許さない)', () => {
     localStorage.setItem('aozoraquest:boardColumns:v1', '[]');
     const cols = loadColumns();
-    expect(cols).toHaveLength(2);
+    expect(cols).toHaveLength(4);
   });
 
   it('未知の kind は filter で除外する', () => {
@@ -75,9 +75,9 @@ describe('resetColumns', () => {
   it('default に戻して localStorage にも書き込む', () => {
     saveColumns([makeColumn('tag', 'foo')]);
     const cols = resetColumns();
-    expect(cols).toHaveLength(2);
+    expect(cols).toHaveLength(4);
     const loaded = loadColumns();
-    expect(loaded).toHaveLength(2);
+    expect(loaded).toHaveLength(4);
   });
 });
 

--- a/apps/web/src/lib/board-columns.ts
+++ b/apps/web/src/lib/board-columns.ts
@@ -22,7 +22,7 @@
 
 import type { Archetype } from '@aozoraquest/core';
 
-export type ColumnKind = 'open' | 'mine' | 'applied' | 'tag' | 'job' | 'issuer';
+export type ColumnKind = 'open' | 'assigned' | 'mine' | 'applied' | 'tag' | 'job' | 'issuer';
 
 export interface Column {
   id: string;
@@ -37,7 +37,10 @@ const KEY = 'aozoraquest:boardColumns:v1';
 
 const DEFAULT_COLUMNS: Column[] = [
   { id: 'col-open', kind: 'open', title: '募集中' },
+  // 受託したクエストを見失わないよう既定に追加 (受託者の完了報告導線)
+  { id: 'col-assigned', kind: 'assigned', title: '受託中' },
   { id: 'col-mine', kind: 'mine', title: '自分が出した' },
+  { id: 'col-applied', kind: 'applied', title: '自分が応募した' },
 ];
 
 export function loadColumns(): Column[] {
@@ -75,6 +78,7 @@ export function defaultTitleFor(c: Column): string {
   if (c.title) return c.title;
   switch (c.kind) {
     case 'open':    return '募集中';
+    case 'assigned': return '受託中';
     case 'mine':    return '自分が出した';
     case 'applied': return '自分が応募した';
     case 'tag':     return `#${c.param ?? ''}`;
@@ -87,7 +91,7 @@ function isValidColumn(c: unknown): c is Column {
   if (!c || typeof c !== 'object') return false;
   const obj = c as Record<string, unknown>;
   if (typeof obj.id !== 'string') return false;
-  const kinds: ColumnKind[] = ['open', 'mine', 'applied', 'tag', 'job', 'issuer'];
+  const kinds: ColumnKind[] = ['open', 'assigned', 'mine', 'applied', 'tag', 'job', 'issuer'];
   if (!kinds.includes(obj.kind as ColumnKind)) return false;
   return true;
 }

--- a/apps/web/src/lib/board-columns.ts
+++ b/apps/web/src/lib/board-columns.ts
@@ -34,6 +34,8 @@ export interface Column {
 }
 
 const KEY = 'aozoraquest:boardColumns:v1';
+/** 「受託中」カラム導入の 1 回限りマイグレーション済みフラグ。 */
+const ASSIGNED_MIGRATED_KEY = 'aozoraquest:boardColumns:assignedMigrated';
 
 const DEFAULT_COLUMNS: Column[] = [
   { id: 'col-open', kind: 'open', title: '募集中' },
@@ -49,10 +51,35 @@ export function loadColumns(): Column[] {
     if (!raw) return [...DEFAULT_COLUMNS];
     const parsed = JSON.parse(raw) as Column[];
     if (!Array.isArray(parsed) || parsed.length === 0) return [...DEFAULT_COLUMNS];
-    return parsed.filter(isValidColumn);
+    return migrateAssigned(parsed.filter(isValidColumn));
   } catch {
     return [...DEFAULT_COLUMNS];
   }
+}
+
+/**
+ * 既存ユーザー (localStorage に旧 [open, mine] 等を保存済み) に「受託中」カラムを 1 回だけ
+ * 注入する。これが無いと DEFAULT_COLUMNS 拡張が新規ユーザーにしか届かず、受託者導線の修正が
+ * 本番の既存ユーザーに反映されない。保存もするので workspace の board inner (同じ key を
+ * read-time 参照) にも効く。ユーザーが後で意図的に削除したら、フラグ済みなので再注入しない。
+ */
+function migrateAssigned(cols: Column[]): Column[] {
+  try {
+    if (localStorage.getItem(ASSIGNED_MIGRATED_KEY)) return cols;
+    localStorage.setItem(ASSIGNED_MIGRATED_KEY, '1');
+  } catch {
+    return cols;
+  }
+  if (cols.some(c => c.kind === 'assigned')) return cols;
+  const next: Column[] = [];
+  for (const c of cols) {
+    next.push(c);
+    if (c.kind === 'open') next.push({ id: 'col-assigned', kind: 'assigned', title: '受託中' });
+  }
+  if (!next.some(c => c.kind === 'assigned')) next.unshift({ id: 'col-assigned', kind: 'assigned', title: '受託中' });
+  if (!next.some(c => c.kind === 'applied')) next.push({ id: 'col-applied', kind: 'applied', title: '自分が応募した' });
+  saveColumns(next);
+  return next;
 }
 
 export function saveColumns(columns: Column[]): void {

--- a/apps/web/src/lib/quest-api.ts
+++ b/apps/web/src/lib/quest-api.ts
@@ -126,6 +126,8 @@ export interface QuestIndexSummary {
   rewardPoints: number;
   deadline?: string;
   status: string;
+  /** 受託者 DID (status>=assigned)。受託者が「自分が受けたクエスト」を一覧で判定するのに使う。 */
+  assignee?: Did;
   createdAt: string;
 }
 
@@ -152,6 +154,7 @@ function questToSummary(q: UserQuest): QuestIndexSummary {
     rewardPoints: q.rewardPoints,
     ...(q.deadline ? { deadline: q.deadline } : {}),
     status: q.status,
+    ...(q.assignee ? { assignee: q.assignee } : {}),
     createdAt: q.createdAt,
   };
 }

--- a/apps/web/src/routes/board-detail.tsx
+++ b/apps/web/src/routes/board-detail.tsx
@@ -434,8 +434,10 @@ export function BoardDetail() {
             {state === 'AWAITING_APPROVAL' && ' (完了報告済み、承認待ち)'}
             {state === 'REVISION_REQUESTED' && ' (やり直し依頼中)'}
           </p>
-          {/* 受託者は作業中(未報告) と 差し戻し中 のとき報告できる。報告後(承認待ち)は隠す。 */}
-          {isAssignee && (state === 'IN_PROGRESS' || state === 'REVISION_REQUESTED') && (
+          {/* 受託者は作業中(未報告) と 差し戻し中 のとき報告できる。報告後(承認待ち)は隠す。
+              completions ロード中 (null) は state が IN_PROGRESS に見えるため、確定するまで
+              報告ボタンを出さない (ちらつき + 報告済みなのに再報告で二重 report を防ぐ)。 */}
+          {isAssignee && completions !== null && (state === 'IN_PROGRESS' || state === 'REVISION_REQUESTED') && (
             !reportForm.open ? (
               <button onClick={() => setReportForm({ open: true, message: '' })} disabled={busy}>完了を報告する</button>
             ) : (

--- a/apps/web/src/routes/board-detail.tsx
+++ b/apps/web/src/routes/board-detail.tsx
@@ -38,7 +38,8 @@ import { isoToLocalInput } from '@/lib/datetime';
 import { resolveHandle } from '@/lib/handle-cache';
 import {
   isExpired,
-  isCompleted as isCompletedFn,
+  effectiveState,
+  type EffectiveState,
   formatNotificationPost,
   type NotificationAction,
   type UserQuest,
@@ -137,7 +138,8 @@ export function BoardDetail() {
   const myApp = applications
     ?.filter(a => a.did === session.did && !a.withdrawn)
     .sort((a, b) => b.createdAt.localeCompare(a.createdAt))[0] ?? null;
-  const completedByApproval = isCompletedFn(quest, completions ?? []);
+  // 全状態・操作の gate は effectiveState を唯一の真実に (status は受託者の報告を反映しない)。
+  const state = effectiveState(quest, completions ?? []);
 
   async function cancelQuest() {
     if (!session.agent || !quest || !isOwner) return;
@@ -306,7 +308,7 @@ export function BoardDetail() {
         <span style={{ color: 'var(--color-accent)' }}>
           <RewardPoints did={quest.did} points={quest.rewardPoints} />
         </span>
-        <span style={{ marginLeft: 'auto' }}>{statusLabel(quest.status, expired, completedByApproval)}</span>
+        <span style={{ marginLeft: 'auto' }}>{statusLabel(state)}</span>
       </div>
 
       <div style={{ marginTop: '0.6em', whiteSpace: 'pre-wrap', lineHeight: 1.6 }}>{quest.body}</div>
@@ -424,14 +426,16 @@ export function BoardDetail() {
         );
       })()}
 
-      {/* assigned 中: 受託者の表示 + 受託者の完了報告フォーム */}
-      {(quest.status === 'assigned' || quest.status === 'reported') && quest.assignee && (
+      {/* 受託確定〜完了前: 受託者の表示 + 受託者の完了報告フォーム (state は completion 由来) */}
+      {(state === 'IN_PROGRESS' || state === 'AWAITING_APPROVAL' || state === 'REVISION_REQUESTED') && quest.assignee && (
         <section style={{ marginTop: '1.4em' }}>
           <p style={{ fontSize: '0.85em' }}>
             受託者: <strong><Handle did={quest.assignee} /></strong>
-            {quest.status === 'reported' && ' (完了報告済み、承認待ち)'}
+            {state === 'AWAITING_APPROVAL' && ' (完了報告済み、承認待ち)'}
+            {state === 'REVISION_REQUESTED' && ' (やり直し依頼中)'}
           </p>
-          {isAssignee && quest.status === 'assigned' && (
+          {/* 受託者は作業中(未報告) と 差し戻し中 のとき報告できる。報告後(承認待ち)は隠す。 */}
+          {isAssignee && (state === 'IN_PROGRESS' || state === 'REVISION_REQUESTED') && (
             !reportForm.open ? (
               <button onClick={() => setReportForm({ open: true, message: '' })} disabled={busy}>完了を報告する</button>
             ) : (
@@ -454,7 +458,7 @@ export function BoardDetail() {
               </div>
             )
           )}
-          {isOwner && quest.status === 'reported' && (
+          {isOwner && state === 'AWAITING_APPROVAL' && (
             <div style={{ marginTop: '0.4em' }}>
               {!approveForm.open && !revisionForm.open && (
                 <div style={{ display: 'flex', gap: '0.6em' }}>
@@ -504,7 +508,7 @@ export function BoardDetail() {
       )}
 
       {/* 完了済み: 報酬表示 */}
-      {(quest.status === 'completed' || completedByApproval) && (
+      {state === 'COMPLETED' && (
         <section style={{ marginTop: '1.4em' }} className="dq-window">
           <p style={{ margin: 0, fontSize: '0.9em' }}>
             完了! 受託者 <strong>{quest.assignee ? <Handle did={quest.assignee} /> : '—'}</strong> に{' '}
@@ -536,15 +540,16 @@ export function BoardDetail() {
   );
 }
 
-function statusLabel(status: string, expired: boolean, completedByApproval: boolean): string {
-  if (completedByApproval && status !== 'completed') return '完了 (承認済み)';
-  if (status === 'completed') return '完了';
-  if (expired) return '期限切れ';
-  if (status === 'open') return '募集中';
-  if (status === 'assigned') return '受託中';
-  if (status === 'reported') return '完了報告中 (承認待ち)';
-  if (status === 'cancelled') return 'キャンセル';
-  return status;
+function statusLabel(state: EffectiveState): string {
+  switch (state) {
+    case 'COMPLETED':          return '完了';
+    case 'EXPIRED':            return '期限切れ';
+    case 'OPEN':               return '募集中';
+    case 'IN_PROGRESS':        return '受託中';
+    case 'AWAITING_APPROVAL':  return '完了報告中 (承認待ち)';
+    case 'REVISION_REQUESTED': return 'やり直し対応中';
+    case 'CANCELLED':          return 'キャンセル';
+  }
 }
 
 function roleLabel(role: string): string {

--- a/apps/web/src/routes/board.tsx
+++ b/apps/web/src/routes/board.tsx
@@ -96,6 +96,7 @@ export function Board() {
             column={col}
             indexData={{ index, myQuests, myApplicationQuestUris }}
             pendingUris={pendingUris}
+            selfDid={session.did ?? null}
             onRemove={() => removeColumn(col.id)}
           />
         ))}
@@ -121,6 +122,7 @@ function ColumnControls({ onAdd, onReset }: { onAdd: (kind: ColumnKind, param?: 
       <div style={{ fontSize: '0.8em', color: 'var(--color-muted)', marginBottom: '0.3em' }}>カラムを追加</div>
       <div style={{ display: 'flex', gap: '0.4em', flexWrap: 'wrap' }}>
         <SmallBtn onClick={() => onAdd('open')}>＋ 募集中</SmallBtn>
+        <SmallBtn onClick={() => onAdd('assigned')}>＋ 受託中</SmallBtn>
         <SmallBtn onClick={() => onAdd('mine')}>＋ 自分が出した</SmallBtn>
         <SmallBtn onClick={() => onAdd('applied')}>＋ 自分が応募</SmallBtn>
         <SmallBtn onClick={() => setPicker('tag')}>＋ タグ別</SmallBtn>
@@ -171,14 +173,15 @@ interface BoardInnerColumnViewProps {
     myApplicationQuestUris: ReturnType<typeof useBoardData>['myApplicationQuestUris'];
   };
   pendingUris: Set<string>;
+  selfDid: string | null;
   onRemove: () => void;
 }
 
-function BoardInnerColumnView({ column, indexData, pendingUris, onRemove }: BoardInnerColumnViewProps) {
+function BoardInnerColumnView({ column, indexData, pendingUris, selfDid, onRemove }: BoardInnerColumnViewProps) {
   const { index, myQuests, myApplicationQuestUris } = indexData;
   const items = useMemo(
-    () => filterForBoard(column, index, myQuests, myApplicationQuestUris),
-    [column, index, myQuests, myApplicationQuestUris],
+    () => filterForBoard(column, index, myQuests, myApplicationQuestUris, selfDid),
+    [column, index, myQuests, myApplicationQuestUris, selfDid],
   );
   return (
     <section className="board-column">


### PR DESCRIPTION
## 何を直すか
オーナー報告「受託確定後、受託者からクエストが消えて何もできない」の根治。

### 原因
board に「自分が受託したクエスト (assignee==自分)」を見る手段が無く(filter kind に `assigned` 不在、既定 `[open, mine]`)、受託で status が open を外れると受託者の視界から消えた。加えて board-detail の承認ボタンが `quest.status === 'reported'` gate で、本番では status が `assigned` のままなので**承認ボタンも出ていなかった**。

## 修正
- `QuestIndexSummary.assignee` 追加 / filter kind **`assigned`** / 既定カラム **`[open, assigned, mine, applied]`** + 「＋ 受託中」。
- board-detail の報告/承認/やり直し/状態表示を **effectiveState** gate に統一(受託者「報告」= IN_PROGRESS/REVISION、発注者「承認/やり直し」= AWAITING_APPROVAL、statusLabel = EffectiveState)。
- **既存ユーザー移行**: localStorage 保存済みの旧カラムに「受託中」を 1 回だけ注入(保存して workspace inner にも反映)。
- **ロード中ガード**: completions=null 中は報告ボタンを出さない(ちらつき/二重報告防止)。

## 検証
core 164 + web 193 / typecheck / build 緑。最終検証は **PR-5 の 2 アカウント E2E**。

## Review
§1.5 3 並列 (設計/実装/UX)。**マージ可・★★★ なし**。
- **★★ → PR 内対応**: (1) 既存ユーザーに新カラムが届かない → idempotent 移行追加 (実装★★) / (2) completions ロード中の報告ボタンちらつき・二重報告余地 → null ガード (設計★★)。
- **★★ → issue #127**: 落選/第三者の状態表示、applied/assigned 重複、受託中カラムの空表示、一覧 status 近似と詳細 effectiveState のズレ(B遅延の稀ケース)。docs/17 §3 の残り。
- **★ (確認済)**: statusLabel は EffectiveState exhaustive switch で型安全 / gate 相互排他 / completedByApproval 削除は等価 / assignee の index 伝播 (questToSummary→buildQuestIndexFromDirectory) 正常 / open 系 gate を status 直読みで残したのは意図的(completion 非依存・期限切れでも操作可)。