### PR TITLE
feat(workspace): PC でカラム幅をドラッグで可変に + 保存

### DIFF
--- a/apps/web/src/components/workspace.tsx
+++ b/apps/web/src/components/workspace.tsx
@@ -205,6 +205,19 @@ export function Workspace() {
     edit((cols) => cols.map((c) => (c.id === id ? ({ ...c, ...patch } as AppColumn) : c)));
   }
 
+  /** カラム幅を変更/リセットする。width=undefined は width キーを削除して既定幅に戻す
+   *  (exactOptionalPropertyTypes 下では undefined を代入できないのでキーごと外す)。 */
+  function resizeColumn(id: string, width: number | undefined) {
+    edit((cols) => cols.map((c) => {
+      if (c.id !== id) return c;
+      if (width === undefined) {
+        const { width: _drop, ...rest } = c;
+        return rest as AppColumn;
+      }
+      return { ...c, width } as AppColumn;
+    }));
+  }
+
   /** anchor 位置にカラムを挿入する */
   function insertColumn(col: AppColumn, anchor: PickerAnchor) {
     edit((cols) => {
@@ -243,7 +256,7 @@ export function Workspace() {
               onAddRight={() => setPickerAnchor(i)}
               onRefresh={() => refreshColumn(col)}
               onRefreshAll={() => refreshAll(columns ?? [])}
-              onResize={(width) => patchColumn(col.id, { width })}
+              onResize={(width) => resizeColumn(col.id, width)}
             >
               <ColumnContent
                 key={refreshNonce[col.id] ?? 0}
@@ -307,8 +320,8 @@ interface ColumnViewProps {
   onAddRight: () => void;
   onRefresh: () => void;
   onRefreshAll: () => void;
-  /** 右端ドラッグでカラム幅 (px) を変更し確定したとき。 */
-  onResize: (width: number) => void;
+  /** 右端ドラッグでカラム幅 (px) を変更し確定したとき。undefined で既定幅に戻す。 */
+  onResize: (width: number | undefined) => void;
   children: ReactNode;
 }
 
@@ -382,8 +395,10 @@ function ColumnView({ column, canMoveLeft, canMoveRight, onMoveLeft, onMoveRight
     onResize(clampColumnWidth(st.w + (e.clientX - st.x)));
   }
 
-  const sectionStyle = column.width
-    ? ({ ['--col-width']: `${column.width}px` } as CSSProperties)
+  // 保存値も念のため clamp して描画 (壊れた範囲外値が flex-basis に流れないよう
+  // 二重防御。検証は isValidAppColumn で型を、ここで範囲を担保)。
+  const sectionStyle = column.width != null
+    ? ({ ['--col-width']: `${clampColumnWidth(column.width)}px` } as CSSProperties)
     : undefined;
 
   return (
@@ -429,6 +444,10 @@ function ColumnView({ column, canMoveLeft, canMoveRight, onMoveLeft, onMoveRight
           <button type="button" disabled={!canMoveLeft} onClick={() => { onMoveLeft(); setMenuOpen(false); }}>← 左へ移動</button>
           <button type="button" disabled={!canMoveRight} onClick={() => { onMoveRight(); setMenuOpen(false); }}>→ 右へ移動</button>
           <button type="button" onClick={() => { onAddRight(); setMenuOpen(false); }}>＋ 右にカラムを追加</button>
+          {/* 幅を変更済みのときだけ「既定幅に戻す」を出す (ポインタ以外の幅リセット経路) */}
+          {column.width != null && (
+            <button type="button" onClick={() => { onResize(undefined); setMenuOpen(false); }}>↔ カラム幅を既定に戻す</button>
+          )}
           {/* 単一カラム時は「すべて」= 自カラムでラベルと実体が一致しないので隠す */}
           {(canMoveLeft || canMoveRight) && (
             <button type="button" onClick={() => { onRefreshAll(); setMenuOpen(false); }}>

--- a/apps/web/src/components/workspace.tsx
+++ b/apps/web/src/components/workspace.tsx
@@ -11,7 +11,7 @@
  * body 要素を ColumnScrollContext で配って内部の VirtualFeed が
  * 「カラム内スクロール」モードで動けるようにする。
  */
-import { Fragment, useEffect, useRef, useState, type ReactNode } from 'react';
+import { Fragment, useEffect, useRef, useState, type CSSProperties, type PointerEvent as ReactPointerEvent, type ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 import { useSession } from '@/lib/session';
 import {
@@ -22,6 +22,7 @@ import {
   moveColumnRight,
   removeColumn,
   appColumnTitle,
+  clampColumnWidth,
   type AppColumn,
   type AppColumnKind,
 } from '@/lib/app-columns';
@@ -242,6 +243,7 @@ export function Workspace() {
               onAddRight={() => setPickerAnchor(i)}
               onRefresh={() => refreshColumn(col)}
               onRefreshAll={() => refreshAll(columns ?? [])}
+              onResize={(width) => patchColumn(col.id, { width })}
             >
               <ColumnContent
                 key={refreshNonce[col.id] ?? 0}
@@ -305,10 +307,15 @@ interface ColumnViewProps {
   onAddRight: () => void;
   onRefresh: () => void;
   onRefreshAll: () => void;
+  /** 右端ドラッグでカラム幅 (px) を変更し確定したとき。 */
+  onResize: (width: number) => void;
   children: ReactNode;
 }
 
-function ColumnView({ column, canMoveLeft, canMoveRight, onMoveLeft, onMoveRight, onRemove, onAddRight, onRefresh, onRefreshAll, children }: ColumnViewProps) {
+function ColumnView({ column, canMoveLeft, canMoveRight, onMoveLeft, onMoveRight, onRemove, onAddRight, onRefresh, onRefreshAll, onResize, children }: ColumnViewProps) {
+  // カラム要素 (リサイズ時に幅を直接いじって再描画を避ける)
+  const sectionRef = useRef<HTMLElement>(null);
+  const resizeStart = useRef<{ x: number; w: number } | null>(null);
   // body 要素を state で持つ (callback ref)。要素の出現が props 変化として
   // 子に伝わり、VirtualFeed がカラム内スクロールへ自然に切り替わる。
   const [bodyEl, setBodyEl] = useState<HTMLElement | null>(null);
@@ -348,8 +355,39 @@ function ColumnView({ column, canMoveLeft, canMoveRight, onMoveLeft, onMoveRight
     setMenuOpen(false);
   }
 
+  // ── 右端ドラッグでのカラム幅リサイズ (PC) ──
+  // ドラッグ中は section の --col-width を直接書き換えて再描画を避け、
+  // pointerup で onResize に確定値を渡して state + localStorage に保存する。
+  function onResizePointerDown(e: ReactPointerEvent<HTMLDivElement>) {
+    const el = sectionRef.current;
+    if (!el) return;
+    e.preventDefault();
+    e.stopPropagation();
+    e.currentTarget.setPointerCapture(e.pointerId);
+    e.currentTarget.classList.add('is-dragging');
+    resizeStart.current = { x: e.clientX, w: el.getBoundingClientRect().width };
+  }
+  function onResizePointerMove(e: ReactPointerEvent<HTMLDivElement>) {
+    const st = resizeStart.current;
+    const el = sectionRef.current;
+    if (!st || !el) return;
+    el.style.setProperty('--col-width', `${clampColumnWidth(st.w + (e.clientX - st.x))}px`);
+  }
+  function onResizePointerUp(e: ReactPointerEvent<HTMLDivElement>) {
+    const st = resizeStart.current;
+    resizeStart.current = null;
+    e.currentTarget.classList.remove('is-dragging');
+    try { e.currentTarget.releasePointerCapture(e.pointerId); } catch { /* no-op */ }
+    if (!st) return;
+    onResize(clampColumnWidth(st.w + (e.clientX - st.x)));
+  }
+
+  const sectionStyle = column.width
+    ? ({ ['--col-width']: `${column.width}px` } as CSSProperties)
+    : undefined;
+
   return (
-    <section className="workspace-column" data-column-kind={column.kind}>
+    <section className="workspace-column" data-column-kind={column.kind} ref={sectionRef} style={sectionStyle}>
       <header className="workspace-column-header">
         <span className="workspace-column-title">{appColumnTitle(column)}</span>
         <button
@@ -418,6 +456,15 @@ function ColumnView({ column, canMoveLeft, canMoveRight, onMoveLeft, onMoveRight
           {children}
         </ColumnScrollContext.Provider>
       </div>
+      {/* 右端のリサイズハンドル (PC のみ表示)。掴んで左右で幅を変える。 */}
+      <div
+        className="workspace-column-resizer"
+        onPointerDown={onResizePointerDown}
+        onPointerMove={onResizePointerMove}
+        onPointerUp={onResizePointerUp}
+        onPointerCancel={onResizePointerUp}
+        aria-hidden="true"
+      />
     </section>
   );
 }

--- a/apps/web/src/lib/app-columns.test.ts
+++ b/apps/web/src/lib/app-columns.test.ts
@@ -10,6 +10,9 @@ import {
   removeColumn,
   appColumnTitle,
   isValidAppColumn,
+  clampColumnWidth,
+  COLUMN_MIN_WIDTH,
+  COLUMN_MAX_WIDTH,
   type AppColumn,
 } from './app-columns';
 
@@ -284,5 +287,49 @@ describe('makeAppColumn (discriminated union)', () => {
     const h = makeAppColumn('home');
     expect(h.kind).toBe('home');
     expect(h.id).toMatch(/^col-/);
+  });
+});
+
+describe('clampColumnWidth', () => {
+  it('範囲内はそのまま (四捨五入)', () => {
+    expect(clampColumnWidth(340)).toBe(340);
+    expect(clampColumnWidth(500.4)).toBe(500);
+    expect(clampColumnWidth(500.6)).toBe(501);
+  });
+  it('下限・上限でクランプ', () => {
+    expect(clampColumnWidth(COLUMN_MIN_WIDTH - 1)).toBe(COLUMN_MIN_WIDTH);
+    expect(clampColumnWidth(0)).toBe(COLUMN_MIN_WIDTH);
+    expect(clampColumnWidth(-9999)).toBe(COLUMN_MIN_WIDTH);
+    expect(clampColumnWidth(COLUMN_MAX_WIDTH + 1)).toBe(COLUMN_MAX_WIDTH);
+    expect(clampColumnWidth(99999)).toBe(COLUMN_MAX_WIDTH);
+  });
+});
+
+describe('カラム幅 (width) の永続化と検証', () => {
+  it('width 付きカラムが save→load で round-trip する', () => {
+    const cols: AppColumn[] = [{ id: 'a', kind: 'home', width: 500 }];
+    saveAppColumns(cols);
+    const loaded = loadAppColumns(true);
+    expect(loaded[0]).toMatchObject({ kind: 'home', width: 500 });
+  });
+
+  it('isValidAppColumn は有限数の width のみ許容、壊れた width は弾く', () => {
+    expect(isValidAppColumn({ id: 'a', kind: 'home', width: 400 })).toBe(true);
+    expect(isValidAppColumn({ id: 'a', kind: 'home' })).toBe(true); // width 無しも可
+    expect(isValidAppColumn({ id: 'a', kind: 'home', width: 'abc' })).toBe(false);
+    expect(isValidAppColumn({ id: 'a', kind: 'home', width: NaN })).toBe(false);
+    expect(isValidAppColumn({ id: 'a', kind: 'home', width: Infinity })).toBe(false);
+    expect(isValidAppColumn({ id: 'a', kind: 'home', width: null })).toBe(false);
+  });
+
+  it('壊れた width のカラムは load 時に除外される', () => {
+    localStorage.setItem(
+      'aozoraquest:appColumns:v1',
+      JSON.stringify([{ id: 'a', kind: 'home', width: 'oops' }, { id: 'b', kind: 'bar', width: 400 }]),
+    );
+    const loaded = loadAppColumns(true);
+    // 壊れた home は除外、正常な bar は残る
+    expect(loaded.map(c => c.kind)).toEqual(['bar']);
+    expect(loaded[0]).toMatchObject({ width: 400 });
   });
 });

--- a/apps/web/src/lib/app-columns.ts
+++ b/apps/web/src/lib/app-columns.ts
@@ -37,6 +37,16 @@ interface ColumnBase {
   id: string;
   /** ヘッダー表示の上書き。未設定なら kind+param から推定。 */
   title?: string;
+  /** PC でのカラム幅 (px)。ユーザーが右端をドラッグして変更し保存する。
+   *  未設定なら CSS 既定 (340px)。モバイルは全幅なので無視される。 */
+  width?: number;
+}
+
+/** カラム幅 (px) の下限・上限。リサイズ時にこの範囲へクランプする。 */
+export const COLUMN_MIN_WIDTH = 240;
+export const COLUMN_MAX_WIDTH = 760;
+export function clampColumnWidth(px: number): number {
+  return Math.max(COLUMN_MIN_WIDTH, Math.min(COLUMN_MAX_WIDTH, Math.round(px)));
 }
 
 export type AppColumn =

--- a/apps/web/src/lib/app-columns.ts
+++ b/apps/web/src/lib/app-columns.ts
@@ -188,6 +188,9 @@ export function isValidAppColumn(c: unknown): c is AppColumn {
   const obj = c as Record<string, unknown>;
   if (typeof obj.id !== 'string') return false;
   if (!APP_KINDS.includes(obj.kind as AppColumnKind)) return false;
+  // width は数値かつ有限のときのみ許容 (壊れた localStorage の "abc"/NaN/null 等で
+  // --col-width に不正値が流れるのを防ぐ。範囲外の数値は描画時に clamp する)。
+  if (obj.width !== undefined && (typeof obj.width !== 'number' || !Number.isFinite(obj.width))) return false;
   // kind 別フィールドの軽い検証 (壊れた値は load 時に丸ごと除外する)
   if (obj.kind === 'board' && obj.inner !== undefined) {
     if (!Array.isArray(obj.inner) || !obj.inner.every(isValidBoardInner)) return false;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -264,6 +264,9 @@ p { margin: 0.4em 0; }
   padding-bottom: 0.4em;
 }
 
+/* リサイズハンドルは PC のみ表示 (モバイルは全幅でリサイズ不要) */
+.workspace-column-resizer { display: none; }
+
 .workspace-column {
   display: flex;
   flex-direction: column;
@@ -450,13 +453,40 @@ p { margin: 0.4em 0; }
 
 @media (min-width: 768px) {
   .workspace-column {
-    flex: 0 0 340px;
+    /* 幅は --col-width (ユーザーがドラッグで保存した値) があればそれ、無ければ 340px。
+       モバイルは別ルール (flex:0 0 100%) が勝つので --col-width は無視される。 */
+    flex: 0 0 var(--col-width, 340px);
     /* モバイルと同じく chrome 実測に追従 (--shell-chrome-height) */
     height: calc(100dvh - var(--shell-chrome-height, 9.5em));
   }
   .workspace-columns {
     scroll-snap-type: none;   /* PC は自由スクロール */
     gap: 0.8em;
+  }
+  /* カラム右端のリサイズハンドル (PC のみ)。掴んで左右にドラッグで幅を変える。 */
+  .workspace-column-resizer {
+    display: block;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    right: -5px;            /* カラム間 gap の中央あたりに重ねる */
+    width: 10px;
+    cursor: col-resize;
+    z-index: 15;
+    touch-action: none;    /* pointer ドラッグを横取りされない */
+  }
+  /* 掴んでいる/ホバー時に中央へ細い線を出す (視認用) */
+  .workspace-column-resizer::after {
+    content: '';
+    position: absolute;
+    top: 0; bottom: 0; left: 4px;
+    width: 2px;
+    background: transparent;
+    transition: background-color 0.1s;
+  }
+  .workspace-column-resizer:hover::after,
+  .workspace-column-resizer.is-dragging::after {
+    background: var(--color-accent);
   }
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -469,19 +469,19 @@ p { margin: 0.4em 0; }
     position: absolute;
     top: 0;
     bottom: 0;
-    right: -5px;            /* カラム間 gap の中央あたりに重ねる */
-    width: 10px;
+    right: -8px;            /* カラム間 gap (0.8em) の中央に重ねる */
+    width: 16px;            /* 掴みやすい当たり判定 (見た目の線は細い) */
     cursor: col-resize;
     z-index: 15;
     touch-action: none;    /* pointer ドラッグを横取りされない */
   }
-  /* 掴んでいる/ホバー時に中央へ細い線を出す (視認用) */
+  /* 中央に縦線。**常時うっすら見せて発見性を確保**し、ホバー/ドラッグで accent に強調。 */
   .workspace-column-resizer::after {
     content: '';
     position: absolute;
-    top: 0; bottom: 0; left: 4px;
+    top: 0; bottom: 0; left: 7px;
     width: 2px;
-    background: transparent;
+    background: rgba(255, 255, 255, 0.22);
     transition: background-color 0.1s;
   }
   .workspace-column-resizer:hover::after,

--- a/docs/16-multicolumn.md
+++ b/docs/16-multicolumn.md
@@ -125,6 +125,7 @@ MVP 完了。以降は下記「既知の制約 / 検討事項」と issue #36 (p
 - **profile カラムの情報量**: フルプロフィール (相性 + 推し量り + 投稿) をそのまま表示している。コンパクト版は issue #36
 - **DM カラム / List カラム**: Bluesky の DM・List API 調査が別途必要 (将来)
 - **drag & drop 並べ替え**: MVP は矢印ボタン (⋯メニュー) のみ。要望次第で dnd-kit
+- **カラム幅のリサイズ (PC)**: 各カラム右端のハンドルをドラッグして幅を変更し、`AppColumn.width` (px) として localStorage 保存。CSS は PC で `flex: 0 0 var(--col-width, 340px)`、ドラッグ中は section の `--col-width` を直接書き換えて再描画を避け、pointerup で state + 保存。幅は `clampColumnWidth` で 240〜760px にクランプ。モバイルは全幅なのでハンドル非表示・`--col-width` 無視。PC は workspace 全幅 (1480px キャップ撤去済) で、カラムが入りきらなければ横スクロール。
 - **PDS 同期 (`app.aozoraquest.layout`)**: カラム構成は localStorage 止まり。端末横断同期は将来の opt-in
 - **iOS Safari の scroll-snap 慣性**: `scroll-snap-stop: always` で軽減。深い tuning は実機検証後
 - **モバイル (<=767px) はカラムを全幅化**: 横幅が枠に食われて本文が窮屈という指摘を受け、スマホでは DQ ウィンドウの太枠・四隅装飾・次カラム peek を省いて本文幅を優先 (~83% → ~97%)。カラム境界は隣接間の `inset 1px` 縦線で示す。「右/左にまだカラムがある」ことは peek の代わりに `.workspace-swipe-hint` (▶ / ◀) で知らせる (▶ は初回スワイプまで点滅、末尾のコンテンツカラムで消える、`pointer-events:none` の純粋な視覚マーカー)。**PC (>=768px) は従来どおり太枠 340px カラム + 自由スクロール**。DESIGN.md の DQ ウィンドウ様式はモバイルでのみ緩める例外。


### PR DESCRIPTION
156

---

## §1.5 レビュー結果 (3並列)
**★★★ (UX: 発見性ゼロ) を含む指摘を PR 内対応。**
- **★★★ 発見性**: ハンドルの縦線を常時うっすら可視 (0.22) + 当たり判定 10→16px。
- **★★ width 検証漏れ**: isValidAppColumn で有限数のみ許容 + 描画時 clamp (壊れた localStorage 対策)。
- **★★ 幅リセット手段なし**: ⋯メニューに「幅を既定に戻す」追加。
- **★★ テスト皆無**: clamp 境界 + round-trip + 壊れ値除外を追加 (198 tests)。
- **★ (issue #)**: キーボード/タッチ幅調整・ドラッグ中カーソル固定・上限760の調整。
- 確認済み: pointer capture / 再描画回避と state 一貫性 / border-box / モバイル非干渉。
