### PR TITLE
feat(nav): footer タブ再タップでカラムを最上部へスクロール

### DIFF
--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -129,6 +129,10 @@ export function AppShell() {
       // 該当カラムを削除済みでも「ホーム」等で迷子にならないよう先頭カラムへ
       document.querySelector('.workspace-column');
     el?.scrollIntoView({ behavior, inline: 'start', block: 'nearest' });
+    // 既にそのカラムを見ている時の再タップ等で、カラム内の縦スクロールも最上部へ戻す
+    // (ホーム再タップで TL の先頭に戻る一般的な挙動)。縦スクロール要素は
+    // .workspace-column-body (VirtualFeed の scrollParent)。
+    el?.querySelector('.workspace-column-body')?.scrollTo({ top: 0, behavior });
   }
 
   return (

--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -129,10 +129,13 @@ export function AppShell() {
       // 該当カラムを削除済みでも「ホーム」等で迷子にならないよう先頭カラムへ
       document.querySelector('.workspace-column');
     el?.scrollIntoView({ behavior, inline: 'start', block: 'nearest' });
-    // 既にそのカラムを見ている時の再タップ等で、カラム内の縦スクロールも最上部へ戻す
-    // (ホーム再タップで TL の先頭に戻る一般的な挙動)。縦スクロール要素は
-    // .workspace-column-body (VirtualFeed の scrollParent)。
-    el?.querySelector('.workspace-column-body')?.scrollTo({ top: 0, behavior });
+    // 「今見ているカラムのタブをもう一度タップ」したときだけ、カラム内の縦スクロールを
+    // 最上部へ戻す (ホーム再タップで TL 先頭に戻る一般的な挙動)。別カラムへ移動する
+    // だけの初回タップでは縦位置をリセットせず、前に見ていた位置を保持する。
+    // 縦スクロール要素は .workspace-column-body (VirtualFeed の scrollParent)。
+    if (columnKind === activeWorkspaceKind) {
+      el?.querySelector('.workspace-column-body')?.scrollTo({ top: 0, behavior });
+    }
   }
 
   return (


### PR DESCRIPTION
## 何を

スマホで footer の「ホーム」等のタブを押したとき、横スクロールでカラムを見せるだけでなく、**今見ているカラムのタブを再タップしたとき**にカラム内の縦スクロール (`.workspace-column-body`) を最上部へ戻す。ホーム再タップで TL 先頭に戻る一般的な挙動 (Twitter/iOS のタブ再タップ)。

## 変更
`app-shell.tsx` の `navClick` に、`scrollIntoView` (横) の後に「`columnKind === activeWorkspaceKind` のときだけ」対象カラムの `.workspace-column-body.scrollTo({top:0})` (縦) を追加。別カラムへ移動するだけの初回タップでは縦位置を保持する。`prefers-reduced-motion` 時は `behavior:'auto'`。

## Review
§1.5 の 1 並列 (実装+UX) レビュー実施。**★★★/★★ ゼロ、マージ可**。
- 既存の totop ボタン (workspace.tsx) と全く同じ `bodyEl.scrollTo({top:0})` パターンの再利用。DOM・型・挙動の3軸検証済み。
- ★ (任意): 当初「全タブ初回タップでも top リセット」だった副作用を、レビュー後にオーナー指摘で **アクティブタブ再タップ時のみに限定** (commit 2bd6a4e)。別カラムへの移動では縦位置を保持。