### PR TITLE
feat(quest): ポートフォリオに「クエストで得たXP」を表示 (PR-4)

### DIFF
--- a/apps/web/src/routes/portfolio.tsx
+++ b/apps/web/src/routes/portfolio.tsx
@@ -16,9 +16,11 @@ import {
   summarize,
   distinctRecipients,
   distinctRequesters,
+  questXpEarned,
   type UserQuest,
   type OutcomeSummary,
 } from '@aozoraquest/core';
+import { RadarChart } from '@/components/radar-chart';
 import { useSession } from '@/lib/session';
 import {
   listIssuedQuests,
@@ -112,6 +114,9 @@ function PortfolioView({ did, agent, isSelf, signedIn }: PortfolioViewProps) {
 
   const completedIssued = useMemo(() => (issued ?? []).filter(q => q.status === 'completed'), [issued]);
   const completedReceived = useMemo(() => (received ?? []).filter(q => q.status === 'completed'), [received]);
+  // 受託して完了したクエストから得た累計ステータス XP (完了集合からの派生)。
+  const questXp = useMemo(() => questXpEarned(received ?? [], did ?? ''), [received, did]);
+  const questXpTotal = questXp.atk + questXp.def + questXp.agi + questXp.int + questXp.luk;
 
   /** 受託者視点: 発注者 DID → 獲得 pt の合計 */
   const receivedByIssuer = useMemo(() => {
@@ -174,6 +179,19 @@ function PortfolioView({ did, agent, isSelf, signedIn }: PortfolioViewProps) {
           </p>
         )}
       </section>
+
+      {questXpTotal > 0 && (
+        <section style={{ marginTop: '1em' }} className="dq-window">
+          <h3 style={{ marginTop: 0, fontSize: '0.95em' }}>クエストで得たステータス XP</h3>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '1em', flexWrap: 'wrap' }}>
+            <RadarChart stats={questXp} size={140} normalize showValues />
+            <div style={{ fontSize: '0.85em', color: 'var(--color-muted)' }}>
+              受託して完了したクエストの内容 (タグ) に応じて、各ステータスに合計
+              <strong style={{ color: 'var(--color-accent)' }}> {questXpTotal.toLocaleString()} XP</strong> を獲得。
+            </div>
+          </div>
+        </section>
+      )}
 
       {receivedByIssuer.length > 0 && (
         <section style={{ marginTop: '1em' }} className="dq-window">

--- a/apps/web/src/routes/portfolio.tsx
+++ b/apps/web/src/routes/portfolio.tsx
@@ -115,7 +115,7 @@ function PortfolioView({ did, agent, isSelf, signedIn }: PortfolioViewProps) {
   const completedIssued = useMemo(() => (issued ?? []).filter(q => q.status === 'completed'), [issued]);
   const completedReceived = useMemo(() => (received ?? []).filter(q => q.status === 'completed'), [received]);
   // 受託して完了したクエストから得た累計ステータス XP (完了集合からの派生)。
-  const questXp = useMemo(() => questXpEarned(received ?? [], did ?? ''), [received, did]);
+  const questXp = useMemo(() => questXpEarned(completedReceived, did ?? ''), [completedReceived, did]);
   const questXpTotal = questXp.atk + questXp.def + questXp.agi + questXp.int + questXp.luk;
 
   /** 受託者視点: 発注者 DID → 獲得 pt の合計 */
@@ -188,6 +188,10 @@ function PortfolioView({ did, agent, isSelf, signedIn }: PortfolioViewProps) {
             <div style={{ fontSize: '0.85em', color: 'var(--color-muted)' }}>
               受託して完了したクエストの内容 (タグ) に応じて、各ステータスに合計
               <strong style={{ color: 'var(--color-accent)' }}> {questXpTotal.toLocaleString()} XP</strong> を獲得。
+              <span style={{ display: 'block', marginTop: '0.3em', fontSize: '0.92em' }}>
+                ※ 投稿から診断した「気質ステータス」とは別の、冒険 (受託) で稼いだ経験値です。
+                図は配分のバランス、量は合計 XP を参照してください。
+              </span>
             </div>
           </div>
         </section>


### PR DESCRIPTION
## 何を追加するか
報酬の可視化を完成。**ポイント**(発行者別保有)は既に `holdings` で表示済みだったので、未表示だった **XP** を追加。`questXpEarned`(PR-2 で core 実装、完了受託クエストの `statXpDistribution` 合算)をレーダー + 合計 XP で表示。承認=報酬発行のループが UI 上も閉じる。

## 検証
typecheck / web 193 / build 緑。

## Review
§1.5 (UX+実装)。**マージ可・★★★ なし**。
- **★★ → PR 内対応**: (1) `questXpEarned` の派生元を `completedReceived` に統一 / (2) レーダー normalize の誤読 + 投稿診断ステータスとの混同 → 「診断とは別の受託経験値。図は配分・量は合計参照」の補足文を追加。
- **★★ → 判断記録**: 公開ポートフォリオで他人の XP が見える点は、既存の保有ポイント表示と同じ公開方針に倣う(opt-out は docs/15 Phase 3 でポートフォリオ全体に対して扱う)。
- **★ (確認/任意)**: questXpTotal の非メモ化(微小)、レーダー軸数値の桁区切り(共通コンポ側・スコープ外)。core 側 questXpEarned は PR-2 で網羅テスト済み。