### PR TITLE
fix(theme): ライトで崩れる残りのインライン色をトークン化 + レーダー目盛り (closes #164)

### DIFF
--- a/apps/web/src/components/avatar.tsx
+++ b/apps/web/src/components/avatar.tsx
@@ -33,7 +33,7 @@ export function Avatar({ src, alt = '', size = 32, style, archetype }: AvatarPro
     height: size,
     borderRadius: '50%',
     overflow: 'hidden',
-    backgroundColor: 'rgba(255, 255, 255, 0.08)',
+    backgroundColor: 'var(--color-overlay-soft)',
     boxShadow: equipment
       ? `0 0 0 2px rgba(0,0,0,0.9), 0 0 0 4px ${equipment.accentColor}`
       : 'none',

--- a/apps/web/src/components/compose-modal.tsx
+++ b/apps/web/src/components/compose-modal.tsx
@@ -451,7 +451,7 @@ function ComposeDialog({
             style={{
               padding: '0.5em 0.7em',
               borderLeft: '3px solid var(--color-accent)',
-              background: 'rgba(255, 255, 255, 0.06)',
+              background: 'var(--color-overlay-soft)',
               borderRadius: 2,
               marginBottom: '0.5em',
               fontSize: '0.85em',
@@ -488,13 +488,13 @@ function ComposeDialog({
               <div
                 key={im.previewUrl}
                 style={{
-                  border: '1px solid rgba(255,255,255,0.18)',
+                  border: '1px solid var(--color-subpanel-border)',
                   borderRadius: 6,
                   padding: '0.5em',
                   display: 'flex',
                   gap: '0.6em',
                   alignItems: 'flex-start',
-                  background: 'rgba(0,0,0,0.25)',
+                  background: 'var(--color-subpanel-bg)',
                 }}
               >
                 <img

--- a/apps/web/src/components/post-external.tsx
+++ b/apps/web/src/components/post-external.tsx
@@ -55,7 +55,7 @@ export function PostExternalCard({ external }: { external: PostExternal }) {
         padding: 8,
         border: '1px solid var(--color-border)',
         borderRadius: 6,
-        background: 'rgba(255, 255, 255, 0.03)',
+        background: 'var(--color-overlay-soft)',
       }}
       onClick={(e) => e.stopPropagation()}
     >

--- a/apps/web/src/components/post-metrics.tsx
+++ b/apps/web/src/components/post-metrics.tsx
@@ -169,7 +169,7 @@ export function PostMetrics({ post, onToggleThread, threadExpanded }: PostMetric
               borderRadius: 4,
               fontFamily: 'ui-monospace, monospace',
             }}
-            onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = 'rgba(255,255,255,0.06)')}
+            onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = 'var(--color-overlay-soft)')}
             onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = 'transparent')}
           >
             {threadExpanded ? '▲ 閉じる' : '▼ スレッド'}
@@ -217,7 +217,7 @@ function MetricButton({
         whiteSpace: 'nowrap',
         transition: 'color 120ms ease, background-color 120ms ease',
       }}
-      onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = 'rgba(255,255,255,0.06)')}
+      onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = 'var(--color-overlay-soft)')}
       onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = 'transparent')}
     >
       {children}

--- a/apps/web/src/components/radar-chart.tsx
+++ b/apps/web/src/components/radar-chart.tsx
@@ -110,7 +110,7 @@ export function RadarChart({ stats, compare, size = 220, max = 100, normalize = 
             key={idx}
             d={d}
             fill="none"
-            stroke="rgba(255,255,255,0.25)"
+            stroke="var(--color-chart-grid)"
             strokeWidth={1}
           />
         );
@@ -124,7 +124,7 @@ export function RadarChart({ stats, compare, size = 220, max = 100, normalize = 
           y1={cy}
           x2={cx + v.x * radius}
           y2={cy + v.y * radius}
-          stroke="rgba(255,255,255,0.25)"
+          stroke="var(--color-chart-grid)"
           strokeWidth={1}
         />
       ))}
