### PR TITLE
release: 2026.06.19-2 — スクロール震え修正

### DIFF
--- a/apps/web/src/components/virtual-feed.tsx
+++ b/apps/web/src/components/virtual-feed.tsx
@@ -68,11 +68,26 @@ export function VirtualFeed<T>(props: VirtualFeedProps<T>) {
     };
     measure();
     if (typeof ResizeObserver === 'undefined') return;
-    const ro = new ResizeObserver(measure);
+    // ResizeObserver のコールバックを rAF でデバウンスする。同一フレーム内の
+    // 複数発火を 1 回に畳み込み、measure → setState → reflow → 再発火 の
+    // タイトループ ("ResizeObserver loop" / スクロール震え) を断つ。値が変わら
+    // なければ setContainerMargin は React がバイパスするので再 render も起きない。
+    let raf = 0;
+    const schedule = () => {
+      if (raf) return;
+      raf = requestAnimationFrame(() => {
+        raf = 0;
+        measure();
+      });
+    };
+    const ro = new ResizeObserver(schedule);
     ro.observe(containerEl);
     const above = parentRef.current?.parentElement;
     if (above) ro.observe(above);
-    return () => ro.disconnect();
+    return () => {
+      if (raf) cancelAnimationFrame(raf);
+      ro.disconnect();
+    };
   }, [containerEl]);
 
   // 既知の制約 (旧実装から同じ): window モードの scrollMargin は render 中に
@@ -91,7 +106,11 @@ export function VirtualFeed<T>(props: VirtualFeedProps<T>) {
     // container モードでは container 先頭 = リスト先頭なので 0
     // (column 内にヘッダー等を挟む場合は利用側で要再考)。
     scrollMargin,
-    measureElement: (el) => el.getBoundingClientRect().height,
+    // 実測高さを整数に丸める。getBoundingClientRect().height は小数を返し、
+    // 行の高さが 0.x px 単位で揺れると translateY 補正 → 再測定 → … と
+    // サブピクセルのフィードバックループ (スクロール震え/shimmer) を起こしうる。
+    // 丸めることでこの振動源を断つ (体感の高さ精度には影響しない)。
+    measureElement: (el) => Math.round(el.getBoundingClientRect().height),
   });
 
   // onEndReached: 末尾からの距離で発火

--- a/apps/web/src/lib/app-version.ts
+++ b/apps/web/src/lib/app-version.ts
@@ -12,7 +12,7 @@
  *   3. 同じ値で git tag を打つ:
  *        git tag v2026.06.14-1 && git push origin v2026.06.14-1
  */
-export const APP_VERSION = '2026.06.19-1';
+export const APP_VERSION = '2026.06.19-2';
 
 /** APP_VERSION が `YYYY.MM.DD-N` 形式かを検証する (テスト/CI で形式崩れを検出)。
  *  月 01-12 / 日 01-31 のゼロ詰め 2 桁、枝番は先頭ゼロ不可の 1 以上まで一本でガードする。 */


### PR DESCRIPTION
## リリース 2026.06.19-2

前回リリース (2026.06.19-1) 以降に dev へ積まれた修正を本番へ反映する。

### 含まれる変更
- **#191** fix(virtual-feed): スクロール震え (オシレーション) のフィードバックループを断つ
- **#194** chore(release): APP_VERSION 2026.06.19-2

### なぜ本番に出すか
震え報告は本番ユーザー由来で、報告ユーザーは本番を見るため。低リスクなハードニング (measureElement 整数丸め + ResizeObserver の rAF デバウンス、挙動不変)。

### §1.5 レビュー
- #191 は feature PR 時点で 2 並列 (実装/回帰) レビュー済み。★★★ ゼロ、virtual-core ソースまで裏取り。
- ★★ は issue #192 (テスト基盤) / #193 (残存真因 = PostCard 可変高・mobile dvh) に切り出し済み。
- **再現環境が無いため「震えが解消した」とは断言しない**。最有力の振動源を構造的に除去したハードニング。

### リリース後の確認
- 設定画面隅の APP_VERSION が `2026.06.19-2` になること
- 通常スクロール・load-more が問題ないこと
- 報告ユーザーに「震えていた箇所で再確認」を依頼