### PR TITLE
feat(theme): ライトモード追加 (システム/ライト/ダーク 選択)

### DIFF
--- a/apps/web/src/components/action-link.tsx
+++ b/apps/web/src/components/action-link.tsx
@@ -32,14 +32,16 @@ const pillStyle: CSSProperties = {
   alignItems: 'center',
   gap: '0.4em',
   padding: '0.35em 0.8em',
-  background: 'rgba(0, 0, 0, 0.45)',
-  border: '2px solid rgba(255, 255, 255, 0.85)',
+  // ウィンドウトークンに乗せてテーマ追従させる (ダーク: 黒地+白文字 /
+  // ライト: 白地+濃紺文字)。リテラル色で焼き込むとライトで浮くため。
+  background: 'var(--color-window-bg)',
+  border: '2px solid var(--color-border)',
   borderRadius: '2px',
-  color: '#ffffff',
+  color: 'var(--color-fg)',
   textDecoration: 'none',
   fontSize: '0.95em',
   fontWeight: 500,
-  boxShadow: 'inset 0 0 0 1px rgba(255, 255, 255, 0.2)',
+  boxShadow: 'inset 0 0 0 1px var(--color-window-inner-border)',
   WebkitTapHighlightColor: 'transparent',
   transition: 'background-color 80ms ease, transform 60ms ease',
 };

