### PR TITLE
fix(virtual-feed): スクロール震えのフィードバックループを断つ

### DIFF
--- a/apps/web/src/components/virtual-feed.tsx
+++ b/apps/web/src/components/virtual-feed.tsx
@@ -68,11 +68,26 @@ export function VirtualFeed<T>(props: VirtualFeedProps<T>) {
     };
     measure();
     if (typeof ResizeObserver === 'undefined') return;
-    const ro = new ResizeObserver(measure);
+    // ResizeObserver のコールバックを rAF でデバウンスする。同一フレーム内の
+    // 複数発火を 1 回に畳み込み、measure → setState → reflow → 再発火 の
+    // タイトループ ("ResizeObserver loop" / スクロール震え) を断つ。値が変わら
+    // なければ setContainerMargin は React がバイパスするので再 render も起きない。
+    let raf = 0;
+    const schedule = () => {
+      if (raf) return;
+      raf = requestAnimationFrame(() => {
+        raf = 0;
+        measure();
+      });
+    };
+    const ro = new ResizeObserver(schedule);
     ro.observe(containerEl);
     const above = parentRef.current?.parentElement;
     if (above) ro.observe(above);
-    return () => ro.disconnect();
+    return () => {
+      if (raf) cancelAnimationFrame(raf);
+      ro.disconnect();
+    };
   }, [containerEl]);
 
   // 既知の制約 (旧実装から同じ): window モードの scrollMargin は render 中に
@@ -91,7 +106,11 @@ export function VirtualFeed<T>(props: VirtualFeedProps<T>) {
     // container モードでは container 先頭 = リスト先頭なので 0
     // (column 内にヘッダー等を挟む場合は利用側で要再考)。
     scrollMargin,
-    measureElement: (el) => el.getBoundingClientRect().height,
+    // 実測高さを整数に丸める。getBoundingClientRect().height は小数を返し、
+    // 行の高さが 0.x px 単位で揺れると translateY 補正 → 再測定 → … と
+    // サブピクセルのフィードバックループ (スクロール震え/shimmer) を起こしうる。
+    // 丸めることでこの振動源を断つ (体感の高さ精度には影響しない)。
+    measureElement: (el) => Math.round(el.getBoundingClientRect().height),
   });
 
   // onEndReached: 末尾からの距離で発火


### PR DESCRIPTION
## 背景

ユーザー報告: 「カラムのスクロールが特定位置に来ると、スクロールがずっと震える (上下に振動し続ける)」。オーナー側・開発側とも**再現できていない**。

## 原因仮説 (virtual-feed.tsx + virtual-core ソースを読んで特定)

仮想スクローラに振動 (オシレーション) を起こしうる既知の2経路:
1. `measureElement` が `getBoundingClientRect().height` の**小数**を返し、行高が 0.x px 単位で揺れると `delta !== 0` 判定が毎フレーム真 → `translateY` 補正 → 再測定 のサブピクセル shimmer ループになる。
2. `scrollMargin` を計測する `ResizeObserver` が `measure → setState → reflow → 再発火` のタイトループ ("ResizeObserver loop") を起こしうる。

## 変更

- `measureElement` の実測高さを `Math.round` で整数化 → ①の振動源を断つ。itemSizeCache も start/totalSize も同じ整数ベースで積み上がるため累積ズレは生じない (virtual-core ソースで確認)。
- ResizeObserver コールバックを `requestAnimationFrame` でデバウンス → ②のタイトループを防ぐ。同一フレームの複数発火を1回に畳み込み、unmount で rAF を cancel。

どちらも**挙動を変えない安全側のハードニング**。

## 検証

- typecheck / unit (218) / e2e (workspace + smoke 7件) すべて緑 = **通常スクロール・カラム表示・load-more に回帰なし**。
- **震え自体は再現環境が無いため「解消した」とは断言しない**。最有力の振動源を構造的に除去した位置づけ。

## Review

§1.5 の 2 並列 (実装 / 回帰) レビューを実施。**★★★ ゼロ**。

- **実装レビュー**: rAF ガード・cleanup・SSR 分岐・丸めの内部整合を virtual-core ソースまで裏取りして正しいと確認。
  - **★★** 効果を盛らない記述 + 残りうる真因 (PostCard の遅延ロード可変高による scroll 補正ループ / mobile 100dvh 連動) を明記 → **issue #193 に切り出し**。本 description / commit でも「解消とは断言しない」と明記済み。
  - ★ `Math.round` で行高が最大0.5px低く見積もられうる (累積なし・実害ほぼなし) / 二重 observe は ResizeObserver が畳むので無害 → 見送り。
- **回帰レビュー**: window モード (friends.tsx) は `containerEl` 無しで早期 return のため無影響、container モード各所も丸め・rAF とも整合性を崩さない。PC カラム幅ドラッグ時はむしろ rAF 化で発火が畳まれ望ましい。
  - **★★** 本変更を守る自動テストが皆無 (リポジトリは node 環境 + 純関数 .test.ts のみで component 描画基盤が未導入) → **issue #192 に切り出し**。
  - ★ rAF 化で上部コンテンツ高さ変化の反映が最大1フレーム遅延 (全行一律オフセットのため知覚困難) → 見送り。