### PR TITLE
feat(security): CSP script-src を enforce 化して XSS 多層防御を効かせる

### DIFF
--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -11,18 +11,23 @@
 # - X-Content-Type-Options: MIME sniffing 抑止 (SPA fallback の MIME 事故対策にも効く)
 # - Referrer-Policy: 遷移先に full URL を漏らさない (プライバシー第一の方針と整合)
 # - Permissions-Policy: トラッキング系ブラウザ API (Topics 等) を全 disable
-# - CSP (enforce): frame-ancestors / base-uri / object-src だけ強制。本番動作を壊さない最小セット
-# - CSP-Report-Only: より厳しい完全版を観察モードで配信。違反は DevTools で確認できる
-#   (送信先サーバは持っていないので report-uri は付けない)。enforce へ昇格させる時の参考にする。
-#   connect-src は AT Protocol の任意 PDS (self-hosted も含む) と OAuth 経由のサードパーティ
-#   ホストに届くため `https:` で全許可。scheme 制限による mixed content だけ防げれば実用十分
+# - CSP (enforce): XSS の多層防御。**script の実行元を限定**するのが要 —
+#   self + wasm-unsafe-eval (WASM 推論) + jsdelivr (ONNX/transformers) + 初回テーマ
+#   インライン script の sha256 だけ許可。これで将来 XSS で文字列が注入されても、
+#   許可外の inline/外部 script は実行されない。
+#   ・img/media は AT Protocol の任意 PDS (self-host 含む) から来るので `https:` で広く
+#     許可 (画像/動画は非実行 sink なので scheme 制限で十分、ホスト固定すると壊れる)。
+#   ・connect も任意 PDS / OAuth 先に届くため `https:`。
+#   ・style は React のインラインスタイル (style={{}}) のため unsafe-inline 必須
+#     (スタイル注入は script 実行に比べ低リスク)。
+#   ※ index.html のインライン script を変更したら下の 'sha256-...' を更新すること。
+#     src/csp-inline-hash.test.ts が drift を検知して CI を落とす。
 /*
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: browsing-topics=(), join-ad-interest-group=(), run-ad-auction=()
-  Content-Security-Policy: frame-ancestors 'none'; base-uri 'self'; object-src 'none'
-  Content-Security-Policy-Report-Only: default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: blob: https://cdn.bsky.app https://*.bsky.app https://*.bsky.network https://i.ytimg.com; media-src 'self' blob: https://*.bsky.app https://*.bsky.network; connect-src 'self' https:; worker-src 'self' blob: https://cdn.jsdelivr.net; frame-src https://www.youtube-nocookie.com https://www.youtube.com; frame-ancestors 'none'; base-uri 'self'; object-src 'none'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'sha256-YKin9zMHg8npsYTSijeNtStnfpbl4y3ojuowebzvlEM=' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: blob: https:; media-src 'self' blob: https:; connect-src 'self' https:; worker-src 'self' blob: https://cdn.jsdelivr.net; frame-src https://www.youtube-nocookie.com https://www.youtube.com; frame-ancestors 'none'; base-uri 'self'; object-src 'none'
 
 /index.html
   Cache-Control: public, max-age=0, must-revalidate

--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -12,9 +12,12 @@
 # - Referrer-Policy: 遷移先に full URL を漏らさない (プライバシー第一の方針と整合)
 # - Permissions-Policy: トラッキング系ブラウザ API (Topics 等) を全 disable
 # - CSP (enforce): XSS の多層防御。**script の実行元を限定**するのが要 —
-#   self + wasm-unsafe-eval (WASM 推論) + jsdelivr (ONNX/transformers) + 初回テーマ
-#   インライン script の sha256 だけ許可。これで将来 XSS で文字列が注入されても、
-#   許可外の inline/外部 script は実行されない。
+#   self + wasm-unsafe-eval (WASM 推論) + jsdelivr (ONNX/transformers) + blob:
+#   (transformers.js は通常ブラウザで ONNX の wasm glue .mjs を fetch→Blob 化して
+#   worker 内で import() するため。これが無いと認知機能分析/精霊生成が enforce 下で
+#   壊れる) + 初回テーマインライン script の sha256 だけ許可。これで将来 XSS で文字列が
+#   注入されても、許可外の inline/外部 script は実行されない (blob script の生成自体に
+#   JS 実行が要るので、注入経路を塞いだ状態では blob: は実害にならない)。
 #   ・img/media は AT Protocol の任意 PDS (self-host 含む) から来るので `https:` で広く
 #     許可 (画像/動画は非実行 sink なので scheme 制限で十分、ホスト固定すると壊れる)。
 #   ・connect も任意 PDS / OAuth 先に届くため `https:`。
@@ -27,7 +30,7 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: browsing-topics=(), join-ad-interest-group=(), run-ad-auction=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'sha256-YKin9zMHg8npsYTSijeNtStnfpbl4y3ojuowebzvlEM=' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: blob: https:; media-src 'self' blob: https:; connect-src 'self' https:; worker-src 'self' blob: https://cdn.jsdelivr.net; frame-src https://www.youtube-nocookie.com https://www.youtube.com; frame-ancestors 'none'; base-uri 'self'; object-src 'none'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'sha256-YKin9zMHg8npsYTSijeNtStnfpbl4y3ojuowebzvlEM=' blob: https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: blob: https:; media-src 'self' blob: https:; connect-src 'self' https:; worker-src 'self' blob: https://cdn.jsdelivr.net; frame-src https://www.youtube-nocookie.com https://www.youtube.com; frame-ancestors 'none'; base-uri 'self'; object-src 'none'
 
 /index.html
   Cache-Control: public, max-age=0, must-revalidate

--- a/apps/web/src/csp-inline-hash.test.ts
+++ b/apps/web/src/csp-inline-hash.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+
+/**
+ * index.html の初回テーマ (FOUC 対策) インライン <script> は、本番の CSP enforce で
+ * `script-src 'sha256-...'` により許可している (public/_headers)。スクリプトを 1 文字でも
+ * 変えると hash がズレ、enforce 下でブロックされて FOUC が再発する。このテストは
+ * 「index.html のインライン script の sha256」と「_headers に書いた sha256」の一致を
+ * CI で保証し、ドリフトを検知する。
+ *
+ * 前提: Vite は src 無しのインライン <script> を**変換せず素通し**するため、
+ *       source (index.html) の hash == dist (配信) の hash。
+ */
+describe('CSP inline script hash', () => {
+  it('index.html のインライン script の sha256 が _headers の CSP と一致する', () => {
+    const html = readFileSync('index.html', 'utf8');
+    const m = /<script(?![^>]*\bsrc=)[^>]*>([\s\S]*?)<\/script>/.exec(html);
+    expect(m, 'index.html にインライン <script> が見つからない').not.toBeNull();
+    const body = m![1]!;
+    const hash = createHash('sha256').update(body, 'utf8').digest('base64');
+
+    const headers = readFileSync('public/_headers', 'utf8');
+    const enforceLine = headers
+      .split('\n')
+      .find((l) => l.trim().startsWith('Content-Security-Policy:'));
+    expect(enforceLine, '_headers に enforce CSP 行が無い').toBeTruthy();
+    expect(
+      enforceLine!.includes(`'sha256-${hash}'`),
+      `CSP の script-src に 'sha256-${hash}' が必要 (index.html の inline script を変えたら _headers を更新)`,
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## 概要 (B: セキュリティ多層防御)
CSP の **script-src を本番 enforce** にして XSS の多層防御を効かせる。A (#179) で実際の
XSS 経路は塞いだが、将来の注入バグに備え「許可外の script は実行させない」壁を本番に置く。

これまで完全版 CSP は **Report-Only (観察のみ・実効なし)** だったのを enforce に昇格。

## 変更
`apps/web/public/_headers`:
- enforce CSP を最小 (`frame-ancestors/base-uri/object-src`) → 完全版に拡張。
- **`script-src`**: `'self' 'wasm-unsafe-eval' 'sha256-…(初回テーマ inline script)' https://cdn.jsdelivr.net` に限定 = 要。注入された inline/外部 script は走らない。
- **`img-src`/`media-src`**: `https:` で広く許可。AT Protocol の任意 PDS (self-host 含む) から来る画像/動画は**非実行 sink** なので scheme 制限で十分。ホスト固定すると壊れる。
- `connect-src 'https:'`(任意 PDS/OAuth)、`style-src 'unsafe-inline'`(React のインラインスタイル)は維持。
- Report-Only は enforce が完全版になったので削除。
- `src/csp-inline-hash.test.ts`: index.html のインライン script の sha256 と `_headers` の一致を CI で保証 (script を変えて hash がズレ → enforce でブロック → FOUC 再発、を防ぐ)。

## 検証
- ✅ 実 dist を **enforce CSP 付きでローカル配信** → Chromium で読込: CSP 違反 **0 件**、
  アプリ描画 OK、インライン theme script が enforce 下で実行 (data-theme 設定)。
- ✅ 全 214 テスト緑 (hash guard 含む)。
- ⚠️ **dev で要確認 (ログイン後)**: ① WASM 推論 (認知機能/精霊生成) が動くか
  (`wasm-unsafe-eval`+jsdelivr+worker)、② タイムライン画像・アバター表示、③ OAuth ログイン、
  ④ YouTube 埋め込み。dev デプロイ後にコンソールを開いて CSP 違反が出ないか確認 → 問題なければ main。

## ロールバック
万一 dev で機能が壊れたら、`_headers` の enforce CSP を元の最小セットに戻すだけ (1 行) で即復旧。



## Review
§1.5 セキュリティレビュー (完全性 + 設計/ロールアウト) を実施。2 観点で**結論が割れた** ため自分で実コード検証して決着させた。

### ★★★ (致命) — 解消済 (commit ae44622)
- **設計レビューが検出**: transformers.js v4.1.0 は通常ブラウザで ONNX の wasm glue .mjs を fetch→Blob 化→worker 内で `import()` する (`loadWasmFactory`, transformers.web.js:7587; 直 URL 経路は Chrome 拡張/SW 限定)。この **blob: script の import は `script-src` に従う**ため、blob: が無いと認知機能分析/精霊生成が enforce 下で全ブラウザ壊れる。**完全性レビューはこれを「worker-src blob: でカバー」と誤判定して見落としていた**。
- **自分で実コード確認 + 実証**: `loadWasmFactory` の分岐を精読し設計レビューが正しいと確定。enforce CSP 下で `import(URL.createObjectURL(Blob))` を Chromium で実行 → **blob: ありで成功・違反0、blob: なしで 'Loading the script blob:… violates' でブロック**を実測。
- **対応**: `script-src` に `blob:` を追加。blob script の生成自体に JS 実行が要るので、inline/外部 script 注入を塞いだ本ポリシーでは blob: は XSS 経路にならない (コメント明記)。

### ★★ (issue #182 化)
- **観察手段ゼロ**: report-uri/report-to 無し + Report-Only 削除で、本番ユーザーが踏んだ違反に気づけない。→ `securitypolicyviolation` ログ or report 収集 or 次期候補の Report-Only 並走を #182 に。

### ★ (記録 / 許容)
- `img-src`/`media-src` を `https:` に緩めた判断は妥当 (画像は非実行 sink、AT Proto の任意 PDS 対応に必須、connect-src も既に https:)。
- inline+hash 方式は FOUC 要件 (同期実行) 上妥当、`csp-inline-hash.test.ts` で drift 検知。
- `default-src 'self'` フォールバックは安全側。

### 検証 / ロールアウト
- 完全性レビュー: script(jsdelivr)/wasm(wasm-unsafe-eval)/model(connect https:)/worker(self/jsdelivr/blob)/fonts/youtube/OAuth(top-level nav)/inline hash(実 dist 一致) を全許可と確認。**WebSocket 不使用**で connect-src https: の scheme 穴なし。
- 静的読込: enforce CSP 付きローカル配信で違反0・描画OK。blob: import 経路も実証済。
- **残: dev でログイン後の WASM 推論 (認知機能分析/精霊生成)・画像・OAuth・YouTube を実走確認してから main** (本番実ユーザー保護のため。ロールバックは _headers 1 行で即時)。
