### PR TITLE
release: XSS 修正 + CSP enforce (v2026.06.17-3)

### DIFF
--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -18,6 +18,9 @@
 #   壊れる) + 初回テーマインライン script の sha256 だけ許可。これで将来 XSS で文字列が
 #   注入されても、許可外の inline/外部 script は実行されない (blob script の生成自体に
 #   JS 実行が要るので、注入経路を塞いだ状態では blob: は実害にならない)。
+#   ・static.cloudflareinsights.com: Cloudflare Web Analytics のビーコンを CF がエッジで
+#     自動注入する (ソースには無い)。許可しないと毎ロード CSP 違反 + 解析が動かない。
+#     送信先 cloudflareinsights.com は connect-src https: でカバー済。
 #   ・img/media は AT Protocol の任意 PDS (self-host 含む) から来るので `https:` で広く
 #     許可 (画像/動画は非実行 sink なので scheme 制限で十分、ホスト固定すると壊れる)。
 #   ・connect も任意 PDS / OAuth 先に届くため `https:`。
@@ -30,7 +33,7 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: browsing-topics=(), join-ad-interest-group=(), run-ad-auction=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'sha256-YKin9zMHg8npsYTSijeNtStnfpbl4y3ojuowebzvlEM=' blob: https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: blob: https:; media-src 'self' blob: https:; connect-src 'self' https:; worker-src 'self' blob: https://cdn.jsdelivr.net; frame-src https://www.youtube-nocookie.com https://www.youtube.com; frame-ancestors 'none'; base-uri 'self'; object-src 'none'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'sha256-YKin9zMHg8npsYTSijeNtStnfpbl4y3ojuowebzvlEM=' blob: https://cdn.jsdelivr.net https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: blob: https:; media-src 'self' blob: https:; connect-src 'self' https:; worker-src 'self' blob: https://cdn.jsdelivr.net; frame-src https://www.youtube-nocookie.com https://www.youtube.com; frame-ancestors 'none'; base-uri 'self'; object-src 'none'
 
 /index.html
   Cache-Control: public, max-age=0, must-revalidate

--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -11,18 +11,26 @@
 # - X-Content-Type-Options: MIME sniffing 抑止 (SPA fallback の MIME 事故対策にも効く)
 # - Referrer-Policy: 遷移先に full URL を漏らさない (プライバシー第一の方針と整合)
 # - Permissions-Policy: トラッキング系ブラウザ API (Topics 等) を全 disable
