### PR TITLE
feat(shell): PC で下部ナビを左の縦レールに + 投稿ボタンをレール先頭に

### DIFF
--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -148,8 +148,9 @@ export function AppShell() {
       )}
       <nav className="footer-nav" ref={footerRef}>
         {/* 投稿ボタン: PC では左ナビレールの先頭に置いて押しやすく (CSS で PC のみ表示)。
-            モバイルは従来どおり右下の compose-fab を使う。 */}
-        {session.status === 'signed-in' && (
+            モバイルは従来どおり右下の compose-fab を使う。表示可否は FAB と同じ
+            (composeFabAllowedOnPath = フォーム/認証画面では出さない) に揃える。 */}
+        {showComposeFab && (
           <button
             type="button"
             className="footer-nav-item footer-nav-compose"

--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -59,12 +59,15 @@ export function AppShell() {
       return r.height + parseFloat(cs.marginTop || '0') + parseFloat(cs.marginBottom || '0');
     };
     const update = () => {
+      const header = outerHeight(headerRef.current);
       const footer = outerHeight(footerRef.current);
-      const total = outerHeight(headerRef.current) + footer;
-      document.documentElement.style.setProperty('--shell-chrome-height', `${Math.ceil(total)}px`);
+      document.documentElement.style.setProperty('--shell-chrome-height', `${Math.ceil(header + footer)}px`);
       // footer 単独の占有高も書き出す (compose FAB の bottom 位置を header≒footer
       // 仮定に頼らず footer 実測に追従させる)。
       document.documentElement.style.setProperty('--footer-height', `${Math.ceil(footer)}px`);
+      // header 単独の高さ。PC では footer が「左の縦レール」になり縦方向の chrome に
+      // 含めないため、カラム高は 100dvh - header だけで計算する (--header-height を使う)。
+      document.documentElement.style.setProperty('--header-height', `${Math.ceil(header)}px`);
     };
     update();
     const ro = new ResizeObserver(update);
@@ -144,6 +147,19 @@ export function AppShell() {
         </button>
       )}
       <nav className="footer-nav" ref={footerRef}>
+        {/* 投稿ボタン: PC では左ナビレールの先頭に置いて押しやすく (CSS で PC のみ表示)。
+            モバイルは従来どおり右下の compose-fab を使う。 */}
+        {session.status === 'signed-in' && (
+          <button
+            type="button"
+            className="footer-nav-item footer-nav-compose"
+            aria-label="投稿する"
+            title="投稿する"
+            onClick={() => openCompose()}
+          >
+            <ComposeIcon size={26} />
+          </button>
+        )}
         {(session.status === 'signed-in' ? nav : navLoggedOut).map(({ to, label, icon: Icon, end, key, columnKind }) => (
           <NavLink
             key={to}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -456,8 +456,9 @@ p { margin: 0.4em 0; }
     /* 幅は --col-width (ユーザーがドラッグで保存した値) があればそれ、無ければ 340px。
        モバイルは別ルール (flex:0 0 100%) が勝つので --col-width は無視される。 */
     flex: 0 0 var(--col-width, 340px);
-    /* モバイルと同じく chrome 実測に追従 (--shell-chrome-height) */
-    height: calc(100dvh - var(--shell-chrome-height, 9.5em));
+    /* PC は footer が左の縦レールになり縦方向の chrome に含まれないので、
+       カラム高は header 分だけ引く (--header-height)。 */
+    height: calc(100dvh - var(--header-height, 3em));
   }
   .workspace-columns {
     scroll-snap-type: none;   /* PC は自由スクロール */
@@ -755,7 +756,59 @@ p { margin: 0.4em 0; }
   background: rgba(255, 255, 255, 0.12);
 }
 
-/* ─── DQ 風ウィンドウ ──────────────────────────── */
+/* 投稿ボタンはモバイルでは非表示 (右下 compose-fab を使う)。PC でレールに出す。 */
+.footer-nav-compose { display: none; }
+
+/* ─── PC: 下部ナビを「左の縦レール」に ──────────────────────
+   下部横並びだと投稿ボタン (右下 FAB) が押しづらいというオーナー指摘を受け、
+   PC (>=768px) ではナビを画面左端の固定縦レールにし、先頭に投稿ボタンを置く。
+   レールぶんの幅は .app-shell の padding-left で確保 (固定レールと本文が被らない)。
+   モバイルは従来の下部バー (full-width flush) を維持。 */
+@media (min-width: 768px) {
+  /* 固定レールぶんを全ルートで左に空ける (768px でも margin+padding でレールと
+     本文が重ならない)。 */
+  .app-shell { padding-left: 56px; }
+
+  /* footer-nav を左端の縦レールに (詳細度 .app-shell .footer-nav で base に勝つ)。 */
+  .app-shell .footer-nav {
+    position: fixed;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 56px;
+    margin: 0;
+    padding: 0.5em 0;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: center;
+    gap: 0.15em;
+    border: none;
+    border-right: 2px solid var(--color-window-inner-border);
+    border-radius: 0;
+    background: var(--color-window-bg);
+    box-shadow: 2px 0 8px rgba(0, 0, 0, 0.4);
+    overflow-y: auto;
+    z-index: 30;
+  }
+  .footer-nav-item {
+    flex: 0 0 auto;
+    width: 44px;
+    height: 44px;
+    padding: 0;
+  }
+  /* 投稿ボタン: レール先頭で目立たせる (accent 背景) */
+  .footer-nav-compose {
+    display: flex;
+    opacity: 1;
+    color: var(--color-on-accent);
+    background: var(--color-accent);
+    margin-bottom: 0.4em;
+  }
+  .footer-nav-compose:hover { background: var(--color-accent); opacity: 0.88; }
+
+  /* PC は投稿をレールから行うので右下 FAB は出さない */
+  .compose-fab { display: none; }
+}
 
 .dq-window {
   position: relative;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -765,9 +765,11 @@ p { margin: 0.4em 0; }
    レールぶんの幅は .app-shell の padding-left で確保 (固定レールと本文が被らない)。
    モバイルは従来の下部バー (full-width flush) を維持。 */
 @media (min-width: 768px) {
-  /* 固定レールぶんを全ルートで左に空ける (768px でも margin+padding でレールと
-     本文が重ならない)。 */
-  .app-shell { padding-left: 56px; }
+  /* 固定レールぶんを全ルートで左に空ける + app-shell を左寄せ (margin-left:0)。
+     base の margin:0 auto のままだと中央寄せ本文と left:0 固定レールが分離して
+     レールが画面左隅に孤立するため、左寄せにしてレールが本文に寄り添うようにする
+     (= 左ナビ + 本文、という標準レイアウト)。max-width (非 workspace=680) は維持。 */
+  .app-shell { padding-left: 56px; margin-left: 0; }
 
   /* footer-nav を左端の縦レールに (詳細度 .app-shell .footer-nav で base に勝つ)。 */
   .app-shell .footer-nav {
@@ -805,6 +807,11 @@ p { margin: 0.4em 0; }
     margin-bottom: 0.4em;
   }
   .footer-nav-compose:hover { background: var(--color-accent); opacity: 0.88; }
+
+  /* レールの現在地は左端 accent バーで明示 (横バーの薄い背景だけだと縦レールで埋もれる) */
+  .footer-nav-item.active {
+    box-shadow: inset 3px 0 0 var(--color-accent);
+  }
 
   /* PC は投稿をレールから行うので右下 FAB は出さない */
   .compose-fab { display: none; }

--- a/docs/16-multicolumn.md
+++ b/docs/16-multicolumn.md
@@ -125,6 +125,7 @@ MVP 完了。以降は下記「既知の制約 / 検討事項」と issue #36 (p
 - **profile カラムの情報量**: フルプロフィール (相性 + 推し量り + 投稿) をそのまま表示している。コンパクト版は issue #36
 - **DM カラム / List カラム**: Bluesky の DM・List API 調査が別途必要 (将来)
 - **drag & drop 並べ替え**: MVP は矢印ボタン (⋯メニュー) のみ。要望次第で dnd-kit
+- **PC の左ナビレール**: 下部横並びナビだと投稿ボタン (右下 FAB) が押しづらいため、PC (>=768px) では footer-nav を画面左端の固定縦レール (`position:fixed; width:56px`) にし、先頭に投稿ボタンを置く。レールぶんは `.app-shell { padding-left: 56px }` で確保 (768px でも margin+padding でレールと本文が被らない)。PC は右下 FAB を非表示、投稿はレールから。モバイルは従来の下部バー (full-width flush) 維持。レールは縦方向の chrome に含まれないので、PC のカラム高は `100dvh - var(--header-height)` (footer 込みの `--shell-chrome-height` ではなく header だけ引く)。`--header-height` は AppShell が ResizeObserver で実測。投稿はいまモーダルで開く (将来「投稿カラム」化予定)。
 - **カラム幅のリサイズ (PC)**: 各カラム右端のハンドルをドラッグして幅を変更し、`AppColumn.width` (px) として localStorage 保存。CSS は PC で `flex: 0 0 var(--col-width, 340px)`、ドラッグ中は section の `--col-width` を直接書き換えて再描画を避け、pointerup で state + 保存。幅は `clampColumnWidth` で 240〜760px にクランプ。モバイルは全幅なのでハンドル非表示・`--col-width` 無視。PC は workspace 全幅 (1480px キャップ撤去済) で、カラムが入りきらなければ横スクロール。
 - **PDS 同期 (`app.aozoraquest.layout`)**: カラム構成は localStorage 止まり。端末横断同期は将来の opt-in
 - **iOS Safari の scroll-snap 慣性**: `scroll-snap-stop: always` で軽減。深い tuning は実機検証後


### PR DESCRIPTION
158

---

## §1.5 レビュー結果 (3並列)
設計+UX が **★★★ (固定レール+中央寄せ本文の分離)** を一致指摘 → PR 内対応。
- **★★★**: PC で .app-shell を margin-left:0 (左寄せ) にしレールが本文に寄り添う。実CSSで隙間 ~300px→8px 検証。
- **★★**: 投稿ボタンを showComposeFab ガードに (フォーム画面で非表示)。レール active に accent 左バー。
- **★ (issue #)**: hover ラベル・未読バッジ位置・scrollbar・色の一貫性。投稿カラム化は ④で。
- 実装レビューは ★★★/★★ ゼロ (cascade/詳細度/CSS変数PC非リーク/React key 健全) を確認。
