### PR TITLE
chore(release): APP_VERSION 2026.06.17-1

### DIFF
--- a/apps/web/src/lib/app-version.ts
+++ b/apps/web/src/lib/app-version.ts
@@ -12,7 +12,7 @@
  *   3. 同じ値で git tag を打つ:
  *        git tag v2026.06.14-1 && git push origin v2026.06.14-1
  */
-export const APP_VERSION = '2026.06.16-4';
+export const APP_VERSION = '2026.06.17-1';
 
 /** APP_VERSION が `YYYY.MM.DD-N` 形式かを検証する (テスト/CI で形式崩れを検出)。
  *  月 01-12 / 日 01-31 のゼロ詰め 2 桁、枝番は先頭ゼロ不可の 1 以上まで一本でガードする。 */


### PR DESCRIPTION
カラム見出しめり込み修正 (PR #169) の本番リリース用バージョン bump。

- `APP_VERSION` 2026.06.16-4 → 2026.06.17-1 (JST で日付が 6/17 に変わったため枝番 -1)
- 表示バージョンのみ