### PR TITLE
feat(quest): クエストタブに対応待ち件数の赤カウントバッジ

### DIFF
--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -7,6 +7,7 @@ import { composeFabAllowedOnPath } from '@/lib/compose-fab';
 import { useSession } from '@/lib/session';
 import { getUnreadNotificationCount } from '@/lib/atproto';
 import { useVisibleColumn } from '@/lib/visible-column';
+import { useQuestActionableCount } from '@/lib/quest-actionable';
 import type { AppColumnKind } from '@/lib/app-columns';
 
 /** footer-nav の各タブと workspace カラム kind の対応。
@@ -43,6 +44,8 @@ export function AppShell() {
   const navigate = useNavigate();
   const composeOpen = useComposePaneOpen();
   const [unread, setUnread] = useState(0);
+  // 自分のアクション待ちクエスト件数 (承認待ち + 完了報告待ち)。クエストタブに赤カウント表示。
+  const questActionable = useQuestActionableCount();
   const visibleKind = useVisibleColumn();
   const headerRef = useRef<HTMLElement>(null);
   const footerRef = useRef<HTMLElement>(null);
@@ -216,6 +219,32 @@ export function AppShell() {
                   boxShadow: '0 0 0 2px var(--color-bg, #000)',
                 }}
               />
+            )}
+            {key === 'quests' && session.status === 'signed-in' && questActionable > 0 && (
+              // 自分のアクション待ち (承認 / 完了報告) 件数の赤カウントバッジ。
+              // @mention を見逃しても未対応が残っていれば常に見える。
+              <span
+                aria-label={`対応待ちクエスト ${questActionable} 件`}
+                style={{
+                  position: 'absolute',
+                  top: 1,
+                  right: 'calc(50% - 22px)',
+                  minWidth: 16,
+                  height: 16,
+                  padding: '0 4px',
+                  boxSizing: 'border-box',
+                  borderRadius: 8,
+                  background: '#e53935',
+                  color: '#fff',
+                  fontSize: 10,
+                  fontWeight: 700,
+                  lineHeight: '16px',
+                  textAlign: 'center',
+                  boxShadow: '0 0 0 2px var(--color-bg, #000)',
+                }}
+              >
+                {questActionable > 9 ? '9+' : questActionable}
+              </span>
             )}
           </NavLink>
         ))}

--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -7,7 +7,8 @@ import { composeFabAllowedOnPath } from '@/lib/compose-fab';
 import { useSession } from '@/lib/session';
 import { getUnreadNotificationCount } from '@/lib/atproto';
 import { useVisibleColumn } from '@/lib/visible-column';
-import { useQuestActionableCount } from '@/lib/quest-actionable';
+import { useQuestActionableCount, computeQuestActionableCount, setQuestActionableCount } from '@/lib/quest-actionable';
+import { useRuntimeConfig } from '@/components/config-provider';
 import type { AppColumnKind } from '@/lib/app-columns';
 
 /** footer-nav の各タブと workspace カラム kind の対応。
@@ -46,6 +47,7 @@ export function AppShell() {
   const [unread, setUnread] = useState(0);
   // 自分のアクション待ちクエスト件数 (承認待ち + 完了報告待ち)。クエストタブに赤カウント表示。
   const questActionable = useQuestActionableCount();
+  const runtimeConfig = useRuntimeConfig();
   const visibleKind = useVisibleColumn();
   const headerRef = useRef<HTMLElement>(null);
   const footerRef = useRef<HTMLElement>(null);
@@ -103,6 +105,40 @@ export function AppShell() {
       clearInterval(id);
     };
   }, [session.status, session.agent]);
+
+  // クエストのアクション待ち件数をルート非依存で集計 (board カラムが mount されない
+  // /me 等に直接着地してもバッジが出るように)。サインイン時 + 復帰(focus)時に再計算し、
+  // サインアウトで 0 リセット。focus は throttle し、index は getQuestIndexCached で
+  // board カラムと共有するので、連続発火しても重い discovery を繰り返さない。
+  const directoryKey = runtimeConfig.directory.map((u) => u.did).join(',');
+  useEffect(() => {
+    if (session.status !== 'signed-in' || !session.agent || !session.did) {
+      setQuestActionableCount(0);
+      return;
+    }
+    const agent = session.agent;
+    const did = session.did;
+    const dids = directoryKey ? (directoryKey.split(',') as Parameters<typeof computeQuestActionableCount>[2]) : [];
+    let cancelled = false;
+    let lastRun = 0;
+    const run = () => {
+      const now = Date.now();
+      if (now - lastRun < 60_000) return; // 復帰連打を間引く
+      lastRun = now;
+      void computeQuestActionableCount(agent, did, dids)
+        .then((n) => { if (!cancelled) setQuestActionableCount(n); })
+        .catch(() => {});
+    };
+    run();
+    const onVisible = () => { if (document.visibilityState === 'visible') run(); };
+    window.addEventListener('focus', onVisible);
+    document.addEventListener('visibilitychange', onVisible);
+    return () => {
+      cancelled = true;
+      window.removeEventListener('focus', onVisible);
+      document.removeEventListener('visibilitychange', onVisible);
+    };
+  }, [session.status, session.agent, session.did, directoryKey]);
 
   // 通知タブを開いた瞬間にバッジを消す
   useEffect(() => {
@@ -202,50 +238,54 @@ export function AppShell() {
                 : isActive;
               return `footer-nav-item${active ? ' active' : ''}`;
             }}
-            style={{ position: 'relative' }}
           >
-            <Icon size={26} />
-            {key === 'notifications' && unread > 0 && (
-              <span
-                aria-label={`未読 ${unread} 件`}
-                style={{
-                  position: 'absolute',
-                  top: 4,
-                  right: 'calc(50% - 16px)',
-                  width: 10,
-                  height: 10,
-                  borderRadius: 5,
-                  background: '#e53935',
-                  boxShadow: '0 0 0 2px var(--color-bg, #000)',
-                }}
-              />
-            )}
-            {key === 'quests' && session.status === 'signed-in' && questActionable > 0 && (
-              // 自分のアクション待ち (承認 / 完了報告) 件数の赤カウントバッジ。
-              // @mention を見逃しても未対応が残っていれば常に見える。
-              <span
-                aria-label={`対応待ちクエスト ${questActionable} 件`}
-                style={{
-                  position: 'absolute',
-                  top: 1,
-                  right: 'calc(50% - 22px)',
-                  minWidth: 16,
-                  height: 16,
-                  padding: '0 4px',
-                  boxSizing: 'border-box',
-                  borderRadius: 8,
-                  background: '#e53935',
-                  color: '#fff',
-                  fontSize: 10,
-                  fontWeight: 700,
-                  lineHeight: '16px',
-                  textAlign: 'center',
-                  boxShadow: '0 0 0 2px var(--color-bg, #000)',
-                }}
-              >
-                {questActionable > 9 ? '9+' : questActionable}
-              </span>
-            )}
+            {/* バッジはアイコン基準で配置する。footer-nav はモバイルでは横長タブ、PC では
+                幅 56px の縦レール (44x44 の正方形タブ) になるため、タブ基準 (calc(50%-..))
+                だとレールで位置が破綻する。アイコン右上に固定すれば両レイアウトで成立する。 */}
+            <span style={{ position: 'relative', display: 'inline-flex' }}>
+              <Icon size={26} />
+              {key === 'notifications' && unread > 0 && (
+                <span
+                  aria-label={`未読 ${unread} 件`}
+                  style={{
+                    position: 'absolute',
+                    top: -3,
+                    right: -4,
+                    width: 10,
+                    height: 10,
+                    borderRadius: 5,
+                    background: 'var(--color-notify-badge)',
+                    boxShadow: '0 0 0 2px var(--color-bg, #000)',
+                  }}
+                />
+              )}
+              {key === 'quests' && session.status === 'signed-in' && questActionable > 0 && (
+                // 自分のアクション待ち (承認 / 完了報告) 件数の赤カウントバッジ。
+                // @mention を見逃しても未対応が残っていれば常に見える。
+                <span
+                  aria-label={`対応待ちクエスト ${questActionable} 件`}
+                  style={{
+                    position: 'absolute',
+                    top: -6,
+                    right: -9,
+                    minWidth: 16,
+                    height: 16,
+                    padding: '0 4px',
+                    boxSizing: 'border-box',
+                    borderRadius: 8,
+                    background: 'var(--color-notify-badge)',
+                    color: '#fff',
+                    fontSize: 10,
+                    fontWeight: 700,
+                    lineHeight: '16px',
+                    textAlign: 'center',
+                    boxShadow: '0 0 0 2px var(--color-bg, #000)',
+                  }}
+                >
+                  {questActionable > 9 ? '9+' : questActionable}
+                </span>
+              )}
+            </span>
           </NavLink>
         ))}
       </nav>

