### PR TITLE
release: モバイルのカラム見出しめり込み修正 (v2026.06.17-1)

### DIFF
--- a/apps/web/src/lib/app-version.ts
+++ b/apps/web/src/lib/app-version.ts
@@ -12,7 +12,7 @@
  *   3. 同じ値で git tag を打つ:
  *        git tag v2026.06.14-1 && git push origin v2026.06.14-1
  */
-export const APP_VERSION = '2026.06.16-4';
+export const APP_VERSION = '2026.06.17-1';
 
 /** APP_VERSION が `YYYY.MM.DD-N` 形式かを検証する (テスト/CI で形式崩れを検出)。
  *  月 01-12 / 日 01-31 のゼロ詰め 2 桁、枝番は先頭ゼロ不可の 1 以上まで一本でガードする。 */

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -101,7 +101,13 @@
 
 html, body {
   margin: 0;
+  /* dvh (動的ビューポート) に合わせる。ワークスペースのカラム高は 100dvh 基準
+     なのに、こことシェルが 100vh (= モバイル Safari ではアドレスバー表示時の
+     大きい方) だと、URL バーが出ている間だけシェルが可視領域より高くなり、
+     ページ自体がスクロール → sticky ヘッダーの下にカラム見出しがめり込み、
+     最下部に隙間ができる。vh は古いブラウザ向けの fallback。 */
   min-height: 100vh;
+  min-height: 100dvh;
 }
 
 body {
@@ -239,7 +245,11 @@ p { margin: 0.4em 0; }
   position: relative;
   z-index: 1;
   max-width: 420px;
+  /* カラム高 (100dvh - chrome) と単位を揃える。100vh のままだとモバイルで
+     アドレスバー表示時にシェルが可視領域を超え、ページがスクロールして
+     カラム見出しがヘッダー下にめり込む (vh は fallback)。 */
   min-height: 100vh;
+  min-height: 100dvh;
   margin: 0 auto;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## リリース内容: モバイルのカラム見出しめり込み修正 (v2026.06.17-1)

### 含まれる PR
- **#169** モバイルでワークスペースのカラム見出しがアプリヘッダー下にめり込み、最下部に隙間ができる不具合を修正。
  - 原因: カラム高は `100dvh` 基準なのに `html/body` と `.app-shell` が `100vh` のままで、モバイル Safari の URL バー表示時にシェルが可視領域を超えてページがスクロールしていた。
  - 修正: シェルの `min-height` を `100dvh` に統一 (`100vh` は fallback)。
  - §1.5 3 並列レビュー ★★★ ゼロ。残った同根の小課題は issue #170。
  - **オーナーが dev で実機 iPhone 確認済 (直っている)**。

### バージョン
- `APP_VERSION` 2026.06.16-4 → **2026.06.17-1** (JST で日付が 6/17 に変わったため枝番 -1、PR #171 で dev 反映済)

## Review
dev→main 集約レビュー (本番リスク・APP_VERSION 妥当性) を §1.5 に従い実施し追記する。

---
## Review (dev→main 集約レビュー)
feature PR #169 は個別 §1.5 3 並列レビュー済 + オーナー実機 iPhone 確認済。集約は本番リスク・スコープ・バージョンに特化 → **★★★ ゼロ = リリース可**。

- **APP_VERSION 妥当**: 2026.06.16-4 → 2026.06.17-1。PATTERN 合致。JST で日付が 6/17 に変わったため新しい日の枝番 -1 が正しい。
- **スコープ**: 差分は apps/web/src の 2 ファイルのみ (styles.css の min-height 2段宣言 + app-version.ts)。CI/設定/secrets 混入なし。git log で #169 + バージョン bump の 2 コミットのみ、予期しない変更なし。
- **本番リスク**: min-height 100vh→100dvh (fallback 100vh) は段階宣言で古ブラウザは vh に安全 fallback。PC/多くの Android は dvh==vh で実質無変更。破壊的変更なし。
