### PR TITLE
fix(feed): モバイルでスクロール中に落ちる OOM を修正 (loadMore 暴走 + embedder WASM 固定)

### DIFF
--- a/apps/web/src/lib/embedder.ts
+++ b/apps/web/src/lib/embedder.ts
@@ -25,7 +25,7 @@ export class Embedder {
     return () => this.listeners.delete(l);
   }
 
-  async init(device: 'webgpu' | 'wasm' = 'webgpu'): Promise<void> {
+  async init(device: 'webgpu' | 'wasm' = 'wasm'): Promise<void> {
     if (this.ready) return this.ready;
     this.worker = new Worker(new URL('./embedder.worker.ts', import.meta.url), { type: 'module' });
     this.worker.addEventListener('message', (ev) => this.onMessage(ev));

--- a/apps/web/src/lib/embedder.worker.ts
+++ b/apps/web/src/lib/embedder.worker.ts
@@ -63,7 +63,7 @@ self.addEventListener('message', async (event: MessageEvent<IncomingMessage>) =>
       return;
     }
     if (msg.type === 'embed') {
-      if (!extractor) await ensureExtractor('webgpu');
+      if (!extractor) await ensureExtractor('wasm');
       const output = await extractor(msg.text, { pooling: 'mean', normalize: true });
       const vec = output.data as Float32Array;
       // 所有権を移してコピーを避ける

--- a/apps/web/src/lib/embedder.worker.ts
+++ b/apps/web/src/lib/embedder.worker.ts
@@ -24,7 +24,7 @@ type IncomingMessage =
 
 let extractor: any = null;
 
-async function ensureExtractor(device: 'webgpu' | 'wasm' = 'webgpu'): Promise<void> {
+async function ensureExtractor(device: 'webgpu' | 'wasm' = 'wasm'): Promise<void> {
   if (extractor) return;
   try {
     extractor = await pipeline('feature-extraction', EMBEDDING_MODEL_ID, {
@@ -58,7 +58,7 @@ self.addEventListener('message', async (event: MessageEvent<IncomingMessage>) =>
   const msg = event.data;
   try {
     if (msg.type === 'init') {
-      await ensureExtractor(msg.device ?? 'webgpu');
+      await ensureExtractor(msg.device ?? 'wasm');
       (self as unknown as Worker).postMessage({ type: 'ready' });
       return;
     }

--- a/apps/web/src/lib/use-infinite-feed.ts
+++ b/apps/web/src/lib/use-infinite-feed.ts
@@ -76,12 +76,19 @@ export function useInfiniteFeed<T>(opts: UseInfiniteFeedOptions<T>): InfiniteFee
   const cursorRef = useRef<string | undefined>(undefined);
   const inflight = useRef(false);
   const doneRef = useRef(false);
+  // 連続で「ほぼ重複ページ」(新規が少ない) を踏んだ回数。Bluesky が cursor 付きで
+  // 重複だらけのページを返し続けるケースで loadMore 暴走 (→ モバイル OOM) を止める。
+  const lowProgressRef = useRef(0);
   const fetchPageRef = useRef(fetchPage);
   fetchPageRef.current = fetchPage;
   const keyOfRef = useRef(keyOf);
   keyOfRef.current = keyOf;
   const cacheRef = useRef(cache);
   cacheRef.current = cache;
+  // done 判定 (新規ゼロ検出) 用に、コミット済みの items を ref で参照する。
+  // 件数カウントにのみ使う (state 更新は functional updater のまま = refresh と競合しない)。
+  const itemsRef = useRef<T[]>([]);
+  itemsRef.current = items;
   // hydrate epoch: deps 変化ごとに増やすことで、古い cache.load() の解決が
   // 新しい hydrate を上書きしないようにする (race ガード)
   const hydrateEpoch = useRef(0);
@@ -96,6 +103,17 @@ export function useInfiniteFeed<T>(opts: UseInfiniteFeedOptions<T>): InfiniteFee
     try {
       const nextCursor = resetting ? undefined : cursorRef.current;
       const page = await fetchPageRef.current(nextCursor);
+      // 新規追加件数を、コミット済み items に対してカウントする (done 判定用)。
+      const baseForCount = resetting ? [] : itemsRef.current;
+      const seenForCount = new Set(baseForCount.map((x) => keyOfRef.current(x)));
+      let added = 0;
+      for (const it of page.items) {
+        const k = keyOfRef.current(it);
+        if (!seenForCount.has(k)) {
+          seenForCount.add(k);
+          added += 1;
+        }
+      }
       setItems((prev) => {
         const base = resetting ? [] : prev;
         const seen = new Set(base.map((x) => keyOfRef.current(x)));
@@ -110,7 +128,19 @@ export function useInfiniteFeed<T>(opts: UseInfiniteFeedOptions<T>): InfiniteFee
         return merged;
       });
       cursorRef.current = page.cursor;
-      if (!page.cursor || page.items.length === 0) {
+      // 低進捗バックオフ: append fetch で「ページの大半が重複」(新規が少ない) のが
+      // 連続したら done にする。Bluesky が cursor 付きで重複だらけのページを返し
+      // 続けるケースで、onEndReached → loadMore が空振りフェッチ (30 件取得 + パース)
+      // を連打し、ネットワーク/メモリのチャーンでモバイルが OOM するのを防ぐ。
+      // 健全な TL は毎ページ大量の新規が来るので発火しない。
+      if (!resetting && page.items.length > 0) {
+        const lowThreshold = Math.max(3, Math.floor(page.items.length * 0.3));
+        if (added < lowThreshold) lowProgressRef.current += 1;
+        else lowProgressRef.current = 0;
+      }
+      // done にする条件: 正規の終端 (cursor 無し / 空ページ) か、
+      // 低進捗が 2 連続 (= これ以上 loadMore しても新規はほぼ無い)。
+      if (!page.cursor || page.items.length === 0 || lowProgressRef.current >= 2) {
         doneRef.current = true;
         setDone(true);
       }
@@ -133,6 +163,7 @@ export function useInfiniteFeed<T>(opts: UseInfiniteFeedOptions<T>): InfiniteFee
     setItems([]);
     cursorRef.current = undefined;
     doneRef.current = false;
+    lowProgressRef.current = 0;
     setDone(false);
     setErr(null);
     if (!enabled) return;


### PR DESCRIPTION
## 背景 (実機切り分け)

iPhone でタイムラインをスクロールすると「画面全体がリフレッシュ (= iOS Safari の WebContent プロセスが OOM で破棄)」する不具合。長い切り分けの末、真因は**モデルではなくフィードの loadMore 暴走**と判明。ヘッダにデバッグ計測を出して実測:
- 修正前: 少しスクロールで `fetch:37` 以上 (items は 55 で頭打ち) → クラッシュ
- 修正後: `fetch:2` で停止 → クラッシュしない (実機確認済み)

## 原因

Bluesky の `getTimeline` が「cursor 付きで大半が重複のページ」(30件中 新規1〜2件) を返し続けるケースで `done` 判定 (`!cursor || items===0`) に当たらず、VirtualFeed の `onEndReached` → `loadMore` が**空振りフェッチ (毎回30件取得 + 埋め込みパース) を連打**。ネットワーク/メモリのチャーンで iOS Safari が OOM。

## 変更 (3ファイル・+35/-4)

1. **feed の低進捗バックオフ** (`use-infinite-feed.ts`) — 本丸: append fetch で「新規 < ページの30%」が2連続したら `done` にして停止。新規件数はコミット済み items (itemsRef) で数え、state 更新は functional updater のまま (refresh と非競合)。
2. **embedder を WASM 固定** (`embedder.ts` / `embedder.worker.ts`): device デフォルトを webgpu → wasm (iOS の WebGPU 不安定回避 + 小モデルは WASM が速い)。

## Review

§1.5 の 2 並列 (実装 / 回帰) レビュー実施。**★★★ ゼロ**。core ロジック (race ガード・functional updater 維持・deps リセット・空TL・hydrate 相互作用) は健全と確認。

- **★ (実装)** worker.ts の embed フォールバックだけ `'webgpu'` ハードコードが残存 → **commit 0d75364 で `'wasm'` に修正**。
- **★ (回帰) hideReposts ON 経路で fetch 暴走が残りうる** (raw は伸びるのでバックオフ非発火) → **issue #202**。
- **★★ (実装) refresh() が低進捗 done をリセットしない** (後で TL が伸びても続きを読めないエッジ) → **issue #203**。
- **★★ (回帰) 低トラフィックフィードでの早期 done 調整** (全フィード一律適用) → **issue #204**。
- **★★ (回帰) バックオフのユニットテスト欠如** (jsdom 基盤未導入、#192 と同根) → **issue #205**。
- ★ search/profile の早期 done は軽微 (#204 に内包)。

★★ はすべて issue 化 (§1.5 準拠)。本 PR の主目的 (loadMore 暴走停止による OOM 解消) は実機で実証済み。