### PR TITLE
fix(post-processor): 投稿後解析の ONNX Worker を毎回解放 (iPhone のメモリ蓄積→リロード対策)

### DIFF
--- a/apps/web/src/lib/post-processor.ts
+++ b/apps/web/src/lib/post-processor.ts
@@ -31,7 +31,7 @@ import {
 } from '@aozoraquest/core';
 import { classifyFromVec, type ActionCategory } from './action-classifier';
 import { classifyCognitiveFromVec } from './cognitive-classifier';
-import { getCognitiveOnnxClassifier } from './cognitive-onnx';
+import { getCognitiveOnnxClassifier, disposeCognitiveOnnxClassifier } from './cognitive-onnx';
 import { getEmbedder } from './embedder';
 import { getRecord, putRecord } from './atproto';
 import { deriveActionTypes, type PostStructure } from './structural-action';
@@ -115,22 +115,35 @@ export async function processSelfPost(
   if (trimmed.length === 0) return empty;
 
   // 1) 埋め込みは action 用に 1 回 (cognitive は fine-tune 済 ONNX 直接推論)
-  const embedder = getEmbedder();
-  await embedder.init().catch(() => { /* 既に init 済みなら no-op */ });
-  const cog = getCognitiveOnnxClassifier();
-  await cog.init().catch(() => { /* 既に init 済みなら no-op */ });
-  const vec = await embedder.embed(trimmed);
+  // この解析は投稿のたびに走る。embedder / cognitive の Worker (WASM + ONNX tensor)
+  // を開きっぱなしにすると、モバイル Safari では tensor がプロセスメモリに蓄積し、
+  // メモリ監視 (jetsam) がタブを破棄 → 投稿直後に画面全体がリロードされる。
+  // 推論結果 (postCognitive / actResult / vec) を取り出した時点で用済みなので、
+  // finally で必ず Worker を解放する (次回投稿/診断時に getXxx() が lazy 再 init)。
+  let actResult: Awaited<ReturnType<typeof classifyFromVec>>;
+  let postCognitive: CognitiveScores;
+  try {
+    const embedder = getEmbedder();
+    await embedder.init().catch(() => { /* 既に init 済みなら no-op */ });
+    const cog = getCognitiveOnnxClassifier();
+    await cog.init().catch(() => { /* 既に init 済みなら no-op */ });
+    const vec = await embedder.embed(trimmed);
 
-  // 2) 行動 (vec) & 認知 (text) を並列
-  const [actResult, onnxCognitive] = await Promise.all([
-    classifyFromVec(vec),
-    cog.classifyPost(trimmed).catch((e) => {
-      console.warn('[cognitive] ONNX classify failed, falling back to prototype', e);
-      return null;
-    }),
-  ]);
-  // ONNX が使えなかった場合は従来の prototype embedding にフォールバック
-  const postCognitive = onnxCognitive ?? await classifyCognitiveFromVec(vec, embedder);
+    // 2) 行動 (vec) & 認知 (text) を並列
+    const [act, onnxCognitive] = await Promise.all([
+      classifyFromVec(vec),
+      cog.classifyPost(trimmed).catch((e) => {
+        console.warn('[cognitive] ONNX classify failed, falling back to prototype', e);
+        return null;
+      }),
+    ]);
+    actResult = act;
+    // ONNX が使えなかった場合は従来の prototype embedding にフォールバック
+    postCognitive = onnxCognitive ?? await classifyCognitiveFromVec(vec, embedder);
+  } finally {
+    disposeCognitiveOnnxClassifier();
+    getEmbedder().dispose();
+  }
 
   const action = actResult.action;
   const actionType = action ? (action as ActionType) : null;

--- a/apps/web/src/lib/post-processor.ts
+++ b/apps/web/src/lib/post-processor.ts
@@ -31,8 +31,8 @@ import {
 } from '@aozoraquest/core';
 import { classifyFromVec, type ActionCategory } from './action-classifier';
 import { classifyCognitiveFromVec } from './cognitive-classifier';
-import { getCognitiveOnnxClassifier, disposeCognitiveOnnxClassifier } from './cognitive-onnx';
-import { getEmbedder } from './embedder';
+import { CognitiveOnnxClassifier } from './cognitive-onnx';
+import { Embedder } from './embedder';
 import { getRecord, putRecord } from './atproto';
 import { deriveActionTypes, type PostStructure } from './structural-action';
 
@@ -115,18 +115,23 @@ export async function processSelfPost(
   if (trimmed.length === 0) return empty;
 
   // 1) 埋め込みは action 用に 1 回 (cognitive は fine-tune 済 ONNX 直接推論)
-  // この解析は投稿のたびに走る。embedder / cognitive の Worker (WASM + ONNX tensor)
-  // を開きっぱなしにすると、モバイル Safari では tensor がプロセスメモリに蓄積し、
-  // メモリ監視 (jetsam) がタブを破棄 → 投稿直後に画面全体がリロードされる。
-  // 推論結果 (postCognitive / actResult / vec) を取り出した時点で用済みなので、
-  // finally で必ず Worker を解放する (次回投稿/診断時に getXxx() が lazy 再 init)。
+  //
+  // この解析は投稿のたびに走る。Worker (WASM + ONNX tensor) を開きっぱなしにすると
+  // モバイル Safari では tensor がプロセスメモリに蓄積し、メモリ監視 (jetsam) が
+  // タブを破棄 → 投稿直後に画面全体がリロードされる。よって推論後に必ず解放する。
+  //
+  // ただし共有 singleton (getEmbedder / getCognitiveOnnxClassifier) を解放すると、
+  // 同じ Worker を使う他フロー (診断・相性ランキングの裏診断・TL 認知分析) を巻き
+  // 込んで terminate し、永久 hang やスコア欠落を起こす。そこで投稿解析専用の
+  // ローカルインスタンスを立て、これだけを finally で dispose する。共有 singleton
+  // には一切触れない。モデル本体は Cache/IDB 済なので再 DL は無い (WASM 構築のみ)。
+  const embedder = new Embedder();
+  const cog = new CognitiveOnnxClassifier();
   let actResult: Awaited<ReturnType<typeof classifyFromVec>>;
   let postCognitive: CognitiveScores;
   try {
-    const embedder = getEmbedder();
-    await embedder.init().catch(() => { /* 既に init 済みなら no-op */ });
-    const cog = getCognitiveOnnxClassifier();
-    await cog.init().catch(() => { /* 既に init 済みなら no-op */ });
+    await embedder.init().catch(() => { /* init 失敗時は embed 側が reject → 下で throw */ });
+    await cog.init().catch(() => { /* ONNX 不可なら classifyPost が null → prototype fallback */ });
     const vec = await embedder.embed(trimmed);
 
     // 2) 行動 (vec) & 認知 (text) を並列
@@ -141,8 +146,8 @@ export async function processSelfPost(
     // ONNX が使えなかった場合は従来の prototype embedding にフォールバック
     postCognitive = onnxCognitive ?? await classifyCognitiveFromVec(vec, embedder);
   } finally {
-    disposeCognitiveOnnxClassifier();
-    getEmbedder().dispose();
+    cog.dispose();
+    embedder.dispose();
   }
 
   const action = actResult.action;


### PR DESCRIPTION
## 背景 (ユーザー報告)

iPhone で「**投稿後にすぐ画面全体がリフレッシュされる**ことがよくある」。メモリ不足でタブが落ちている疑い。

## 原因

投稿のたびにバックグラウンドで走る `processSelfPost` (クエスト進行解析) が、端末内 ONNX モデルを2つ Worker で init + 推論する (embedder + cognitive classifier)。これらの Worker を開きっぱなしにするため、モバイル Safari では tensor がプロセスメモリに蓄積 → メモリ監視 (jetsam) がタブを破棄 → 投稿直後にフルリロード。

`cognitive-onnx.ts` は「モバイル Safari で繰り返すと tensor が貯まってクラッシュするので**必須**」と dispose を明記していたが、**呼び出し箇所が一つも無かった** (定義のみで未配線)。

## 変更

`processSelfPost` の推論を **投稿解析専用のローカルインスタンス** (`new Embedder()` / `new CognitiveOnnxClassifier()`) で行い、`try/finally` で**そのローカル分だけ** dispose する。共有 singleton (`getEmbedder` / `getCognitiveOnnxClassifier`) には一切触れない。

- action prototype は事前計算 `.bin` の fetch で embedder Worker 不要、cognitive の prototype fallback は渡したローカル embedder を使うため、全経路がローカルに閉じる。
- モデルは Cache/IDB 済なので再 DL は無い (WASM 構築のみ、解析は非同期 fire-and-forget で UX 非ブロック)。

## スコープ

投稿パスのみ。診断フロー (`runDiagnosis` / 相性ランキングの `diagnoseGivenPosts`) の Worker 解放と embedder timeout 追加は **issue #196**。

## Review

§1.5 の 2 並列 (実装 / 並行・回帰) レビュー + 修正後の検証レビュー 1 本を実施。

- **★★★ (並行レビュー)**: 当初実装は共有 singleton を投稿 finally で無差別 terminate し、並行する**相性ランキング裏診断 (TL 閲覧中ずっと走る)** や診断の in-flight 推論を巻き込み、embedder 永久 hang / 認知スコア無音欠落 → 劣化結果を IDB に 30 日キャッシュ、というリグレッションを生む指摘。
  → **専用インスタンス化で根本解消** (commit 0f838bf)。
- **★★ (実装レビュー)**: 同じ共有 singleton 競合の指摘。同上で解消。
- **検証レビュー (修正後)**: 共有 singleton 非依存・dispose の null/例外安全・リーク経路の不在・機能等価性・typecheck 緑をすべて確認。**指摘なし、マージ可**。
- **★★ (並行レビュー)**: embedder `embed()` に timeout が無い → 本 PR では mid-flight dispose が起きなくなったため踏まないが、診断経路に残る潜在課題として **#196** に追記。
- **★ (実装)**: `getEmbedder()` 二重呼び / dispose 非対称 / コメント文言 → 専用インスタンス化に伴い解消・コメント刷新。

**再現環境 (iPhone) は無いため「リロードしなくなった」とは断言しない**。設計コメントが示す failure mode に対し、他フローを壊さない形で Worker を確実に解放する配線、という位置づけ。

注: CI の `web-ci` (typecheck/build/test/e2e) は緑。`Workers Builds` チェックは 0 秒で即失敗 (ビルドログ無し) しており、本番が既に最新版を配信中であることから CF 側のビルドクォータ/障害と判断 (コード要因ではない)。