### PR TITLE
fix(workspace): 外枠の透明border背景透け + 投稿区切り線の視認性

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -454,10 +454,12 @@ p { margin: 0.4em 0; }
 @media (max-width: 767px) {
   /* 大きいスマホ (420px 超) でも workspace は全幅に (通常の 420px キャップを外す) */
   .app-shell:has([data-workspace="1"]) { max-width: 100%; }
-  /* .content の余白を撤去。base の margin:0.6em 0.5em が残っていると workspace の
-     上下左右に 8px ずつ背景 (青空/地面) が覗くため、モバイルでは 0 にして
-     ダークを画面いっぱいに敷き詰める。 */
-  .app-shell:has([data-workspace="1"]) .content { margin: 0; padding: 0; }
+  /* .content の余白・枠を撤去。
+     - base の margin:0.6em 0.5em が残ると workspace の上下左右に 8px ずつ背景が覗く。
+     - さらに base の border:3px は workspace 既定で border-color:transparent にされて
+       いるだけで **幅 3px は残っており**、.content 背景も透明なので透明枠から body の
+       青空/地面が左右に透ける (= 「外枠の左右に背景」)。border ごと 0 にして塞ぐ。 */
+  .app-shell:has([data-workspace="1"]) .content { margin: 0; padding: 0; border: none; }
 
   /* footer-nav を全幅フラッシュに。base は width:min(340px,80%) の中央寄せピルで
      周囲と下に地面が見え、タイムラインとの間に空白ができていた。モバイルでは
@@ -506,7 +508,9 @@ p { margin: 0.4em 0; }
      状態色が読めなくなるため、フィード投稿だけに限定する。 */
   .workspace-column-body .feed-post {
     border: none;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+    /* 投稿間の区切り。控えめだが視認できる 1px ヘアライン (0.2 では埋もれて
+       見えなかったため 0.5 に。場所は取らず線だけで分離)。 */
+    border-bottom: 1px solid rgba(255, 255, 255, 0.5);
     border-radius: 0;
     box-shadow: none;
     padding-left: 0.5em;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -508,9 +508,11 @@ p { margin: 0.4em 0; }
      状態色が読めなくなるため、フィード投稿だけに限定する。 */
   .workspace-column-body .feed-post {
     border: none;
-    /* 投稿間の区切り。控えめだが視認できる 1px ヘアライン (0.2 では埋もれて
-       見えなかったため 0.5 に。場所は取らず線だけで分離)。 */
-    border-bottom: 1px solid rgba(255, 255, 255, 0.5);
+    /* 投稿間の区切り。控えめだが視認できる 1px ヘアライン。footer 上辺・カラム境界
+       など窓内の区切りで使う標準トークン (--color-window-inner-border = 白 0.35) に
+       揃える (旧 0.2 のリテラルは埋もれて見えず、0.5 は逆に投稿間だけ最も明るくなり
+       階層が逆転していた)。 */
+    border-bottom: 1px solid var(--color-window-inner-border);
     border-radius: 0;
     box-shadow: none;
     padding-left: 0.5em;


### PR DESCRIPTION
## 背景 (実機指摘)
1. **外枠の左右に背景が見える**: workspace の `.content` は base の `border:3px` に対し
   既定で `border-color:transparent` を当てているだけで**幅 3px が残り**、`.content` 背景も
   透明なので透明枠から body の青空/地面が左右に透けていた。
2. **投稿間の区切り線が見えない**: `.feed-post` の下辺ヘアラインが `rgba(255,255,255,0.2)`
   で薄すぎて埋もれていた。

## 変更 (モバイル <=767px)
- `.content` を `border: none` に (透明枠ごと撤去 → 背景の透けを塞ぐ)。
- `.feed-post` の下辺ヘアラインを `0.2 → 0.5` に。控えめだが視認できる 1px 線 (場所は取らない)。

## 確認
- typecheck / build 緑。実機確認は dev デプロイ後。

## Review
§1.5 の 3 並列レビューを実施し結果を追記する。

---

## §1.5 必須レビュー結果 (3 並列 subagent)

設計 / 実装 / UX を独立実施。**★★★ ゼロ**。一貫した ★★ を PR 内対応 (commit e6b23ba)。

### ★★ 対応済
- **区切り線がトークン規約から外れた一点もの (0.5 リテラル)** — 窓内区切りの標準 `--color-window-inner-border` (白 0.35) を飛ばし、投稿間だけ画面内で最も明るい白になり階層が逆転 (footer/カラム境界より目立つ)。**対応**: トークン `var(--color-window-inner-border)` に統一。0.35 は他所で既に視認できる「控えめだが見える」標準値で、オーナー要望 (控えめ) にも合致。

### ★ 記録 / 別 issue 候補
- workspace 既定 override (styles.css:239) が `border-color:transparent` + 幅 3px 残しで、PC でも同構造 (PC は `--color-border` 不透明なので透けないだけ)。将来 `--color-border` を半透明化すると PC で再発しうる → 根治は line 239 を `border:0` にすることだが、PC は「手帳が浮かぶ」世界観で背景が見える意図があるためスコープ外。
- リポスト見出し付き投稿の帰属は構造上正しい (border-bottom は投稿全体の下)。各 feed-post は base の縦 padding 0.8em があり息継ぎは確保済み。
- 本文左右 0.5em は情報密度優先のオーナー判断。窮屈なら 0.6-0.75em に調整可。

### 確認済み (問題なし)
- `.content { border:none }` の詳細度 (0,3,0) が base/override を正しく上書き。四隅装飾は display:none 済。カラム高計算に無影響。PC 非波及。
