### PR TITLE
fix(mobile): 投稿の区切り線を border-top に (仮想化で消えていた真因)

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -540,14 +540,19 @@ p { margin: 0.4em 0; }
      board のクエストカード (.dq-window.compact, 状態色枠) は .feed-post を持たず対象外。 */
   .workspace-column-body .feed-post {
     border: none;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.55);
+    /* 区切りは **border-top** に置く。VirtualFeed は各投稿を position:absolute +
+       translateY で隙間なく重ねるため、border-bottom だと次の投稿 (後に描画) の
+       背景が前の投稿の下端 1px を覆って線が消える (= 濃さを上げても見えなかった真因)。
+       border-top は「線を持つ投稿自身」が後に描画されるので覆われず確実に見える。 */
+    border-top: 1px solid rgba(255, 255, 255, 0.5);
     border-radius: 0;
     box-shadow: none;
     padding-left: 0;
     padding-right: 0;
     margin-bottom: 0;
   }
-  .workspace-column-body .feed-post:last-child { border-bottom: none; }
+  /* 先頭投稿 (index 0) は header 直下なので上線を出さない */
+  .workspace-column-body [data-index="0"] .feed-post { border-top: none; }
   .workspace-column-body .feed-post::before,
   .workspace-column-body .feed-post::after { display: none; }
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -551,7 +551,8 @@ p { margin: 0.4em 0; }
     padding-right: 0;
     margin-bottom: 0;
   }
-  /* 先頭投稿 (index 0) は header 直下なので上線を出さない */
+  /* カラム最上部の投稿 (index 0) には上線を出さない (列ヘッダ/上部コンテンツ
+     (HomeSummary 等) との二重線を避ける) */
   .workspace-column-body [data-index="0"] .feed-post { border-top: none; }
   .workspace-column-body .feed-post::before,
   .workspace-column-body .feed-post::after { display: none; }


### PR DESCRIPTION
## 真因
投稿間の区切り線が濃さを 0.2→0.35→0.55 と上げても実機で見えなかった。原因は濃さでなく
**描画順**: VirtualFeed は各投稿を `position:absolute` + `translateY` で隙間なく重ねるため、
`border-bottom` だと**次の投稿 (後に描画) の背景**が前の投稿の下端 1px を覆い隠していた。

## 修正
- 区切りを `border-top` に置く (線を持つ投稿自身が後に描画されるので覆われない)。
- 先頭投稿 (`[data-index="0"]`) は header 直下なので上線を抑止。

## 検証 (実 dist CSS + 実際の仮想化レイアウトをピクセル再現)
- border-bottom 版: 仮想化再現で**線が一切出ない**ことを確認 (真因の再現)。
- border-top 版: 同じレイアウトで**線が明確に出る**ことを確認。先頭投稿は上線なし。

CSS のみの微修正。§1.5 高速パス (軽量レビュー1観点)。

---

## §1.5 軽量レビュー (CSS高速パス・実装1観点)
**★★★/★★ ゼロ。** cascade・詳細度・media境界・data-index ラッパ前提すべて正しいと確認。★ (コメントの「header直下」が home-column の HomeSummary を考慮すると不正確) → コメントを一般化して対応済。
