### PR TITLE
chore(release): APP_VERSION 2026.06.24-3

### DIFF
--- a/apps/web/src/lib/app-version.ts
+++ b/apps/web/src/lib/app-version.ts
@@ -12,7 +12,7 @@
  *   3. 同じ値で git tag を打つ:
  *        git tag v2026.06.14-1 && git push origin v2026.06.14-1
  */
-export const APP_VERSION = '2026.06.24-2';
+export const APP_VERSION = '2026.06.24-3';
 
 /** APP_VERSION が `YYYY.MM.DD-N` 形式かを検証する (テスト/CI で形式崩れを検出)。
  *  月 01-12 / 日 01-31 のゼロ詰め 2 桁、枝番は先頭ゼロ不可の 1 以上まで一本でガードする。 */


### PR DESCRIPTION
本番リリース bump。内容: フィードのデバイス出し分け (#218 PC=content-visibility/スマホ=仮想化) + card-art を LFS 解除 (#219, CF ビルド復旧)。CF 復旧したので今回から自動デプロイ。