### PR TITLE
fix(lightbox): ボタンを下部に集約 (片手操作 + 画像に重ねない)

### DIFF
--- a/apps/web/src/components/image-lightbox.tsx
+++ b/apps/web/src/components/image-lightbox.tsx
@@ -166,19 +166,7 @@ export function ImageLightbox({
           type="button"
           onClick={(e) => { e.stopPropagation(); onClose(); }}
           aria-label="閉じる"
-          style={{
-            width: 44,
-            height: 44,
-            borderRadius: 22,
-            border: 'none',
-            background: 'rgba(255,255,255,0.15)',
-            color: '#fff',
-            cursor: 'pointer',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            padding: 0,
-          }}
+          style={navBtnStyle(true)}
         >
           <CloseIcon />
         </button>

--- a/apps/web/src/components/image-lightbox.tsx
+++ b/apps/web/src/components/image-lightbox.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, type CSSProperties } from 'react';
 import { createPortal } from 'react-dom';
 import type { PostImage } from '@/lib/post-embed';
 
@@ -99,141 +99,110 @@ export function ImageLightbox({
         else go(-1);
       }}
     >
-      {/* 閉じる */}
-      <button
-        type="button"
-        onClick={(e) => {
-          e.stopPropagation();
-          onClose();
-        }}
-        aria-label="閉じる"
-        style={{
-          position: 'absolute',
-          top: 12,
-          right: 12,
-          width: 40,
-          height: 40,
-          borderRadius: 20,
-          border: 'none',
-          background: 'rgba(255,255,255,0.15)',
-          color: '#fff',
-          cursor: 'pointer',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          padding: 0,
-        }}
-      >
-        <CloseIcon />
-      </button>
-
-      {/* 左 */}
-      {multi && (
-        <button
-          type="button"
-          disabled={!hasPrev}
-          onClick={(e) => {
-            e.stopPropagation();
-            go(-1);
-          }}
-          aria-label="前の画像"
+      {/* 画像エリア (残りの高さいっぱい。ボタンは画像に重ねない) */}
+      <div style={{ flex: 1, minHeight: 0, width: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <img
+          src={current.fullsize}
+          alt={current.alt}
+          onClick={(e) => e.stopPropagation()}
           style={{
-            position: 'absolute',
-            left: 12,
-            top: '50%',
-            transform: 'translateY(-50%)',
-            width: 44,
-            height: 44,
-            borderRadius: 22,
-            border: 'none',
-            background: hasPrev ? 'rgba(255,255,255,0.15)' : 'rgba(255,255,255,0.05)',
-            color: hasPrev ? '#fff' : 'rgba(255,255,255,0.35)',
-            cursor: hasPrev ? 'pointer' : 'default',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            padding: 0,
+            maxWidth: '100%',
+            maxHeight: '100%',
+            objectFit: 'contain',
+            userSelect: 'none',
           }}
-        >
-          <ChevronIcon dir="left" />
-        </button>
-      )}
+        />
+      </div>
 
-      {/* 画像 */}
-      <img
-        src={current.fullsize}
-        alt={current.alt}
-        onClick={(e) => e.stopPropagation()}
-        style={{
-          maxWidth: '92vw',
-          maxHeight: '84vh',
-          objectFit: 'contain',
-          userSelect: 'none',
-        }}
-      />
-
-      {/* 右 */}
-      {multi && (
-        <button
-          type="button"
-          disabled={!hasNext}
-          onClick={(e) => {
-            e.stopPropagation();
-            go(1);
-          }}
-          aria-label="次の画像"
-          style={{
-            position: 'absolute',
-            right: 12,
-            top: '50%',
-            transform: 'translateY(-50%)',
-            width: 44,
-            height: 44,
-            borderRadius: 22,
-            border: 'none',
-            background: hasNext ? 'rgba(255,255,255,0.15)' : 'rgba(255,255,255,0.05)',
-            color: hasNext ? '#fff' : 'rgba(255,255,255,0.35)',
-            cursor: hasNext ? 'pointer' : 'default',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            padding: 0,
-          }}
-        >
-          <ChevronIcon dir="right" />
-        </button>
-      )}
-
-      {/* カウンタ + alt */}
+      {/* 下部コントロール: 親指で届く位置に。前後 ‹›・カウンタは画像の下、
+          閉じる × は最下部 (画面上部まで指を伸ばさなくて済むように)。 */}
       <div
         onClick={(e) => e.stopPropagation()}
         style={{
-          position: 'absolute',
-          bottom: 16,
-          left: 0,
-          right: 0,
+          flex: '0 0 auto',
+          width: '100%',
           display: 'flex',
           flexDirection: 'column',
           alignItems: 'center',
-          gap: 6,
-          padding: '0 16px',
+          gap: 10,
+          paddingTop: 10,
+          paddingBottom: 'calc(8px + env(safe-area-inset-bottom, 0px))',
           color: 'rgba(255,255,255,0.9)',
           fontSize: 13,
-          pointerEvents: 'none',
         }}
       >
-        {multi && (
-          <span style={{ fontFamily: 'ui-monospace, monospace' }}>
-            {idx + 1} / {images.length}
-          </span>
-        )}
         {current.alt && (
-          <span style={{ maxWidth: 720, textAlign: 'center', lineHeight: 1.5 }}>{current.alt}</span>
+          <span style={{ maxWidth: 720, textAlign: 'center', lineHeight: 1.5, padding: '0 16px' }}>{current.alt}</span>
         )}
+
+        {multi && (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 20 }}>
+            <button
+              type="button"
+              disabled={!hasPrev}
+              onClick={(e) => { e.stopPropagation(); go(-1); }}
+              aria-label="前の画像"
+              style={navBtnStyle(hasPrev)}
+            >
+              <ChevronIcon dir="left" />
+            </button>
+            <span style={{ fontFamily: 'ui-monospace, monospace', minWidth: '3.5em', textAlign: 'center' }}>
+              {idx + 1} / {images.length}
+            </span>
+            <button
+              type="button"
+              disabled={!hasNext}
+              onClick={(e) => { e.stopPropagation(); go(1); }}
+              aria-label="次の画像"
+              style={navBtnStyle(hasNext)}
+            >
+              <ChevronIcon dir="right" />
+            </button>
+          </div>
+        )}
+
+        {/* 閉じる (最下部・中央) */}
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); onClose(); }}
+          aria-label="閉じる"
+          style={{
+            width: 44,
+            height: 44,
+            borderRadius: 22,
+            border: 'none',
+            background: 'rgba(255,255,255,0.15)',
+            color: '#fff',
+            cursor: 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: 0,
+          }}
+        >
+          <CloseIcon />
+        </button>
       </div>
     </div>,
     document.body,
   );