@@ -159,7 +159,7 @@ export function RadarChart({ stats, compare, size = 220, max = 100, normalize = 
             x={p.x}
             y={p.y}
             fontSize={fontSize}
-            fill="#ffffff"
+            fill="var(--color-fg)"
             textAnchor="middle"
             dominantBaseline="central"
             style={{ userSelect: 'none' }}

--- a/apps/web/src/components/radar-chart.tsx
+++ b/apps/web/src/components/radar-chart.tsx
@@ -133,16 +133,18 @@ export function RadarChart({ stats, compare, size = 220, max = 100, normalize = 
       {comparePath && (
         <path
           d={comparePath}
-          fill="rgba(255, 170, 110, 0.22)"
-          stroke="#ffaa6e"
+          fill="var(--color-radar-compare)"
+          fillOpacity={0.22}
+          stroke="var(--color-radar-compare)"
           strokeWidth={2}
           strokeDasharray="4 3"
           strokeLinejoin="round"
         />
       )}
 
-      {/* データ多角形 (= 自分) */}
-      <path d={valuePath} fill="rgba(159, 215, 255, 0.35)" stroke="var(--color-accent)" strokeWidth={2} strokeLinejoin="round" />
+      {/* データ多角形 (= 自分)。fill は accent + fillOpacity でテーマ追従
+         (ダーク accent=#9fd7ff なので従来の rgba(159,215,255,0.35) と一致)。 */}
+      <path d={valuePath} fill="var(--color-accent)" fillOpacity={0.35} stroke="var(--color-accent)" strokeWidth={2} strokeLinejoin="round" />
 
       {/* 各頂点の点 */}
       {AXES.map((a, i) => {

--- a/apps/web/src/routes/board-detail.tsx
+++ b/apps/web/src/routes/board-detail.tsx
@@ -405,7 +405,7 @@ export function BoardDetail() {
                 </p>
                 <p style={{ margin: '0.3em 0', fontSize: '0.9em', whiteSpace: 'pre-wrap' }}>{a.message}</p>
                 {pendingAssign === a.did ? (
-                  <div style={{ marginTop: '0.4em', padding: '0.4em', background: 'rgba(255,255,255,0.06)', borderRadius: '2px' }}>
+                  <div style={{ marginTop: '0.4em', padding: '0.4em', background: 'var(--color-overlay-soft)', borderRadius: '2px' }}>
                     <p style={{ margin: '0 0 0.4em', fontSize: '0.85em' }}>
                       <strong><Handle did={a.did} /></strong> を受託者に指定しますか?<br />
                       <span style={{ fontSize: '0.78em', color: 'var(--color-muted)' }}>

--- a/apps/web/src/routes/friends.tsx
+++ b/apps/web/src/routes/friends.tsx
@@ -246,7 +246,7 @@ function RankRow({ entry, rank }: { entry: ResonanceRankEntry; rank: number }) {
         alignItems: 'center',
         gap: '0.8em',
         padding: '0.6em 0.4em',
-        borderBottom: '1px solid rgba(255,255,255,0.15)',
+        borderBottom: '1px solid var(--color-subpanel-border)',
         textAlign: 'left',
         color: 'inherit',
         textDecoration: 'none',

--- a/apps/web/src/routes/portfolio.tsx
+++ b/apps/web/src/routes/portfolio.tsx
@@ -202,7 +202,7 @@ function PortfolioView({ did, agent, isSelf, signedIn }: PortfolioViewProps) {
           <h3 style={{ marginTop: 0, fontSize: '0.95em' }}>保有ポイント (発行者別)</h3>
           <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
             {receivedByIssuer.map(([did, pt]) => (
-              <li key={did} style={{ display: 'flex', justifyContent: 'space-between', padding: '0.3em 0', borderBottom: '1px dotted rgba(255,255,255,0.1)' }}>
+              <li key={did} style={{ display: 'flex', justifyContent: 'space-between', padding: '0.3em 0', borderBottom: '1px dotted var(--color-subpanel-border)' }}>
                 <span><Handle did={did} suffix="ポイント" /></span>
                 <span style={{ fontFamily: 'ui-monospace, monospace', color: 'var(--color-accent)' }}>
                   {pt.toLocaleString()} pt

--- a/apps/web/src/routes/profile.tsx
+++ b/apps/web/src/routes/profile.tsx
@@ -269,7 +269,7 @@ function CompatView({
                   fontSize: '0.9em',
                   fontWeight: 700,
                   color: 'var(--color-fg)',
-                  borderTop: '1px dashed rgba(255,255,255,0.25)',
+                  borderTop: '1px dashed var(--color-subpanel-border)',
                   paddingTop: '0.3em',
                 }}>
                   <span>合計</span>
@@ -312,7 +312,7 @@ function MiniBar({ label, hint, points, max }: { label: string; hint?: string; p
           {points} / {max}
         </span>
       </div>
-      <div style={{ height: 4, background: 'rgba(255,255,255,0.15)', borderRadius: 2, overflow: 'hidden', marginTop: '0.15em' }}>
+      <div style={{ height: 4, background: 'var(--color-track-bg)', borderRadius: 2, overflow: 'hidden', marginTop: '0.15em' }}>
         <div style={{ width: `${pct}%`, height: '100%', background: 'var(--color-accent)' }} />
       </div>
     </div>
@@ -498,7 +498,7 @@ function FollowButton({
         fontSize: '0.85em',
         fontWeight: 700,
         background: following ? 'transparent' : 'var(--color-accent)',
-        color: following ? 'var(--color-fg)' : '#000',
+        color: following ? 'var(--color-fg)' : 'var(--color-on-accent)',
         border: `2px solid ${following ? 'var(--color-border)' : 'var(--color-accent)'}`,
         borderRadius: 4,
         cursor: busy ? 'wait' : 'pointer',

--- a/apps/web/src/routes/quests.tsx
+++ b/apps/web/src/routes/quests.tsx
@@ -374,8 +374,8 @@ function QuestRow({ quest }: { quest: Quest }) {
   return (
     <div
       style={{
-        background: 'rgba(0,0,0,0.25)',
-        border: '1px solid rgba(255,255,255,0.1)',
+        background: 'var(--color-subpanel-bg)',
+        border: '1px solid var(--color-subpanel-border)',
         borderRadius: 4,
         padding: '0.4em 0.5em',
         ...(done ? { opacity: 0.55 } : {}),
@@ -432,8 +432,8 @@ function ActivityRow({ entry }: { entry: ActivityEntry }) {
   return (
     <div
       style={{
-        background: 'rgba(0,0,0,0.4)',
-        border: '1px solid rgba(255,255,255,0.08)',
+        background: 'var(--color-subpanel-bg)',
+        border: '1px solid var(--color-subpanel-border)',
         borderRadius: 4,
         padding: '0.35em 0.5em',
         fontSize: '0.78em',

--- a/apps/web/src/routes/spirit.tsx
+++ b/apps/web/src/routes/spirit.tsx
@@ -358,7 +358,7 @@ export function Spirit() {
             <div style={{ fontSize: '0.8em', color: 'var(--color-muted)', marginBottom: '0.3em' }}>
               あおぞらパワー {points.viaPosts} / {SUMMON_THRESHOLD}
             </div>
-            <div style={{ height: 8, background: 'rgba(255,255,255,0.15)', borderRadius: 4, overflow: 'hidden' }}>
+            <div style={{ height: 8, background: 'var(--color-track-bg)', borderRadius: 4, overflow: 'hidden' }}>
               <div
                 style={{
                   width: `${(points.viaPosts / SUMMON_THRESHOLD) * 100}%`,
@@ -382,9 +382,9 @@ export function Spirit() {
               marginTop: '1em',
               padding: '0.7em 1.6em',
               fontSize: '1em',
-              background: 'rgba(0, 0, 0, 0.6)',
-              color: '#ffffff',
-              border: '3px solid #ffffff',
+              background: 'var(--color-pill-bg)',
+              color: 'var(--color-fg)',
+              border: '3px solid var(--color-pill-border)',
               boxShadow: '0 0 20px rgba(159, 215, 255, 0.45)',
             }}
           >

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -56,6 +56,8 @@
   --color-track-border: rgba(255, 255, 255, 0.6);
   /* 控えめなオーバーレイ/区切り (バッジ地・hover 地・点線境界) */
   --color-overlay-soft: rgba(255, 255, 255, 0.1);
+  /* レーダーチャートのグリッド/軸線 (SVG stroke)。ライトで白だと消えるため */
+  --color-chart-grid: rgba(255, 255, 255, 0.25);
 
   --font-main: 'Hiragino Maru Gothic ProN', 'Hiragino Maru Gothic Pro', 'Noto Sans JP', sans-serif;
 }
@@ -93,6 +95,7 @@
   --color-pill-bg: rgba(255, 255, 255, 0.85);
   --color-pill-border: var(--color-border);
   --color-pill-inner: rgba(0, 0, 0, 0.12);
+  --color-chart-grid: rgba(0, 0, 0, 0.18);
 }
 
 * {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -58,6 +58,8 @@
   --color-overlay-soft: rgba(255, 255, 255, 0.1);
   /* レーダーチャートのグリッド/軸線 (SVG stroke)。ライトで白だと消えるため */
   --color-chart-grid: rgba(255, 255, 255, 0.25);
+  /* レーダーの比較多角形 (目標ジョブ)。ダークは橙、ライトは白地で沈むので濃い橙 */
+  --color-radar-compare: #ffaa6e;
 
   --font-main: 'Hiragino Maru Gothic ProN', 'Hiragino Maru Gothic Pro', 'Noto Sans JP', sans-serif;
 }
@@ -87,7 +89,8 @@
   --color-item-selected-bg: rgba(39, 115, 181, 0.16);
   --color-item-selected-border: var(--color-accent-deep);
   --color-subpanel-bg: rgba(0, 0, 0, 0.05);
-  --color-subpanel-border: rgba(0, 0, 0, 0.1);
+  /* feed-divider (0.16) に揃える。0.1 だと白地でパネル境界が溶けて見えない */
+  --color-subpanel-border: rgba(0, 0, 0, 0.16);
   --color-track-bg: rgba(0, 0, 0, 0.1);
   --color-track-border: rgba(0, 0, 0, 0.2);
   --color-overlay-soft: rgba(0, 0, 0, 0.08);
@@ -96,6 +99,7 @@
   --color-pill-border: var(--color-border);
   --color-pill-inner: rgba(0, 0, 0, 0.12);
   --color-chart-grid: rgba(0, 0, 0, 0.18);
+  --color-radar-compare: #c2571a;
 }
 
 * {


### PR DESCRIPTION
## 概要
ライトモードで崩れる残りのインラインスタイル/SVG の焼き込み色をトークン化 (closes #164)。
**オーナー報告のレーダーチャートの目盛り(グリッド/軸線/ラベル)が白でライト時に
見えなかった問題**を含む。

## 対応
- **radar-chart**: グリッド五角形・軸線を `--color-chart-grid`、軸ラベルを `--color-fg` に。
- 新トークン `--color-chart-grid` (ダーク `rgba(255,255,255,0.25)` / ライト `rgba(0,0,0,0.18)`)。
- profile / spirit / quests / compose-modal / post-metrics / post-external / avatar /
  portfolio / board-detail / friends の焼き込み半透明色を既存トークン
  (`item` / `subpanel` / `track` / `overlay-soft` / `pill`) に寄せる。
  profile のフォローボタン文字 `#000` → `--color-on-accent`。

## 非対象 (意図通り)
spirit-icon (白い雲のマスコット=世界観)、mana-symbol / job-card (固定カード絵)、
media/backdrop の黒 (`#000` / `rgba(0,0,0,.55)`)、debug-me (本番非登録)。

## ダーク非干渉
新旧トークンのダーク既定値は元リテラルに一致 (共通化で残る差は控えめオーバーレイの
±0.05 程度のみ、体感差なし)。

## 検証
- typecheck / build / test (206) 緑。
- 実ビルド CSS を Playwright で検証: radar グリッドが light=`rgba(0,0,0,0.18)` /
  dark=`rgba(255,255,255,0.25)` (ダーク byte 一致)、label が light=濃紺 / dark=白。
  ライトで目盛りが視認できることをスクショで確認。



## Review
§1.5 レビュー (実装 + UX) → **★★★ ゼロ = 出荷可**。
- 実装: 各置換のダーク既定値が元リテラルと一致 (差は控えめオーバーレイの ±0.05、最大でも召喚ボタン地 -0.15 だが発光で視認性は地非依存)、radar の grid/axis 2 箇所とも置換済み、新トークンの :root/light 両定義あり、hover 解除 transparent でリークなし、SVG var() 解決 OK → 出荷可 (★★ なし)。
- UX: レーダー目盛りはライトで明確に視認可。**★★ 2 件を PR 内で対応** (commit 0904bf6):
  - ★★-1: レーダーの compare 多角形(橙)とデータ fill が焼き込みでライト低コントラスト → compare を `--color-radar-compare`(ライト #c2571a)、データ fill を accent+fillOpacity に。ダーク byte 一致。
  - ★★-2: ライト `--color-subpanel-border` を 0.1→0.16 (feed-divider と同値) に強化、白地でパネル境界が溶ける問題を解消。
- ★ (召喚ボタンの儀式感・データ fill 面積) は柔軟。実ビルド CSS を Playwright で両モード検証済 (ダーク byte 一致)。
