### PR TITLE
fix(theme): 初回ロードの FOUC を pre-paint script で排除 (closes #165)

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -8,6 +8,25 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="theme-color" content="#378ADD">
   <title>あおぞらくえすと</title>
+  <!-- テーマの初回ペイント前適用 (FOUC 防止)。CSS の :root 既定はダークなので、
+       ライト/システム(=OS ライト) のユーザーは JS バンドル評価まで一瞬ダークが
+       ちらつく。ここで lib/theme.ts と同じ解決を first paint 前に走らせて
+       <html data-theme> を確定させる。main.tsx の initTheme() が後で再適用
+       (冪等) + system 監視を張る。キーは prefs.ts の KEY_THEME と一致させること。 -->
+  <script>
+    (function () {
+      try {
+        var t = localStorage.getItem('aozoraquest:theme');
+        if (t !== 'light' && t !== 'dark' && t !== 'system') t = 'system';
+        var resolved = t;
+        if (t === 'system') {
+          resolved = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches)
+            ? 'dark' : 'light';
+        }
+        document.documentElement.setAttribute('data-theme', resolved);
+      } catch (e) { /* localStorage 不可時は CSS の :root 既定 (ダーク) のまま */ }
+    })();
+  </script>
 </head>
 <body>
   <div id="root"></div>


### PR DESCRIPTION
## 概要
ライト/システム(OS ライト)のユーザーが初回ロードで一瞬ダークがちらつく FOUC を、index.html の `<head>` に最小インラインスクリプトを置いて first paint 前に `<html data-theme>` を確定させることで排除。

## 実装
- `index.html`: localStorage `aozoraquest:theme` + `prefers-color-scheme` を読み、lib/theme.ts と同じ規則で 'light'|'dark' を解決して data-theme を即時セット。
- main.tsx の initTheme() は後で再適用(冪等)+ system 監視を張る。
- pre-paint 実行はインライン即時実行が必須(モジュール import を待つと paint 後)。resolveTheme ロジックの重複は許容し、キー名・解決規則を theme.ts と一致 (コメントで明示)。

## 検証
- typecheck / test (206) 緑。Vite ビルドでインラインスクリプトは dist/index.html に保持。
- 実 dist を Playwright で検証: saved=light/dark、system×OS dark/light、未設定×OS light の 5 ケースとも **バンドル評価前に** data-theme が正しく確定。



## Review
§1.5 レビュー (実装/セキュリティ + UX) → **★★★/★★ ゼロ = 出荷可**。
- 実装: 解決規則・キー名が theme.ts/prefs.ts と完全一致 (ちらつき再発なし)、localStorage 値は 'light'|'dark'|'system' に厳格ホワイトリスト化で XSS/属性インジェクションなし、try/catch で例外吸収、initTheme() 二重適用は冪等、Vite ビルドで dist に保持を確認。
- UX: モバイル背景 (--color-mobile-bg) がテーマ依存で初回ペイントの支配色のため効果大、theme-color 紺据え置きは妥当、ダークユーザーは体感不変。
- **★ (記録)**: `public/_headers` の **Report-Only** CSP `script-src` を将来 enforce へ昇格させる際は、このインラインスクリプトに `sha256-` hash か nonce が必要 (無いと FOUC 再発)。昇格時の対応事項として記録。
