### PR TITLE
release: 2026.06.24-2 — iOS 投稿クラッシュ修正

### DIFF
--- a/apps/web/src/lib/app-version.ts
+++ b/apps/web/src/lib/app-version.ts
@@ -12,7 +12,7 @@
  *   3. 同じ値で git tag を打つ:
  *        git tag v2026.06.14-1 && git push origin v2026.06.14-1
  */
-export const APP_VERSION = '2026.06.24-1';
+export const APP_VERSION = '2026.06.24-2';
 
 /** APP_VERSION が `YYYY.MM.DD-N` 形式かを検証する (テスト/CI で形式崩れを検出)。
  *  月 01-12 / 日 01-31 のゼロ詰め 2 桁、枝番は先頭ゼロ不可の 1 以上まで一本でガードする。 */

--- a/apps/web/src/lib/post-processor.ts
+++ b/apps/web/src/lib/post-processor.ts
@@ -31,7 +31,6 @@ import {
 } from '@aozoraquest/core';
 import { classifyFromVec, type ActionCategory } from './action-classifier';
 import { classifyCognitiveFromVec } from './cognitive-classifier';
-import { CognitiveOnnxClassifier } from './cognitive-onnx';
 import { Embedder } from './embedder';
 import { getRecord, putRecord } from './atproto';
 import { deriveActionTypes, type PostStructure } from './structural-action';
@@ -114,39 +113,27 @@ export async function processSelfPost(
   const empty: ProcessResult = { action: null, incremented: [], completed: [], xpGained: 0 };
   if (trimmed.length === 0) return empty;
 
-  // 1) 埋め込みは action 用に 1 回 (cognitive は fine-tune 済 ONNX 直接推論)
+  // 投稿のたびに走る解析。**端末内 ONNX モデルは「埋め込み 1 個」だけ**ロードする。
   //
-  // この解析は投稿のたびに走る。Worker (WASM + ONNX tensor) を開きっぱなしにすると
-  // モバイル Safari では tensor がプロセスメモリに蓄積し、メモリ監視 (jetsam) が
-  // タブを破棄 → 投稿直後に画面全体がリロードされる。よって推論後に必ず解放する。
+  // 以前は embedder + cognitive の 2 モデルを同時にロードしていたが、iOS Safari は
+  // 2 モデル同時ロードの瞬間メモリスパイクに耐えられず (8GB の iPhone でも)、投稿直後に
+  // WebContent プロセスが jetsam で破棄され画面全体がリロードされる (実機切り分けで確定:
+  // モデル推論を切ると落ちない / 2 モデルは落ちる / 1 モデルは通る)。
   //
-  // ただし共有 singleton (getEmbedder / getCognitiveOnnxClassifier) を解放すると、
-  // 同じ Worker を使う他フロー (診断・相性ランキングの裏診断・TL 認知分析) を巻き
-  // 込んで terminate し、永久 hang やスコア欠落を起こす。そこで投稿解析専用の
-  // ローカルインスタンスを立て、これだけを finally で dispose する。共有 singleton
-  // には一切触れない。モデル本体は Cache/IDB 済なので再 DL は無い (WASM 構築のみ)。
+  // そこで行動分類・認知スコアとも **埋め込みベクトルの prototype cosine** で求め、
+  // cognitive の ONNX 分類器は投稿パスでは使わない。認知スコアの精度は /me のフル診断
+  // (runDiagnosis) 側で ONNX を使って担保し、投稿ごとの更新は α=COGNITIVE_BLEND_ALPHA の
+  // 微小 nudge なので prototype で十分。embedder は専用ローカルインスタンスにして共有
+  // singleton (診断 / 相性ランキング / TL 認知分析) を巻き込まず、推論後に dispose する。
   const embedder = new Embedder();
-  const cog = new CognitiveOnnxClassifier();
   let actResult: Awaited<ReturnType<typeof classifyFromVec>>;
   let postCognitive: CognitiveScores;
   try {
     await embedder.init().catch(() => { /* init 失敗時は embed 側が reject → 下で throw */ });
-    await cog.init().catch(() => { /* ONNX 不可なら classifyPost が null → prototype fallback */ });
     const vec = await embedder.embed(trimmed);
-
-    // 2) 行動 (vec) & 認知 (text) を並列
-    const [act, onnxCognitive] = await Promise.all([
-      classifyFromVec(vec),
-      cog.classifyPost(trimmed).catch((e) => {
-        console.warn('[cognitive] ONNX classify failed, falling back to prototype', e);
-        return null;
-      }),
-    ]);
-    actResult = act;
-    // ONNX が使えなかった場合は従来の prototype embedding にフォールバック
-    postCognitive = onnxCognitive ?? await classifyCognitiveFromVec(vec, embedder);
+    actResult = await classifyFromVec(vec);                          // 行動: prototype cosine
+    postCognitive = await classifyCognitiveFromVec(vec, embedder);   // 認知: prototype cosine
   } finally {
-    cog.dispose();
     embedder.dispose();
   }
 


### PR DESCRIPTION
## リリース 2026.06.24-2 (緊急度: 高 — 本番の投稿クラッシュ修正)

### 含まれる変更
- **#215** fix(post-processor): 投稿後解析を埋め込み1モデルのみにして iOS 投稿クラッシュを解消。投稿のたび ONNX 2モデル同時ロードしていた瞬間メモリスパイクで、8GB の iPhone 16 Pro でも投稿1回で落ちていた (本番にも残存)。1モデル化で解消、実機確認済み。
- **#216** chore(release): APP_VERSION 2026.06.24-2

### §1.5 レビュー
#215 は feature PR で実装+回帰レビュー済み、★★★/★★/★ ゼロ。classifyCognitiveFromVec が追加モデルをロードしない (事前計算 .bin の cosine のみ) ことを確認済み。共有 singleton 非汚染。

### リリース後の確認
- 設定画面隅の APP_VERSION が 2026.06.24-2
- iPhone で投稿しても落ちないこと

### デプロイ
CF Workers Builds 障害が続くため wrangler 手動デプロイ。