### PR TITLE
fix(layout): 掲示板カラム dvh 統一 + visualViewport 再測定 (closes #170)

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -301,7 +301,10 @@ p { margin: 0.4em 0; }
 @media (min-width: 768px) {
   .board-column {
     flex: 0 0 320px;
+    /* ワークスペースのカラム高 (100dvh 基準) と単位を揃える。100vh だと
+       タブレット等のアドレスバー表示時にビューポートを超えうる (vh は fallback)。 */
     max-height: calc(100vh - 12em);
+    max-height: calc(100dvh - 12em);
     overflow-y: auto;
   }
 }


### PR DESCRIPTION
## 概要
PR #169 (カラム見出しめり込み) の集約レビューで残った同根の単位不整合を解消 (closes #170)。

**掲示板カラムの単位統一**: `.board-column { max-height: calc(100vh - 12em) }` を
`calc(100dvh - 12em)` に (vh は dvh 非対応向け fallback)。ワークスペースのカラム高
(100dvh 基準) と揃え、タブレット縦持ち等のアドレスバー表示時にビューポートを超える
潜在バグを解消。dvh==vh の PC では無変更。

## #170 part 2 (アドレスバー遷移中の一過性ズレ) の扱い
当初 visualViewport の resize で chrome を測り直すフックを検討したが、§1.5 レビューで
**header/footer の実 px はバー遷移で変わらず、再測定は実効ほぼ無し (no-op)** と判明。
遷移追従の実体は dvh 統一側 (#169 + 本 PR) が担う。「動かないコードを足さない」方針で
リスナーは入れず、CSS の dvh 統一に絞った。実機 (#169 で確認済) でズレが残るようなら
`visualViewport.height` ベースの CSS 変数化が次の手。

## 検証
- typecheck / build / test (206) 緑。CSS のみ変更。
- dvh 挙動は headless 再現不可 → 実機での最終確認は #169 と同じ経路。

## Review
§1.5 レビュー (実装 + 設計) → **★★★ ゼロ = 出荷可**。
- 両観点とも「part 1 (board-column dvh) は確立済みパターンへの正しい追従・回帰ゼロ」で一致。
- **★★ 対応済**: 「visualViewport で update() 再実行は header/footer 実 px が不変で no-op に近く、コメントが効果を過大に表現」との指摘 → **リスナーを削除し dvh 統一のみに絞った** (動かないコードを残さない)。#170 part 2 は dvh 統一で吸収、実機でズレ残存時のみ visualViewport.height 化を別途検討、と整理。
- ★ (fallback 順序・board コメントの主語) は記録のみ。
