### PR TITLE
release: ライトモード仕上げ + 掲示板カラム dvh (v2026.06.17-2)

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -8,6 +8,25 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="theme-color" content="#378ADD">
   <title>あおぞらくえすと</title>
+  <!-- テーマの初回ペイント前適用 (FOUC 防止)。CSS の :root 既定はダークなので、
+       ライト/システム(=OS ライト) のユーザーは JS バンドル評価まで一瞬ダークが
+       ちらつく。ここで lib/theme.ts と同じ解決を first paint 前に走らせて
+       <html data-theme> を確定させる。main.tsx の initTheme() が後で再適用
+       (冪等) + system 監視を張る。キーは prefs.ts の KEY_THEME と一致させること。 -->
+  <script>
+    (function () {
+      try {
+        var t = localStorage.getItem('aozoraquest:theme');
+        if (t !== 'light' && t !== 'dark' && t !== 'system') t = 'system';
+        var resolved = t;
+        if (t === 'system') {
+          resolved = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches)
+            ? 'dark' : 'light';
+        }
+        document.documentElement.setAttribute('data-theme', resolved);
+      } catch (e) { /* localStorage 不可時は CSS の :root 既定 (ダーク) のまま */ }
+    })();
+  </script>
 </head>
 <body>
   <div id="root"></div>

--- a/apps/web/src/components/avatar.tsx
+++ b/apps/web/src/components/avatar.tsx
@@ -33,7 +33,7 @@ export function Avatar({ src, alt = '', size = 32, style, archetype }: AvatarPro
     height: size,
     borderRadius: '50%',
     overflow: 'hidden',
-    backgroundColor: 'rgba(255, 255, 255, 0.08)',
+    backgroundColor: 'var(--color-overlay-soft)',
     boxShadow: equipment
       ? `0 0 0 2px rgba(0,0,0,0.9), 0 0 0 4px ${equipment.accentColor}`
       : 'none',

--- a/apps/web/src/components/compose-modal.tsx
+++ b/apps/web/src/components/compose-modal.tsx
@@ -451,7 +451,7 @@ function ComposeDialog({
             style={{
               padding: '0.5em 0.7em',
               borderLeft: '3px solid var(--color-accent)',
-              background: 'rgba(255, 255, 255, 0.06)',
+              background: 'var(--color-overlay-soft)',
               borderRadius: 2,
               marginBottom: '0.5em',
               fontSize: '0.85em',
@@ -488,13 +488,13 @@ function ComposeDialog({
               <div
                 key={im.previewUrl}
                 style={{
-                  border: '1px solid rgba(255,255,255,0.18)',
+                  border: '1px solid var(--color-subpanel-border)',
                   borderRadius: 6,
                   padding: '0.5em',
                   display: 'flex',
                   gap: '0.6em',
                   alignItems: 'flex-start',
-                  background: 'rgba(0,0,0,0.25)',
+                  background: 'var(--color-subpanel-bg)',
                 }}
               >
                 <img

--- a/apps/web/src/components/post-external.tsx
+++ b/apps/web/src/components/post-external.tsx
@@ -55,7 +55,7 @@ export function PostExternalCard({ external }: { external: PostExternal }) {
         padding: 8,
         border: '1px solid var(--color-border)',
         borderRadius: 6,
-        background: 'rgba(255, 255, 255, 0.03)',
+        background: 'var(--color-overlay-soft)',
       }}
       onClick={(e) => e.stopPropagation()}
     >

--- a/apps/web/src/components/post-metrics.tsx
+++ b/apps/web/src/components/post-metrics.tsx
@@ -169,7 +169,7 @@ export function PostMetrics({ post, onToggleThread, threadExpanded }: PostMetric
               borderRadius: 4,
               fontFamily: 'ui-monospace, monospace',
             }}
-            onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = 'rgba(255,255,255,0.06)')}
+            onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = 'var(--color-overlay-soft)')}
             onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = 'transparent')}
           >
             {threadExpanded ? '▲ 閉じる' : '▼ スレッド'}
@@ -217,7 +217,7 @@ function MetricButton({
         whiteSpace: 'nowrap',
         transition: 'color 120ms ease, background-color 120ms ease',
       }}
-      onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = 'rgba(255,255,255,0.06)')}
+      onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = 'var(--color-overlay-soft)')}
       onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = 'transparent')}
     >
       {children}

