### PR TITLE
feat(workspace): モバイルのカラムを全幅化 + ▶点滅でスワイプ誘導

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -155,6 +155,7 @@ font-size は **em ベース** で書く。html/body には絶対サイズを指
 - **app-shell**: 中央寄せ。`max-width: 420px` を基本、`@media (min-width: 768px)` で `680px` に拡張。それ以上には広げない (1 列の冒険ログという読み心地を保つため)。
 - **header**: 上部 sticky。半透明グラデ + backdrop-blur。
 - **content**: app-shell の中身を 1 枚の大きな DQ ウィンドウで包む。内側に置く個別ウィンドウは `.dq-window` でさらに二重枠にする (DQ で「持ち物」の中に「やくそう ×3」が表示される入れ子構造)。
+  - *例外*: workspace のカラムはモバイル (<=767px) では本文幅を優先し、太枠・四隅装飾・peek を省いて全幅化する (横幅が枠に食われる問題への対処)。カラム送りは ▶/◀ のスワイプヒントで示す。PC では従来どおり太枠カラム。詳細は `docs/16-multicolumn.md`。
 - **footer-nav**: 下部 sticky。`min(340px, 80%)` で中央寄せ。タブで「ホーム/通知/検索/自分」など主要 route を切替。
 
 spacing は em ベースの 0.3 / 0.5 / 0.8 / 1.0 / 1.6em を主軸に。px 直書きは枠線・装飾 (3px border, 6px 四隅装飾) のみ。

--- a/apps/web/src/components/workspace.tsx
+++ b/apps/web/src/components/workspace.tsx
@@ -59,7 +59,9 @@ export function Workspace() {
 
   // モバイル全幅カラムでは「次カラムの peek」を出さない代わりに、横スクロールの
   // 端 (左右にまだカラムがあるか) を検知して ▶ / ◀ のスワイプヒントを出す。
-  // swiped = 一度でも横スワイプしたら ▶ の点滅を止める (知らせ終わったので静める)。
+  // swiped = 一度でも横スワイプしたら ▶ の点滅を止める。粒度は workspace 全体で
+  // セッション中 1 回きり (= 「このアプリは横送りできる」を学べば十分なので、
+  // カラムごとには点滅し直さない)。静かな常駐 (is-idle) には切り替わる。
   const [edges, setEdges] = useState({ atStart: true, atEnd: true });
   const [swiped, setSwiped] = useState(false);
 
@@ -139,9 +141,15 @@ export function Workspace() {
     const scroller = scrollerRef.current;
     if (!scroller) return;
     const update = () => {
-      const { scrollLeft, scrollWidth, clientWidth } = scroller;
+      const { scrollLeft, clientWidth } = scroller;
       const atStart = scrollLeft <= 1;
-      const atEnd = scrollLeft + clientWidth >= scrollWidth - 1;
+      // 「右にまだ "カラム" がある」= 末尾の追加タイル (data-column-kind を持たない)
+      // を除いた、最後のコンテンツカラムの右端を越えていないか。追加タイルを対象に
+      // 入れると最終コンテンツ列でも ▶ が消えず誤誘導するため除外する。
+      const contentCols = scroller.querySelectorAll<HTMLElement>('[data-column-kind]');
+      const last = contentCols[contentCols.length - 1];
+      const lastRight = last ? last.offsetLeft + last.offsetWidth : scroller.scrollWidth;
+      const atEnd = scrollLeft + clientWidth >= lastRight - 1;
       setEdges((prev) => (prev.atStart === atStart && prev.atEnd === atEnd ? prev : { atStart, atEnd }));
     };
     const onScroll = () => { setSwiped(true); update(); };
@@ -205,13 +213,6 @@ export function Workspace() {
       return next;
     });
     setPickerAnchor(null);
-  }
-
-  /** スワイプヒントのタップでカラム 1 枚ぶん送る (scroll-snap が次カラムに吸着)。 */
-  function scrollByColumn(dir: 1 | -1) {
-    const scroller = scrollerRef.current;
-    if (!scroller) return;
-    scroller.scrollBy({ left: dir * scroller.clientWidth * 0.92, behavior: 'smooth' });
   }
 
   const picker = (
@@ -279,28 +280,16 @@ export function Workspace() {
         )}
       </div>
 
