### PR TITLE
feat(quest-core): 複数人受託の状態機械 (段階1/3: core)

### DIFF
--- a/packages/core/src/__tests__/user-quest.test.ts
+++ b/packages/core/src/__tests__/user-quest.test.ts
@@ -11,6 +11,7 @@ import {
   questMaxAssignees,
   hasOpenSlot,
   completionTarget,
+  isCompletedForAssignee,
   rewardForMe,
   MAX_ASSIGNEES_PER_QUEST,
   questXpScalar,
@@ -530,8 +531,36 @@ describe('複数受託 (multi-assignee)', () => {
     expect(questAssignees(legacy)).toEqual([A]);
   });
 
-  it('MAX_ASSIGNEES_PER_QUEST が定義されている', () => {
-    expect(MAX_ASSIGNEES_PER_QUEST).toBeGreaterThanOrEqual(10);
+  it('ある受託者への承認は別の受託者の状態に漏れない (target フィルタの効き)', () => {
+    const q = multi();
+    const comps = [report(A, '01'), approve(A, '02')]; // A のみ報告+承認、B は何もしていない
+    expect(effectiveStateForAssignee(q, comps, A)).toBe('COMPLETED');
+    expect(effectiveStateForAssignee(q, comps, B)).toBe('IN_PROGRESS'); // B には漏れない
+    expect(isCompletedForAssignee(q, comps, A)).toBe(true);
+    expect(isCompletedForAssignee(q, comps, B)).toBe(false);
+  });
+
+  it('isCompletedForAssignee は受託者ごとに判定 (isCompleted の複数受託版)', () => {
+    const q = multi();
+    const comps = [report(A, '01'), approve(A, '02'), report(B, '03')];
+    expect(isCompletedForAssignee(q, comps, A)).toBe(true);
+    expect(isCompletedForAssignee(q, comps, B)).toBe(false); // B は報告のみ未承認
+  });
+
+  it('questAssignees: assignees の重複 DID は除去する (水増し防止)', () => {
+    expect(questAssignees(multi({ assignees: [A, A, B] }))).toEqual([A, B]);
+    // 重複 assignee でも totalIssued は承認された実人数ぶんに留まる
+    const q = multi({ assignees: [A, A], maxAssignees: 2, rewardPoints: 500 });
+    const byUri = new Map([[URI, [report(A, '01'), approve(A, '02')]]]);
+    expect(totalIssued([q], byUri)).toBe(500); // A 1 人ぶん (重複で 1000 にならない)
+  });
+
+  it('questAssignees: assignees:[] (明示空) は legacy assignee に fallback する', () => {
+    expect(questAssignees({ assignees: [], assignee: A })).toEqual([A]);
+  });
+
+  it('MAX_ASSIGNEES_PER_QUEST = 20 (確定値)', () => {
+    expect(MAX_ASSIGNEES_PER_QUEST).toBe(20);
   });
 });
 

--- a/packages/core/src/__tests__/user-quest.test.ts
+++ b/packages/core/src/__tests__/user-quest.test.ts
@@ -5,6 +5,14 @@ import {
   isValidCompletion,
   needsRequesterApproval,
   effectiveState,
+  effectiveStateForAssignee,
+  questLevelState,
+  questAssignees,
+  questMaxAssignees,
+  hasOpenSlot,
+  completionTarget,
+  rewardForMe,
+  MAX_ASSIGNEES_PER_QUEST,
   questXpScalar,
   outcomeOf,
   holdings,
@@ -420,6 +428,110 @@ describe('checkIssuanceLimits', () => {
     const r = checkIssuanceLimits(qs, NOW);
     expect(r.ok).toBe(true);
     expect(r.todayCount).toBe(0);
+  });
+});
+
+describe('複数受託 (multi-assignee)', () => {
+  const owner = 'did:plc:owner';
+  const A = 'did:plc:alice';
+  const B = 'did:plc:bob';
+  const URI = 'at://did:plc:owner/app.aozoraquest.userQuest/multi';
+  const multi = (over: Partial<UserQuest> = {}): UserQuest =>
+    mk({ uri: URI, did: owner, status: 'assigned', assignees: [A, B], maxAssignees: 2, rewardPoints: 500, ...over });
+  const report = (who: string, at: string): QuestCompletion =>
+    ({ uri: `rep-${who}-${at}`, did: who, questUri: URI, role: 'assigneeReport', createdAt: at });
+  const approve = (target: string, at: string): QuestCompletion =>
+    ({ uri: `app-${target}-${at}`, did: owner, questUri: URI, role: 'requesterApproval', targetAssignee: target, createdAt: at });
+  const revise = (target: string, at: string): QuestCompletion =>
+    ({ uri: `rev-${target}-${at}`, did: owner, questUri: URI, role: 'requesterRevision', targetAssignee: target, createdAt: at });
+
+  describe('正規化ヘルパー', () => {
+    it('questAssignees: assignees 優先・無ければ legacy assignee・両方無しは空', () => {
+      expect(questAssignees(multi())).toEqual([A, B]);
+      expect(questAssignees(mk({ assignee: A }))).toEqual([A]);
+      expect(questAssignees(mk({}))).toEqual([]);
+    });
+    it('questMaxAssignees: 未指定 legacy は 1', () => {
+      expect(questMaxAssignees(multi())).toBe(2);
+      expect(questMaxAssignees(mk({}))).toBe(1);
+    });
+    it('hasOpenSlot: 空き枠の有無', () => {
+      expect(hasOpenSlot(multi({ assignees: [A], maxAssignees: 2 }))).toBe(true);
+      expect(hasOpenSlot(multi({ assignees: [A, B], maxAssignees: 2 }))).toBe(false);
+    });
+    it('completionTarget: targetAssignee → 唯一assignee → 複数で不明は null', () => {
+      expect(completionTarget(approve(A, 't'), multi())).toBe(A);
+      // legacy 単数: target 無し approval は唯一の assignee に解決
+      const legacy = mk({ assignee: A });
+      expect(completionTarget({ uri: 'x', did: owner, questUri: legacy.uri, role: 'requesterApproval', createdAt: 't' }, legacy)).toBe(A);
+      // 複数受託で target 無しは曖昧 → null
+      expect(completionTarget({ uri: 'x', did: owner, questUri: URI, role: 'requesterApproval', createdAt: 't' }, multi())).toBeNull();
+    });
+  });
+
+  it('受託者ごとに独立して進行する (A承認済み・B報告済み未承認)', () => {
+    const q = multi();
+    const comps = [report(A, '01'), approve(A, '02'), report(B, '03')];
+    expect(effectiveStateForAssignee(q, comps, A)).toBe('COMPLETED');
+    expect(effectiveStateForAssignee(q, comps, B)).toBe('AWAITING_APPROVAL');
+    expect(questLevelState(q, comps)).toBe('ASSIGNED'); // 全員 COMPLETED ではない
+    expect(needsRequesterApproval(q, comps)).toBe(true); // B が承認待ち
+  });
+
+  it('全員承認で questLevelState=COMPLETED', () => {
+    const q = multi();
+    const comps = [report(A, '01'), approve(A, '02'), report(B, '03'), approve(B, '04')];
+    expect(questLevelState(q, comps)).toBe('COMPLETED');
+    expect(needsRequesterApproval(q, comps)).toBe(false);
+  });
+
+  it('1人やり直し中・1人完了の混在', () => {
+    const q = multi();
+    const comps = [report(A, '01'), approve(A, '02'), report(B, '03'), revise(B, '04')];
+    expect(effectiveStateForAssignee(q, comps, A)).toBe('COMPLETED');
+    expect(effectiveStateForAssignee(q, comps, B)).toBe('REVISION_REQUESTED');
+    expect(questLevelState(q, comps)).toBe('ASSIGNED');
+  });
+
+  it('isValidCompletion: 各受託者の報告は本人なら正当 / target が集合外の承認は無効', () => {
+    const q = multi();
+    expect(isValidCompletion(report(A, 't'), q)).toBe(true);
+    expect(isValidCompletion(report(B, 't'), q)).toBe(true);
+    expect(isValidCompletion(report('did:plc:stranger', 't'), q)).toBe(false);
+    expect(isValidCompletion(approve(A, 't'), q)).toBe(true);
+    expect(isValidCompletion(approve('did:plc:stranger', 't'), q)).toBe(false); // target が assignees 外
+    // 複数受託で target 無し approval は曖昧 → 無効 (偽の一括完了防止)
+    expect(isValidCompletion({ uri: 'x', did: owner, questUri: URI, role: 'requesterApproval', createdAt: 't' }, q)).toBe(false);
+  });
+
+  it('報酬は承認された受託者それぞれに満額 (per-assignee 承認ベース)', () => {
+    const q = multi(); // rewardPoints: 500
+    const comps = [report(A, '01'), approve(A, '02'), report(B, '03')]; // A 承認, B 未承認
+    const byUri = new Map([[URI, comps]]);
+    expect(rewardForMe(q, A, comps)).toBe(500);
+    expect(rewardForMe(q, B, comps)).toBe(0);
+    expect(holdings([q], A, byUri)).toBe(500);
+    expect(holdings([q], B, byUri)).toBe(0);
+    expect(totalIssued([q], byUri)).toBe(500); // 承認済み 1 人ぶん
+    expect(distinctRecipients([q], byUri)).toBe(1);
+    // 全員承認後は 2 人ぶん発行
+    const comps2 = [...comps, approve(B, '04')];
+    const byUri2 = new Map([[URI, comps2]]);
+    expect(totalIssued([q], byUri2)).toBe(1000);
+    expect(distinctRecipients([q], byUri2)).toBe(2);
+    expect(questXpScalar([q], A, byUri2)).toBe(questXpScalar([q], B, byUri2)); // 各自 1 件ぶん
+  });
+
+  it('後方互換: legacy 単数 assignee + status=completed は従来どおり (completions 無し fallback)', () => {
+    const legacy = mk({ status: 'completed', assignee: A, rewardPoints: 300 });
+    expect(rewardForMe(legacy, A)).toBe(300);
+    expect(holdings([legacy], A)).toBe(300);
+    expect(effectiveState(legacy, [])).toBe('COMPLETED');
+    expect(questAssignees(legacy)).toEqual([A]);
+  });
+
+  it('MAX_ASSIGNEES_PER_QUEST が定義されている', () => {
+    expect(MAX_ASSIGNEES_PER_QUEST).toBeGreaterThanOrEqual(10);
   });
 });
 

