### PR TITLE
feat(board): 受託者にも「あなたの番」導線 (バナー+カードバッジ)

### DIFF
--- a/apps/web/src/components/column-content/board-column.tsx
+++ b/apps/web/src/components/column-content/board-column.tsx
@@ -18,6 +18,7 @@ import {
   boardFilterTitle,
   QuestCard,
   ApprovalPendingBanner,
+  ReportPendingBanner,
   type BoardFilter,
 } from './board-shared';
 
@@ -41,7 +42,7 @@ export function BoardColumn({ inner }: { inner?: BoardInner[] | undefined }) {
   const activeIndex = Math.min(tabIndex, tabs.length - 1);
   const active = tabs[activeIndex]!;
 
-  const { index, myQuests, myApplicationQuestUris, pendingApproval, err, sessionDid } = useBoardData();
+  const { index, myQuests, myApplicationQuestUris, pendingApproval, assigneeStates, reportPending, err, sessionDid } = useBoardData();
   const items = useMemo(
     () => filterForBoard(active, index, myQuests, myApplicationQuestUris, sessionDid),
     [active, index, myQuests, myApplicationQuestUris, sessionDid],
@@ -73,8 +74,10 @@ export function BoardColumn({ inner }: { inner?: BoardInner[] | undefined }) {
 
       {err && <p style={{ color: 'var(--color-danger)', fontSize: '0.85em' }}>取得に失敗: {err}</p>}
 
-      {/* どのタブを見ていても承認待ちに気づけるよう、リスト上部に常設 */}
+      {/* どのタブを見ていても「自分の番」に気づけるよう、リスト上部に常設
+          (発注者=承認待ち / 受託者=報告する番)。 */}
       <ApprovalPendingBanner pending={pendingApproval} />
+      <ReportPendingBanner pending={reportPending} />
 
       {items == null ? (
         <p style={{ fontSize: '0.8em', color: 'var(--color-muted)' }}>読み込み中...</p>
@@ -82,11 +85,19 @@ export function BoardColumn({ inner }: { inner?: BoardInner[] | undefined }) {
         <BoardEmpty filter={active} />
       ) : (
         <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
-          {items.map((q) => (
-            <li key={q.uri}>
-              <QuestCard summary={q} expired={isExpiredSummary(q)} needsApproval={pendingUris.has(q.uri)} />
-            </li>
-          ))}
+          {items.map((q) => {
+            const aState = active.kind === 'assigned' ? assigneeStates.get(q.uri) : undefined;
+            return (
+              <li key={q.uri}>
+                <QuestCard
+                  summary={q}
+                  expired={isExpiredSummary(q)}
+                  needsApproval={pendingUris.has(q.uri)}
+                  {...(aState ? { assigneeState: aState } : {})}
+                />
+              </li>
+            );
+          })}
         </ul>
       )}
     </div>

--- a/apps/web/src/components/column-content/board-shared.tsx
+++ b/apps/web/src/components/column-content/board-shared.tsx
@@ -9,7 +9,7 @@ import { Link } from 'react-router-dom';
 import type { QuestIndex, QuestIndexSummary } from '@/lib/quest-api';
 import { listIssuedQuests, listMyApplications, listCompletionsFor, buildQuestIndexViaDiscovery, questPath } from '@/lib/quest-api';
 import { getQuestIndexCached } from '@/lib/quest-index-cache';
-import { needsRequesterApproval, type UserQuest } from '@aozoraquest/core';
+import { needsRequesterApproval, effectiveState, type EffectiveState, type UserQuest } from '@aozoraquest/core';
 import { useSession } from '@/lib/session';
 import { useRuntimeConfig } from '@/components/config-provider';
 import { RewardPoints } from '@/components/handle';
@@ -30,6 +30,12 @@ export function useBoardData() {
   // 自分が発注したクエストのうち「受託者の完了報告が届き承認待ち」のもの。
   // status は受託者が書けず assigned のままなので、completion record から判定する。
   const [pendingApproval, setPendingApproval] = useState<UserQuest[]>([]);
+  // 自分が受託したクエストの effective state (uri → state)。受託中カラムのカードで
+  // 「あなたが報告する番 / 承認待ち / やり直し」を出し分けるのに使う。
+  const [assigneeStates, setAssigneeStates] = useState<Map<string, EffectiveState>>(new Map());
+  // 上記のうち「あなたが (再)完了報告する番」(IN_PROGRESS / REVISION_REQUESTED) のクエスト。
+  // 発注者の pendingApproval と対称な、受託者向けの気づき導線 (ReportPendingBanner)。
+  const [reportPending, setReportPending] = useState<UserQuest[]>([]);
   const [err, setErr] = useState<string | null>(null);
 
   // 集約 Worker が未デプロイの間は、発見ディレクトリの DID 群 (+ 自分) から
@@ -52,6 +58,47 @@ export function useBoardData() {
     return () => { cancelled = true; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [agent, aggregationKey]);
+
+  // 受託者視点: index から「自分が受託 (assignee==自分 かつ status==assigned)」の
+  // クエストを拾い、completion を読んで effective state を出す。発注者の承認待ち判定
+  // (下の effect) と対称。index ロード後に走る。
+  useEffect(() => {
+    if (!index || !selfDid) {
+      setAssigneeStates(new Map());
+      setReportPending([]);
+      return;
+    }
+    const mine = index.quests.filter((q) => q.assignee === selfDid && q.status === 'assigned');
+    if (mine.length === 0) {
+      setAssigneeStates(new Map());
+      setReportPending([]);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      const states = new Map<string, EffectiveState>();
+      const pend: UserQuest[] = [];
+      await Promise.all(mine.map(async (s) => {
+        const q = summaryToQuest(s);
+        try {
+          const comps = await listCompletionsFor(undefined, q);
+          const st = effectiveState(q, comps);
+          states.set(q.uri, st);
+          if (st === 'IN_PROGRESS' || st === 'REVISION_REQUESTED') pend.push(q);
+        } catch (e) {
+          console.warn('[board] assignee effectiveState', e);
+          // 失敗時は「報告する番」に倒す (= 受託者が見落とすより、出して気づかせる)
+          states.set(q.uri, 'IN_PROGRESS');
+          pend.push(q);
+        }
+      }));
+      if (!cancelled) {
+        setAssigneeStates(states);
+        setReportPending(pend);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [index, selfDid]);
 
   useEffect(() => {
     if (session.status !== 'signed-in' || !session.agent || !session.did) return;
@@ -87,7 +134,27 @@ export function useBoardData() {
     return () => { cancelled = true; };
   }, [session.status, session.agent, session.did]);
 
-  return { index, myQuests, myApplicationQuestUris, pendingApproval, err, sessionDid: session.did ?? null };
+  return { index, myQuests, myApplicationQuestUris, pendingApproval, assigneeStates, reportPending, err, sessionDid: session.did ?? null };
+}
+
+/** QuestIndexSummary を effectiveState / listCompletionsFor が必要とする最小 UserQuest に。
+ *  これらは uri/did/status/assignee/deadline しか見ないので body 等はダミーで十分。 */
+function summaryToQuest(s: QuestIndexSummary): UserQuest {
+  const q: UserQuest = {
+    uri: s.uri,
+    did: s.did,
+    title: s.title,
+    body: '',
+    tags: s.tags,
+    visibility: 'public',
+    status: s.status as UserQuest['status'],
+    rewardPoints: s.rewardPoints,
+    createdAt: s.createdAt,
+    updatedAt: s.createdAt,
+  };
+  if (s.assignee !== undefined) q.assignee = s.assignee;
+  if (s.deadline !== undefined) q.deadline = s.deadline;
+  return q;
 }
 
 export function filterForBoard(
@@ -160,14 +227,31 @@ export function isExpiredSummary(s: QuestIndexSummary): boolean {
   return new Date(s.deadline) < new Date();
 }
 
-export function QuestCard({ summary, expired, needsApproval }: { summary: QuestIndexSummary; expired?: boolean; needsApproval?: boolean }) {
+/** 受託者カードの状態バッジ文言 (あなたの番かどうか)。null なら出さない。 */
+function assigneeBadge(state: EffectiveState): { text: string; accent: boolean } | null {
+  if (state === 'IN_PROGRESS')        return { text: '● あなたが完了報告する番', accent: true };
+  if (state === 'REVISION_REQUESTED') return { text: '● やり直し依頼 — 再報告する番', accent: true };
+  if (state === 'AWAITING_APPROVAL')  return { text: '承認待ち（相手の番）', accent: false };
+  return null;
+}
+
+export function QuestCard({ summary, expired, needsApproval, assigneeState }: { summary: QuestIndexSummary; expired?: boolean; needsApproval?: boolean; assigneeState?: EffectiveState }) {
+  const badge = assigneeState ? assigneeBadge(assigneeState) : null;
+  // あなたの番 (発注者=承認 / 受託者=報告) のときカードを accent 強調する。
+  const myTurn = needsApproval || (badge?.accent ?? false);
   return (
     <Link to={questPath(summary.uri)} style={{ textDecoration: 'none' }}>
-      <div className="dq-window compact" style={{ borderColor: needsApproval ? 'var(--color-accent)' : expired ? 'var(--color-muted)' : undefined }}>
+      <div className="dq-window compact" style={{ borderColor: myTurn ? 'var(--color-accent)' : expired ? 'var(--color-muted)' : undefined }}>
         {needsApproval && (
           // 発注者の「完了報告が来た = 承認すれば達成」を見逃さないための強調バッジ
           <div style={{ fontSize: '0.72em', fontWeight: 700, color: 'var(--color-accent)', marginBottom: '0.2em' }}>
             ● 承認待ち（完了報告が届いています）
+          </div>
+        )}
+        {!needsApproval && badge && (
+          // 受託者の「自分の番か / 相手待ちか」を一覧で示す (発注者バッジと対称)
+          <div style={{ fontSize: '0.72em', fontWeight: badge.accent ? 700 : 400, color: badge.accent ? 'var(--color-accent)' : 'var(--color-muted)', marginBottom: '0.2em' }}>
+            {badge.text}
           </div>
         )}
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: '0.5em' }}>
@@ -180,8 +264,8 @@ export function QuestCard({ summary, expired, needsApproval }: { summary: QuestI
           {summary.tags.slice(0, 3).map(t => <span key={t}>#{t.replace(/^#/, '')}</span>)}
           <span style={{ marginLeft: 'auto' }}>
             {expired ? '期限切れ' : summary.deadline ? `〆 ${formatDate(summary.deadline)}` : ''}
-            {/* needsApproval のときは上の accent バッジが状態を示すので muted ラベルは重複させない */}
-            {!needsApproval && summary.status !== 'open' && <span style={{ marginLeft: '0.6em' }}>{labelOf(summary.status)}</span>}
+            {/* needsApproval / assignee バッジが状態を示すときは muted ラベルを重複させない */}
+            {!needsApproval && !badge && summary.status !== 'open' && <span style={{ marginLeft: '0.6em' }}>{labelOf(summary.status)}</span>}
           </span>
         </div>
       </div>
@@ -207,6 +291,32 @@ export function ApprovalPendingBanner({ pending }: { pending: UserQuest[] }) {
           <li key={q.uri} style={{ marginTop: '0.25em' }}>
             <Link to={questPath(q.uri)} style={{ fontSize: '0.82em', wordBreak: 'break-word' }}>
               「{q.title}」を承認する →
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+/** 受託者の「(再)完了報告する番」が 1 件以上あるとき、掲示板上部に出す気づき導線。
+ *  発注者の ApprovalPendingBanner と対称。`pending` は useBoardData が completion record
+ *  から effectiveState で算出済み (IN_PROGRESS / REVISION_REQUESTED)。 */
+export function ReportPendingBanner({ pending }: { pending: UserQuest[] }) {
+  if (pending.length === 0) return null;
+  return (
+    <div className="dq-window compact" style={{ borderColor: 'var(--color-accent)', background: 'rgba(159,215,255,0.08)', marginBottom: '0.5em' }}>
+      <div style={{ fontSize: '0.85em', fontWeight: 700, color: 'var(--color-accent)' }}>
+        ● あなたが完了報告する番が {pending.length} 件
+      </div>
+      <div style={{ fontSize: '0.75em', color: 'var(--color-muted)', marginTop: '0.2em' }}>
+        受託したクエストです。作業が終わったら各クエストを開いて「完了を報告」しましょう。
+      </div>
+      <ul style={{ listStyle: 'none', padding: 0, margin: '0.4em 0 0' }}>
+        {pending.map((q) => (
+          <li key={q.uri} style={{ marginTop: '0.25em' }}>
+            <Link to={questPath(q.uri)} style={{ fontSize: '0.82em', wordBreak: 'break-word' }}>
+              「{q.title}」を報告する →
             </Link>
           </li>
         ))}

--- a/apps/web/src/routes/board.tsx
+++ b/apps/web/src/routes/board.tsx
@@ -25,7 +25,9 @@ import {
   emptyMessageForBoard,
   QuestCard,
   ApprovalPendingBanner,
+  ReportPendingBanner,
 } from '@/components/column-content/board-shared';
+import type { EffectiveState } from '@aozoraquest/core';
 import { BookIcon, PlusIcon, CalendarIcon } from '@/components/icons';
 import { ActionLink } from '@/components/action-link';
 import { useSession } from '@/lib/session';
@@ -34,7 +36,7 @@ export function Board() {
   const session = useSession();
   const signedIn = session.status === 'signed-in';
   const [columns, setColumns] = useState<Column[]>(() => loadColumns());
-  const { index, myQuests, myApplicationQuestUris, pendingApproval, err } = useBoardData();
+  const { index, myQuests, myApplicationQuestUris, pendingApproval, assigneeStates, reportPending, err } = useBoardData();
   const pendingUris = useMemo(() => new Set(pendingApproval.map((q) => q.uri)), [pendingApproval]);
 
   // 未ログイン時は「自分が出した / 応募」など自分前提のカラムを描画しない
@@ -86,8 +88,9 @@ export function Board() {
 
       {err && <p style={{ color: 'var(--color-danger)' }}>取得に失敗: {err}</p>}
 
-      {/* 承認待ち (完了報告が届いた自分の依頼) を最上部で promote。各クエストへ直リンク。 */}
+      {/* 「自分の番」を最上部で promote。発注者=承認待ち / 受託者=報告する番。各クエストへ直リンク。 */}
       <ApprovalPendingBanner pending={pendingApproval} />
+      <ReportPendingBanner pending={reportPending} />
 
       <div className="board-columns">
         {visibleColumns.map((col) => (
@@ -96,6 +99,7 @@ export function Board() {
             column={col}
             indexData={{ index, myQuests, myApplicationQuestUris }}
             pendingUris={pendingUris}
+            assigneeStates={assigneeStates}
             selfDid={session.did ?? null}
             onRemove={() => removeColumn(col.id)}
           />
@@ -173,11 +177,12 @@ interface BoardInnerColumnViewProps {
     myApplicationQuestUris: ReturnType<typeof useBoardData>['myApplicationQuestUris'];
   };
   pendingUris: Set<string>;
+  assigneeStates: Map<string, EffectiveState>;
   selfDid: string | null;
   onRemove: () => void;
 }
 
-function BoardInnerColumnView({ column, indexData, pendingUris, selfDid, onRemove }: BoardInnerColumnViewProps) {
+function BoardInnerColumnView({ column, indexData, pendingUris, assigneeStates, selfDid, onRemove }: BoardInnerColumnViewProps) {
   const { index, myQuests, myApplicationQuestUris } = indexData;
   const items = useMemo(
     () => filterForBoard(column, index, myQuests, myApplicationQuestUris, selfDid),
@@ -198,11 +203,19 @@ function BoardInnerColumnView({ column, indexData, pendingUris, selfDid, onRemov
         <p style={{ fontSize: '0.8em', color: 'var(--color-muted)' }}>{emptyMessageForBoard(column)}</p>
       ) : (
         <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
-          {items.map((q) => (
-            <li key={q.uri}>
-              <QuestCard summary={q} expired={isExpiredSummary(q)} needsApproval={pendingUris.has(q.uri)} />
-            </li>
-          ))}
+          {items.map((q) => {
+            const aState = column.kind === 'assigned' ? assigneeStates.get(q.uri) : undefined;
+            return (
+              <li key={q.uri}>
+                <QuestCard
+                  summary={q}
+                  expired={isExpiredSummary(q)}
+                  needsApproval={pendingUris.has(q.uri)}
+                  {...(aState ? { assigneeState: aState } : {})}
+                />
+              </li>
+            );
+          })}
         </ul>
       )}
     </section>


### PR DESCRIPTION
## 何を
board の「自分の番」シグナルが発注者側にしか無く、受託者は「完了報告する番」か一覧で分からなかった。発注者の承認バナーと対称の受託者導線を追加。

## 変更
useBoardData 拡張: index から assignee==自分 && status==assigned の completion → effectiveState 算出。
- IN_PROGRESS / REVISION_REQUESTED → ReportPendingBanner + 強調バッジ
- AWAITING_APPROVAL → 「承認待ち（相手の番）」muted
board フルページ・workspace カラム両方に配線。

## Review
§1.5 実装+回帰レビュー実施。**★★★/★★ ゼロ、マージ可**。effectiveState 準拠の状態分類・カードバッジ衝突なし・両配線揃い・回帰なし・パフォーマンスは発注者 pendingApproval と同等を確認。
★ (テスト追加 / summaryToQuest 重複) → **issue https://github.com/kojira/aozoraquest/issues/212** に切り出し。