### PR TITLE
release: 2026.06.19-3 — モバイル TL スクロール OOM 修正

### DIFF
--- a/apps/web/src/lib/app-version.ts
+++ b/apps/web/src/lib/app-version.ts
@@ -12,7 +12,7 @@
  *   3. 同じ値で git tag を打つ:
  *        git tag v2026.06.14-1 && git push origin v2026.06.14-1
  */
-export const APP_VERSION = '2026.06.19-2';
+export const APP_VERSION = '2026.06.19-3';
 
 /** APP_VERSION が `YYYY.MM.DD-N` 形式かを検証する (テスト/CI で形式崩れを検出)。
  *  月 01-12 / 日 01-31 のゼロ詰め 2 桁、枝番は先頭ゼロ不可の 1 以上まで一本でガードする。 */

--- a/apps/web/src/lib/embedder.ts
+++ b/apps/web/src/lib/embedder.ts
@@ -25,7 +25,7 @@ export class Embedder {
     return () => this.listeners.delete(l);
   }
 
-  async init(device: 'webgpu' | 'wasm' = 'webgpu'): Promise<void> {
+  async init(device: 'webgpu' | 'wasm' = 'wasm'): Promise<void> {
     if (this.ready) return this.ready;
     this.worker = new Worker(new URL('./embedder.worker.ts', import.meta.url), { type: 'module' });
     this.worker.addEventListener('message', (ev) => this.onMessage(ev));

--- a/apps/web/src/lib/embedder.worker.ts
+++ b/apps/web/src/lib/embedder.worker.ts
@@ -24,7 +24,7 @@ type IncomingMessage =
 
 let extractor: any = null;
 
-async function ensureExtractor(device: 'webgpu' | 'wasm' = 'webgpu'): Promise<void> {
+async function ensureExtractor(device: 'webgpu' | 'wasm' = 'wasm'): Promise<void> {
   if (extractor) return;
   try {
     extractor = await pipeline('feature-extraction', EMBEDDING_MODEL_ID, {
@@ -58,12 +58,12 @@ self.addEventListener('message', async (event: MessageEvent<IncomingMessage>) =>
   const msg = event.data;
   try {
     if (msg.type === 'init') {
-      await ensureExtractor(msg.device ?? 'webgpu');
+      await ensureExtractor(msg.device ?? 'wasm');
       (self as unknown as Worker).postMessage({ type: 'ready' });
       return;
     }
     if (msg.type === 'embed') {
-      if (!extractor) await ensureExtractor('webgpu');
+      if (!extractor) await ensureExtractor('wasm');
       const output = await extractor(msg.text, { pooling: 'mean', normalize: true });
       const vec = output.data as Float32Array;
       // 所有権を移してコピーを避ける

--- a/apps/web/src/lib/post-processor.ts
+++ b/apps/web/src/lib/post-processor.ts
@@ -31,8 +31,8 @@ import {
 } from '@aozoraquest/core';
 import { classifyFromVec, type ActionCategory } from './action-classifier';
 import { classifyCognitiveFromVec } from './cognitive-classifier';
-import { getCognitiveOnnxClassifier } from './cognitive-onnx';
-import { getEmbedder } from './embedder';
+import { CognitiveOnnxClassifier } from './cognitive-onnx';
+import { Embedder } from './embedder';
 import { getRecord, putRecord } from './atproto';
 import { deriveActionTypes, type PostStructure } from './structural-action';
 
@@ -115,22 +115,40 @@ export async function processSelfPost(
   if (trimmed.length === 0) return empty;
 
   // 1) 埋め込みは action 用に 1 回 (cognitive は fine-tune 済 ONNX 直接推論)
-  const embedder = getEmbedder();
-  await embedder.init().catch(() => { /* 既に init 済みなら no-op */ });
-  const cog = getCognitiveOnnxClassifier();
-  await cog.init().catch(() => { /* 既に init 済みなら no-op */ });
-  const vec = await embedder.embed(trimmed);
+  //
+  // この解析は投稿のたびに走る。Worker (WASM + ONNX tensor) を開きっぱなしにすると
+  // モバイル Safari では tensor がプロセスメモリに蓄積し、メモリ監視 (jetsam) が
+  // タブを破棄 → 投稿直後に画面全体がリロードされる。よって推論後に必ず解放する。
+  //
+  // ただし共有 singleton (getEmbedder / getCognitiveOnnxClassifier) を解放すると、
+  // 同じ Worker を使う他フロー (診断・相性ランキングの裏診断・TL 認知分析) を巻き
+  // 込んで terminate し、永久 hang やスコア欠落を起こす。そこで投稿解析専用の
+  // ローカルインスタンスを立て、これだけを finally で dispose する。共有 singleton
+  // には一切触れない。モデル本体は Cache/IDB 済なので再 DL は無い (WASM 構築のみ)。
+  const embedder = new Embedder();
+  const cog = new CognitiveOnnxClassifier();
+  let actResult: Awaited<ReturnType<typeof classifyFromVec>>;
+  let postCognitive: CognitiveScores;
+  try {
+    await embedder.init().catch(() => { /* init 失敗時は embed 側が reject → 下で throw */ });
+    await cog.init().catch(() => { /* ONNX 不可なら classifyPost が null → prototype fallback */ });
+    const vec = await embedder.embed(trimmed);
 
-  // 2) 行動 (vec) & 認知 (text) を並列
-  const [actResult, onnxCognitive] = await Promise.all([
-    classifyFromVec(vec),
-    cog.classifyPost(trimmed).catch((e) => {
-      console.warn('[cognitive] ONNX classify failed, falling back to prototype', e);
-      return null;
-    }),
-  ]);
-  // ONNX が使えなかった場合は従来の prototype embedding にフォールバック
-  const postCognitive = onnxCognitive ?? await classifyCognitiveFromVec(vec, embedder);
+    // 2) 行動 (vec) & 認知 (text) を並列
+    const [act, onnxCognitive] = await Promise.all([
+      classifyFromVec(vec),
+      cog.classifyPost(trimmed).catch((e) => {
+        console.warn('[cognitive] ONNX classify failed, falling back to prototype', e);
+        return null;
+      }),
+    ]);
+    actResult = act;
+    // ONNX が使えなかった場合は従来の prototype embedding にフォールバック
+    postCognitive = onnxCognitive ?? await classifyCognitiveFromVec(vec, embedder);
+  } finally {
+    cog.dispose();
+    embedder.dispose();
+  }
 
   const action = actResult.action;
   const actionType = action ? (action as ActionType) : null;

--- a/apps/web/src/lib/use-infinite-feed.ts
+++ b/apps/web/src/lib/use-infinite-feed.ts
@@ -76,12 +76,19 @@ export function useInfiniteFeed<T>(opts: UseInfiniteFeedOptions<T>): InfiniteFee
   const cursorRef = useRef<string | undefined>(undefined);
   const inflight = useRef(false);
   const doneRef = useRef(false);
+  // 連続で「ほぼ重複ページ」(新規が少ない) を踏んだ回数。Bluesky が cursor 付きで
+  // 重複だらけのページを返し続けるケースで loadMore 暴走 (→ モバイル OOM) を止める。
+  const lowProgressRef = useRef(0);
   const fetchPageRef = useRef(fetchPage);
   fetchPageRef.current = fetchPage;
   const keyOfRef = useRef(keyOf);
   keyOfRef.current = keyOf;
   const cacheRef = useRef(cache);
   cacheRef.current = cache;
+  // done 判定 (新規ゼロ検出) 用に、コミット済みの items を ref で参照する。
+  // 件数カウントにのみ使う (state 更新は functional updater のまま = refresh と競合しない)。
+  const itemsRef = useRef<T[]>([]);
+  itemsRef.current = items;
   // hydrate epoch: deps 変化ごとに増やすことで、古い cache.load() の解決が
   // 新しい hydrate を上書きしないようにする (race ガード)
   const hydrateEpoch = useRef(0);
@@ -96,6 +103,17 @@ export function useInfiniteFeed<T>(opts: UseInfiniteFeedOptions<T>): InfiniteFee
     try {
       const nextCursor = resetting ? undefined : cursorRef.current;
       const page = await fetchPageRef.current(nextCursor);
+      // 新規追加件数を、コミット済み items に対してカウントする (done 判定用)。
+      const baseForCount = resetting ? [] : itemsRef.current;
+      const seenForCount = new Set(baseForCount.map((x) => keyOfRef.current(x)));
+      let added = 0;
+      for (const it of page.items) {
+        const k = keyOfRef.current(it);
+        if (!seenForCount.has(k)) {
+          seenForCount.add(k);
+          added += 1;
+        }
+      }
       setItems((prev) => {
         const base = resetting ? [] : prev;
         const seen = new Set(base.map((x) => keyOfRef.current(x)));
@@ -110,7 +128,19 @@ export function useInfiniteFeed<T>(opts: UseInfiniteFeedOptions<T>): InfiniteFee
         return merged;
       });
       cursorRef.current = page.cursor;
-      if (!page.cursor || page.items.length === 0) {
+      // 低進捗バックオフ: append fetch で「ページの大半が重複」(新規が少ない) のが
+      // 連続したら done にする。Bluesky が cursor 付きで重複だらけのページを返し
+      // 続けるケースで、onEndReached → loadMore が空振りフェッチ (30 件取得 + パース)
+      // を連打し、ネットワーク/メモリのチャーンでモバイルが OOM するのを防ぐ。
+      // 健全な TL は毎ページ大量の新規が来るので発火しない。
+      if (!resetting && page.items.length > 0) {
+        const lowThreshold = Math.max(3, Math.floor(page.items.length * 0.3));
+        if (added < lowThreshold) lowProgressRef.current += 1;
+        else lowProgressRef.current = 0;
+      }
+      // done にする条件: 正規の終端 (cursor 無し / 空ページ) か、
+      // 低進捗が 2 連続 (= これ以上 loadMore しても新規はほぼ無い)。
+      if (!page.cursor || page.items.length === 0 || lowProgressRef.current >= 2) {
         doneRef.current = true;
         setDone(true);
       }
@@ -133,6 +163,7 @@ export function useInfiniteFeed<T>(opts: UseInfiniteFeedOptions<T>): InfiniteFee
     setItems([]);
     cursorRef.current = undefined;
     doneRef.current = false;
+    lowProgressRef.current = 0;
     setDone(false);
     setErr(null);
     if (!enabled) return;


### PR DESCRIPTION
## リリース 2026.06.19-3

dev に積まれた修正を本番 (aozoraquest.app) へ反映する。**実ユーザーに影響するモバイルのクラッシュ修正**。

### 含まれる変更
- **#201** fix(feed): モバイルでスクロール中に落ちる OOM を修正 (loadMore 暴走 + embedder WASM 固定)。**実機 iPhone で実証済み** (fetch:37→2、クラッシュ解消)。
- **#197** fix(post-processor): 投稿後 ONNX Worker を解放 (メモリ蓄積対策の hardening)。
- **#206** chore(release): APP_VERSION 2026.06.19-3

### §1.5 レビュー
- #201 / #197 とも feature PR 時点で 2〜3 並列レビュー済み (★★★ ゼロ)。
- #201 の ★★ は issue #202〜205 に切り出し済み (hideReposts 経路 / refresh リセット / 早期done調整 / テスト)。

### リリース後の確認
- 設定画面隅の APP_VERSION が `2026.06.19-3` になること
- iPhone で TL を長くスクロールしても落ちないこと

### デプロイ注意
CF Workers Builds 障害が続く場合は wrangler 手動デプロイで本番反映する。