--- a/apps/web/src/components/column-content/board-shared.tsx
+++ b/apps/web/src/components/column-content/board-shared.tsx
@@ -10,6 +10,7 @@ import type { QuestIndex, QuestIndexSummary } from '@/lib/quest-api';
 import { listIssuedQuests, listMyApplications, listCompletionsFor, buildQuestIndexViaDiscovery, questPath } from '@/lib/quest-api';
 import { getQuestIndexCached } from '@/lib/quest-index-cache';
 import { needsRequesterApproval, effectiveState, type EffectiveState, type UserQuest } from '@aozoraquest/core';
+import { setQuestActionableCount } from '@/lib/quest-actionable';
 import { useSession } from '@/lib/session';
 import { useRuntimeConfig } from '@/components/config-provider';
 import { RewardPoints } from '@/components/handle';
@@ -133,6 +134,12 @@ export function useBoardData() {
       .catch((e) => { if (!cancelled) console.warn('[board] listMyApplications', e); });
     return () => { cancelled = true; };
   }, [session.status, session.agent, session.did]);
+
+  // 「自分のアクション待ち件数」(承認待ち + 完了報告待ち) を共有ストアへ publish。
+  // footer-nav の「クエスト」タブが赤カウントバッジで表示し、@mention を見逃しても気付ける。
+  useEffect(() => {
+    setQuestActionableCount(pendingApproval.length + reportPending.length);
+  }, [pendingApproval, reportPending]);
 
   return { index, myQuests, myApplicationQuestUris, pendingApproval, assigneeStates, reportPending, err, sessionDid: session.did ?? null };
 }