--- a/apps/web/src/components/radar-chart.tsx
+++ b/apps/web/src/components/radar-chart.tsx
@@ -110,7 +110,7 @@ export function RadarChart({ stats, compare, size = 220, max = 100, normalize = 
             key={idx}
             d={d}
             fill="none"
-            stroke="rgba(255,255,255,0.25)"
+            stroke="var(--color-chart-grid)"
             strokeWidth={1}
           />
         );
@@ -124,7 +124,7 @@ export function RadarChart({ stats, compare, size = 220, max = 100, normalize = 
           y1={cy}
           x2={cx + v.x * radius}
           y2={cy + v.y * radius}
-          stroke="rgba(255,255,255,0.25)"
+          stroke="var(--color-chart-grid)"
           strokeWidth={1}
         />
       ))}
@@ -133,16 +133,18 @@ export function RadarChart({ stats, compare, size = 220, max = 100, normalize = 
       {comparePath && (
         <path
           d={comparePath}
-          fill="rgba(255, 170, 110, 0.22)"
-          stroke="#ffaa6e"
+          fill="var(--color-radar-compare)"
+          fillOpacity={0.22}
+          stroke="var(--color-radar-compare)"
           strokeWidth={2}
           strokeDasharray="4 3"
           strokeLinejoin="round"
         />
       )}
 
-      {/* データ多角形 (= 自分) */}
-      <path d={valuePath} fill="rgba(159, 215, 255, 0.35)" stroke="var(--color-accent)" strokeWidth={2} strokeLinejoin="round" />
+      {/* データ多角形 (= 自分)。fill は accent + fillOpacity でテーマ追従
+         (ダーク accent=#9fd7ff なので従来の rgba(159,215,255,0.35) と一致)。 */}
+      <path d={valuePath} fill="var(--color-accent)" fillOpacity={0.35} stroke="var(--color-accent)" strokeWidth={2} strokeLinejoin="round" />
 
       {/* 各頂点の点 */}
       {AXES.map((a, i) => {
@@ -159,7 +161,7 @@ export function RadarChart({ stats, compare, size = 220, max = 100, normalize = 
             x={p.x}
             y={p.y}
             fontSize={fontSize}
-            fill="#ffffff"
+            fill="var(--color-fg)"
             textAnchor="middle"
             dominantBaseline="central"
             style={{ userSelect: 'none' }}

--- a/apps/web/src/lib/app-version.ts
+++ b/apps/web/src/lib/app-version.ts
@@ -12,7 +12,7 @@
  *   3. 同じ値で git tag を打つ:
  *        git tag v2026.06.14-1 && git push origin v2026.06.14-1
  */
-export const APP_VERSION = '2026.06.17-1';
+export const APP_VERSION = '2026.06.17-2';
 
 /** APP_VERSION が `YYYY.MM.DD-N` 形式かを検証する (テスト/CI で形式崩れを検出)。
  *  月 01-12 / 日 01-31 のゼロ詰め 2 桁、枝番は先頭ゼロ不可の 1 以上まで一本でガードする。 */

--- a/apps/web/src/routes/board-detail.tsx
+++ b/apps/web/src/routes/board-detail.tsx
@@ -405,7 +405,7 @@ export function BoardDetail() {
                 </p>
                 <p style={{ margin: '0.3em 0', fontSize: '0.9em', whiteSpace: 'pre-wrap' }}>{a.message}</p>
                 {pendingAssign === a.did ? (
-                  <div style={{ marginTop: '0.4em', padding: '0.4em', background: 'rgba(255,255,255,0.06)', borderRadius: '2px' }}>
+                  <div style={{ marginTop: '0.4em', padding: '0.4em', background: 'var(--color-overlay-soft)', borderRadius: '2px' }}>
                     <p style={{ margin: '0 0 0.4em', fontSize: '0.85em' }}>
                       <strong><Handle did={a.did} /></strong> を受託者に指定しますか?<br />
                       <span style={{ fontSize: '0.78em', color: 'var(--color-muted)' }}>

--- a/apps/web/src/routes/friends.tsx
+++ b/apps/web/src/routes/friends.tsx
@@ -246,7 +246,7 @@ function RankRow({ entry, rank }: { entry: ResonanceRankEntry; rank: number }) {
         alignItems: 'center',
         gap: '0.8em',
         padding: '0.6em 0.4em',
-        borderBottom: '1px solid rgba(255,255,255,0.15)',
+        borderBottom: '1px solid var(--color-subpanel-border)',
         textAlign: 'left',
         color: 'inherit',
         textDecoration: 'none',

--- a/apps/web/src/routes/portfolio.tsx
+++ b/apps/web/src/routes/portfolio.tsx
@@ -202,7 +202,7 @@ function PortfolioView({ did, agent, isSelf, signedIn }: PortfolioViewProps) {
           <h3 style={{ marginTop: 0, fontSize: '0.95em' }}>保有ポイント (発行者別)</h3>
           <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
             {receivedByIssuer.map(([did, pt]) => (
-              <li key={did} style={{ display: 'flex', justifyContent: 'space-between', padding: '0.3em 0', borderBottom: '1px dotted rgba(255,255,255,0.1)' }}>
+              <li key={did} style={{ display: 'flex', justifyContent: 'space-between', padding: '0.3em 0', borderBottom: '1px dotted var(--color-subpanel-border)' }}>
                 <span><Handle did={did} suffix="ポイント" /></span>
                 <span style={{ fontFamily: 'ui-monospace, monospace', color: 'var(--color-accent)' }}>
                   {pt.toLocaleString()} pt

--- a/apps/web/src/routes/profile.tsx
+++ b/apps/web/src/routes/profile.tsx
@@ -269,7 +269,7 @@ function CompatView({
                   fontSize: '0.9em',
                   fontWeight: 700,
                   color: 'var(--color-fg)',
-                  borderTop: '1px dashed rgba(255,255,255,0.25)',
+                  borderTop: '1px dashed var(--color-subpanel-border)',
                   paddingTop: '0.3em',
                 }}>
                   <span>合計</span>
@@ -312,7 +312,7 @@ function MiniBar({ label, hint, points, max }: { label: string; hint?: string; p
           {points} / {max}
         </span>
       </div>
-      <div style={{ height: 4, background: 'rgba(255,255,255,0.15)', borderRadius: 2, overflow: 'hidden', marginTop: '0.15em' }}>
+      <div style={{ height: 4, background: 'var(--color-track-bg)', borderRadius: 2, overflow: 'hidden', marginTop: '0.15em' }}>
         <div style={{ width: `${pct}%`, height: '100%', background: 'var(--color-accent)' }} />
       </div>
     </div>
@@ -498,7 +498,7 @@ function FollowButton({
         fontSize: '0.85em',
         fontWeight: 700,
         background: following ? 'transparent' : 'var(--color-accent)',
-        color: following ? 'var(--color-fg)' : '#000',
+        color: following ? 'var(--color-fg)' : 'var(--color-on-accent)',
         border: `2px solid ${following ? 'var(--color-border)' : 'var(--color-accent)'}`,
         borderRadius: 4,
         cursor: busy ? 'wait' : 'pointer',

--- a/apps/web/src/routes/quests.tsx
+++ b/apps/web/src/routes/quests.tsx
@@ -374,8 +374,8 @@ function QuestRow({ quest }: { quest: Quest }) {
   return (
     <div
       style={{
-        background: 'rgba(0,0,0,0.25)',
-        border: '1px solid rgba(255,255,255,0.1)',
+        background: 'var(--color-subpanel-bg)',
+        border: '1px solid var(--color-subpanel-border)',
         borderRadius: 4,
         padding: '0.4em 0.5em',
         ...(done ? { opacity: 0.55 } : {}),
@@ -432,8 +432,8 @@ function ActivityRow({ entry }: { entry: ActivityEntry }) {
   return (
     <div
       style={{
-        background: 'rgba(0,0,0,0.4)',
-        border: '1px solid rgba(255,255,255,0.08)',
+        background: 'var(--color-subpanel-bg)',
+        border: '1px solid var(--color-subpanel-border)',
         borderRadius: 4,
         padding: '0.35em 0.5em',
         fontSize: '0.78em',

--- a/apps/web/src/routes/spirit.tsx
+++ b/apps/web/src/routes/spirit.tsx
@@ -358,7 +358,7 @@ export function Spirit() {
             <div style={{ fontSize: '0.8em', color: 'var(--color-muted)', marginBottom: '0.3em' }}>
               あおぞらパワー {points.viaPosts} / {SUMMON_THRESHOLD}
             </div>
-            <div style={{ height: 8, background: 'rgba(255,255,255,0.15)', borderRadius: 4, overflow: 'hidden' }}>
+            <div style={{ height: 8, background: 'var(--color-track-bg)', borderRadius: 4, overflow: 'hidden' }}>
               <div
                 style={{
                   width: `${(points.viaPosts / SUMMON_THRESHOLD) * 100}%`,
@@ -382,9 +382,9 @@ export function Spirit() {
               marginTop: '1em',
               padding: '0.7em 1.6em',
               fontSize: '1em',
-              background: 'rgba(0, 0, 0, 0.6)',
-              color: '#ffffff',
-              border: '3px solid #ffffff',
+              background: 'var(--color-pill-bg)',
+              color: 'var(--color-fg)',
+              border: '3px solid var(--color-pill-border)',
               boxShadow: '0 0 20px rgba(159, 215, 255, 0.45)',
             }}
           >

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -56,6 +56,10 @@
   --color-track-border: rgba(255, 255, 255, 0.6);
   /* 控えめなオーバーレイ/区切り (バッジ地・hover 地・点線境界) */
   --color-overlay-soft: rgba(255, 255, 255, 0.1);
+  /* レーダーチャートのグリッド/軸線 (SVG stroke)。ライトで白だと消えるため */
+  --color-chart-grid: rgba(255, 255, 255, 0.25);
+  /* レーダーの比較多角形 (目標ジョブ)。ダークは橙、ライトは白地で沈むので濃い橙 */
+  --color-radar-compare: #ffaa6e;
 
   --font-main: 'Hiragino Maru Gothic ProN', 'Hiragino Maru Gothic Pro', 'Noto Sans JP', sans-serif;
 }
@@ -85,7 +89,8 @@
   --color-item-selected-bg: rgba(39, 115, 181, 0.16);
   --color-item-selected-border: var(--color-accent-deep);
   --color-subpanel-bg: rgba(0, 0, 0, 0.05);
-  --color-subpanel-border: rgba(0, 0, 0, 0.1);
+  /* feed-divider (0.16) に揃える。0.1 だと白地でパネル境界が溶けて見えない */
+  --color-subpanel-border: rgba(0, 0, 0, 0.16);
   --color-track-bg: rgba(0, 0, 0, 0.1);
   --color-track-border: rgba(0, 0, 0, 0.2);
   --color-overlay-soft: rgba(0, 0, 0, 0.08);
@@ -93,6 +98,8 @@
   --color-pill-bg: rgba(255, 255, 255, 0.85);
   --color-pill-border: var(--color-border);
   --color-pill-inner: rgba(0, 0, 0, 0.12);
+  --color-chart-grid: rgba(0, 0, 0, 0.18);
+  --color-radar-compare: #c2571a;
 }
 
 * {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -301,7 +301,10 @@ p { margin: 0.4em 0; }
 @media (min-width: 768px) {
   .board-column {
     flex: 0 0 320px;
+    /* ワークスペースのカラム高 (100dvh 基準) と単位を揃える。100vh だと
+       タブレット等のアドレスバー表示時にビューポートを超えうる (vh は fallback)。 */
     max-height: calc(100vh - 12em);
+    max-height: calc(100dvh - 12em);
     overflow-y: auto;
   }
 }


### PR DESCRIPTION
## リリース内容: ライトモード仕上げ + 掲示板カラム dvh (v2026.06.17-2)

### 含まれる PR (すべて dev で個別 §1.5 レビュー済 + オーナー dev 確認済)
- **#173** (#165) 初回ロードの FOUC を index.html pre-paint script で排除
- **#174** (#164) ライトで崩れる残りのインライン色をトークン化。**レーダーチャートの目盛り**
  (オーナー報告) + profile/spirit/quests/compose/post-metrics 等。compare 多角形・進捗バー・
  パネル境界も視認性改善
- **#175** (#170) 掲示板カラムを dvh に統一 (ワークスペースカラムと単位を揃える)

### バージョン
- `APP_VERSION` 2026.06.17-1 → **2026.06.17-2** (本日 2 回目、PR #176 で dev 反映済)

## Review
dev→main 集約レビュー (本番リスク・APP_VERSION 妥当性) を §1.5 に従い実施し追記する。

## Review (dev→main 集約レビュー)
各 feature PR (#173/#174/#175) は個別 §1.5 済 + オーナー dev 実機確認済 (「なおったね」)。集約は本番リスク・スコープ・バージョンに特化 → **★★★/★★ ゼロ = リリース可**。

- **APP_VERSION 妥当**: 2026.06.17-1 → 2026.06.17-2 (同日 2 回目、PATTERN 合致・正しい連番)。
- **スコープ**: 差分 14 ファイルすべて apps/web 配下。CI/設定/secrets 混入なし。git log は #173/#174/#175 + bump の 4 コミットのみ、予期しない変更なし。
- **ダーク非干渉 (値レベル確認)**: pre-paint script はダークで data-theme=dark を正しく付与、radar の grid/compare/データ fill/label のダーク値は旧リテラルと完全一致 (#ffaa6e / accent=#9fd7ff@0.35 / #fff)、ライト変更は :root[data-theme='light'] 内のみ。board-column dvh は PC 無変更。
- **★ (issue #178 化)**: index.html の pre-paint インライン script が CSP **Report-Only** の script-src に違反 (enforce は script-src 無しで無害)。将来 enforce 昇格時に hash/nonce が必要 → #178 に記録。本番動作は阻害しない。