--- a/packages/core/src/user-quest.ts
+++ b/packages/core/src/user-quest.ts
@@ -39,8 +39,16 @@ export interface UserQuest {
   deadline?: string;
   visibility: UserQuestVisibility;
   status: UserQuestStatus;
-  /** 受託者 DID (status >= assigned) */
+  /**
+   * @deprecated 旧・単数受託者 DID。後方互換のため **読み取り時のみ** 参照する
+   * (本番 PDS に既存 record があるため)。新規書き込みでは使わず `assignees` に寄せる。
+   * 読みは必ず `questAssignees(q)` を通すこと。
+   */
   assignee?: Did;
+  /** 受託者 DID 群 (新形式)。発注者が応募者から上限 `maxAssignees` まで個別に追加する。 */
+  assignees?: Did[];
+  /** 受託上限人数 (作成時に発注者が指定、1〜MAX_ASSIGNEES_PER_QUEST)。未指定の legacy は 1 とみなす。 */
+  maxAssignees?: number;
   /** 発注者が指定する報酬ポイント (= 発注者発行通貨での pt 数)。0 以上の整数 */
   rewardPoints: number;
   /** Bluesky 告知 post の at-uri (任意) */
@@ -64,10 +72,51 @@ export interface QuestCompletion {
   did: Did;
   questUri: AtUri;
   role: QuestCompletionRole;
+  /**
+   * `requesterApproval` / `requesterRevision` が **どの受託者向けか** を示す (複数受託対応)。
+   * `assigneeReport` では未使用 (書き手 `did` が受託者自身)。
+   * legacy (targetAssignee 無し) の approval/revision は「唯一の assignee 向け」と解釈する
+   * (`completionTarget` 参照)。
+   */
+  targetAssignee?: Did;
   /** rating は MVP 未使用 (将来用) */
   rating?: number;
   comment?: string;
   createdAt: string;
+}
+
+// ─── 受託者集合の正規化 (新旧形式を吸収する読み取りの単一窓口) ─────
+
+/** 受託上限。未指定 legacy は 1 (旧 = 単数受託)。 */
+export const MAX_ASSIGNEES_PER_QUEST = 20;
+export const MIN_ASSIGNEES_PER_QUEST = 1;
+
+/** quest の受託者 DID を新旧両形式から正規化する。書き込み済み record を壊さない読み取りの窓口。 */
+export function questAssignees(q: Pick<UserQuest, 'assignees' | 'assignee'>): Did[] {
+  if (q.assignees && q.assignees.length > 0) return q.assignees;
+  return q.assignee ? [q.assignee] : [];
+}
+
+/** 受託上限人数 (未指定 legacy は 1)。 */
+export function questMaxAssignees(q: Pick<UserQuest, 'maxAssignees'>): number {
+  return q.maxAssignees ?? 1;
+}
+
+/** まだ受託者を追加できる空き枠があるか。 */
+export function hasOpenSlot(q: UserQuest): boolean {
+  return questAssignees(q).length < questMaxAssignees(q);
+}
+
+/**
+ * completion (approval/revision) が向けた受託者を正規化する。
+ * - `targetAssignee` があればそれ。
+ * - 無く、受託者が唯一なら その人 (= legacy 単数時代の record 互換)。
+ * - 無く、受託者が複数いて不明なら `null` (= 偽の一括完了を防ぐため無効扱い)。
+ */
+export function completionTarget(c: QuestCompletion, q: UserQuest): Did | null {
+  if (c.targetAssignee) return c.targetAssignee;
+  const list = questAssignees(q);
+  return list.length === 1 ? list[0]! : null;
 }
 
 // ─── 期限切れ判定 ──────────────────────────────────────────
@@ -100,9 +149,15 @@ export function isCompleted(q: UserQuest, completions: QuestCompletion[]): boole
  *  集計・表示の前に flooring すると、不正な record を排除できる。 */
 export function isValidCompletion(c: QuestCompletion, q: UserQuest): boolean {
   if (c.questUri !== q.uri) return false;
-  if (c.role === 'assigneeReport')      return q.assignee ? c.did === q.assignee : false;
-  if (c.role === 'requesterApproval')   return c.did === q.did;
-  if (c.role === 'requesterRevision')   return c.did === q.did;
+  const list = questAssignees(q);
+  // 受託者の報告: 書き手が受託者集合の誰か本人であること
+  if (c.role === 'assigneeReport') return list.includes(c.did);
+  // 発注者の承認/やり直し: 発注者本人が書き、向け先 (target) が受託者集合内であること
+  if (c.role === 'requesterApproval' || c.role === 'requesterRevision') {
+    if (c.did !== q.did) return false;
+    const t = completionTarget(c, q);
+    return t !== null && list.includes(t);
+  }
   return false;
 }
 
@@ -124,7 +179,11 @@ function latestCreatedAt(items: QuestCompletion[]): string | null {
  *  - 最後の報告 (assigneeReport) が最後の差し戻し (requesterRevision) より新しければ「承認待ち」。
  *    差し戻しの方が新しければ受託者の再報告待ちなので false。 */
 export function needsRequesterApproval(q: UserQuest, completions: QuestCompletion[]): boolean {
-  return effectiveState(q, completions) === 'AWAITING_APPROVAL';
+  if (q.status === 'completed' || q.status === 'cancelled') return false;
+  // 複数受託では「誰か 1 人でも報告済み・未承認」なら発注者の番。
+  return questAssignees(q).some(
+    d => effectiveStateForAssignee(q, completions, d) === 'AWAITING_APPROVAL',
+  );
 }
 
 /**
@@ -148,23 +207,70 @@ export type EffectiveState =
   | 'OPEN' | 'IN_PROGRESS' | 'AWAITING_APPROVAL' | 'REVISION_REQUESTED'
   | 'COMPLETED' | 'CANCELLED' | 'EXPIRED';
 
+/** 受託者 1 人ぶんの進行状態。複数受託では受託者ごとに独立して進む。 */
+export type AssigneeState = 'IN_PROGRESS' | 'AWAITING_APPROVAL' | 'REVISION_REQUESTED' | 'COMPLETED';
+
+/**
+ * **受託者 1 人ぶん**の実効状態を completion record から導出する (複数受託の真実)。
+ * その受託者の `assigneeReport` と、その人に向いた (targetAssignee 一致) `requesterApproval`
+ * / `requesterRevision` だけを見る。報酬・XP・「あなたの番」判定はこれが基準。
+ */
+export function effectiveStateForAssignee(
+  q: UserQuest,
+  completions: QuestCompletion[],
+  assigneeDid: Did,
+): AssigneeState {
+  const valid = completions.filter(c => isValidCompletion(c, q));
+  // この受託者向けの承認があれば確定 COMPLETED (status を信じない = 耐故障性)
+  const approved = valid.some(
+    c => c.role === 'requesterApproval' && completionTarget(c, q) === assigneeDid,
+  );
+  if (approved) return 'COMPLETED';
+  const lastReport = latestCreatedAt(
+    valid.filter(c => c.role === 'assigneeReport' && c.did === assigneeDid),
+  );
+  if (lastReport === null) return 'IN_PROGRESS';
+  const lastRevision = latestCreatedAt(
+    valid.filter(c => c.role === 'requesterRevision' && completionTarget(c, q) === assigneeDid),
+  );
+  if (lastRevision !== null && lastRevision > lastReport) return 'REVISION_REQUESTED';
+  return 'AWAITING_APPROVAL';
+}
+
+/** クエスト全体の状態 (募集枠・進行の概況)。報酬の真実は assignee 別状態を見ること。 */
+export type QuestLevelState = 'OPEN' | 'ASSIGNED' | 'COMPLETED' | 'CANCELLED' | 'EXPIRED';
+
+export function questLevelState(
+  q: UserQuest,
+  completions: QuestCompletion[],
+  now: Date = new Date(),
+): QuestLevelState {
+  if (q.status === 'cancelled') return 'CANCELLED';
+  if (q.status === 'completed') return 'COMPLETED'; // 発注者が明示クローズ
+  const list = questAssignees(q);
+  if (list.length === 0) return isExpired(q, now) ? 'EXPIRED' : 'OPEN';
+  if (list.every(d => effectiveStateForAssignee(q, completions, d) === 'COMPLETED')) return 'COMPLETED';
+  return 'ASSIGNED';
+}
+
+/**
+ * **後方互換ラッパ**。旧・単数受託前提の UI / 集計が引き続き動くよう、quest 全体に 1 つの
+ * EffectiveState を返す。受託者 0 人なら従来どおり OPEN/EXPIRED/CANCELLED/COMPLETED、
+ * 1 人以上なら「最初の (legacy では唯一の) 受託者の状態」を返す。
+ * 複数受託を正しく扱う新コードは `effectiveStateForAssignee` / `questLevelState` を直接使うこと。
+ */
 export function effectiveState(
   q: UserQuest,
   completions: QuestCompletion[],
   now: Date = new Date(),
 ): EffectiveState {
   if (q.status === 'cancelled') return 'CANCELLED';
-  if (isCompleted(q, completions)) return 'COMPLETED';
-  if (!q.assignee) {
+  if (q.status === 'completed') return 'COMPLETED';
+  const list = questAssignees(q);
+  if (list.length === 0) {
     return isExpired(q, now) ? 'EXPIRED' : 'OPEN';
   }
-  // 受託確定済み (assignee あり)。completion record から進行を判定する。
-  const valid = completions.filter(c => isValidCompletion(c, q));
-  const lastReport = latestCreatedAt(valid.filter(c => c.role === 'assigneeReport'));
-  if (lastReport === null) return 'IN_PROGRESS';
-  const lastRevision = latestCreatedAt(valid.filter(c => c.role === 'requesterRevision'));
-  if (lastRevision !== null && lastRevision > lastReport) return 'REVISION_REQUESTED';
-  return 'AWAITING_APPROVAL';
+  return effectiveStateForAssignee(q, completions, list[0]!);
 }
 
 // ─── 発注者視点: 成功 / 失敗 / キャンセル / 進行中 ─────────
@@ -173,39 +279,78 @@ export type Outcome = 'success' | 'failure' | 'cancelled' | 'inProgress';
 
 export function outcomeOf(q: UserQuest): Outcome {
   if (q.status === 'completed') return 'success';
-  if (q.status === 'cancelled') return q.assignee ? 'failure' : 'cancelled';
+  if (q.status === 'cancelled') return questAssignees(q).length > 0 ? 'failure' : 'cancelled';
   return 'inProgress';
 }
 
 // ─── ポイント集計 ──────────────────────────────────────────
+//
+// 複数受託では「各受託者が個別に承認された時点でそれぞれ満額」付与する (オーナー仕様)。
+// よって報酬は quest.status ではなく **受託者ごとの承認 (completion record)** が真実。
+// completions マップを渡すと per-assignee 承認ベースで判定し、省略時は従来の status ベースに
+// fallback する (legacy 単数クエストは status='completed' のままなので壊れない)。
 
-/** 「issuer (DID) が発注した完了済み quest のうち、me が受託したもの」のポイント合計 */
-export function holdings(issuerQuests: UserQuest[], me: Did): number {
-  return issuerQuests
-    .filter(q => q.status === 'completed' && q.assignee === me)
-    .reduce((sum, q) => sum + q.rewardPoints, 0);
+/** quest 1 件で me に確定した報酬。completions があれば per-assignee 承認で判定。 */
+export function rewardForMe(q: UserQuest, me: Did, completions?: QuestCompletion[]): number {
+  if (completions) {
+    return effectiveStateForAssignee(q, completions, me) === 'COMPLETED' ? q.rewardPoints : 0;
+  }
+  return q.status === 'completed' && questAssignees(q).includes(me) ? q.rewardPoints : 0;
 }
 
-/** 「issuer が発行した総ポイント (= 流通量)」 */
-export function totalIssued(issuerQuests: UserQuest[]): number {
-  return issuerQuests
-    .filter(q => q.status === 'completed')
-    .reduce((sum, q) => sum + q.rewardPoints, 0);
+/** 「issuer (DID) が発注した quest のうち、me が承認されたもの」のポイント合計 */
+export function holdings(
+  issuerQuests: UserQuest[],
+  me: Did,
+  completionsByUri?: Map<AtUri, QuestCompletion[]>,
+): number {
+  return issuerQuests.reduce(
+    (sum, q) => sum + rewardForMe(q, me, completionsByUri?.get(q.uri)),
+    0,
+  );
+}
+
+/** 「issuer が発行した総ポイント (= 流通量)」。複数受託では承認された人数ぶん発行される。 */
+export function totalIssued(
+  issuerQuests: UserQuest[],
+  completionsByUri?: Map<AtUri, QuestCompletion[]>,
+): number {
+  return issuerQuests.reduce((sum, q) => {
+    const comps = completionsByUri?.get(q.uri);
+    const completedCount = comps
+      ? questAssignees(q).filter(d => effectiveStateForAssignee(q, comps, d) === 'COMPLETED').length
+      : (q.status === 'completed' ? questAssignees(q).length || 1 : 0);
+    return sum + completedCount * q.rewardPoints;
+  }, 0);
 }
 
 /** 「me が持つ issuer ポイントの総発行に対するシェア % (0-100)」 */
-export function shareOf(issuerQuests: UserQuest[], me: Did): number {
-  const total = totalIssued(issuerQuests);
-  return total === 0 ? 0 : (holdings(issuerQuests, me) / total) * 100;
+export function shareOf(
+  issuerQuests: UserQuest[],
+  me: Did,
+  completionsByUri?: Map<AtUri, QuestCompletion[]>,
+): number {
+  const total = totalIssued(issuerQuests, completionsByUri);
+  return total === 0 ? 0 : (holdings(issuerQuests, me, completionsByUri) / total) * 100;
 }
 
 // ─── 関わった人数 ──────────────────────────────────────────
 
 /** 発注者視点: 完了済みクエストで実際に報酬を渡したユニーク受取人数 */
-export function distinctRecipients(myIssuedQuests: UserQuest[]): number {
+export function distinctRecipients(
+  myIssuedQuests: UserQuest[],
+  completionsByUri?: Map<AtUri, QuestCompletion[]>,
+): number {
   const set = new Set<Did>();
   for (const q of myIssuedQuests) {
-    if (q.status === 'completed' && q.assignee) set.add(q.assignee);
+    const comps = completionsByUri?.get(q.uri);
+    if (comps) {
+      for (const d of questAssignees(q)) {
+        if (effectiveStateForAssignee(q, comps, d) === 'COMPLETED') set.add(d);
+      }
+    } else if (q.status === 'completed') {
+      for (const d of questAssignees(q)) set.add(d);
+    }
   }
   return set.size;
 }
@@ -248,15 +393,21 @@ export function summarize(quests: UserQuest[]): OutcomeSummary {
  * 承認済み (`status==='completed'`) のクエストのみ対象。この XP は全体 LV (playerLevel) と
  * 現職 LV (jobLevel) の両方に乗せて表示する (= 冒険で確かにレベルが上がる)。
  *
- * 引数は `status` / `assignee` だけ見るので、完全な UserQuest でも questIndex の
- * summary でも渡せる。承認の真実は発注者 record の `status='completed'` (承認時に発注者が
- * 書く) で、受託者はそれを公開 read できる。
+ * 複数受託対応: completions マップを渡すと「me がその quest で承認された (per-assignee
+ * COMPLETED)」件数を数える。省略時は従来どおり `status==='completed'` かつ me が受託者集合に
+ * 含まれる件数に fallback する (legacy 単数クエストは status で完了が分かるので壊れない)。
  */
 export function questXpScalar(
-  receivedQuests: { status: string; assignee?: Did }[],
+  receivedQuests: UserQuest[],
   me: Did,
+  completionsByUri?: Map<AtUri, QuestCompletion[]>,
 ): number {
-  const n = receivedQuests.filter(q => q.status === 'completed' && q.assignee === me).length;
+  const n = receivedQuests.filter(q => {
+    const comps = completionsByUri?.get(q.uri);
+    return comps
+      ? effectiveStateForAssignee(q, comps, me) === 'COMPLETED'
+      : q.status === 'completed' && questAssignees(q).includes(me);
+  }).length;
   return n * XP_REWARDS.questComplete;
 }
 

--- a/packages/core/src/user-quest.ts
+++ b/packages/core/src/user-quest.ts
@@ -93,7 +93,9 @@ export const MIN_ASSIGNEES_PER_QUEST = 1;
 
 /** quest の受託者 DID を新旧両形式から正規化する。書き込み済み record を壊さない読み取りの窓口。 */
 export function questAssignees(q: Pick<UserQuest, 'assignees' | 'assignee'>): Did[] {
-  if (q.assignees && q.assignees.length > 0) return q.assignees;
+  // 重複 DID は除去する (集計の水増し防止 = 防御。書き込み側 addAssignee も重複拒否するが、
+  // 不正/壊れた record でも totalIssued 等が水増しされないよう読み取り窓口でも担保)。
+  if (q.assignees && q.assignees.length > 0) return [...new Set(q.assignees)];
   return q.assignee ? [q.assignee] : [];
 }
 
@@ -143,6 +145,20 @@ export function isCompleted(q: UserQuest, completions: QuestCompletion[]): boole
     c.role === 'requesterApproval' &&
     c.did === q.did,
   );
+}
+
+/**
+ * **複数受託では `isCompleted` を完了判定に使わないこと** (= owner の approval が 1 件でも
+ * あれば true を返すため、複数受託で「1 人承認 = quest 全体完了」に化ける)。
+ * 報酬・冪等性・per-assignee の完了は **この関数** (= その受託者向けの承認があるか) を使う。
+ * `isCompleted` は legacy 単数 / quest 全体の概況用に限定する。
+ */
+export function isCompletedForAssignee(
+  q: UserQuest,
+  completions: QuestCompletion[],
+  assigneeDid: Did,
+): boolean {
+  return effectiveStateForAssignee(q, completions, assigneeDid) === 'COMPLETED';
 }
 
 /** completion record の owner DID が role に対応する正当な書き手かを検証する。


### PR DESCRIPTION
## 背景
クエストを複数人受託可 (発注者が作成時に上限人数を指定、最大10〜20) にする。本 PR は **段階1/3 (core のみ)**。本番運用中なので既存の単数 assignee レコードの後方互換が必須。

確定仕様 (オーナー決定): 各受託者に報酬**満額** / 受託者ごとに**個別承認** / 発注者が**選んで確定**。

## 設計: 「quest 全体状態」と「受託者別状態」を分離
- `effectiveStateForAssignee(q,comps,did)`: 受託者1人の進行 (報酬・XP・「あなたの番」の真実)
- `questLevelState(q,comps)`: quest 全体の概況 (OPEN/ASSIGNED/COMPLETED/...)
- `effectiveState` は「最初の受託者の状態」を返す**後方互換ラッパ** → 旧 UI がそのまま動く
- 承認/やり直しに `targetAssignee` を追加。legacy (target 無し) は唯一 assignee 向け、複数で不明なら無効 (偽の一括完了防止)

## 変更 (core のみ)
- `UserQuest.assignees?` / `maxAssignees?`、`QuestCompletion.targetAssignee?` 追加 (旧 assignee は読取専用で残す)
- 正規化ヘルパー questAssignees(dedup付)/questMaxAssignees/hasOpenSlot/completionTarget
- isValidCompletion 複数対応、needsRequesterApproval は per-assignee
- isCompletedForAssignee 新設 (per-assignee 完了判定)
- 報酬を per-assignee 承認ベースへ (rewardForMe + 各集計に任意 completionsByUri、省略時 status fallback)

## 検証
- core test **174 件 green** (既存全件 + 複数受託 15 件)。web typecheck/test も green。
- 後方互換: 既存単数クエストは completions 無し fallback で従来どおり完了・報酬。

## Review (§1.5 3並列: 設計 / 実装 / 後方互換・セキュリティ)
- **★★★ (設計) isCompleted が複数受託で「1人承認=全体完了」に化ける地雷** → `isCompletedForAssignee` 新設 + isCompleted の scope を docstring 明示 (commit dad98af)。
- **★★ (実装) assignees 重複で totalIssued 水増し** → questAssignees で dedup (dad98af)。
- ★ テスト網羅 (承認の受託者間非干渉・空配列fallback 等) → 追加 (dad98af)。
- セキュリティ: ★★★ なし。偽造防止 (assignees 外 report / 非発注者 approval / target 集合外 / 複数で target 無し) は全て弾くことを追試確認。報酬水増し (重複 approval) も承認実人数ベースで防止。
- **段階2 PR で対応 (本 PR スコープ外の seam)**: `listCompletionsFor`/`listReceivedQuests` を `questAssignees` 経由に / `addAssignee` で `hasOpenSlot` エンフォース+重複拒否 / approveCompletion 冪等性を isCompletedForAssignee へ / sticky approval (承認後 revision 不可) を docs 化 + 段階3 UI で承認後 revision ボタン無効化。
- 段階2 着手時の注意: `effectiveState` ラッパは受託者視点に使わず `effectiveStateForAssignee` を直接使う。

実装レビュー: typecheck / core test (174) green を worktree で確認済み。