### PR TITLE
docs(test): .env.e2e.example を API 結合テスト方式に更新

### DIFF
--- a/apps/web/.env.e2e.example
+++ b/apps/web/.env.e2e.example
@@ -1,15 +1,16 @@
-# 依頼クエストの 2 アカウント結合 E2E テスト用 (apps/web/e2e/quest-flow.spec.ts)。
+# 依頼クエストの 2 アカウント結合 E2E (apps/web/e2e/quest-flow-api.test.ts) 用。
 #
 # 使い方:
 #   1. このファイルを `apps/web/.env.e2e.local` にコピー (.env.*.local は gitignore 済)
 #   2. 下記にテスト用 2 アカウントの handle と **app-password** を入れる
 #      (app-password は bsky.social → Settings → App Passwords で発行。本パスワードは使わない)
-#   3. `pnpm --filter @aozoraquest/web test:quest-e2e` で実行 (creds 無ければ自動 skip)
+#   3. `pnpm --filter @aozoraquest/web test:quest-integration` で実行 (creds 無ければ自動 skip)
 #
-# 注意: テストは実 PDS に quest/application/completion レコードを作り、最後に削除する。
-#       実アカウント上で動くので、**捨てて良いテスト専用アカウント** を使うこと。
-#       cleanup は env 分離された collection (既定 app.aozoraquest.local.*) のみ対象で、
-#       production NSID (env 無し) のときは安全のため削除を中止する。
+# 方式: Bluesky の OAuth ウェブログインは app-password を受け付けない (本パスワード必須) ため、
+#       UI ではなく **API レベル** で実 quest-api 関数を実 PDS に対し駆動して全フローを検証する。
+# 安全: 書き込み先 NSID は隔離 env (app.aozoraquest.e2etest.*) に固定 (vitest.integration.config.ts)。
+#       本番 (env 無し) は絶対に触らない。テストは beforeAll/afterAll で対象アカウントの e2etest
+#       レコードを全削除する。必ず **捨てて良いテスト専用アカウント** を使うこと。
 
 QUEST_E2E_SERVICE=https://bsky.social
 
@@ -20,8 +21,3 @@ QUEST_E2E_A_PASSWORD=xxxx-xxxx-xxxx-xxxx
 # 受託者役
 QUEST_E2E_B_HANDLE=bob-test.bsky.social
 QUEST_E2E_B_PASSWORD=xxxx-xxxx-xxxx-xxxx
-
-# 任意: アプリの書き込み先 NSID env (preview の .env.development に合わせ既定 local)。
-# 通常は変更不要。
-# QUEST_E2E_NSID_ROOT=app.aozoraquest
-# QUEST_E2E_NSID_ENV=local


### PR DESCRIPTION
PR #129 の UI→API 切替で .env.e2e.example の追従が squash に乗り損ねた分。コメントのみ(template doc)。test:quest-integration / app-password 非対応の経緯 / e2etest NSID 隔離に更新。§1.5 は doc-only のため省略。