### PR TITLE
chore(release): APP_VERSION 2026.06.17-3

### DIFF
--- a/apps/web/src/lib/app-version.ts
+++ b/apps/web/src/lib/app-version.ts
@@ -12,7 +12,7 @@
  *   3. 同じ値で git tag を打つ:
  *        git tag v2026.06.14-1 && git push origin v2026.06.14-1
  */
-export const APP_VERSION = '2026.06.17-2';
+export const APP_VERSION = '2026.06.17-3';
 
 /** APP_VERSION が `YYYY.MM.DD-N` 形式かを検証する (テスト/CI で形式崩れを検出)。
  *  月 01-12 / 日 01-31 のゼロ詰め 2 桁、枝番は先頭ゼロ不可の 1 以上まで一本でガードする。 */


### PR DESCRIPTION
XSS 修正 (#179) + CSP enforce (#181/#183) の本番リリース用バージョン bump。

- `APP_VERSION` 2026.06.17-2 → 2026.06.17-3 (本日 3 回目)
- 表示バージョンのみ