### PR TITLE
fix(security): 投稿リンクを http/https のみ許可し javascript: XSS を防ぐ

### DIFF
--- a/apps/web/src/components/post-external.tsx
+++ b/apps/web/src/components/post-external.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import type { PostExternal } from '@/lib/post-embed';
 import { useTranslation } from '@/lib/translate';
 import { TranslationControls } from './post-body';
+import { safeLinkUri } from './post-text';
 
 /**
  * 外部リンクカード (app.bsky.embed.external#view)。
@@ -14,6 +15,10 @@ import { TranslationControls } from './post-body';
  */
 export function PostExternalCard({ external }: { external: PostExternal }) {
   const host = safeHost(external.uri);
+  // OG カードの uri は投稿者が自由に付けられる (embed)。post-text の facet link と
+  // 同じく javascript:/data: 等の保存型 XSS が成立するため http/https のみ許可。
+  // 許可外は href を付けず (= クリックしても遷移しない非リンクカード) にする。
+  const safeUri = safeLinkUri(external.uri);
   // useTranslation は uri=undefined or text=空 / 短い時は no-op (= isNonJapanese=false)
   // なので、title/desc が無い OG カードでも安全に呼べる。
   const titleHasText = !!external.title && external.title.length > 0;
@@ -60,7 +65,7 @@ export function PostExternalCard({ external }: { external: PostExternal }) {
       onClick={(e) => e.stopPropagation()}
     >
       <a
-        href={external.uri}
+        {...(safeUri ? { href: safeUri } : {})}
         target="_blank"
         rel="noopener noreferrer"
         style={{

--- a/apps/web/src/components/post-text.test.ts
+++ b/apps/web/src/components/post-text.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { segmentPost, type Facet, type FacetFeature } from './post-text';
+import { segmentPost, safeLinkUri, type Facet, type FacetFeature } from './post-text';
 
 // byte index は UTF-8。テスト用に文字列の byte offset を測るヘルパ。
 const enc = new TextEncoder();
@@ -74,5 +74,57 @@ describe('segmentPost', () => {
     const segs = segmentPost('@bob.test と #ねこ');
     expect(segs).toContainEqual({ kind: 'mention', text: '@bob.test', handle: 'bob.test' });
     expect(segs).toContainEqual({ kind: 'tag', text: '#ねこ', tag: 'ねこ' });
+  });
+
+  // ─── XSS: facet の uri は投稿者が自由に付けられるので scheme を検証する ───
+  it('link facet の uri が javascript: のときはリンク化せず素のテキストにする', () => {
+    const text = 'click here';
+    const facets = [facetAt(text, 'here', { $type: 'app.bsky.richtext.facet#link', uri: 'javascript:alert(document.cookie)' })];
+    const segs = segmentPost(text, facets);
+    // link セグメントを作らない (= <a href="javascript:..."> が描画されない)
+    expect(segs.some((s) => s.kind === 'link')).toBe(false);
+    // 原文は欠落しない
+    expect(segs.map((s) => s.text).join('')).toBe(text);
+  });
+
+  it('link facet の uri が data: のときもリンク化しない', () => {
+    const text = 'x data y';
+    const facets = [facetAt(text, 'data', { $type: 'app.bsky.richtext.facet#link', uri: 'data:text/html,<script>alert(1)</script>' })];
+    const segs = segmentPost(text, facets);
+    expect(segs.some((s) => s.kind === 'link')).toBe(false);
+  });
+
+  it('link facet の http/https はこれまで通りリンク化する', () => {
+    const text = 'a link b';
+    for (const uri of ['https://example.com/x', 'http://example.com']) {
+      const facets = [facetAt(text, 'link', { $type: 'app.bsky.richtext.facet#link', uri })];
+      expect(segmentPost(text, facets)).toContainEqual({ kind: 'link', text: 'link', uri });
+    }
+  });
+});
+
+describe('safeLinkUri', () => {
+  it('http/https はそのまま返す', () => {
+    expect(safeLinkUri('https://example.com/x')).toBe('https://example.com/x');
+    expect(safeLinkUri('http://example.com')).toBe('http://example.com');
+  });
+
+  it('javascript: / data: / vbscript: / mailto: は null', () => {
+    expect(safeLinkUri('javascript:alert(1)')).toBeNull();
+    expect(safeLinkUri('data:text/html,x')).toBeNull();
+    expect(safeLinkUri('vbscript:msgbox(1)')).toBeNull();
+    expect(safeLinkUri('mailto:a@b.com')).toBeNull();
+  });
+
+  it('空白/制御文字による scheme 回避 (java\\tscript:) も null', () => {
+    expect(safeLinkUri(' javascript:alert(1)')).toBeNull();
+    expect(safeLinkUri('java\tscript:alert(1)')).toBeNull();
+    expect(safeLinkUri('JavaScript:alert(1)')).toBeNull();
+  });
+
+  it('相対 URL や不正な文字列は null', () => {
+    expect(safeLinkUri('/foo/bar')).toBeNull();
+    expect(safeLinkUri('not a url')).toBeNull();
+    expect(safeLinkUri('')).toBeNull();
   });
 });

--- a/apps/web/src/components/post-text.tsx
+++ b/apps/web/src/components/post-text.tsx
@@ -60,11 +60,30 @@ function autoLinkSegments(text: string): PostSegment[] {
   return out;
 }
 
+/**
+ * リンク先 URI を http/https のみ許可する。facet の uri は投稿者が自由に付けられる
+ * ため、`javascript:` / `data:` / `vbscript:` 等を `<a href>` に通すと、クリックで
+ * 閲覧者のオリジン上でコードが走る (保存型 XSS)。`new URL` で正規化して scheme を
+ * 判定するので、`java\tscript:` のような空白/制御文字による回避もパーサ側で潰れる。
+ * 許可外は null を返し、呼び出し側は素のテキストにフォールバックする。
+ */
+export function safeLinkUri(uri: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(uri);
+  } catch {
+    return null; // 相対 URL や不正な文字列は弾く (facet の uri は絶対 URL 前提)
+  }
+  return parsed.protocol === 'http:' || parsed.protocol === 'https:' ? uri : null;
+}
+
 /** facet 1 つ分のセグメント化。未知 feature は素のテキストとして返す。 */
 function featureSegment(segment: string, feature: FacetFeature | undefined): PostSegment {
   const t = feature?.$type;
   if (t === 'app.bsky.richtext.facet#link' && feature?.uri) {
-    return { kind: 'link', text: segment, uri: feature.uri };
+    // http/https 以外 (javascript: 等) はリンク化せず素のテキストに (XSS 回避)
+    const safe = safeLinkUri(feature.uri);
+    return safe ? { kind: 'link', text: segment, uri: safe } : { kind: 'text', text: segment };
   }
   if (t === 'app.bsky.richtext.facet#mention' && feature?.did) {
     return { kind: 'mention', text: segment, handle: segment.replace(/^@/, '') };
@@ -160,9 +179,13 @@ function renderSegment(seg: PostSegment, key: number): ReactNode {
 }
 
 function ExternalLink({ href, label }: { href: string; label: string }) {
+  // 多層防御: セグメント化側でも弾いているが、ここでも http/https 以外は
+  // リンクにせず素のテキストにして、危険な scheme が <a href> に届かないようにする。
+  const safe = safeLinkUri(href);
+  if (!safe) return <span style={{ wordBreak: 'break-all' }}>{label}</span>;
   return (
     <a
-      href={href}
+      href={safe}
       target="_blank"
       rel="noopener noreferrer"
       onClick={(e) => e.stopPropagation()}


### PR DESCRIPTION
## 概要 (セキュリティ修正)
投稿内リンクの `href` に scheme 検証が無く、**`javascript:` 等を仕込んだ投稿による
保存型 XSS** が成立していた。これを http/https のみ許可して塞ぐ。

## 脆弱性
- `post-text.tsx` の `featureSegment` は facet (`app.bsky.richtext.facet#link`) の
  `feature.uri` を**そのまま** `<a href>` に入れていた。
- facet は投稿者が自由に付けられるため、`uri: "javascript:..."` のリンクを作れる。
- 閲覧者がそのリンクをクリックすると、**aozoraquest.app のオリジン上で任意 JS が実行**
  される (Cookie/セッション窃取・なりすまし投稿等が可能)。
- 自動リンク経路 (本文の URL を正規表現で拾う方) は `https?://` 限定で元々安全。穴は facet 経由のみ。

## 修正
- `safeLinkUri(uri)`: `new URL` で正規化して scheme を判定し、`http:`/`https:` 以外は
  `null`。`new URL` の正規化により `java<tab>script:` / 前後空白 / 大文字化などの回避も潰れる。
- `featureSegment`: 許可外はリンク化せず**素のテキスト**にフォールバック。
- `ExternalLink`: 描画直前にも同じ検証 (多層防御)。

## 影響
正規の Bluesky リンクは facet/自動リンクとも http(s) なので**機能影響なし**。

## 検証
- typecheck / build / test (213, +7) 緑。
- 追加テスト: `javascript:` / `data:` / `vbscript:` / `mailto:` / 相対 URL は非リンク化、
  `java<tab>script:` / 先頭空白 / `JavaScript:` の回避も null、http/https は従来通りリンク。



## Review
§1.5 セキュリティ重点レビュー (敵対的バイパス検証 + 完全性 sink 探索) → **★★★ ゼロ = 出荷可**。

- **バイパス検証**: `safeLinkUri` の `new URL` scheme 判定を、大文字/制御文字 (`java\tscript:`)/空白/scheme混同/Node vs 実Chromium 差分 まで実測で総当たり攻撃 → **javascript:/data:/vbscript:/blob: は実ブラウザでも確実に block、突破口なし**。text フォールバックは React 自動エスケープで無害、autoLink 経路は http(s) のみ。
- **完全性 (他 sink 探索)**: post-text 以外で **post-external.tsx の OG カード `href={external.uri}`** に同一の保存型 XSS が残存と判明 → **本 PR 内で修正** (commit 97d56a4、safeLinkUri を re-use し許可外は href を付けない)。それ以外: innerHTML/eval/document.write/window.open/location 代入は**コードベースに皆無**、YouTube iframe は id を厳格バリデート+host 許可リスト済、img/media の src は非実行 sink、target=_blank は全て rel=noopener 付与済 → 追加リスクなし。
- **★★ (issue #180 化)**: `safeLinkUri` が生 uri を返すため `https://a.com\t@evil.com` でホスト不一致 (フィッシング寄り、XSS 非該当)。正規化 (parsed.href) は既存リンク挙動に波及するため別 issue。
- **★ (記録)**: Node↔ブラウザ差分の回帰テスト追加・許可リスト方針のコメントは #180 で。

## 検証
typecheck/build/test (213, +7 XSS ケース) 緑。post-text + post-external の2 sink を http/https 許可リストで封鎖。