--- a/apps/web/src/components/home-summary.tsx
+++ b/apps/web/src/components/home-summary.tsx
@@ -217,7 +217,7 @@ function QuestRow({ quest, showIcon, compact = false }: { quest: Quest; showIcon
   if (compact) {
     return (
       <div style={{ display: 'flex', alignItems: 'center', gap: '0.45em', fontSize: '0.85em' }}>
-        <span style={{ fontSize: '0.68em', padding: '0.05em 0.35em', border: `1px solid ${typeColor}`, color: typeColor, borderRadius: 2, background: 'rgba(255,255,255,0.1)', flexShrink: 0 }}>
+        <span style={{ fontSize: '0.68em', padding: '0.05em 0.35em', border: `1px solid ${typeColor}`, color: typeColor, borderRadius: 2, background: 'var(--color-overlay-soft)', flexShrink: 0 }}>
           {typeBadge}
         </span>
         <span style={{ flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', ...(done ? { color: 'var(--color-muted)', textDecoration: 'line-through' } : {}) }}>
@@ -246,7 +246,7 @@ function QuestRow({ quest, showIcon, compact = false }: { quest: Quest; showIcon
             border: `1px solid ${typeColor}`,
             color: typeColor,
             borderRadius: 2,
-            background: 'rgba(255,255,255,0.1)',
+            background: 'var(--color-overlay-soft)',
           }}
         >
           {typeBadge}
@@ -345,7 +345,7 @@ function ActivityAudit({ activity }: { activity: ActivityEntry[] }) {
   const panelId = 'activity-audit-panel';
 
   return (
-    <div style={{ borderTop: '1px solid rgba(255,255,255,0.15)', paddingTop: '0.5em' }}>
+    <div style={{ borderTop: '1px solid var(--color-subpanel-border)', paddingTop: '0.5em' }}>
       <div style={{ fontSize: '0.78em', color: 'var(--color-muted)', marginBottom: '0.35em' }}>
         今日カウントされた行動 ({sorted.length})
       </div>
@@ -370,9 +370,9 @@ function ActivityAudit({ activity }: { activity: ActivityEntry[] }) {
                 padding: '0.3em 0.7em',
                 fontSize: '0.82em',
                 borderRadius: 999,
-                background: active ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.35)',
+                background: active ? 'var(--color-item-selected-bg)' : 'var(--color-subpanel-bg)',
                 border: '1px solid',
-                borderColor: active ? 'var(--color-primary)' : 'rgba(255,255,255,0.15)',
+                borderColor: active ? 'var(--color-primary)' : 'var(--color-subpanel-border)',
                 color: c.accent ? 'var(--color-accent)' : 'var(--color-muted)',
                 boxShadow: 'none',
               }}
@@ -412,8 +412,8 @@ function ActivityRow({ entry }: { entry: ActivityEntry }) {
   return (
     <div
       style={{
-        background: 'rgba(0,0,0,0.35)',
-        border: '1px solid rgba(255,255,255,0.1)',
+        background: 'var(--color-subpanel-bg)',
+        border: '1px solid var(--color-subpanel-border)',
         borderRadius: 4,
         padding: '0.4em 0.5em',
         fontSize: '0.8em',

--- a/apps/web/src/lib/prefs.ts
+++ b/apps/web/src/lib/prefs.ts
@@ -122,3 +122,24 @@ export function getPostQuestNotificationsDefault(): boolean {
   const env = (import.meta.env.VITE_NSID_ENV as string | undefined)?.trim();
   return env !== 'dev';
 }
+
+// ─── テーマ (ライト/ダーク) ────────────────────────────────
+const KEY_THEME = 'aozoraquest:theme';
+
+/** ユーザーが選んだテーマ。'system' は OS の prefers-color-scheme に追従。
+ *  既定は 'system' (= 新規/未設定ユーザーは OS 設定に従う)。 */
+export type ThemeChoice = 'system' | 'light' | 'dark';
+
+export function getTheme(): ThemeChoice {
+  try {
+    const v = localStorage.getItem(KEY_THEME);
+    if (v === 'light' || v === 'dark' || v === 'system') return v;
+  } catch {/* no-op */}
+  return 'system';
+}
+
+export function setTheme(v: ThemeChoice): void {
+  try {
+    localStorage.setItem(KEY_THEME, v);
+  } catch {/* no-op */}
+}

--- a/apps/web/src/lib/theme.test.ts
+++ b/apps/web/src/lib/theme.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+
+// テスト環境は node なので window/document/localStorage を手で用意する。
+// matchMedia は「変化リスナーの張り直し/解除」を検証するためにスパイ可能なモックにする。
+
+let mediaMatches = false; // (prefers-color-scheme: dark) の現在値
+const addSpy = vi.fn();
+const removeSpy = vi.fn();
+
+beforeAll(() => {
+  if (typeof globalThis.localStorage === 'undefined') {
+    const store = new Map<string, string>();
+    (globalThis as unknown as { localStorage: Storage }).localStorage = {
+      getItem: (k) => (store.has(k) ? store.get(k)! : null),
+      setItem: (k, v) => { store.set(k, String(v)); },
+      removeItem: (k) => { store.delete(k); },
+      clear: () => { store.clear(); },
+      key: (i) => Array.from(store.keys())[i] ?? null,
+      get length() { return store.size; },
+    };
+  }
+  const attrs = new Map<string, string>();
+  (globalThis as unknown as { document: unknown }).document = {
+    documentElement: {
+      setAttribute: (k: string, v: string) => { attrs.set(k, v); },
+      getAttribute: (k: string) => attrs.get(k) ?? null,
+    },
+  };
+  (globalThis as unknown as { window: unknown }).window = {
+    matchMedia: (q: string) => ({
+      matches: q.includes('dark') ? mediaMatches : false,
+      addEventListener: addSpy,
+      removeEventListener: removeSpy,
+    }),
+  };
+  // theme.ts は window/document を直接参照するのでグローバルにも生やす
+  (globalThis as unknown as { matchMedia: unknown }).matchMedia =
+    (globalThis as unknown as { window: { matchMedia: unknown } }).window.matchMedia;
+});
+
+beforeEach(() => {
+  localStorage.clear();
+  mediaMatches = false;
+  addSpy.mockClear();
+  removeSpy.mockClear();
+  vi.resetModules(); // theme.ts のモジュールレベル mql 状態を毎回リセット
+});
+
+function currentDataTheme(): string | null {
+  return (globalThis as unknown as { document: { documentElement: { getAttribute(k: string): string | null } } })
+    .document.documentElement.getAttribute('data-theme');
+}
+
+describe('resolveTheme', () => {
+  it('light/dark はそのまま返す', async () => {
+    const m = await import('./theme');
+    expect(m.resolveTheme('light')).toBe('light');
+    expect(m.resolveTheme('dark')).toBe('dark');
+  });
+
+  it('system は OS の prefers-color-scheme に従う', async () => {
+    const m = await import('./theme');
+    mediaMatches = false;
+    expect(m.resolveTheme('system')).toBe('light');
+    mediaMatches = true;
+    expect(m.resolveTheme('system')).toBe('dark');
+  });
+});
+
+describe('getTheme フォールバック', () => {
+  it('未設定なら system', async () => {
+    const { getTheme } = await import('./prefs');
+    expect(getTheme()).toBe('system');
+  });
+
+  it('不正値なら system に倒す', async () => {
+    localStorage.setItem('aozoraquest:theme', 'wat');
+    const { getTheme } = await import('./prefs');
+    expect(getTheme()).toBe('system');
+  });
+
+  it('保存済みの light/dark/system は round-trip する', async () => {
+    const { getTheme, setTheme } = await import('./prefs');
+    setTheme('light');
+    expect(getTheme()).toBe('light');
+    setTheme('dark');
+    expect(getTheme()).toBe('dark');
+  });
+});
+
+describe('applyTheme', () => {
+  it('html[data-theme] に解決後の値を入れる', async () => {
+    const m = await import('./theme');
+    m.applyTheme('light');
+    expect(currentDataTheme()).toBe('light');
+    m.applyTheme('dark');
+    expect(currentDataTheme()).toBe('dark');
+    mediaMatches = true;
+    m.applyTheme('system');
+    expect(currentDataTheme()).toBe('dark');
+  });
+
+  it("system 選択時だけ matchMedia リスナーを張り、light/dark では張らない", async () => {
+    const m = await import('./theme');
+    m.applyTheme('system');
+    expect(addSpy).toHaveBeenCalledTimes(1);
+    // light に切り替えると system 監視は解除される
+    m.applyTheme('light');
+    expect(removeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('system を連打してもリスナーは二重登録されない (毎回 remove→add)', async () => {
+    const m = await import('./theme');
+    m.applyTheme('system');
+    m.applyTheme('system');
+    m.applyTheme('system');
+    // 2 回目以降は古いリスナーを remove してから add するので add=回数, remove=回数-1
+    expect(addSpy).toHaveBeenCalledTimes(3);
+    expect(removeSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/src/lib/theme.ts
+++ b/apps/web/src/lib/theme.ts
@@ -1,0 +1,50 @@
+/**
+ * テーマ (ライト/ダーク) の適用。font-scale.ts と同じ流儀で、ユーザー設定
+ * (prefs の getTheme) を読んで `<html data-theme="light|dark">` に反映する。
+ *
+ * - 選択肢は 'system' | 'light' | 'dark' (既定 'system')。
+ * - 'system' のときは OS の prefers-color-scheme に追従し、変化も監視する。
+ * - CSS 側は :root[data-theme="light"] で明色トークンを上書きする
+ *   (ダークが :root の既定値)。data-theme は常に解決後の 'light'|'dark' を入れる。
+ */
+import { getTheme, setTheme, type ThemeChoice } from './prefs';
+
+function systemPrefersDark(): boolean {
+  return typeof window !== 'undefined'
+    && !!window.matchMedia?.('(prefers-color-scheme: dark)').matches;
+}
+
+/** 選択を実効テーマ ('light'|'dark') に解決する。 */
+export function resolveTheme(choice: ThemeChoice): 'light' | 'dark' {
+  if (choice === 'system') return systemPrefersDark() ? 'dark' : 'light';
+  return choice;
+}
+
+/** 実効テーマを html[data-theme] に反映する。 */
+function applyResolved(choice: ThemeChoice): void {
+  if (typeof document === 'undefined') return;
+  document.documentElement.setAttribute('data-theme', resolveTheme(choice));
+}
+
+let mql: MediaQueryList | null = null;
+let mqlListener: ((e: MediaQueryListEvent) => void) | null = null;
+
+/** ユーザーがテーマを変更したときに呼ぶ。保存 + 即時反映 + system 監視の張り直し。 */
+export function applyTheme(choice: ThemeChoice): void {
+  setTheme(choice);
+  applyResolved(choice);
+  // 'system' のときだけ OS のテーマ変化を監視して追従する。
+  if (mql && mqlListener) mql.removeEventListener('change', mqlListener);
+  mql = null;
+  mqlListener = null;
+  if (choice === 'system' && typeof window !== 'undefined' && window.matchMedia) {
+    mql = window.matchMedia('(prefers-color-scheme: dark)');
+    mqlListener = () => applyResolved('system');
+    mql.addEventListener('change', mqlListener);
+  }
+}
+
+/** 起動時に保存済みテーマを適用する (main.tsx から呼ぶ)。 */
+export function initTheme(): void {
+  applyTheme(getTheme());
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -28,9 +28,11 @@ import { SessionProvider } from '@/components/session-provider';
 import { ConfigProvider } from '@/components/config-provider';
 import { ComposeProvider } from '@/components/compose-modal';
 import { initFontScale } from '@/lib/font-scale';
+import { initTheme } from '@/lib/theme';
 import '@/styles.css';
 
 initFontScale();
+initTheme();
 
 const router = createBrowserRouter([
   {

--- a/apps/web/src/routes/friends.tsx
+++ b/apps/web/src/routes/friends.tsx
@@ -171,8 +171,8 @@ function RunningView({ state }: { state: Extract<RunState, { status: 'running' }
           position: 'relative',
           width: '100%',
           height: '10px',
-          background: 'rgba(255,255,255,0.2)',
-          border: '1px solid rgba(255,255,255,0.6)',
+          background: 'var(--color-track-bg)',
+          border: '1px solid var(--color-track-border)',
           borderRadius: 5,
           overflow: 'hidden',
         }}

--- a/apps/web/src/routes/me.tsx
+++ b/apps/web/src/routes/me.tsx
@@ -226,8 +226,8 @@ export function MyProfile() {
               position: 'relative',
               width: '100%',
               height: '10px',
-              background: 'rgba(255,255,255,0.2)',
-              border: '1px solid rgba(255,255,255,0.6)',
+              background: 'var(--color-track-bg)',
+              border: '1px solid var(--color-track-border)',
               borderRadius: 5,
               overflow: 'hidden',
             }}

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -243,10 +243,10 @@ export function Settings() {
                     style={{
                       padding: '0.5em 0.5em 0.5em 0.8em',
                       fontSize: '0.85em',
-                      background: isCurrent ? 'rgba(255,255,255,0.18)' : 'rgba(0,0,0,0.4)',
-                      border: `2px solid ${isCurrent ? '#ffffff' : 'rgba(255,255,255,0.5)'}`,
+                      background: isCurrent ? 'var(--color-item-selected-bg)' : 'var(--color-item-bg)',
+                      border: `2px solid ${isCurrent ? 'var(--color-item-selected-border)' : 'var(--color-item-border)'}`,
                       borderRadius: 2,
-                      color: '#ffffff',
+                      color: 'var(--color-fg)',
                       cursor: targetBusy ? 'wait' : 'pointer',
                       display: 'flex',
                       alignItems: 'center',

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -7,8 +7,9 @@ import { useSession } from '@/lib/session';
 import { signOut } from '@/lib/oauth';
 import { createTaggedPost, getRecord, putRecord } from '@/lib/atproto';
 import { COL } from '@/lib/collections';
-import { getAutoTranslate, setAutoTranslate, getAnalyzePosts, setAnalyzePosts, getHideReposts, setHideReposts, getFontScale, setFontScale, FONT_SCALE_MIN, FONT_SCALE_MAX, FONT_SCALE_DEFAULT, clampFontScale, getPostQuestNotifications, setPostQuestNotifications, getPostQuestNotificationsDefault } from '@/lib/prefs';
+import { getAutoTranslate, setAutoTranslate, getAnalyzePosts, setAnalyzePosts, getHideReposts, setHideReposts, getFontScale, setFontScale, FONT_SCALE_MIN, FONT_SCALE_MAX, FONT_SCALE_DEFAULT, clampFontScale, getPostQuestNotifications, setPostQuestNotifications, getPostQuestNotificationsDefault, getTheme, type ThemeChoice } from '@/lib/prefs';
 import { applyFontScale } from '@/lib/font-scale';
+import { applyTheme } from '@/lib/theme';
 import { APP_VERSION } from '@/lib/app-version';
 import { TextField } from '@/components/text-field';
 import { RadarChart } from '@/components/radar-chart';
@@ -325,6 +326,7 @@ export function Settings() {
 
       <section style={{ marginTop: '2em' }}>
         <h3 style={{ fontSize: '0.95em' }}>表示設定</h3>
+        <ThemeSelector />
         <FontScaleSlider />
         <AutoTranslateToggle />
         <AnalyzePostsToggle />
@@ -378,6 +380,53 @@ function AppVersionFooter() {
       >
         {copied ? 'コピーしました' : label}
       </button>
+    </div>
+  );
+}
+
+const THEME_OPTIONS: ReadonlyArray<{ value: ThemeChoice; label: string }> = [
+  { value: 'system', label: 'システム' },
+  { value: 'light', label: 'ライト' },
+  { value: 'dark', label: 'ダーク' },
+];
+
+function ThemeSelector() {
+  const [choice, setChoice] = useState<ThemeChoice>(() => getTheme());
+
+  function pick(v: ThemeChoice) {
+    setChoice(v);
+    applyTheme(v);    // 保存 + 即時 <html data-theme> 反映 + system 監視の張り直し
+  }
+
+  return (
+    <div style={{ marginTop: '0.5em', marginBottom: '0.8em' }}>
+      <div style={{ fontSize: '0.9em', marginBottom: '0.4em' }}>テーマ</div>
+      <div role="radiogroup" aria-label="テーマ" style={{ display: 'flex', gap: '0.4em' }}>
+        {THEME_OPTIONS.map((opt) => {
+          const active = choice === opt.value;
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              role="radio"
+              aria-checked={active}
+              onClick={() => pick(opt.value)}
+              style={{
+                flex: 1,
+                padding: '0.4em 0.5em',
+                fontSize: '0.85em',
+                fontWeight: active ? 700 : 400,
+                background: active ? 'var(--color-accent)' : 'var(--color-window-bg)',
+                color: active ? 'var(--color-on-accent)' : 'var(--color-fg)',
+                borderColor: active ? 'var(--color-accent-deep)' : 'var(--color-border)',
+              }}
+            >{opt.label}</button>
+          );
+        })}
+      </div>
+      <p style={{ fontSize: '0.75em', color: 'var(--color-muted)', marginTop: '0.3em' }}>
+        画面全体の配色を切り替えます。「システム」は端末の設定 (ダーク/ライト) に追従します。
+      </p>
     </div>
   );
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -26,7 +26,33 @@
   /* accent 背景の上に乗せる文字色 (選択日セルなど)。濃紺で十分なコントラスト。 */
   --color-on-accent: #06223a;
 
+  /* モバイルで青空/草地を隠す全画面背景 (PR #144 の全幅ダーク)。
+     ライトでは明色に切り替える。 */
+  --color-mobile-bg: #0e1318;
+  /* 投稿と投稿の間の区切り線 (VirtualFeed の border-top)。 */
+  --color-feed-divider: rgba(255, 255, 255, 0.5);
+
   --font-main: 'Hiragino Maru Gothic ProN', 'Hiragino Maru Gothic Pro', 'Noto Sans JP', sans-serif;
+}
+
+/*
+ * ライトテーマ。「世界観を残して明るく」方針: 青空グラデーションとヘッダー紺は
+ * 両モード共通で残し、ウィンドウ地・文字色・境界・accent だけを明色へ反転する。
+ * data-theme は theme.ts が常に解決後の 'light'|'dark' を入れる。ダークは :root 既定。
+ */
+:root[data-theme='light'] {
+  --color-primary: #15212c;
+  --color-accent: #2b7cc0;
+  --color-accent-deep: #1f5e96;
+  --color-fg: #15212c;
+  --color-muted: #51616f;
+  --color-border: #38506a;
+  --color-window-bg: rgba(255, 255, 255, 0.9);
+  --color-window-bg-alt: rgba(255, 255, 255, 0.97);
+  --color-window-inner-border: rgba(0, 0, 0, 0.16);
+  --color-on-accent: #ffffff;
+  --color-mobile-bg: #cfe6f3;
+  --color-feed-divider: rgba(0, 0, 0, 0.16);
 }
 
 * {
@@ -500,7 +526,7 @@ p { margin: 0.4em 0; }
 @media (max-width: 767px) {
   /* 青空/草原を出さない。body を不透明ダークにして、どの隙間 (外枠・footer 下・
      カラム下端) からも地面/空が透けない (= 緑のにじみ・外枠透け・隙間を一掃)。 */
-  body { background: #0e1318; }
+  body { background: var(--color-mobile-bg); }
   /* base body::before の白い雲もモバイルでは消す (ダーク統一の徹底) */
   body::before { display: none; }
 
@@ -577,7 +603,7 @@ p { margin: 0.4em 0; }
        translateY で隙間なく重ねるため、border-bottom だと次の投稿 (後に描画) の
        背景が前の投稿の下端 1px を覆って線が消える (= 濃さを上げても見えなかった真因)。
        border-top は「線を持つ投稿自身」が後に描画されるので覆われず確実に見える。 */
-    border-top: 1px solid rgba(255, 255, 255, 0.5);
+    border-top: 1px solid var(--color-feed-divider);
     border-radius: 0;
     box-shadow: none;
     padding-left: 0;
@@ -655,7 +681,7 @@ p { margin: 0.4em 0; }
   flex: 1;
   padding: 1em;
   margin: 0.6em 0.5em;
-  background: rgba(0, 0, 0, 0.72);
+  background: var(--color-window-bg);
   color: var(--color-fg);
   border: 3px solid var(--color-border);
   border-radius: 3px;
@@ -694,7 +720,7 @@ p { margin: 0.4em 0; }
   align-items: center;
   justify-content: center;
   padding: 0;
-  color: #ffffff;
+  color: var(--color-fg);
   background: var(--color-window-bg);
   border: 3px solid var(--color-border);
   border-radius: 3px;
@@ -734,7 +760,7 @@ p { margin: 0.4em 0; }
   align-items: center;
   justify-content: center;
   padding: 0.45em 0.2em;
-  color: #ffffff;
+  color: var(--color-fg);
   opacity: 0.55;
   border: none;
   border-radius: 8px;
@@ -1739,3 +1765,71 @@ p { margin: 0.4em 0; }
   margin-top: 0.6em;
 }
 .dtp-actions button { font-size: 0.85em; padding: 0.25em 0.8em; }
+
+/* ═══════════════════════════════════════════════════════════════════
+   ライトテーマの個別補正
+   ───────────────────────────────────────────────────────────────────
+   大半のサーフェス (ウィンドウ地・文字・境界・accent) は :root の
+   トークンを :root[data-theme='light'] で差し替えるだけで反転する。
+   ここに置くのは「ダーク前提で焼き込まれた」リテラル色 —
+   半透明黒パネル・白文字・白ホバー — だけ。ライトでそのまま使うと
+   白地に白で消える/コントラスト不足になるものをライト専用で上書きする。
+
+   全ルールを :root[data-theme='light'] 配下に閉じてあるので、ダーク
+   (:root 既定) の既存ルールには一切触れない (= ダークは byte 不変)。
+   セレクタに [data-theme='light'] が付くぶん特異度が base より高いので、
+   ソース順に依らず確実に勝つ。
+   ═══════════════════════════════════════════════════════════════════ */
+
+/* リンク hover の白は明地で消えるので accent-deep に */
+:root[data-theme='light'] a:hover {
+  color: var(--color-accent-deep);
+  border-bottom-color: var(--color-accent-deep);
+}
+
+/* 焼き込み黒パネル → ウィンドウ地に合わせて明色に */
+:root[data-theme='light'] .board-column {
+  background: rgba(255, 255, 255, 0.82);
+}
+
+/* タブ見出し: 焼き込み黒 + 白文字 → 明色ピル。アクティブは accent で塗る。 */
+:root[data-theme='light'] .dq-tab {
+  background: rgba(0, 0, 0, 0.05);
+  color: var(--color-muted);
+  border-color: rgba(0, 0, 0, 0.2);
+}
+:root[data-theme='light'] .dq-tab:hover {
+  color: var(--color-fg);
+  border-color: var(--color-accent-deep);
+}
+:root[data-theme='light'] .dq-tab:active:not(.active) {
+  background: rgba(0, 0, 0, 0.08);
+}
+:root[data-theme='light'] .dq-tab.active {
+  background: var(--color-accent);
+  color: var(--color-on-accent);
+  border-color: var(--color-accent-deep);
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.4),
+    0 0 0 1px rgba(0, 0, 0, 0.12);
+}
+
+/* 白ホバー/アクティブのオーバーレイ → 明地では暗く反転 */
+:root[data-theme='light'] .workspace-column-menu-btn:hover:not(:disabled),
+:root[data-theme='light'] .workspace-column-refresh-btn:hover:not(:disabled),
+:root[data-theme='light'] .workspace-column-totop-btn:hover:not(:disabled),
+:root[data-theme='light'] .footer-nav-item:hover {
+  background: rgba(0, 0, 0, 0.06);
+}
+:root[data-theme='light'] .footer-nav-item:active {
+  background: rgba(0, 0, 0, 0.12);
+}
+/* 選択中タブ: 白ハイライトは明地で消えて現在地が分からないので暗く */
+:root[data-theme='light'] .footer-nav-item.active {
+  background: rgba(0, 0, 0, 0.08);
+}
+
+/* カラム間リサイザーの縦線 (白) → 明地では暗い線で発見性を確保 */
+:root[data-theme='light'] .workspace-column-resizer::after {
+  background: rgba(0, 0, 0, 0.18);
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -32,6 +32,24 @@
   /* 投稿と投稿の間の区切り線 (VirtualFeed の border-top)。 */
   --color-feed-divider: rgba(255, 255, 255, 0.5);
 
+  /* ── インラインスタイルがダーク前提で焼き込んでいた半透明色のトークン化 ──
+     tsx の style={{}} は CSS セレクタで上書きできないため、ライト追従には
+     値そのものをトークン経由にするしかない。ダーク既定値は元のリテラルに
+     合わせてある (= ダーク非干渉)。ライトは :root[data-theme='light'] で反転。 */
+  /* 選択可能なアイテム/タイル (ジョブ選択ボタン等) */
+  --color-item-bg: rgba(0, 0, 0, 0.4);
+  --color-item-border: rgba(255, 255, 255, 0.5);
+  --color-item-selected-bg: rgba(255, 255, 255, 0.18);
+  --color-item-selected-border: #ffffff;
+  /* 窓内のインセット小パネル (アクティビティ行等) */
+  --color-subpanel-bg: rgba(0, 0, 0, 0.35);
+  --color-subpanel-border: rgba(255, 255, 255, 0.1);
+  /* 進捗バーのトラック (空き部分) */
+  --color-track-bg: rgba(255, 255, 255, 0.2);
+  --color-track-border: rgba(255, 255, 255, 0.6);
+  /* 控えめなオーバーレイ/区切り (バッジ地・hover 地・点線境界) */
+  --color-overlay-soft: rgba(255, 255, 255, 0.1);
+
   --font-main: 'Hiragino Maru Gothic ProN', 'Hiragino Maru Gothic Pro', 'Noto Sans JP', sans-serif;
 }
 
@@ -42,7 +60,8 @@
  */
 :root[data-theme='light'] {
   --color-primary: #15212c;
-  --color-accent: #2b7cc0;
+  /* #2b7cc0 だと白地で 4.42:1 と AA (4.5) をわずかに下回るので一段濃く */
+  --color-accent: #2773b5;
   --color-accent-deep: #1f5e96;
   --color-fg: #15212c;
   --color-muted: #51616f;
@@ -53,6 +72,16 @@
   --color-on-accent: #ffffff;
   --color-mobile-bg: #cfe6f3;
   --color-feed-divider: rgba(0, 0, 0, 0.16);
+  /* インラインスタイル由来トークンのライト反転 */
+  --color-item-bg: rgba(0, 0, 0, 0.05);
+  --color-item-border: rgba(0, 0, 0, 0.2);
+  --color-item-selected-bg: rgba(39, 115, 181, 0.16);
+  --color-item-selected-border: var(--color-accent-deep);
+  --color-subpanel-bg: rgba(0, 0, 0, 0.05);
+  --color-subpanel-border: rgba(0, 0, 0, 0.1);
+  --color-track-bg: rgba(0, 0, 0, 0.1);
+  --color-track-border: rgba(0, 0, 0, 0.2);
+  --color-overlay-soft: rgba(0, 0, 0, 0.08);
 }
 
 * {
@@ -1788,7 +1817,9 @@ p { margin: 0.4em 0; }
 }
 
 /* 焼き込み黒パネル → ウィンドウ地に合わせて明色に */
-:root[data-theme='light'] .board-column {
+:root[data-theme='light'] .board-column,
+:root[data-theme='light'] .workspace-column-menu,
+:root[data-theme='light'] .workspace-column-add {
   background: rgba(255, 255, 255, 0.82);
 }
 
@@ -1797,6 +1828,8 @@ p { margin: 0.4em 0; }
   background: rgba(0, 0, 0, 0.05);
   color: var(--color-muted);
   border-color: rgba(0, 0, 0, 0.2);
+  /* ダークの黒影 (白文字を浮かせる用) は明地で濃文字が滲むので消す */
+  text-shadow: none;
 }
 :root[data-theme='light'] .dq-tab:hover {
   color: var(--color-fg);


### PR DESCRIPTION
## 概要

実質ダーク固定だった配色に **ライトモード** と **システム設定追従** を追加。
スマホ・PC 両方で有効。設定 → 表示設定 → 「テーマ」で システム/ライト/ダーク
を選択できる。

オーナー要望「いまダークモードになってるようなもんだから、ライトモードも
選べるようにして欲しい。スマホもPCも」を受けたもの。方針は AskUserQuestion で
**「世界観を残して明るく」** + 既定 **「システム設定に従う」** に確定済み。

## 方針: 世界観を残して明るく

- 青空 + 草地グラデーションとヘッダー紺は **両モード共通で残す** (世界観維持)。
- ウィンドウ地 / 文字 / 境界 / accent **だけ** を明色へ反転する。

## 実装

| ファイル | 変更 |
|---|---|
| `lib/prefs.ts` | `getTheme`/`setTheme` + `ThemeChoice` ('system'\|'light'\|'dark')、既定 'system' |
| `lib/theme.ts` (新規) | `resolveTheme`/`applyTheme`/`initTheme`。`html[data-theme]` に解決後の 'light'\|'dark' を反映。'system' のとき `matchMedia` で OS テーマ変化を監視 |
| `main.tsx` | 起動時 `initTheme()` (`initFontScale()` と同じ流儀) |
| `styles.css` | `:root` をダーク既定のまま、`:root[data-theme='light']` でトークン差し替え。焼き込みリテラル色をトークン化 + 賄えない焼き込みコンポーネントだけライト専用補正 (ダークは byte 不変) |
| `routes/settings.tsx` | 表示設定に「テーマ」セグメント (システム/ライト/ダーク) |
| `components/action-link.tsx` | CTA ピルをウィンドウトークンに乗せてテーマ追従 |

## ダーク非干渉の担保

ライト用の個別補正はすべて `:root[data-theme='light']` 配下に閉じてあり、
`[data-theme='light']` のぶん特異度が base より高いのでソース順に依らず勝つ。
**ダーク (`:root` 既定) の既存ルールには一切触れていない。**

## 検証

- `typecheck` / `build` / `test` (198 passed) 緑。
- 実ビルド CSS (`dist/assets/index-*.css`) を Playwright で両モードレンダリングし、
  算出色を確認:
  - **ダーク**: `.content` 地 rgba(0,0,0,.78)・dq-tab 白枠・footer 白ハイライト …
    すべて従来と byte 一致 (リグレッション無し)。
  - **ライト**: body 文字 rgb(21,33,44)・`.content` 白地・active タブ accent 青 +
    白文字・footer active 暗オーバーレイ … 明地で読めることを確認。


## Review

PR 作成後、§1.5 の 3 並列 subagent レビュー (設計 / 実装 / UX) を実施。検出と対応:

### ★★★ (致命的 — PR 内で必ず修正) — 1 件、対応済
- **設計レビュー指摘**: インラインスタイル (style={{}}) の焼き込み色は CSS で
  上書きできず、デフォルト可視画面 (設定/ホーム/me/friends) がライトで崩れる。
  特に設定のジョブ選択ボタンは選択時に**白文字+白枠+白地で読めない**。
  → commit `e17a83a`: 意味トークン 9 個を新設しダーク既定値を元リテラルに一致
    させたうえでライト反転。settings (ジョブ選択) / home-summary (アクティビティ
    行・バッジ・カテゴリボタン・区切り) / me・friends (進捗トラック) を置換。

### ★★ (対応 or issue 化) — 対応済 + 一部 issue
- **accent コントラスト** (UX): ライト accent #2b7cc0 が 4.42:1 で AA 未達
  → #2773b5 に。`e17a83a`
- **.dq-tab text-shadow 残り** (実装/UX): ライトで濃文字が滲む → `text-shadow:none`。`e17a83a`
- **PC workspace ドロップダウン/追加タイルの黒浮き** (UX): `.workspace-column-menu`
  /`.workspace-column-add` をライト補正。`e17a83a`
- **theme.ts ユニットテスト不在** (実装): resolveTheme / getTheme フォールバック /
  applyTheme の data-theme 反映 / system リスナー張り直し・二重登録防止を追加 (8 ケース)。`e17a83a`
- **残りのインラインリテラル色** (profile/spirit/quests/compose/post-metrics 等): → #164
- **初回ロードの FOUC** (設計/実装): index.html pre-paint script で別途排除 → #165

### ★ (柔軟) — 記録のみ / issue
- ダーク微変化 (action-link pill 0.45→窓トークン, .content 0.72→0.78): トークン
  統一による意図的変更。可読性は向上方向。コミットに記録済。
- radiogroup の矢印キー roving / focus-visible: #164 に含める。
- SSR フォールバック light 固定: 本アプリは CSR のみで実害なし。

### 検証
- typecheck / build / test (206 passed, +8 theme) 緑。
- 実ビルド CSS を Playwright で両モードレンダリングし算出色 + コントラスト確認:
  ダークは settings/home/me/friends で byte 一致、ライトは fg 16.33:1 / muted 6.38:1。