--- a/apps/web/src/lib/quest-actionable.test.ts
+++ b/apps/web/src/lib/quest-actionable.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import {
+  setQuestActionableCount,
+  subscribeQuestActionable,
+  getQuestActionableSnapshot,
+} from './quest-actionable';
+
+describe('quest-actionable store', () => {
+  it('set した値が snapshot に反映される', () => {
+    setQuestActionableCount(3);
+    expect(getQuestActionableSnapshot()).toBe(3);
+    setQuestActionableCount(0);
+    expect(getQuestActionableSnapshot()).toBe(0);
+  });
+
+  it('値が変わると購読者へ通知する', () => {
+    setQuestActionableCount(0);
+    let calls = 0;
+    const off = subscribeQuestActionable(() => { calls += 1; });
+    setQuestActionableCount(2);
+    expect(calls).toBe(1);
+    expect(getQuestActionableSnapshot()).toBe(2);
+    off();
+  });
+
+  it('同値の set では通知しない (同値ガード)', () => {
+    setQuestActionableCount(5);
+    let calls = 0;
+    const off = subscribeQuestActionable(() => { calls += 1; });
+    setQuestActionableCount(5); // 同値 → 通知なし
+    expect(calls).toBe(0);
+    setQuestActionableCount(6); // 変化 → 通知
+    expect(calls).toBe(1);
+    off();
+  });
+
+  it('解除後は通知が来ない', () => {
+    setQuestActionableCount(0);
+    let calls = 0;
+    const off = subscribeQuestActionable(() => { calls += 1; });
+    off();
+    setQuestActionableCount(9);
+    expect(calls).toBe(0);
+  });
+});

--- a/apps/web/src/lib/quest-actionable.ts
+++ b/apps/web/src/lib/quest-actionable.ts
@@ -1,14 +1,27 @@
 /**
- * 「自分のアクション待ちクエスト件数」を app 全体で共有する軽量ストア。
+ * 「自分のアクション待ちクエスト件数」を app 全体で共有する軽量ストア + 集計関数。
  *
  * 発注者の承認待ち (pendingApproval) + 受託者の完了報告待ち (reportPending) の合計を
- * useBoardData が publish し、footer-nav の「クエスト」タブが赤カウントバッジで表示する。
- * @mention 通知を見逃しても、未対応が残っていれば常にバッジで気付ける (= 通知に依存しない)。
+ * footer-nav の「クエスト」タブが赤カウントバッジで表示する。@mention 通知を見逃しても、
+ * 未対応が残っていればバッジで気付ける (= 通知に依存しない)。
  *
- * 件数は完了集合/ completion record からの派生なので、ユーザーが承認/報告すると自然に減る
+ * 件数の供給は 2 経路 (どちらも同じ値を書くので競合しても一致する):
+ *  1. app-shell が computeQuestActionableCount をサインイン時 / 復帰(focus)時に呼ぶ。
+ *     ルート非依存で、ホーム以外に直接着地してもバッジが出る (これが基準値)。
+ *  2. board カラム / routes/board の useBoardData が、表示中はライブに publish する
+ *     (承認/報告した直後に即減る)。
+ * サインアウト時は app-shell が 0 にリセットする。
+ *
+ * 件数は completion record からの派生なので、ユーザーが承認/報告すると自然に減る
  * (バッジを「既読」でリセットはしない = 実際の未対応状態を映す)。
  */
 import { useSyncExternalStore } from 'react';
