### PR TITLE
feat(compose): クリップボードから画像を貼り付けて添付

### DIFF
--- a/apps/web/src/components/compose-modal.tsx
+++ b/apps/web/src/components/compose-modal.tsx
@@ -2,6 +2,7 @@ import { createContext, useCallback, useContext, useEffect, useRef, useState, ty
 import { useSession } from '@/lib/session';
 import { createPost, createPostWithImages, MAX_POST_IMAGES, type ReplyRef } from '@/lib/atproto';
 import { compressImage } from '@/lib/image-compress';
+import { imageFilesFromClipboard } from '@/lib/clipboard-images';
 import { TextField } from './text-field';
 import { processSelfPost } from '@/lib/post-processor';
 import { bumpPower } from '@/lib/points';
@@ -226,6 +227,22 @@ function ComposeDialog({
   async function onFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     const selected = Array.from(e.target.files ?? []);
     e.target.value = ''; // 同じファイルを再選択しても change が起きるように
+    await addFiles(selected);
+  }
+
+  // クリップボードから画像を貼り付けて添付する (スクショ等)。テキストだけの貼り付けは
+  // 邪魔しない (画像が無ければ preventDefault せず通常の貼り付けに任せる)。
+  function onPaste(e: React.ClipboardEvent) {
+    if (replyTo) return; // 返信は画像添付不可 (showImageUi=false と揃える)
+    if (loading || compressing) return; // 投稿中/圧縮中は受け付けない (ボタンの disabled と揃える)
+    const files = imageFilesFromClipboard(e.clipboardData?.items);
+    if (files.length === 0) return; // 画像が無ければ通常のテキスト貼り付けに委ねる
+    e.preventDefault();
+    void addFiles(files);
+  }
+
+  // ファイル選択・クリップボード貼り付け共通の取り込み処理 (圧縮 → 上限内に収めて添付)。
+  async function addFiles(selected: File[]) {
     if (selected.length === 0) return;
 
     // 既存枚数 + 今回分が上限を超えるぶんは切り捨てて警告
@@ -425,6 +442,7 @@ function ComposeDialog({
           overflow: isColumn ? 'visible' : 'auto',
         }}
         onClick={isColumn ? undefined : (e) => e.stopPropagation()}
+        onPaste={onPaste}
       >
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '0.4em' }}>
           <h3 style={{ margin: 0, fontSize: '1em' }}>{replyTo ? '返信' : '投稿する'}</h3>
@@ -576,6 +594,11 @@ function ComposeDialog({
               {compressing && (
                 <span style={{ fontSize: '0.75em', color: 'var(--color-muted)', marginLeft: '0.5em' }}>
                   投稿用に画像を準備しています…
+                </span>
+              )}
+              {!compressing && images.length < MAX_POST_IMAGES && (
+                <span style={{ fontSize: '0.72em', color: 'var(--color-muted)', marginLeft: '0.5em' }}>
+                  貼り付け (クリップボード) でも添付できます
                 </span>
               )}
             </div>

--- a/apps/web/src/components/compose-modal.tsx
+++ b/apps/web/src/components/compose-modal.tsx
@@ -184,6 +184,9 @@ function ComposeDialog({
   // 複数枚を逐次処理する間「進んでいる」ことを見せる (高解像度 4 枚は数秒かかり、固まったと誤解されるため)
   const [compressProgress, setCompressProgress] = useState<{ done: number; total: number } | null>(null);
   const [err, setErr] = useState<string | null>(null);
+  // 添付完了の読み上げ用 (aria-live)。貼り付けは間接操作で「受け取った」合図が薄いので、
+  // ファイル選択・貼り付け共通でスクリーンリーダーに枚数を知らせる。
+  const [addNotice, setAddNotice] = useState('');
   const fileInputRef = useRef<HTMLInputElement>(null);
   const imagesRef = useRef<DialogState[]>(images);
   imagesRef.current = images;
@@ -232,6 +235,9 @@ function ComposeDialog({
 
   // クリップボードから画像を貼り付けて添付する (スクショ等)。テキストだけの貼り付けは
   // 邪魔しない (画像が無ければ preventDefault せず通常の貼り付けに任せる)。
+  // 仕様: ハンドラはカード全体に付くので、alt (画像説明) 欄にフォーカス中に画像を貼っても
+  // その欄に紐づくのではなく**常に末尾へ新規画像として追加**する (差し替えは概念的に
+  // 複雑で混乱を招くため、「貼り付け=新規添付」に一貫させる)。
   function onPaste(e: React.ClipboardEvent) {
     if (replyTo) return; // 返信は画像添付不可 (showImageUi=false と揃える)
     if (loading || compressing) return; // 投稿中/圧縮中は受け付けない (ボタンの disabled と揃える)
@@ -297,12 +303,17 @@ function ComposeDialog({
       return;
     }
     if (added.length > 0) {
+      let total = 0;
       setImages((prev) => {
         const merged = [...prev, ...added];
         // 上限超過で落ちた分の objectURL を revoke (await を挟む間に prev が増えても漏らさない)
         for (const dropped of merged.slice(MAX_POST_IMAGES)) URL.revokeObjectURL(dropped.previewUrl);
-        return merged.slice(0, MAX_POST_IMAGES);
+        const next = merged.slice(0, MAX_POST_IMAGES);
+        total = next.length;
+        return next;
       });
+      // 貼り付け/選択どちらでも「添付された」ことを読み上げる (毎回更新で再アナウンス)。
+      setAddNotice(`画像を添付しました (${total}/${MAX_POST_IMAGES} 枚)`);
     }
     // スキップ内訳をまとめて 1 つの文言に
     const notes: string[] = [];
@@ -492,6 +503,15 @@ function ComposeDialog({
           disabled={loading}
           autoFocus
         />
+
+        {/* 添付完了の読み上げ (視覚的には非表示)。プレビューが画面外/圧縮が一瞬でも、
+           貼り付け/選択で「添付された」ことをスクリーンリーダーに伝える。 */}
+        <span
+          aria-live="polite"
+          style={{ position: 'absolute', width: 1, height: 1, padding: 0, margin: -1, overflow: 'hidden', clip: 'rect(0 0 0 0)', whiteSpace: 'nowrap', border: 0 }}
+        >
+          {addNotice}
+        </span>
 
         {showImageUi && (
           <div style={{ marginTop: '0.5em', display: 'flex', flexDirection: 'column', gap: '0.4em' }}>

--- a/apps/web/src/lib/clipboard-images.test.ts
+++ b/apps/web/src/lib/clipboard-images.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { imageFilesFromClipboard } from './clipboard-images';
+
+// DataTransferItem の最小フェイク (kind / type / getAsFile だけ使う)
+function item(kind: string, type: string, file: File | null): DataTransferItem {
+  return { kind, type, getAsFile: () => file } as unknown as DataTransferItem;
+}
+function list(items: DataTransferItem[]): DataTransferItemList {
+  // for...of で回せれば十分なので配列を DataTransferItemList として渡す
+  return items as unknown as DataTransferItemList;
+}
+const fakeFile = (name: string) => ({ name } as unknown as File);
+
+describe('imageFilesFromClipboard', () => {
+  it('画像ファイルだけを取り出す', () => {
+    const png = fakeFile('shot.png');
+    const files = imageFilesFromClipboard(list([
+      item('string', 'text/plain', null),       // テキスト → 無視
+      item('file', 'image/png', png),            // 画像 → 採用
+      item('file', 'application/pdf', fakeFile('a.pdf')), // 非画像ファイル → 無視
+    ]));
+    expect(files).toEqual([png]);
+  });
+
+  it('複数画像をすべて取り出す', () => {
+    const a = fakeFile('a.png'); const b = fakeFile('b.jpg');
+    const files = imageFilesFromClipboard(list([
+      item('file', 'image/png', a),
+      item('file', 'image/jpeg', b),
+    ]));
+    expect(files).toEqual([a, b]);
+  });
+
+  it('kind が file でも getAsFile が null なら採用しない', () => {
+    expect(imageFilesFromClipboard(list([item('file', 'image/png', null)]))).toEqual([]);
+  });
+
+  it('テキストのみ / null / undefined では空配列', () => {
+    expect(imageFilesFromClipboard(list([item('string', 'text/plain', null)]))).toEqual([]);
+    expect(imageFilesFromClipboard(null)).toEqual([]);
+    expect(imageFilesFromClipboard(undefined)).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/clipboard-images.ts
+++ b/apps/web/src/lib/clipboard-images.ts
@@ -1,0 +1,17 @@
+/**
+ * ClipboardEvent の DataTransferItemList から画像ファイルだけを取り出す純粋関数
+ * (テスト可能・描画非依存)。スクショ等を貼り付けたとき items に kind:'file' /
+ * type:'image/*' のエントリが入る。テキストだけの貼り付けでは空配列を返すので、
+ * 呼び出し側は「空なら preventDefault せず通常の貼り付けに委ねる」判断ができる。
+ */
+export function imageFilesFromClipboard(items: DataTransferItemList | null | undefined): File[] {
+  if (!items) return [];
+  const files: File[] = [];
+  for (const item of items) {
+    if (item.kind === 'file' && item.type.startsWith('image/')) {
+      const f = item.getAsFile();
+      if (f) files.push(f);
+    }
+  }
+  return files;
+}


### PR DESCRIPTION
## 概要
投稿フォームに**クリップボードからの画像貼り付け**(スクショ等)での添付を追加。

## 実装
- compose コンテナに `onPaste` を付与。`clipboardData.items` から画像ファイルを取り出し、
  **ファイル選択と共通の `addFiles`**(圧縮 → 上限内に収めて添付・既存のエラー文言/枚数管理)に流す。
- 画像が無い貼り付けは `preventDefault` せず、**通常のテキスト貼り付けを邪魔しない**。
- 返信時(画像不可・`showImageUi=false`)・投稿中/圧縮中は受け付けない(既存ボタンの `disabled` と整合)。
- 取り出しロジックを `imageFilesFromClipboard` に**純粋関数化**してユニットテスト。
- 「貼り付け (クリップボード) でも添付できます」のヒントを追加(発見性)。

## 挙動
- 4 枚上限・容量超過・非対応形式のスキップは既存ロジックをそのまま共有(貼り付けでも同じ警告)。
- PC は ⌘/Ctrl+V、モバイルは長押し→貼り付けメニューから。

## 検証
- typecheck / build / test (218, +4 clipboard helper) 緑。
- ⚠️ 実際の貼り付け挙動は実機/ブラウザで要確認(dev)。



## Review
§1.5 レビュー (実装 + UX) → **★★★/★★ ゼロ = 出荷可**。
- **実装**: onFileChange→addFiles 抽出は挙動等価 (圧縮/上限/objectURL revoke/compressProgress/mountedRef すべて踏襲)。onPaste のガード (replyTo/loading/compressing) は既存 disabled と整合、画像無しは preventDefault せずテキスト貼り付けを壊さない。並行性 (compressing ガード + imagesRef + setImages slice) で上限超過なし、stale closure なし。clipboard helper は image/* + getAsFile null 除外、HEIC 通過、null ガード。メモリリーク無し。★★★/★★ ゼロ。
- **UX**: コア体験は既存導線に正しく相乗り。**★★ 2 件を PR 内対応** (commit 後述):
  - ★★-2: 添付完了の合図が薄い → aria-live で「画像を添付しました (N/4)」を読み上げ (a11y 兼)。
  - ★★-1: alt 欄での画像貼り付けは『常に末尾へ新規添付』する仕様を onPaste コメントに明記。
  - ★ (上限到達でヒント消滅・モバイルで貼り付け導線が乏しい・SVG は既存同様に弾く) は許容/柔軟。

## 検証
typecheck/build/test (218, +4 clipboard helper) 緑。**実機での paste 挙動 (特に iOS Safari のスクショ貼り付け) は dev で要確認**。