+}
+
+/** 前/次の丸ボタンのスタイル (有効/無効で色を出し分け)。 */
+function navBtnStyle(enabled: boolean): CSSProperties {
+  return {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    border: 'none',
+    background: enabled ? 'rgba(255,255,255,0.15)' : 'rgba(255,255,255,0.05)',
+    color: enabled ? '#fff' : 'rgba(255,255,255,0.35)',
+    cursor: enabled ? 'pointer' : 'default',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 0,
+  };
 }
 
 /** 閉じる × アイコン (グリフだと字形で中央がずれるので SVG で正確に中央化)。 */


### PR DESCRIPTION
## 背景 (実機指摘)
- 閉じる × が画面**上部右**で、親指を上に伸ばすのがしんどい
- 前/次 ‹› が**画像に重なって**いる

## 変更
ライトボックスを flex column 化し、画像を上の可変領域 (flex:1)、操作を下部に集約:
- 画像の下に: alt → **‹ カウンタ(1/2) ›** の行 → **閉じる ×(最下部・中央)**
- 前後ボタンは画像に重ならない。閉じるは親指で届く最下部。
- `env(safe-area-inset-bottom)` で下端余白確保。
- ‹›× は前 PR の SVG アイコンのまま (中央化済)。スワイプ/キー操作/プリロードは不変。

## 確認
typecheck / build 緑。新レイアウトを mockup でピクセル確認 (画像上・操作下・×最下部)。

## Review
§1.5 高速パス相当 (視覚レイアウト変更・TSX 1ファイル) → 実装1観点。

---

## §1.5 軽量レビュー (実装1観点)
**★★★/★★ (新規) ゼロ。** flex column レイアウト・minHeight:0 の縦潰れ回避・機能維持 (stopPropagation/disabled色分け/aria-label/スワイプ/キー/プリロード)・型すべて正しいと確認。
- ★★: 画像外の余白タップで閉じる挙動 → **旧来からの仕様** (画像の外をタップで dismiss は標準的) なので維持。
- ★ DRY: 閉じるボタンを navBtnStyle(true) に統一 (本PRで対応)。alt 長文時の高さ・width冗長は軽微で据え置き。