-      {/* スワイプヒント (モバイル全幅カラム用)。左右にまだカラムがあるときだけ出す。
-          ▶ は初回スワイプまで点滅して「横に送れる」を知らせ、以後は静かな常駐に。
-          PC では枠と自由スクロールで自明なので CSS で非表示。タップで 1 枚送り。 */}
+      {/* スワイプヒント (モバイル全幅カラム用)。左右にまだコンテンツカラムがあるときだけ
+          出す純粋な視覚マーカー (pointer-events:none。タップ送りはしない = スワイプで
+          送れるため冗長 + 本文右端のタップ誤爆を防ぐ)。▶ は初回スワイプまで点滅して
+          「横に送れる」を知らせ、以後は静かな常駐に。PC では枠と自由スクロールで自明
+          なので CSS で非表示。 */}
       {!edges.atStart && (
-        <button
-          type="button"
-          className="workspace-swipe-hint left is-idle"
-          aria-label="前のカラムへ"
-          onClick={() => scrollByColumn(-1)}
-        >
-          ◀
-        </button>
+        <span className="workspace-swipe-hint left is-idle" aria-hidden="true">◀</span>
       )}
       {!edges.atEnd && (
-        <button
-          type="button"
-          className={`workspace-swipe-hint right${swiped ? ' is-idle' : ''}`}
-          aria-label="次のカラムへ"
-          onClick={() => scrollByColumn(1)}
-        >
-          ▶
-        </button>
+        <span className={`workspace-swipe-hint right${swiped ? ' is-idle' : ''}`} aria-hidden="true">▶</span>
       )}
     </div>
   );

--- a/apps/web/src/components/workspace.tsx
+++ b/apps/web/src/components/workspace.tsx
@@ -57,6 +57,12 @@ export function Workspace() {
   // 明示更新なので先頭に戻る挙動は自然 (pull-to-refresh / ↻ ボタンとして妥当)。
   const [refreshNonce, setRefreshNonce] = useState<Record<string, number>>({});
 
+  // モバイル全幅カラムでは「次カラムの peek」を出さない代わりに、横スクロールの
+  // 端 (左右にまだカラムがあるか) を検知して ▶ / ◀ のスワイプヒントを出す。
+  // swiped = 一度でも横スワイプしたら ▶ の点滅を止める (知らせ終わったので静める)。
+  const [edges, setEdges] = useState({ atStart: true, atEnd: true });
+  const [swiped, setSwiped] = useState(false);
+
   /** kind ごとのモジュールキャッシュを無効化する (remount だけでは
    *  取り直さない quest index / profile を真に fresh にするため)。 */
   function bustColumnCache(col: AppColumn) {
@@ -126,6 +132,29 @@ export function Workspace() {
     return () => scroller.removeEventListener('wheel', onWheel);
   }, []);
 
+  // 横スクロールの端を追跡し、左右にまだカラムがあるかでスワイプヒントを出し分ける。
+  // 初回の横スワイプで swiped を立て、▶ の点滅を静める。
+  // deps はカラム数 (= 端の判定が変わる構成変化) のみ。リサイズは ResizeObserver で拾う。
+  useEffect(() => {
+    const scroller = scrollerRef.current;
+    if (!scroller) return;
+    const update = () => {
+      const { scrollLeft, scrollWidth, clientWidth } = scroller;
+      const atStart = scrollLeft <= 1;
+      const atEnd = scrollLeft + clientWidth >= scrollWidth - 1;
+      setEdges((prev) => (prev.atStart === atStart && prev.atEnd === atEnd ? prev : { atStart, atEnd }));
+    };
+    const onScroll = () => { setSwiped(true); update(); };
+    update();
+    scroller.addEventListener('scroll', onScroll, { passive: true });
+    const ro = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(update) : null;
+    ro?.observe(scroller);
+    return () => {
+      scroller.removeEventListener('scroll', onScroll);
+      ro?.disconnect();
+    };
+  }, [columnCount]);
+
   // `/` 離脱時に可視 kind をクリアする (active 残留防止)
   useEffect(() => () => publishVisibleColumn(null), []);
 
@@ -176,6 +205,13 @@ export function Workspace() {
       return next;
     });
     setPickerAnchor(null);
