### PR TITLE
chore(release): APP_VERSION 2026.06.15-1

### DIFF
--- a/apps/web/src/lib/app-version.ts
+++ b/apps/web/src/lib/app-version.ts
@@ -12,7 +12,7 @@
  *   3. 同じ値で git tag を打つ:
  *        git tag v2026.06.14-1 && git push origin v2026.06.14-1
  */
-export const APP_VERSION = '2026.06.14-2';
+export const APP_VERSION = '2026.06.15-1';
 
 /** APP_VERSION が `YYYY.MM.DD-N` 形式かを検証する (テスト/CI で形式崩れを検出)。
  *  月 01-12 / 日 01-31 のゼロ詰め 2 桁、枝番は先頭ゼロ不可の 1 以上まで一本でガードする。 */


### PR DESCRIPTION
dev → main 本番リリースのための APP_VERSION 更新 (`2026.06.14-2` → `2026.06.15-1`)。

リリース対象 (既に dev にマージ済): 依頼クエストのライフサイクル全直し
- #124 深リンク 404 修正 (URL を `board/:repo/:rkey` に)
- #125 core `effectiveState` + `questXpEarned` + approve 冪等化
- #126 受託者がクエストを見失う問題を解消 (assigned カラム + effectiveState gate)
- #128 ポートフォリオに「クエストで得た XP」表示
- #129 2 アカウント API 結合 E2E (実 PDS / 実行緑)
- #130 .env.e2e.example 追従修正

このPR自体は app-version.ts 1 行のみ。dev → main PR に載せるための前段。

## Review
バージョン文字列のみの変更のため軽微。形式は APP_VERSION_PATTERN で CI 検証済。