-# - CSP (enforce): frame-ancestors / base-uri / object-src だけ強制。本番動作を壊さない最小セット
-# - CSP-Report-Only: より厳しい完全版を観察モードで配信。違反は DevTools で確認できる
-#   (送信先サーバは持っていないので report-uri は付けない)。enforce へ昇格させる時の参考にする。
-#   connect-src は AT Protocol の任意 PDS (self-hosted も含む) と OAuth 経由のサードパーティ
-#   ホストに届くため `https:` で全許可。scheme 制限による mixed content だけ防げれば実用十分
+# - CSP (enforce): XSS の多層防御。**script の実行元を限定**するのが要 —
+#   self + wasm-unsafe-eval (WASM 推論) + jsdelivr (ONNX/transformers) + blob:
+#   (transformers.js は通常ブラウザで ONNX の wasm glue .mjs を fetch→Blob 化して
+#   worker 内で import() するため。これが無いと認知機能分析/精霊生成が enforce 下で
+#   壊れる) + 初回テーマインライン script の sha256 だけ許可。これで将来 XSS で文字列が
+#   注入されても、許可外の inline/外部 script は実行されない (blob script の生成自体に
+#   JS 実行が要るので、注入経路を塞いだ状態では blob: は実害にならない)。
+#   ・img/media は AT Protocol の任意 PDS (self-host 含む) から来るので `https:` で広く
+#     許可 (画像/動画は非実行 sink なので scheme 制限で十分、ホスト固定すると壊れる)。
+#   ・connect も任意 PDS / OAuth 先に届くため `https:`。
+#   ・style は React のインラインスタイル (style={{}}) のため unsafe-inline 必須
+#     (スタイル注入は script 実行に比べ低リスク)。
+#   ※ index.html のインライン script を変更したら下の 'sha256-...' を更新すること。
+#     src/csp-inline-hash.test.ts が drift を検知して CI を落とす。
 /*
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: browsing-topics=(), join-ad-interest-group=(), run-ad-auction=()
-  Content-Security-Policy: frame-ancestors 'none'; base-uri 'self'; object-src 'none'
-  Content-Security-Policy-Report-Only: default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: blob: https://cdn.bsky.app https://*.bsky.app https://*.bsky.network https://i.ytimg.com; media-src 'self' blob: https://*.bsky.app https://*.bsky.network; connect-src 'self' https:; worker-src 'self' blob: https://cdn.jsdelivr.net; frame-src https://www.youtube-nocookie.com https://www.youtube.com; frame-ancestors 'none'; base-uri 'self'; object-src 'none'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'sha256-YKin9zMHg8npsYTSijeNtStnfpbl4y3ojuowebzvlEM=' blob: https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: blob: https:; media-src 'self' blob: https:; connect-src 'self' https:; worker-src 'self' blob: https://cdn.jsdelivr.net; frame-src https://www.youtube-nocookie.com https://www.youtube.com; frame-ancestors 'none'; base-uri 'self'; object-src 'none'
 
 /index.html
   Cache-Control: public, max-age=0, must-revalidate

--- a/apps/web/src/components/post-external.tsx
+++ b/apps/web/src/components/post-external.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import type { PostExternal } from '@/lib/post-embed';
 import { useTranslation } from '@/lib/translate';
 import { TranslationControls } from './post-body';
+import { safeLinkUri } from './post-text';
 
 /**
  * 外部リンクカード (app.bsky.embed.external#view)。
@@ -14,6 +15,10 @@ import { TranslationControls } from './post-body';
  */
 export function PostExternalCard({ external }: { external: PostExternal }) {
   const host = safeHost(external.uri);
+  // OG カードの uri は投稿者が自由に付けられる (embed)。post-text の facet link と
+  // 同じく javascript:/data: 等の保存型 XSS が成立するため http/https のみ許可。
+  // 許可外は href を付けず (= クリックしても遷移しない非リンクカード) にする。
+  const safeUri = safeLinkUri(external.uri);
   // useTranslation は uri=undefined or text=空 / 短い時は no-op (= isNonJapanese=false)
   // なので、title/desc が無い OG カードでも安全に呼べる。
   const titleHasText = !!external.title && external.title.length > 0;
@@ -60,7 +65,7 @@ export function PostExternalCard({ external }: { external: PostExternal }) {
       onClick={(e) => e.stopPropagation()}
     >
       <a
-        href={external.uri}
+        {...(safeUri ? { href: safeUri } : {})}
         target="_blank"
         rel="noopener noreferrer"
         style={{

--- a/apps/web/src/components/post-text.test.ts
+++ b/apps/web/src/components/post-text.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { segmentPost, type Facet, type FacetFeature } from './post-text';
+import { segmentPost, safeLinkUri, type Facet, type FacetFeature } from './post-text';
 
 // byte index は UTF-8。テスト用に文字列の byte offset を測るヘルパ。
 const enc = new TextEncoder();
@@ -74,5 +74,57 @@ describe('segmentPost', () => {
     const segs = segmentPost('@bob.test と #ねこ');
     expect(segs).toContainEqual({ kind: 'mention', text: '@bob.test', handle: 'bob.test' });
     expect(segs).toContainEqual({ kind: 'tag', text: '#ねこ', tag: 'ねこ' });
+  });
+
+  // ─── XSS: facet の uri は投稿者が自由に付けられるので scheme を検証する ───
+  it('link facet の uri が javascript: のときはリンク化せず素のテキストにする', () => {
+    const text = 'click here';
+    const facets = [facetAt(text, 'here', { $type: 'app.bsky.richtext.facet#link', uri: 'javascript:alert(document.cookie)' })];
+    const segs = segmentPost(text, facets);
+    // link セグメントを作らない (= <a href="javascript:..."> が描画されない)
+    expect(segs.some((s) => s.kind === 'link')).toBe(false);
+    // 原文は欠落しない
+    expect(segs.map((s) => s.text).join('')).toBe(text);
+  });
+
+  it('link facet の uri が data: のときもリンク化しない', () => {
+    const text = 'x data y';
+    const facets = [facetAt(text, 'data', { $type: 'app.bsky.richtext.facet#link', uri: 'data:text/html,<script>alert(1)</script>' })];
+    const segs = segmentPost(text, facets);
+    expect(segs.some((s) => s.kind === 'link')).toBe(false);
+  });
+
+  it('link facet の http/https はこれまで通りリンク化する', () => {
+    const text = 'a link b';
+    for (const uri of ['https://example.com/x', 'http://example.com']) {
+      const facets = [facetAt(text, 'link', { $type: 'app.bsky.richtext.facet#link', uri })];
+      expect(segmentPost(text, facets)).toContainEqual({ kind: 'link', text: 'link', uri });
+    }
+  });
+});
+
+describe('safeLinkUri', () => {
+  it('http/https はそのまま返す', () => {
+    expect(safeLinkUri('https://example.com/x')).toBe('https://example.com/x');
+    expect(safeLinkUri('http://example.com')).toBe('http://example.com');
+  });
+
+  it('javascript: / data: / vbscript: / mailto: は null', () => {
+    expect(safeLinkUri('javascript:alert(1)')).toBeNull();
+    expect(safeLinkUri('data:text/html,x')).toBeNull();
+    expect(safeLinkUri('vbscript:msgbox(1)')).toBeNull();
+    expect(safeLinkUri('mailto:a@b.com')).toBeNull();
+  });
+
+  it('空白/制御文字による scheme 回避 (java\\tscript:) も null', () => {
+    expect(safeLinkUri(' javascript:alert(1)')).toBeNull();
+    expect(safeLinkUri('java\tscript:alert(1)')).toBeNull();
+    expect(safeLinkUri('JavaScript:alert(1)')).toBeNull();
+  });
+
+  it('相対 URL や不正な文字列は null', () => {
+    expect(safeLinkUri('/foo/bar')).toBeNull();
+    expect(safeLinkUri('not a url')).toBeNull();
+    expect(safeLinkUri('')).toBeNull();
   });
 });

--- a/apps/web/src/components/post-text.tsx
+++ b/apps/web/src/components/post-text.tsx
@@ -60,11 +60,30 @@ function autoLinkSegments(text: string): PostSegment[] {
   return out;
 }
 
+/**
+ * リンク先 URI を http/https のみ許可する。facet の uri は投稿者が自由に付けられる
+ * ため、`javascript:` / `data:` / `vbscript:` 等を `<a href>` に通すと、クリックで
+ * 閲覧者のオリジン上でコードが走る (保存型 XSS)。`new URL` で正規化して scheme を
+ * 判定するので、`java\tscript:` のような空白/制御文字による回避もパーサ側で潰れる。
+ * 許可外は null を返し、呼び出し側は素のテキストにフォールバックする。
+ */
+export function safeLinkUri(uri: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(uri);
+  } catch {
+    return null; // 相対 URL や不正な文字列は弾く (facet の uri は絶対 URL 前提)
+  }
+  return parsed.protocol === 'http:' || parsed.protocol === 'https:' ? uri : null;
+}
+
 /** facet 1 つ分のセグメント化。未知 feature は素のテキストとして返す。 */
 function featureSegment(segment: string, feature: FacetFeature | undefined): PostSegment {
   const t = feature?.$type;
   if (t === 'app.bsky.richtext.facet#link' && feature?.uri) {
-    return { kind: 'link', text: segment, uri: feature.uri };
+    // http/https 以外 (javascript: 等) はリンク化せず素のテキストに (XSS 回避)
+    const safe = safeLinkUri(feature.uri);
+    return safe ? { kind: 'link', text: segment, uri: safe } : { kind: 'text', text: segment };
   }
   if (t === 'app.bsky.richtext.facet#mention' && feature?.did) {
     return { kind: 'mention', text: segment, handle: segment.replace(/^@/, '') };
@@ -160,9 +179,13 @@ function renderSegment(seg: PostSegment, key: number): ReactNode {
 }
 
 function ExternalLink({ href, label }: { href: string; label: string }) {
+  // 多層防御: セグメント化側でも弾いているが、ここでも http/https 以外は
+  // リンクにせず素のテキストにして、危険な scheme が <a href> に届かないようにする。
+  const safe = safeLinkUri(href);
+  if (!safe) return <span style={{ wordBreak: 'break-all' }}>{label}</span>;
   return (
     <a
-      href={href}
+      href={safe}
       target="_blank"
       rel="noopener noreferrer"
       onClick={(e) => e.stopPropagation()}

--- a/apps/web/src/csp-inline-hash.test.ts
+++ b/apps/web/src/csp-inline-hash.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+
+/**
+ * index.html の初回テーマ (FOUC 対策) インライン <script> は、本番の CSP enforce で
+ * `script-src 'sha256-...'` により許可している (public/_headers)。スクリプトを 1 文字でも
+ * 変えると hash がズレ、enforce 下でブロックされて FOUC が再発する。このテストは
+ * 「index.html のインライン script の sha256」と「_headers に書いた sha256」の一致を
+ * CI で保証し、ドリフトを検知する。
+ *
+ * 前提: Vite は src 無しのインライン <script> を**変換せず素通し**するため、
+ *       source (index.html) の hash == dist (配信) の hash。
+ */
+describe('CSP inline script hash', () => {
+  it('index.html のインライン script の sha256 が _headers の CSP と一致する', () => {
+    const html = readFileSync('index.html', 'utf8');
+    const m = /<script(?![^>]*\bsrc=)[^>]*>([\s\S]*?)<\/script>/.exec(html);
+    expect(m, 'index.html にインライン <script> が見つからない').not.toBeNull();
+    const body = m![1]!;
+    const hash = createHash('sha256').update(body, 'utf8').digest('base64');
+
+    const headers = readFileSync('public/_headers', 'utf8');
+    const enforceLine = headers
+      .split('\n')
+      .find((l) => l.trim().startsWith('Content-Security-Policy:'));
+    expect(enforceLine, '_headers に enforce CSP 行が無い').toBeTruthy();
+    expect(
+      enforceLine!.includes(`'sha256-${hash}'`),
+      `CSP の script-src に 'sha256-${hash}' が必要 (index.html の inline script を変えたら _headers を更新)`,
+    ).toBe(true);
+  });
+});

--- a/apps/web/src/lib/app-version.ts
+++ b/apps/web/src/lib/app-version.ts
@@ -12,7 +12,7 @@
  *   3. 同じ値で git tag を打つ:
  *        git tag v2026.06.14-1 && git push origin v2026.06.14-1
  */
-export const APP_VERSION = '2026.06.17-2';
+export const APP_VERSION = '2026.06.17-3';
 
 /** APP_VERSION が `YYYY.MM.DD-N` 形式かを検証する (テスト/CI で形式崩れを検出)。
  *  月 01-12 / 日 01-31 のゼロ詰め 2 桁、枝番は先頭ゼロ不可の 1 以上まで一本でガードする。 */


### PR DESCRIPTION
## リリース内容: XSS 修正 + CSP enforce 化 (v2026.06.17-3) — セキュリティ

### 含まれる PR (すべて dev で §1.5 済 + オーナー dev 確認済)
- **#179** (A) 投稿リンク (本文 facet + OG カード) の `href` を **http/https のみ許可**し、
  `javascript:` 等を仕込んだ投稿による**保存型 XSS** を封鎖。敵対的レビューで実 Chromium
  バイパス検証済 (突破不可)、完全性レビューで同一 sink (post-external) も検出→同 PR で修正。
- **#181** (B) CSP の **script-src を本番 enforce** 化 (Report-Only → enforce 昇格)。注入
  された inline/外部 script を実行させない多層防御。img/media は非実行 sink として https:。
- **#183** Cloudflare Insights ビーコンを script-src に許可 (dev 確認で判明したエッジ注入 script)。

### dev 実機確認 (オーナー)
- WASM 推論 (認知機能分析/精霊生成) が enforce 下で動作、コンソールに CSP エラー無し を確認済。

### バージョン
- `APP_VERSION` 2026.06.17-2 → **2026.06.17-3** (本日 3 回目、PR #184 で dev 反映済)

### follow-up issue
- #180 (safeLinkUri の host 正規化)、#182 (CSP 違反の観察手段)。いずれもリリースを妨げない。

## Review
dev→main 集約レビュー (本番リスク・APP_VERSION) を §1.5 で実施し追記する。

---
## Review (dev→main 集約レビュー)
feature #179/#181/#183 は個別 §1.5 済 + オーナー dev 実機確認済。集約は本番リスク・スコープ・バージョン特化 → **★★★/★★/★ ゼロ = リリース可**。
- APP_VERSION 2026.06.17-3 (同日 -3、PATTERN 合致)。差分 6 ファイル apps/web のみ、想定外コミットなし。
- CSP enforce: sha256 を独立再計算し _headers と一致を確認、blob:(WASM)/jsdelivr/CF Insights 許可、img/media/connect は https: で任意 PDS を壊さない。
- XSS: post-text/post-external 両 sink を safeLinkUri で http/https 限定 + ExternalLink 二重防御、正規リンク非破壊。
- ロールバックは _headers 1 行で即時。