+  }
+
+  /** スワイプヒントのタップでカラム 1 枚ぶん送る (scroll-snap が次カラムに吸着)。 */
+  function scrollByColumn(dir: 1 | -1) {
+    const scroller = scrollerRef.current;
+    if (!scroller) return;
+    scroller.scrollBy({ left: dir * scroller.clientWidth * 0.92, behavior: 'smooth' });
   }
 
   const picker = (
@@ -242,6 +278,30 @@ export function Workspace() {
           </section>
         )}
       </div>
+
+      {/* スワイプヒント (モバイル全幅カラム用)。左右にまだカラムがあるときだけ出す。
+          ▶ は初回スワイプまで点滅して「横に送れる」を知らせ、以後は静かな常駐に。
+          PC では枠と自由スクロールで自明なので CSS で非表示。タップで 1 枚送り。 */}
+      {!edges.atStart && (
+        <button
+          type="button"
+          className="workspace-swipe-hint left is-idle"
+          aria-label="前のカラムへ"
+          onClick={() => scrollByColumn(-1)}
+        >
+          ◀
+        </button>
+      )}
+      {!edges.atEnd && (
+        <button
+          type="button"
+          className={`workspace-swipe-hint right${swiped ? ' is-idle' : ''}`}
+          aria-label="次のカラムへ"
+          onClick={() => scrollByColumn(1)}
+        >
+          ▶
+        </button>
+      )}
     </div>
   );
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -269,7 +269,9 @@ p { margin: 0.4em 0; }
      CJK 連続文字があると min-content がカラムを flex-basis より広げてしまう
      (= 長文投稿でホームカラムが膨らむバグ)。min-width:0 で basis を守る。 */
   min-width: 0;
-  /* モバイル: ほぼ画面幅。次のカラムの端を少し見せて「右にまだある」を示す */
+  /* flex-basis はメディアクエリで上書きされる (モバイル <=767px = 全幅 100%、
+     PC >=768px = 340px)。下の calc は両クエリ外の保険値。モバイルで「右にまだ
+     カラムがある」ことは peek ではなく .workspace-swipe-hint (▶) で知らせる。 */
   flex: 0 0 calc(100% - 1.6em);
   scroll-snap-align: start;
   scroll-snap-stop: always;            /* 1 スワイプ = 1 カラム送り */
@@ -486,7 +488,9 @@ p { margin: 0.4em 0; }
   background: rgba(159, 215, 255, 0.92);   /* accent */
   border: none;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
-  cursor: pointer;
+  /* 純粋な視覚マーカー。タップ送りはしない (スワイプで送れるため冗長 +
+     本文右端のリンク/アクションのタップ誤爆を防ぐ)。 */
+  pointer-events: none;
 }
 .workspace-swipe-hint.right { right: 0; border-radius: 8px 0 0 8px; }
 .workspace-swipe-hint.left  { left: 0;  border-radius: 0 8px 8px 0; }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -233,6 +233,9 @@ p { margin: 0.4em 0; }
   .app-shell:has([data-workspace="1"]) { max-width: min(100vw - 1.5em, 1480px); }
 }
 
+/* スワイプヒント (▶ / ◀) を絶対配置する基準 */
+[data-workspace="1"] { position: relative; }
+
 .app-shell:has([data-workspace="1"]) .content {
   background: transparent;
   border-color: transparent;
@@ -437,6 +440,71 @@ p { margin: 0.4em 0; }
     scroll-snap-type: none;   /* PC は自由スクロール */
     gap: 0.8em;
   }
