### PR TITLE
feat(workspace): PC でブラウザ横幅をフルに使う (1480px キャップ撤去)

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -230,7 +230,9 @@ p { margin: 0.4em 0; }
    幅緩和は 768px から (1100px 始まりだとタブレット縦持ちで 680px 枠内に
    340px カラムが 2 列弱しか見えず破綻するため)。 */
 @media (min-width: 768px) {
-  .app-shell:has([data-workspace="1"]) { max-width: min(100vw - 1.5em, 1480px); }
+  /* workspace はブラウザ横幅をフルに使う (旧 1480px キャップを撤去)。
+     カラムは固定幅で並び、入りきらなければ横スクロール。 */
+  .app-shell:has([data-workspace="1"]) { max-width: 100%; }
 }
 
 /* スワイプヒント (▶ / ◀) を絶対配置する基準 */


### PR DESCRIPTION
## 背景
PC の workspace が `max-width: min(100vw-1.5em, 1480px)` で 1480px 頭打ちになり、
広いモニタで左右に大きな余白が出てブラウザ幅を活かせていなかった (オーナー指摘)。

## 変更
`.app-shell:has([data-workspace]) { max-width: 100% }` (PC) でブラウザ横幅をフルに使う。
カラムは固定幅で並び、入りきらなければ横スクロール (TweetDeck 的)。モバイルは不変。

## 位置づけ
PC レイアウト改善の第1弾。後続: ②カラム幅ドラッグ可変 ③PC 左ナビレール ④投稿カラム。

## 確認
typecheck / build 緑。CSS 1 行のため高速パス (実装1観点レビュー)。

---

## §1.5 軽量レビュー (実装1観点)
**指摘ゼロ。** 100vw でなく 100% でスクロールバー二重発生を回避、:has (0,2,0) が非workspaceルートの680pxに波及せず、固定幅カラムは超広幅でも間延びせず横スクロール維持。
