### PR TITLE
fix(lightbox): 閉じる×・前後‹›ボタンの記号を中央化

### DIFF
--- a/apps/web/src/components/image-lightbox.tsx
+++ b/apps/web/src/components/image-lightbox.tsx
@@ -117,12 +117,14 @@ export function ImageLightbox({
           border: 'none',
           background: 'rgba(255,255,255,0.15)',
           color: '#fff',
-          fontSize: 22,
           cursor: 'pointer',
-          lineHeight: 1,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: 0,
         }}
       >
-        ×
+        <CloseIcon />
       </button>
 
       {/* 左 */}
@@ -146,11 +148,14 @@ export function ImageLightbox({
             border: 'none',
             background: hasPrev ? 'rgba(255,255,255,0.15)' : 'rgba(255,255,255,0.05)',
             color: hasPrev ? '#fff' : 'rgba(255,255,255,0.35)',
-            fontSize: 24,
             cursor: hasPrev ? 'pointer' : 'default',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: 0,
           }}
         >
-          ‹
+          <ChevronIcon dir="left" />
         </button>
       )}
 
@@ -188,11 +193,14 @@ export function ImageLightbox({
             border: 'none',
             background: hasNext ? 'rgba(255,255,255,0.15)' : 'rgba(255,255,255,0.05)',
             color: hasNext ? '#fff' : 'rgba(255,255,255,0.35)',
-            fontSize: 24,
             cursor: hasNext ? 'pointer' : 'default',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: 0,
           }}
         >
-          ›
+          <ChevronIcon dir="right" />
         </button>
       )}
 
@@ -225,5 +233,24 @@ export function ImageLightbox({
       </div>
     </div>,
     document.body,
+  );
+}
+
+/** 閉じる × アイコン (グリフだと字形で中央がずれるので SVG で正確に中央化)。 */
+function CloseIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden focusable="false">
+      <path d="M6 6 18 18M18 6 6 18" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+/** 前/次の山形アイコン (グリフ ‹ › は字形が左右非対称で中央がずれるため SVG)。 */
+function ChevronIcon({ dir }: { dir: 'left' | 'right' }) {
+  const d = dir === 'left' ? 'M15 5 8 12 15 19' : 'M9 5 16 12 9 19';
+  return (
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden focusable="false">
+      <path d={d} stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
   );
 }


### PR DESCRIPTION
## 背景
画像ライトボックスの 閉じる(×) / 前(‹) / 次(›) ボタンの記号が円の中で中央からずれて
格好悪かった (実機指摘)。

## 原因と修正
ボタンに flex 中央寄せがなく、グリフのメトリクス任せ (× は字形、‹ › は左右非対称) で
ずれていた。`display:flex + align/justify center + padding:0` にし、記号を SVG アイコン
(CloseIcon / ChevronIcon) に置換して正確に中央化。絵文字不使用の既存方針 (RefreshIcon 等) と一致。

## 確認
typecheck / build 緑。3 ボタンの中央化を mockup でピクセル確認。

## Review
§1.5 高速パス相当 (小さな視覚修正・TSX 1ファイル) → 実装1観点。

---

## §1.5 軽量レビュー (実装1観点)
**★★★/★★ ゼロ。** flex中央寄せ+SVG で正しく中央化、SVG path 対称、stopPropagation/disabled色分け/aria-label 維持、currentColor 継承で disabled 色も反映、typecheck緑、テスト影響なし。