+}
+
+/* ─── モバイル: カラムを全幅で使う (横幅を枠に食わせない) ───────────
+   1 スワイプ = 1 カラムなので、左右の太枠・四隅装飾・次カラム peek を省いて
+   本文に幅を回す。横幅ロス ~66px → ~12px。代わりに「右にまだカラムがある」は
+   .workspace-swipe-hint (▶ 点滅) で知らせる。PC (>=768px) は従来の太枠カラム維持。 */
+@media (max-width: 767px) {
+  .app-shell:has([data-workspace="1"]) .content { padding: 0; }
+  .workspace-columns { gap: 0; padding-bottom: 0; }
+  .workspace-column {
+    flex: 0 0 100%;            /* peek を出さず全幅 */
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+  }
+  /* 四隅のコーナー装飾は全幅では出さない */
+  .workspace-column::before,
+  .workspace-column::after { display: none; }
+  /* 隣接カラムの境目だけ薄い縦線で示す (スワイプ後の「別カラム」感) */
+  .workspace-column + .workspace-column {
+    box-shadow: inset 1px 0 0 var(--color-window-inner-border);
+  }
+  .workspace-column-body { padding: 0.55em 0.35em; }   /* 22.4px → 11.2px L/R */
+}
+
+/* ─── カラム送りのスワイプヒント (▶ / ◀) ───────────────────────
+   モバイル全幅で peek を消した代償に「横に送れる」を明示する。左右の端に
+   まだカラムがあるときだけ表示 (端に着いたら消える)。▶ は初回スワイプまで
+   点滅して気づかせ、以後は is-idle で静かな常駐に。タップで 1 枚送り。 */
+.workspace-swipe-hint {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.6em;
+  height: 2.6em;
+  padding: 0;
+  font-size: 1em;
+  line-height: 1;
+  color: var(--color-on-accent);
+  background: rgba(159, 215, 255, 0.92);   /* accent */
+  border: none;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+  cursor: pointer;
+}
+.workspace-swipe-hint.right { right: 0; border-radius: 8px 0 0 8px; }
+.workspace-swipe-hint.left  { left: 0;  border-radius: 0 8px 8px 0; }
+/* 初期 (未スワイプ) の ▶ は点滅 + わずかに右へ動いて送りを誘導 */
+.workspace-swipe-hint.right:not(.is-idle) {
+  animation: swipe-hint-blink 1.15s ease-in-out infinite;
+}
+.workspace-swipe-hint.is-idle { opacity: 0.5; }
+@keyframes swipe-hint-blink {
+  0%, 100% { opacity: 1;    transform: translateY(-50%) translateX(0); }
+  50%      { opacity: 0.3;  transform: translateY(-50%) translateX(3px); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .workspace-swipe-hint.right:not(.is-idle) { animation: none; opacity: 0.85; }
+}
+/* PC は枠 + 自由スクロールで送りが自明なのでヒント不要 */
+@media (min-width: 768px) {
+  .workspace-swipe-hint { display: none; }
 }
 
 .header {

--- a/docs/16-multicolumn.md
+++ b/docs/16-multicolumn.md
@@ -127,6 +127,7 @@ MVP 完了。以降は下記「既知の制約 / 検討事項」と issue #36 (p
 - **drag & drop 並べ替え**: MVP は矢印ボタン (⋯メニュー) のみ。要望次第で dnd-kit
 - **PDS 同期 (`app.aozoraquest.layout`)**: カラム構成は localStorage 止まり。端末横断同期は将来の opt-in
 - **iOS Safari の scroll-snap 慣性**: `scroll-snap-stop: always` で軽減。深い tuning は実機検証後
+- **モバイル (<=767px) はカラムを全幅化**: 横幅が枠に食われて本文が窮屈という指摘を受け、スマホでは DQ ウィンドウの太枠・四隅装飾・次カラム peek を省いて本文幅を優先 (~83% → ~97%)。カラム境界は隣接間の `inset 1px` 縦線で示す。「右/左にまだカラムがある」ことは peek の代わりに `.workspace-swipe-hint` (▶ / ◀) で知らせる (▶ は初回スワイプまで点滅、末尾のコンテンツカラムで消える、`pointer-events:none` の純粋な視覚マーカー)。**PC (>=768px) は従来どおり太枠 340px カラム + 自由スクロール**。DESIGN.md の DQ ウィンドウ様式はモバイルでのみ緩める例外。
 
 ## 関連ドキュメント
 


### PR DESCRIPTION
## 背景
スマホで workspace のカラムが「枠の描画」に横幅の約 2 割を食われ、本文が窮屈という
オーナー指摘 (実機)。内訳: カラム border 3px×2 + body padding 0.7em×2 + 次カラム
peek 1.6em で左右計 ~66px (390px 中)。1 スワイプ=1 カラムで複数を同時に見ない以上、
これらは本文幅を削るだけ。

## 変更
- **モバイル (<=767px) 限定でカラムを全幅化**: 左右の太枠・四隅装飾・peek を省き、
  body padding を 0.7em→0.35em に。本文テキスト幅 ~83% → ~97% (+53px)。
  隣接カラムの境目は薄い縦線 (inset 1px) で残す。
- **▶ / ◀ スワイプヒント**: peek を消した代償に「横に送れる」を明示。横スクロールの
  端を検知し、左右にまだカラムがあるときだけ表示 (端で消える)。▶ は初回スワイプまで
  点滅して誘導 → 以後 is-idle で静かな常駐。タップで 1 枚送り (scroll-snap 吸着)。
- **PC (>=768px) は不変**: 従来の太枠 340px カラム + 自由スクロール。ヒントは非表示。
- `prefers-reduced-motion` で点滅停止。

サンプル → 実装の流れでオーナーが 案B (全幅) + ▶点滅 を選択。

## 確認
- typecheck / 193 unit test / build 緑 (ローカル)。
- 実機確認は dev デプロイ後に行う (モバイル実機でスワイプ誘導と全幅を確認)。

## Review
PR 作成後、§1.5 の 3 並列 subagent レビュー (設計/実装/UX) を実施し、結果を追記する。

---

## §1.5 必須レビュー結果 (3 並列 subagent)

設計 / 実装 / UX の 3 観点を独立実施。**★★★ (致命的) は全観点ゼロ**。3 レビュー全員が同一の最重要 ★★ (ヒントボタンが本文右端のタップを誤爆) を指摘 → **PR 内で対応**。

### ★★ 対応 (すべて PR 内対応, commit adece7a)
- **ヒントが本文タップを誤爆 / タップ領域 44px 未満** → ▶/◀ を `pointer-events:none` の純粋な視覚マーカーに (button→span)。タップ送り廃止で**誤爆と 44px 問題を同時解消**。
- **▶ が末尾の追加タイルを指して最終カラムでも消えない** → `atEnd` 判定を「追加タイル (data-column-kind 無し) を除く最後のコンテンツカラムの右端」に修正。
- **`scrollBy` の smooth が reduced-motion を無視** → tap 送り廃止 (scrollByColumn 削除) で自然に解消。
- **DESIGN.md / docs/16 にモバイル例外を未記載** → 両 doc に全幅化の例外を追記。

### ★ 対応 / 記録
- `swiped` の粒度 (workspace 全体でセッション 1 回きり) をコメントで明記。
- 旧 peek コメント (flex calc) を実態に合わせ「メディアクエリで上書きされる保険値」に修正。
- ◀ が常に静的・端判定 1px tolerance 等は許容範囲。実機確認で最終チェック。

### 良かった点 (レビュー総括)
- 新 effect の cleanup / deps / `typeof ResizeObserver` ガードは健全、既存 193 テストへの影響なし。
- scroll-snap / pull-to-refresh 軸ロック / IntersectionObserver 可視カラム検知と矛盾しない。