+import { listIssuedQuests, listCompletionsFor, buildQuestIndexViaDiscovery, type QuestIndexSummary } from './quest-api';
+import { getQuestIndexCached } from './quest-index-cache';
+import { effectiveState, needsRequesterApproval, type UserQuest } from '@aozoraquest/core';
+
+type Agent = Parameters<typeof buildQuestIndexViaDiscovery>[0];
+type Did = Parameters<typeof buildQuestIndexViaDiscovery>[1][number];
 
 let count = 0;
 const subscribers = new Set<() => void>();
@@ -21,16 +34,89 @@ export function setQuestActionableCount(n: number): void {
   }
 }
 
-function subscribe(cb: () => void): () => void {
+/** 件数変化を購読する (useSyncExternalStore 用 / テスト用)。返り値で解除。 */
+export function subscribeQuestActionable(cb: () => void): () => void {
   subscribers.add(cb);
   return () => { subscribers.delete(cb); };
 }
 
-function getSnapshot(): number {
+/** 現在のアクション待ち件数 (snapshot)。 */
+export function getQuestActionableSnapshot(): number {
   return count;
 }
 
 /** footer-nav 等が購読するフック。アクション待ち件数を返す。 */
 export function useQuestActionableCount(): number {
-  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  return useSyncExternalStore(subscribeQuestActionable, getQuestActionableSnapshot, getQuestActionableSnapshot);
+}
+
+/** QuestIndexSummary → UserQuest (board-shared と同じ最小変換。completion 判定に必要な分だけ)。 */
+function summaryToQuest(s: QuestIndexSummary): UserQuest {
+  const q: UserQuest = {
+    uri: s.uri,
+    did: s.did,
+    title: s.title,
+    body: '',
+    tags: s.tags,
+    visibility: 'public',
+    status: s.status as UserQuest['status'],
+    rewardPoints: s.rewardPoints,
+    createdAt: s.createdAt,
+    updatedAt: s.createdAt,
+  };
+  if (s.assignee !== undefined) q.assignee = s.assignee;
+  if (s.deadline !== undefined) q.deadline = s.deadline;
+  return q;
+}
+
+/**
+ * 「自分のアクション待ち件数」をルート非依存で集計する (useBoardData と同じ判定)。
+ *  = 受託者として(再)完了報告する番 (IN_PROGRESS / REVISION_REQUESTED)
+ *  + 発注者として承認する番 (needsRequesterApproval)。
+ * index は getQuestIndexCached (TTL 30s) 経由なので board カラムと取得を共有する。
+ */
+export async function computeQuestActionableCount(
+  agent: Agent,
+  did: Did,
+  directoryDids: Did[],
+): Promise<number> {
+  // 受託者視点: index から自分が受託中のものを拾い completion で effective state 判定。
+  let reportPending = 0;
+  try {
+    const idx = await getQuestIndexCached(() => buildQuestIndexViaDiscovery(agent, directoryDids, did));
+    const mine = idx.quests.filter((q) => q.assignee === did && q.status === 'assigned');
+    await Promise.all(mine.map(async (s) => {
+      const q = summaryToQuest(s);
+      try {
+        const comps = await listCompletionsFor(undefined, q);
+        const st = effectiveState(q, comps);
+        if (st === 'IN_PROGRESS' || st === 'REVISION_REQUESTED') reportPending += 1;
+      } catch {
+        // 失敗時は「報告する番」に倒す (見落とすより出して気づかせる。useBoardData と対称)
+        reportPending += 1;
+      }
+    }));
+  } catch {
+    /* index 取得失敗時は受託側 0 のまま */
+  }
+
+  // 発注者視点: 自分の発注クエストのうち受託者の報告が来て未承認のもの。
+  let pendingApproval = 0;
+  try {
+    const qs = await listIssuedQuests(agent, did);
+    const candidates = qs.filter((q) => q.status === 'assigned');
+    const checked = await Promise.all(candidates.map(async (q) => {
+      try {
+        const comps = await listCompletionsFor(undefined, q);
+        return needsRequesterApproval(q, comps);
+      } catch {
+        return false;
+      }
+    }));
+    pendingApproval = checked.filter(Boolean).length;
+  } catch {
+    /* 発注側取得失敗時は 0 のまま */
+  }
+
+  return reportPending + pendingApproval;
 }

--- a/apps/web/src/lib/quest-actionable.ts
+++ b/apps/web/src/lib/quest-actionable.ts
@@ -1,0 +1,36 @@
+/**
+ * 「自分のアクション待ちクエスト件数」を app 全体で共有する軽量ストア。
+ *
+ * 発注者の承認待ち (pendingApproval) + 受託者の完了報告待ち (reportPending) の合計を
+ * useBoardData が publish し、footer-nav の「クエスト」タブが赤カウントバッジで表示する。
+ * @mention 通知を見逃しても、未対応が残っていれば常にバッジで気付ける (= 通知に依存しない)。
+ *
+ * 件数は完了集合/ completion record からの派生なので、ユーザーが承認/報告すると自然に減る
+ * (バッジを「既読」でリセットはしない = 実際の未対応状態を映す)。
+ */
+import { useSyncExternalStore } from 'react';
+
+let count = 0;
+const subscribers = new Set<() => void>();
+
+export function setQuestActionableCount(n: number): void {
+  if (n === count) return;
+  count = n;
+  for (const s of subscribers) {
+    try { s(); } catch { /* no-op */ }
+  }
+}
+
+function subscribe(cb: () => void): () => void {
+  subscribers.add(cb);
+  return () => { subscribers.delete(cb); };
+}
+
+function getSnapshot(): number {
+  return count;
+}
+
+/** footer-nav 等が購読するフック。アクション待ち件数を返す。 */
+export function useQuestActionableCount(): number {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -18,6 +18,10 @@
   --color-window-bg-alt: rgba(0, 0, 0, 0.88);
   --color-window-inner-border: rgba(255, 255, 255, 0.35);
   --color-danger: #ff7272;
+  /* footer-nav の通知ドット / クエスト対応待ちカウントの赤バッジ色。
+     --color-danger (#ff7272) は淡く、10px の白文字カウントを乗せるとコントラスト不足に
+     なるため、視認性優先で濃い赤を専用トークンとして持つ (DESIGN.md の danger とは別用途)。 */
+  --color-notify-badge: #e53935;
 
   /* カレンダーの週末色。ステータス色 (atk/def/agi/int/luk) や accent の
      意味と干渉しないよう専用に持つ (DESIGN.md: ステータス色は流用しない)。 */


### PR DESCRIPTION
## 背景
「@mention 通知を1度見逃すと、クエストが自分のアクション待ちになったことに気付きにくい」という報告。通知に依存しない常設の気付き導線が必要。

## 変更
- `quest-actionable.ts`: アクション待ち件数の軽量共有ストア (useSyncExternalStore) + ルート非依存集計関数 `computeQuestActionableCount`。
- `app-shell` がサインイン時 + 復帰(focus, 60s throttle)時に集計し、footer-nav「クエスト」タブに赤カウントバッジ (9+ 丸め、サインイン時・>0 のみ)。サインアウトで 0 リセット。
- `useBoardData` も表示中はライブに publish (承認/報告した直後に即減る)。両経路は同値。
- 件数 = 承認待ち + 完了報告待ち。completion record 派生なので対応すると自然に減る (既読リセットしない)。

## Review (§1.5 3並列: 設計 / 実装 / UX)
- **★★★ (設計) バッジが board カラム mount=`/` 滞在時しか出ない** → `computeQuestActionableCount` を app-shell でルート非依存に集計するよう変更 (commit 4a981f3)。index は getQuestIndexCached で board と共有しコスト増を抑制。
- **★★★ (UX) バッジ色 #e53935 が DESIGN.md パレット違反** → `--color-notify-badge` トークン新設、通知ドット/カウント双方で使用 (4a981f3)。
- **★★ (UX) PC 縦レールでバッジ位置破綻** → アイコン基準配置に変更 (4a981f3)。
- **★★ (実装/設計) サインアウトで前ユーザー件数が残る** → app-shell でサインアウト時 0 リセット (4a981f3)。
- **★★ (設計) 複数 publisher の source-of-truth** → app-shell=基準値 / board=ライブ更新の二経路 (同値) として意図的に併存、コードに明記。
- **★ (実装) ストア単体テスト無し** → 4 件追加 (4a981f3)。
- ★ ドット/カウントの位置不揃い → アイコン基準化で同時に解消。

実装レビュー: typecheck / test (222) green を確認済み。