### PR TITLE
fix(layout): モバイルでカラム見出しがヘッダーにめり込む不具合

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -101,7 +101,13 @@
 
 html, body {
   margin: 0;
+  /* dvh (動的ビューポート) に合わせる。ワークスペースのカラム高は 100dvh 基準
+     なのに、こことシェルが 100vh (= モバイル Safari ではアドレスバー表示時の
+     大きい方) だと、URL バーが出ている間だけシェルが可視領域より高くなり、
+     ページ自体がスクロール → sticky ヘッダーの下にカラム見出しがめり込み、
+     最下部に隙間ができる。vh は古いブラウザ向けの fallback。 */
   min-height: 100vh;
+  min-height: 100dvh;
 }
 
 body {
@@ -239,7 +245,11 @@ p { margin: 0.4em 0; }
   position: relative;
   z-index: 1;
   max-width: 420px;
+  /* カラム高 (100dvh - chrome) と単位を揃える。100vh のままだとモバイルで
+     アドレスバー表示時にシェルが可視領域を超え、ページがスクロールして
+     カラム見出しがヘッダー下にめり込む (vh は fallback)。 */
   min-height: 100vh;
+  min-height: 100dvh;
   margin: 0 auto;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## 症状
モバイルで、ワークスペースのカラム見出し (「ホーム」等) が「あおぞらくえすと」の
アプリヘッダーの下にめり込んでしまうことがある。その結果、画面下部にも隙間ができる。
(オーナー報告 + スクショ。発生は「ことがある」= 断続的)

## 根本原因
- ワークスペースのカラム高は `calc(100dvh - chrome)` で **動的ビューポート (dvh)** 基準。
- 一方 `html, body` と `.app-shell` の縦サイズは **`100vh`** のままだった。
- モバイル Safari の `100vh` は **アドレスバー表示時の大きい方**のビューポートを指す。
  → URL バーが出ている間だけシェルが可視領域 (`100dvh`) より高くなり、**ページ自体が
    スクロール可能**になる。その状態でスクロールすると、`position:sticky` のアプリ
    ヘッダーは画面上端に貼り付いたまま、カラム見出しが**その下にめり込む**。余った
    高さぶん最下部に**隙間**ができる。
- 「ことがある」= アドレスバーの表示状態 (`100vh` と `100dvh` が一致するか) に依存。

## 修正
`html, body` と `.app-shell` の `min-height` を `100dvh` に揃える (カラム高と同単位)。
`100vh` は dvh 非対応の古いブラウザ向け fallback として残す (2 段宣言)。
これでシェル・本文・カラムが全て動的ビューポートに追従し、URL バー開閉でズレない。

## 検証
- typecheck / build / test (206) 緑。
- **dvh と vh の差はモバイル Safari の URL バー挙動に依存し、headless では再現不可**
  (headless Chromium は dvh==vh)。→ **実機 iPhone での確認が必須**。dev デプロイ後に
  オーナーに確認依頼。

## Review
§1.5 の 3 並列レビュー (設計 / 実装 / UX) を実施 → **★★★ ゼロ = 出荷可**。

- 3 観点とも「シェル 100vh とカラム 100dvh の単位不一致が根本原因」「dvh への統一は根本修正 (ハックでない)」「fallback の 2 段宣言の順序も正しい」「既存コードが既に dvh 全面依存なので新規依存なし」「dvh==vh 環境 (PC/多くの Android) では実質無変更」「footer/safe-area・非 workspace のフッター位置はむしろ改善」と一致。
- **★★ (issue #170 化)**: (1) `.board-column max-height: calc(100vh - 12em)` の同根の単位不整合 (別 route)、(2) `--shell-chrome-height` (px) と 100dvh のアドレスバー遷移中の一過性ズレ (本 PR 起因でない既存課題)。いずれも本 PR スコープ外 → #170。
- **★ (記録)**: svh でなく dvh を選んだ理由 = カラム高と単位統一 + アドレスバー隠れ時に下端へ隙間が出るのを避けるため。

## 検証
- typecheck / build / test (206) 緑。CSS のみ変更で CI の e2e は自動スキップ (paths-filter)、typecheck/unit/build は実行。
- **dvh 挙動は headless 再現不可** → dev デプロイ後に **実機 iPhone** で確認必須:
  (a) カラム見出しが sticky ヘッダー直下に正しく見える、(b) アドレスバー開閉時に
  カラム下端と footer に隙間が出ない。
