### PR TITLE
fix(theme): ダーク不変性を厳密化 (.content/ピル専用トークン)

### DIFF
--- a/apps/web/src/components/action-link.tsx
+++ b/apps/web/src/components/action-link.tsx
@@ -32,16 +32,16 @@ const pillStyle: CSSProperties = {
   alignItems: 'center',
   gap: '0.4em',
   padding: '0.35em 0.8em',
-  // ウィンドウトークンに乗せてテーマ追従させる (ダーク: 黒地+白文字 /
-  // ライト: 白地+濃紺文字)。リテラル色で焼き込むとライトで浮くため。
-  background: 'var(--color-window-bg)',
-  border: '2px solid var(--color-border)',
+  // ピル専用トークンでテーマ追従させる (ダーク: 薄黒地+白枠+白文字 /
+  // ライト: 白地+濃紺枠+濃紺文字)。ダーク値は元リテラルに一致 = ダーク不変。
+  background: 'var(--color-pill-bg)',
+  border: '2px solid var(--color-pill-border)',
   borderRadius: '2px',
   color: 'var(--color-fg)',
   textDecoration: 'none',
   fontSize: '0.95em',
   fontWeight: 500,
-  boxShadow: 'inset 0 0 0 1px var(--color-window-inner-border)',
+  boxShadow: 'inset 0 0 0 1px var(--color-pill-inner)',
   WebkitTapHighlightColor: 'transparent',
   transition: 'background-color 80ms ease, transform 60ms ease',
 };

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -35,7 +35,14 @@
   /* ── インラインスタイルがダーク前提で焼き込んでいた半透明色のトークン化 ──
      tsx の style={{}} は CSS セレクタで上書きできないため、ライト追従には
      値そのものをトークン経由にするしかない。ダーク既定値は元のリテラルに
-     合わせてある (= ダーク非干渉)。ライトは :root[data-theme='light'] で反転。 */
+     合わせてある (共通トークン化で残る差は控えめオーバーレイの ±0.05 程度のみ)。
+     ライトは :root[data-theme='light'] で反転。 */
+  /* .content (メインのウィンドウ地)。他の窓 (0.78) より僅かに薄い 0.72。 */
+  --color-content-bg: rgba(0, 0, 0, 0.72);
+  /* CTA ピル (action-link)。窓と区別するため独自の薄黒地 + 白枠。 */
+  --color-pill-bg: rgba(0, 0, 0, 0.45);
+  --color-pill-border: rgba(255, 255, 255, 0.85);
+  --color-pill-inner: rgba(255, 255, 255, 0.2);
   /* 選択可能なアイテム/タイル (ジョブ選択ボタン等) */
   --color-item-bg: rgba(0, 0, 0, 0.4);
   --color-item-border: rgba(255, 255, 255, 0.5);
@@ -82,6 +89,10 @@
   --color-track-bg: rgba(0, 0, 0, 0.1);
   --color-track-border: rgba(0, 0, 0, 0.2);
   --color-overlay-soft: rgba(0, 0, 0, 0.08);
+  --color-content-bg: rgba(255, 255, 255, 0.9);
+  --color-pill-bg: rgba(255, 255, 255, 0.85);
+  --color-pill-border: var(--color-border);
+  --color-pill-inner: rgba(0, 0, 0, 0.12);
 }
 
 * {
@@ -710,7 +721,7 @@ p { margin: 0.4em 0; }
   flex: 1;
   padding: 1em;
   margin: 0.6em 0.5em;
-  background: var(--color-window-bg);
+  background: var(--color-content-bg);
   color: var(--color-fg);
   border: 3px solid var(--color-border);
   border-radius: 3px;


### PR DESCRIPTION
PR #167 集約レビューの ★★ 対応。共通 window トークン化でダーク (全既存ユーザーの既定) の .content (0.72→0.78) と action-link ピル (0.45→0.78) が変化していたのを、専用トークン (--color-content-bg / --color-pill-*) でダーク既定値を元リテラルに一致させて解消。ライトのみ反転。

実ビルド CSS を Playwright で検証: ダーク = content rgba(0,0,0,0.72) / pill rgba(0,0,0,0.45) / pill border rgba(255,255,255,0.85) と **元リテラルに byte 一致**。ライト = 白地 + 濃紺枠。typecheck/build/test(206) 緑。

CSS/定数のみ・ロジック非干渉。