### PR TITLE
feat(quest-ui): 複数人受託の作成/受託/承認 UI (段階3a/3)

### DIFF
--- a/apps/web/src/components/column-content/board-shared.tsx
+++ b/apps/web/src/components/column-content/board-shared.tsx
@@ -9,7 +9,7 @@ import { Link } from 'react-router-dom';
 import type { QuestIndex, QuestIndexSummary } from '@/lib/quest-api';
 import { listIssuedQuests, listMyApplications, listCompletionsFor, buildQuestIndexViaDiscovery, questPath } from '@/lib/quest-api';
 import { getQuestIndexCached } from '@/lib/quest-index-cache';
-import { needsRequesterApproval, effectiveState, type EffectiveState, type UserQuest } from '@aozoraquest/core';
+import { needsRequesterApproval, effectiveState, effectiveStateForAssignee, questAssignees, questMaxAssignees, type EffectiveState, type UserQuest } from '@aozoraquest/core';
 import { setQuestActionableCount } from '@/lib/quest-actionable';
 import { useSession } from '@/lib/session';
 import { useRuntimeConfig } from '@/components/config-provider';
@@ -69,7 +69,7 @@ export function useBoardData() {
       setReportPending([]);
       return;
     }
-    const mine = index.quests.filter((q) => q.assignee === selfDid && q.status === 'assigned');
+    const mine = index.quests.filter((q) => questAssignees(q).includes(selfDid) && q.status === 'assigned');
     if (mine.length === 0) {
       setAssigneeStates(new Map());
       setReportPending([]);
@@ -83,7 +83,8 @@ export function useBoardData() {
         const q = summaryToQuest(s);
         try {
           const comps = await listCompletionsFor(undefined, q);
-          const st = effectiveState(q, comps);
+          // 複数受託: 自分ぶんの状態だけを見る (他の受託者の進行は無関係)。
+          const st = effectiveStateForAssignee(q, comps, selfDid);
           states.set(q.uri, st);
           if (st === 'IN_PROGRESS' || st === 'REVISION_REQUESTED') pend.push(q);
         } catch (e) {
@@ -160,6 +161,8 @@ function summaryToQuest(s: QuestIndexSummary): UserQuest {
     updatedAt: s.createdAt,
   };
   if (s.assignee !== undefined) q.assignee = s.assignee;
+  if (s.assignees !== undefined) q.assignees = s.assignees;
+  if (s.maxAssignees !== undefined) q.maxAssignees = s.maxAssignees;
   if (s.deadline !== undefined) q.deadline = s.deadline;
   return q;
 }
@@ -181,7 +184,7 @@ export function filterForBoard(
     // 抜ける)。これが無いと受託者は受託後にクエストを見失い完了報告に到達できない。
     if (!index) return null;
     if (!selfDid) return [];
-    return index.quests.filter(q => q.assignee === selfDid && q.status === 'assigned');
+    return index.quests.filter(q => questAssignees(q).includes(selfDid) && q.status === 'assigned');
   }
   if (c.kind === 'mine') {
     if (!myQuests) return null;
@@ -269,6 +272,10 @@ export function QuestCard({ summary, expired, needsApproval, assigneeState }: { 
         </div>
         <div style={{ display: 'flex', gap: '0.5em', flexWrap: 'wrap', fontSize: '0.72em', color: 'var(--color-muted)', marginTop: '0.3em' }}>
           {summary.tags.slice(0, 3).map(t => <span key={t}>#{t.replace(/^#/, '')}</span>)}
+          {questMaxAssignees(summary) > 1 && (
+            // 複数受託クエスト: 確定済み人数 / 上限を示す (募集枠の埋まり具合)
+            <span title="受託者数 / 上限">👥 {questAssignees(summary).length}/{questMaxAssignees(summary)}</span>
+          )}
           <span style={{ marginLeft: 'auto' }}>
             {expired ? '期限切れ' : summary.deadline ? `〆 ${formatDate(summary.deadline)}` : ''}
             {/* needsApproval / assignee バッジが状態を示すときは muted ラベルを重複させない */}

--- a/apps/web/src/components/column-content/board-shared.tsx
+++ b/apps/web/src/components/column-content/board-shared.tsx
@@ -9,7 +9,7 @@ import { Link } from 'react-router-dom';
 import type { QuestIndex, QuestIndexSummary } from '@/lib/quest-api';
 import { listIssuedQuests, listMyApplications, listCompletionsFor, buildQuestIndexViaDiscovery, questPath } from '@/lib/quest-api';
 import { getQuestIndexCached } from '@/lib/quest-index-cache';
-import { needsRequesterApproval, effectiveState, effectiveStateForAssignee, questAssignees, questMaxAssignees, type EffectiveState, type UserQuest } from '@aozoraquest/core';
+import { needsRequesterApproval, effectiveStateForAssignee, questAssignees, questMaxAssignees, type EffectiveState, type UserQuest } from '@aozoraquest/core';
 import { setQuestActionableCount } from '@/lib/quest-actionable';
 import { useSession } from '@/lib/session';
 import { useRuntimeConfig } from '@/components/config-provider';
@@ -274,7 +274,7 @@ export function QuestCard({ summary, expired, needsApproval, assigneeState }: { 
           {summary.tags.slice(0, 3).map(t => <span key={t}>#{t.replace(/^#/, '')}</span>)}
           {questMaxAssignees(summary) > 1 && (
             // 複数受託クエスト: 確定済み人数 / 上限を示す (募集枠の埋まり具合)
-            <span title="受託者数 / 上限">👥 {questAssignees(summary).length}/{questMaxAssignees(summary)}</span>
+            <span title="受託者数 / 上限">受託 {questAssignees(summary).length}/{questMaxAssignees(summary)}</span>
           )}
           <span style={{ marginLeft: 'auto' }}>
             {expired ? '期限切れ' : summary.deadline ? `〆 ${formatDate(summary.deadline)}` : ''}

--- a/apps/web/src/lib/quest-actionable.ts
+++ b/apps/web/src/lib/quest-actionable.ts
@@ -18,7 +18,7 @@
 import { useSyncExternalStore } from 'react';
 import { listIssuedQuests, listCompletionsFor, buildQuestIndexViaDiscovery, type QuestIndexSummary } from './quest-api';
 import { getQuestIndexCached } from './quest-index-cache';
-import { effectiveState, needsRequesterApproval, type UserQuest } from '@aozoraquest/core';
+import { effectiveStateForAssignee, needsRequesterApproval, questAssignees, type UserQuest } from '@aozoraquest/core';
 
 type Agent = Parameters<typeof buildQuestIndexViaDiscovery>[0];
 type Did = Parameters<typeof buildQuestIndexViaDiscovery>[1][number];
@@ -65,6 +65,8 @@ function summaryToQuest(s: QuestIndexSummary): UserQuest {
     updatedAt: s.createdAt,
   };
   if (s.assignee !== undefined) q.assignee = s.assignee;
+  if (s.assignees !== undefined) q.assignees = s.assignees;
+  if (s.maxAssignees !== undefined) q.maxAssignees = s.maxAssignees;
   if (s.deadline !== undefined) q.deadline = s.deadline;
   return q;
 }
@@ -84,12 +86,13 @@ export async function computeQuestActionableCount(
   let reportPending = 0;
   try {
     const idx = await getQuestIndexCached(() => buildQuestIndexViaDiscovery(agent, directoryDids, did));
-    const mine = idx.quests.filter((q) => q.assignee === did && q.status === 'assigned');
+    const mine = idx.quests.filter((q) => questAssignees(q).includes(did) && q.status === 'assigned');
     await Promise.all(mine.map(async (s) => {
       const q = summaryToQuest(s);
       try {
         const comps = await listCompletionsFor(undefined, q);
-        const st = effectiveState(q, comps);
+        // 複数受託: 自分ぶんの状態だけ見る (他受託者の進行は無関係)。
+        const st = effectiveStateForAssignee(q, comps, did);
         if (st === 'IN_PROGRESS' || st === 'REVISION_REQUESTED') reportPending += 1;
       } catch {
         // 失敗時は「報告する番」に倒す (見落とすより出して気づかせる。useBoardData と対称)

--- a/apps/web/src/routes/board-detail.tsx
+++ b/apps/web/src/routes/board-detail.tsx
@@ -324,9 +324,13 @@ export function BoardDetail() {
         <span style={{ color: 'var(--color-accent)' }}>
           <RewardPoints did={quest.did} points={quest.rewardPoints} />
         </span>
-        <span style={{ marginLeft: 'auto' }}>{questLevelLabel(qState)}</span>
+        {/* 空き枠が残る間は「受託中」でなく「募集中」と出す (複数受託で 1 人確定済みでも
+            まだ応募を受け付けているため。👥 N/M で確定済み人数も併記)。 */}
+        <span style={{ marginLeft: 'auto' }}>
+          {qState === 'ASSIGNED' && openSlot ? '募集中' : questLevelLabel(qState)}
+        </span>
         {questMaxAssignees(quest) > 1 && (
-          <span title="受託者数 / 上限">👥 {assignees.length}/{questMaxAssignees(quest)}</span>
+          <span title="受託者数 / 上限">受託 {assignees.length}/{questMaxAssignees(quest)}</span>
         )}
       </div>
 
@@ -342,8 +346,10 @@ export function BoardDetail() {
         </p>
       )}
 
-      {/* 発注者向け: 期限変更 / キャンセル (open 中のみ) */}
-      {isOwner && quest.status === 'open' && (
+      {/* 発注者向け: 期限変更 / キャンセル (募集枠が残る間 = まだ受付中のクエストのみ)。
+          複数受託では 1 人確定後 (status=assigned) でも空き枠がある間は募集継続なので操作可。
+          単数 (満枠 1/1) や完了/キャンセル後は従来どおり非表示。 */}
+      {isOwner && openSlot && qState !== 'CANCELLED' && qState !== 'COMPLETED' && (
         <div style={{ marginTop: '1em' }}>
           <div style={{ display: 'flex', gap: '0.6em' }}>
             <button onClick={() => {
@@ -408,6 +414,14 @@ export function BoardDetail() {
         </div>
       )}
 
+      {/* 満枠 (空き枠なし・未完了) のとき、非受託の訪問者に「もう応募できない理由」を明示する
+          (無言で応募導線が消えると認知ギャップになる、UX レビュー指摘)。 */}
+      {!isOwner && !isAssignee && !openSlot && qState === 'ASSIGNED' && questMaxAssignees(quest) > 1 && (
+        <p style={{ marginTop: '1em', fontSize: '0.85em', color: 'var(--color-muted)' }}>
+          受託枠が埋まりました ({assignees.length}/{questMaxAssignees(quest)} 人)。
+        </p>
+      )}
+
       {/* 発注者向け応募者一覧: 空き枠がある間表示。withdrawn と確定済み受託者は除外 */}
       {isOwner && openSlot && qState !== 'CANCELLED' && qState !== 'COMPLETED' && (() => {
         const activeApps = applications?.filter(a => !a.withdrawn && !assignees.includes(a.did)) ?? null;
@@ -462,7 +476,7 @@ export function BoardDetail() {
             const st = stateOf(aDid);
             const meRow = session.did === aDid;
             return (
-              <div key={aDid} className="dq-window compact" style={{ marginTop: '0.4em' }}>
+              <div key={aDid} className="dq-window compact" style={{ marginTop: '0.4em', borderColor: actionTarget === aDid ? 'var(--color-accent)' : undefined }}>
                 <p style={{ margin: 0, fontSize: '0.85em' }}>
                   <strong><Handle did={aDid} /></strong>
                   <span style={{ marginLeft: '0.5em', fontSize: '0.85em', color: st === 'COMPLETED' ? 'var(--color-accent)' : 'var(--color-muted)' }}>
@@ -520,8 +534,8 @@ export function BoardDetail() {
 
                 {/* この受託者が承認済み: 報酬発行を表示 */}
                 {st === 'COMPLETED' && (
-                  <p style={{ margin: '0.3em 0 0', fontSize: '0.82em' }}>
-                    ✅ <RewardPoints did={quest.did} points={quest.rewardPoints} /> を発行しました。
+                  <p style={{ margin: '0.3em 0 0', fontSize: '0.82em', color: 'var(--color-accent)' }}>
+                    ✓ <RewardPoints did={quest.did} points={quest.rewardPoints} /> を発行しました。
                   </p>
                 )}
               </div>
@@ -565,7 +579,7 @@ function assigneeStateLabel(state: AssigneeState): string {
     case 'IN_PROGRESS':        return '作業中';
     case 'AWAITING_APPROVAL':  return '完了報告済み (承認待ち)';
     case 'REVISION_REQUESTED': return 'やり直し対応中';
-    case 'COMPLETED':          return '✅ 完了 (承認済み)';
+    case 'COMPLETED':          return '✓ 完了 (承認済み)';
   }
 }
 

--- a/apps/web/src/routes/board-detail.tsx
+++ b/apps/web/src/routes/board-detail.tsx
@@ -17,7 +17,7 @@ import {
   applyToQuest,
   withdrawApplication,
   listApplicationsFor,
-  setAssignee,
+  addAssignee,
   reportCompletion,
   approveCompletion,
   requestRevision,
@@ -38,8 +38,13 @@ import { isoToLocalInput } from '@/lib/datetime';
 import { resolveHandle } from '@/lib/handle-cache';
 import {
   isExpired,
-  effectiveState,
-  type EffectiveState,
+  effectiveStateForAssignee,
+  questLevelState,
+  questAssignees,
+  questMaxAssignees,
+  hasOpenSlot,
+  type AssigneeState,
+  type QuestLevelState,
   formatNotificationPost,
   type NotificationAction,
   type UserQuest,
@@ -66,6 +71,8 @@ export function BoardDetail() {
   const [revisionForm, setRevisionForm] = useState<{ open: boolean; message: string }>({ open: false, message: '' });
   /** 受託者指定の確認: applicant did を保持 (= 確認 UI を開いている対象) */
   const [pendingAssign, setPendingAssign] = useState<string | null>(null);
+  /** 承認/やり直しフォームの対象受託者 did (複数受託で「誰を」承認/差し戻すか)。 */
+  const [actionTarget, setActionTarget] = useState<string | null>(null);
 
   // URI 変更 (= 別 quest へ遷移) 時に inline form の state を初期化する。
   // 第三者レビューの指摘 (UI: form 持ち越し)。
@@ -77,6 +84,7 @@ export function BoardDetail() {
     setApproveForm({ open: false, message: '' });
     setRevisionForm({ open: false, message: '' });
     setPendingAssign(null);
+    setActionTarget(null);
     setErr(null);
     setBusy(false);
   }, [uri]);
@@ -132,14 +140,20 @@ export function BoardDetail() {
 
   const expired = isExpired(quest);
   const isOwner = session.did === quest.did;
-  const isAssignee = session.did === quest.assignee;
+  const assignees = questAssignees(quest);
+  const isAssignee = !!session.did && assignees.includes(session.did);
+  const openSlot = hasOpenSlot(quest);
   // 自分の応募の中で、取り下げてないものを最新順で先頭から (= 複数応募していても
   // 最新のアクティブ応募を「自分の応募」として扱う)。
   const myApp = applications
     ?.filter(a => a.did === session.did && !a.withdrawn)
     .sort((a, b) => b.createdAt.localeCompare(a.createdAt))[0] ?? null;
-  // 全状態・操作の gate は effectiveState を唯一の真実に (status は受託者の報告を反映しない)。
-  const state = effectiveState(quest, completions ?? []);
+  // quest 全体状態と、受託者ごとの状態 (複数受託では受託者ごとに独立進行)。status は信じず
+  // completion record から導出する (status は受託者の報告を反映しないため)。
+  const qState: QuestLevelState = questLevelState(quest, completions ?? []);
+  const comps = completions ?? [];
+  const stateOf = (did: string): AssigneeState => effectiveStateForAssignee(quest, comps, did);
+  const myState: AssigneeState | null = isAssignee && session.did ? stateOf(session.did) : null;
 
   async function cancelQuest() {
     if (!session.agent || !quest || !isOwner) return;
@@ -235,7 +249,7 @@ export function BoardDetail() {
     if (!session.agent || !quest || !isOwner) return;
     setBusy(true);
     try {
-      await setAssignee(session.agent, quest, applicantDid);
+      await addAssignee(session.agent, quest, applicantDid);
       await notifyBluesky('assigned', applicantDid);
       setPendingAssign(null);
       await refresh();
@@ -263,13 +277,14 @@ export function BoardDetail() {
   }
 
   async function submitApprove() {
-    if (!session.agent || !session.did || !quest || !isOwner) return;
+    if (!session.agent || !session.did || !quest || !isOwner || !actionTarget) return;
     setBusy(true);
     try {
       const comment = approveForm.message.trim();
-      await approveCompletion(session.agent, session.did, quest, comment || undefined);
-      if (quest.assignee) await notifyBluesky('approved', quest.assignee);
+      await approveCompletion(session.agent, session.did, quest, comment || undefined, actionTarget);
+      await notifyBluesky('approved', actionTarget);
       setApproveForm({ open: false, message: '' });
+      setActionTarget(null);
       await refresh();
     } catch (e) {
       setErr(String((e as Error)?.message ?? e));
@@ -279,14 +294,15 @@ export function BoardDetail() {
   }
 
   async function submitRevision() {
-    if (!session.agent || !session.did || !quest || !isOwner) return;
+    if (!session.agent || !session.did || !quest || !isOwner || !actionTarget) return;
     const comment = revisionForm.message.trim();
     if (!comment) return;
     setBusy(true);
     try {
-      await requestRevision(session.agent, session.did, quest, comment);
-      if (quest.assignee) await notifyBluesky('revisionRequested', quest.assignee);
+      await requestRevision(session.agent, session.did, quest, comment, actionTarget);
+      await notifyBluesky('revisionRequested', actionTarget);
       setRevisionForm({ open: false, message: '' });
+      setActionTarget(null);
       await refresh();
     } catch (e) {
       setErr(String((e as Error)?.message ?? e));
@@ -308,7 +324,10 @@ export function BoardDetail() {
         <span style={{ color: 'var(--color-accent)' }}>
           <RewardPoints did={quest.did} points={quest.rewardPoints} />
         </span>
-        <span style={{ marginLeft: 'auto' }}>{statusLabel(state)}</span>
+        <span style={{ marginLeft: 'auto' }}>{questLevelLabel(qState)}</span>
+        {questMaxAssignees(quest) > 1 && (
+          <span title="受託者数 / 上限">👥 {assignees.length}/{questMaxAssignees(quest)}</span>
+        )}
       </div>
 
       <div style={{ marginTop: '0.6em', whiteSpace: 'pre-wrap', lineHeight: 1.6 }}>{quest.body}</div>
@@ -354,8 +373,9 @@ export function BoardDetail() {
         </div>
       )}
 
-      {/* 応募者向け: 応募フォーム / 自分の応募表示 */}
-      {!isOwner && session.status === 'signed-in' && quest.status === 'open' && !expired && (
+      {/* 応募者向け: 応募フォーム / 自分の応募表示。複数受託では空き枠がある間 (assigned でも) 応募可。 */}
+      {!isOwner && session.status === 'signed-in' && !isAssignee && openSlot
+        && qState !== 'CANCELLED' && qState !== 'COMPLETED' && !expired && (
         <div style={{ marginTop: '1em' }}>
           {!myApp ? (
             !applyForm.open ? (
@@ -388,12 +408,15 @@ export function BoardDetail() {
         </div>
       )}
 
-      {/* 発注者向け応募者一覧 (open のとき): withdrawn は除外 */}
-      {isOwner && quest.status === 'open' && (() => {
-        const activeApps = applications?.filter(a => !a.withdrawn) ?? null;
+      {/* 発注者向け応募者一覧: 空き枠がある間表示。withdrawn と確定済み受託者は除外 */}
+      {isOwner && openSlot && qState !== 'CANCELLED' && qState !== 'COMPLETED' && (() => {
+        const activeApps = applications?.filter(a => !a.withdrawn && !assignees.includes(a.did)) ?? null;
         return (
           <section style={{ marginTop: '1.4em' }}>
-            <h3 style={{ fontSize: '0.95em' }}>応募者 ({activeApps?.length ?? 0})</h3>
+            <h3 style={{ fontSize: '0.95em' }}>
+              応募者 ({activeApps?.length ?? 0})
+              {questMaxAssignees(quest) > 1 && <span style={{ fontSize: '0.8em', color: 'var(--color-muted)', fontWeight: 400 }}> ・受託 {assignees.length}/{questMaxAssignees(quest)} 人</span>}
+            </h3>
             {!activeApps && <p style={{ fontSize: '0.85em', color: 'var(--color-muted)' }}>読み込み中...</p>}
             {activeApps && activeApps.length === 0 && (
               <p style={{ fontSize: '0.85em', color: 'var(--color-muted)' }}>まだ応募がありません。</p>
@@ -409,7 +432,9 @@ export function BoardDetail() {
                     <p style={{ margin: '0 0 0.4em', fontSize: '0.85em' }}>
                       <strong><Handle did={a.did} /></strong> を受託者に指定しますか?<br />
                       <span style={{ fontSize: '0.78em', color: 'var(--color-muted)' }}>
-                        他の応募者には自動通知は送られませんが、ステータスが「受託中」に変わり追加応募は受け付けられなくなります。
+                        {questMaxAssignees(quest) > 1
+                          ? `この人が受託者に加わります (受託 ${assignees.length + 1}/${questMaxAssignees(quest)} 人)。空き枠がある間は他の人も追加できます。`
+                          : '他の応募者には自動通知は送られませんが、ステータスが「受託中」に変わり追加応募は受け付けられなくなります。'}
                       </span>
                     </p>
                     <div style={{ display: 'flex', gap: '0.5em' }}>
@@ -426,99 +451,82 @@ export function BoardDetail() {
         );
       })()}
 
-      {/* 受託確定〜完了前: 受託者の表示 + 受託者の完了報告フォーム (state は completion 由来) */}
-      {(state === 'IN_PROGRESS' || state === 'AWAITING_APPROVAL' || state === 'REVISION_REQUESTED') && quest.assignee && (
+      {/* 受託者一覧: 受託者ごとに状態を表示。受託者は自分ぶんを報告でき、発注者は受託者ごとに
+          個別に承認/やり直しできる (複数受託対応)。状態は completion record から導出 (status 非依存)。 */}
+      {assignees.length > 0 && (
         <section style={{ marginTop: '1.4em' }}>
-          <p style={{ fontSize: '0.85em' }}>
-            受託者: <strong><Handle did={quest.assignee} /></strong>
-            {state === 'AWAITING_APPROVAL' && ' (完了報告済み、承認待ち)'}
-            {state === 'REVISION_REQUESTED' && ' (やり直し依頼中)'}
-          </p>
-          {/* 受託者は作業中(未報告) と 差し戻し中 のとき報告できる。報告後(承認待ち)は隠す。
-              completions ロード中 (null) は state が IN_PROGRESS に見えるため、確定するまで
-              報告ボタンを出さない (ちらつき + 報告済みなのに再報告で二重 report を防ぐ)。 */}
-          {isAssignee && completions !== null && (state === 'IN_PROGRESS' || state === 'REVISION_REQUESTED') && (
-            !reportForm.open ? (
-              <button onClick={() => setReportForm({ open: true, message: '' })} disabled={busy}>完了を報告する</button>
-            ) : (
-              <div className="dq-window compact">
-                <h4 style={{ margin: '0 0 0.4em', fontSize: '0.9em' }}>完了を報告する</h4>
-                <label htmlFor="report-msg" style={{ display: 'block', fontSize: '0.8em', color: 'var(--color-muted)', marginBottom: '0.3em' }}>成果物の URL・一言コメント (任意)</label>
-                <textarea
-                  id="report-msg"
-                  value={reportForm.message}
-                  onChange={(e) => setReportForm({ ...reportForm, message: e.target.value })}
-                  rows={4}
-                  autoFocus
-                  placeholder="例: https://example.com/illust.png&#10;こんな感じになりました!"
-                  style={{ width: '100%' }}
-                />
-                <div style={{ display: 'flex', gap: '0.5em', marginTop: '0.5em' }}>
-                  <button onClick={submitReport} disabled={busy}>完了を報告する</button>
-                  <button className="secondary" onClick={() => setReportForm({ open: false, message: '' })} disabled={busy}>キャンセル</button>
-                </div>
-              </div>
-            )
-          )}
-          {isOwner && state === 'AWAITING_APPROVAL' && (
-            <div style={{ marginTop: '0.4em' }}>
-              {!approveForm.open && !revisionForm.open && (
-                <div style={{ display: 'flex', gap: '0.6em' }}>
-                  <button onClick={() => setApproveForm({ open: true, message: '' })} disabled={busy}>承認する (報酬を発行)</button>
-                  <button onClick={() => setRevisionForm({ open: true, message: '' })} disabled={busy} className="secondary">やり直しを依頼</button>
-                </div>
-              )}
-              {approveForm.open && (
-                <div className="dq-window compact">
-                  <h4 style={{ margin: '0 0 0.4em', fontSize: '0.9em' }}>完了を承認する (報酬を発行)</h4>
-                  <label htmlFor="approve-msg" style={{ display: 'block', fontSize: '0.8em', color: 'var(--color-muted)', marginBottom: '0.3em' }}>承認コメント (任意)</label>
-                  <textarea
-                    id="approve-msg"
-                    value={approveForm.message}
-                    onChange={(e) => setApproveForm({ ...approveForm, message: e.target.value })}
-                    rows={3}
-                    autoFocus
-                    style={{ width: '100%' }}
-                  />
-                  <div style={{ display: 'flex', gap: '0.5em', marginTop: '0.5em' }}>
-                    <button onClick={submitApprove} disabled={busy}>承認する</button>
-                    <button className="secondary" onClick={() => setApproveForm({ open: false, message: '' })} disabled={busy}>戻る</button>
-                  </div>
-                </div>
-              )}
-              {revisionForm.open && (
-                <div className="dq-window compact">
-                  <h4 style={{ margin: '0 0 0.4em', fontSize: '0.9em' }}>やり直しを依頼する</h4>
-                  <label htmlFor="revision-msg" style={{ display: 'block', fontSize: '0.8em', color: 'var(--color-muted)', marginBottom: '0.3em' }}>依頼する理由 (必須)</label>
-                  <textarea
-                    id="revision-msg"
-                    value={revisionForm.message}
-                    onChange={(e) => setRevisionForm({ ...revisionForm, message: e.target.value })}
-                    rows={4}
-                    autoFocus
-                    style={{ width: '100%' }}
-                  />
-                  <div style={{ display: 'flex', gap: '0.5em', marginTop: '0.5em' }}>
-                    <button onClick={submitRevision} disabled={busy || !revisionForm.message.trim()}>送信する</button>
-                    <button className="secondary" onClick={() => setRevisionForm({ open: false, message: '' })} disabled={busy}>戻る</button>
-                  </div>
-                </div>
-              )}
-            </div>
-          )}
-        </section>
-      )}
+          <h3 style={{ fontSize: '0.95em' }}>
+            受託者{questMaxAssignees(quest) > 1 ? ` (${assignees.length}/${questMaxAssignees(quest)})` : ''}
+          </h3>
+          {assignees.map((aDid) => {
+            const st = stateOf(aDid);
+            const meRow = session.did === aDid;
+            return (
+              <div key={aDid} className="dq-window compact" style={{ marginTop: '0.4em' }}>
+                <p style={{ margin: 0, fontSize: '0.85em' }}>
+                  <strong><Handle did={aDid} /></strong>
+                  <span style={{ marginLeft: '0.5em', fontSize: '0.85em', color: st === 'COMPLETED' ? 'var(--color-accent)' : 'var(--color-muted)' }}>
+                    {assigneeStateLabel(st)}
+                  </span>
+                </p>
 
-      {/* 完了済み: 報酬表示 */}
-      {state === 'COMPLETED' && (
-        <section style={{ marginTop: '1.4em' }} className="dq-window">
-          <p style={{ margin: 0, fontSize: '0.9em' }}>
-            完了! 受託者 <strong>{quest.assignee ? <Handle did={quest.assignee} /> : '—'}</strong> に{' '}
-            <span style={{ color: 'var(--color-accent)' }}>
-              <RewardPoints did={quest.did} points={quest.rewardPoints} />
-            </span>{' '}
-            が発行されました。
-          </p>
+                {/* この受託者本人: 報告 (作業中 / やり直し中、completions ロード後のみ) */}
+                {meRow && completions !== null && (st === 'IN_PROGRESS' || st === 'REVISION_REQUESTED') && (
+                  !reportForm.open ? (
+                    <button style={{ marginTop: '0.4em' }} onClick={() => setReportForm({ open: true, message: '' })} disabled={busy}>完了を報告する</button>
+                  ) : (
+                    <div style={{ marginTop: '0.4em' }}>
+                      <label htmlFor="report-msg" style={{ display: 'block', fontSize: '0.8em', color: 'var(--color-muted)', marginBottom: '0.3em' }}>成果物の URL・一言コメント (任意)</label>
+                      <textarea id="report-msg" value={reportForm.message} onChange={(e) => setReportForm({ ...reportForm, message: e.target.value })} rows={4} autoFocus placeholder="例: https://example.com/illust.png&#10;こんな感じになりました!" style={{ width: '100%' }} />
+                      <div style={{ display: 'flex', gap: '0.5em', marginTop: '0.5em' }}>
+                        <button onClick={submitReport} disabled={busy}>完了を報告する</button>
+                        <button className="secondary" onClick={() => setReportForm({ open: false, message: '' })} disabled={busy}>キャンセル</button>
+                      </div>
+                    </div>
+                  )
+                )}
+
+                {/* 発注者: この受託者が承認待ちなら、この受託者を対象に承認/やり直し */}
+                {isOwner && st === 'AWAITING_APPROVAL' && (
+                  <div style={{ marginTop: '0.4em' }}>
+                    {actionTarget !== aDid && (
+                      <div style={{ display: 'flex', gap: '0.6em' }}>
+                        <button onClick={() => { setActionTarget(aDid); setApproveForm({ open: true, message: '' }); setRevisionForm({ open: false, message: '' }); }} disabled={busy}>承認する (報酬を発行)</button>
+                        <button className="secondary" onClick={() => { setActionTarget(aDid); setRevisionForm({ open: true, message: '' }); setApproveForm({ open: false, message: '' }); }} disabled={busy}>やり直しを依頼</button>
+                      </div>
+                    )}
+                    {actionTarget === aDid && approveForm.open && (
+                      <div style={{ marginTop: '0.4em' }}>
+                        <label htmlFor="approve-msg" style={{ display: 'block', fontSize: '0.8em', color: 'var(--color-muted)', marginBottom: '0.3em' }}>承認コメント (任意)</label>
+                        <textarea id="approve-msg" value={approveForm.message} onChange={(e) => setApproveForm({ ...approveForm, message: e.target.value })} rows={3} autoFocus style={{ width: '100%' }} />
+                        <div style={{ display: 'flex', gap: '0.5em', marginTop: '0.5em' }}>
+                          <button onClick={submitApprove} disabled={busy}>承認する</button>
+                          <button className="secondary" onClick={() => { setApproveForm({ open: false, message: '' }); setActionTarget(null); }} disabled={busy}>戻る</button>
+                        </div>
+                      </div>
+                    )}
+                    {actionTarget === aDid && revisionForm.open && (
+                      <div style={{ marginTop: '0.4em' }}>
+                        <label htmlFor="revision-msg" style={{ display: 'block', fontSize: '0.8em', color: 'var(--color-muted)', marginBottom: '0.3em' }}>依頼する理由 (必須)</label>
+                        <textarea id="revision-msg" value={revisionForm.message} onChange={(e) => setRevisionForm({ ...revisionForm, message: e.target.value })} rows={4} autoFocus style={{ width: '100%' }} />
+                        <div style={{ display: 'flex', gap: '0.5em', marginTop: '0.5em' }}>
+                          <button onClick={submitRevision} disabled={busy || !revisionForm.message.trim()}>送信する</button>
+                          <button className="secondary" onClick={() => { setRevisionForm({ open: false, message: '' }); setActionTarget(null); }} disabled={busy}>戻る</button>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {/* この受託者が承認済み: 報酬発行を表示 */}
+                {st === 'COMPLETED' && (
+                  <p style={{ margin: '0.3em 0 0', fontSize: '0.82em' }}>
+                    ✅ <RewardPoints did={quest.did} points={quest.rewardPoints} /> を発行しました。
+                  </p>
+                )}
+              </div>
+            );
+          })}
         </section>
       )}
 
@@ -542,15 +550,22 @@ export function BoardDetail() {
   );
 }
 
-function statusLabel(state: EffectiveState): string {
+function questLevelLabel(state: QuestLevelState): string {
   switch (state) {
-    case 'COMPLETED':          return '完了';
-    case 'EXPIRED':            return '期限切れ';
-    case 'OPEN':               return '募集中';
-    case 'IN_PROGRESS':        return '受託中';
-    case 'AWAITING_APPROVAL':  return '完了報告中 (承認待ち)';
+    case 'COMPLETED': return '完了';
+    case 'EXPIRED':   return '期限切れ';
+    case 'OPEN':      return '募集中';
+    case 'ASSIGNED':  return '受託中';
+    case 'CANCELLED': return 'キャンセル';
+  }
+}
+
+function assigneeStateLabel(state: AssigneeState): string {
+  switch (state) {
+    case 'IN_PROGRESS':        return '作業中';
+    case 'AWAITING_APPROVAL':  return '完了報告済み (承認待ち)';
     case 'REVISION_REQUESTED': return 'やり直し対応中';
-    case 'CANCELLED':          return 'キャンセル';
+    case 'COMPLETED':          return '✅ 完了 (承認済み)';
   }
 }
 

--- a/apps/web/src/routes/board-new.tsx
+++ b/apps/web/src/routes/board-new.tsx
@@ -7,7 +7,7 @@
  */
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ARCHETYPES, JOBS_BY_ID, jobDisplayName, formatQuestAnnouncement, checkIssuanceLimits } from '@aozoraquest/core';
+import { ARCHETYPES, JOBS_BY_ID, jobDisplayName, formatQuestAnnouncement, checkIssuanceLimits, MAX_ASSIGNEES_PER_QUEST } from '@aozoraquest/core';
 import { useSession } from '@/lib/session';
 import { createQuest, listIssuedQuests, questUrlOf, questPath } from '@/lib/quest-api';
 import { refreshQuestIndex } from '@/lib/quest-index-cache';
@@ -29,6 +29,7 @@ export function BoardNew() {
   const [targetJob, setTargetJob] = useState<string>('');
   const [deadline, setDeadline] = useState('');
   const [rewardPoints, setRewardPoints] = useState(100);
+  const [maxAssignees, setMaxAssignees] = useState(1);
   const [announceText, setAnnounceText] = useState('');
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
@@ -83,6 +84,7 @@ export function BoardNew() {
         ...(targetJob ? { targetJob } : {}),
         ...(deadline ? { deadline: new Date(deadline).toISOString() } : {}),
         rewardPoints,
+        maxAssignees,
       });
       // Bluesky 告知は常時 ON (= 掲示板で他人に見えるために必須。発行者が
       // off にできる導線は廃止)。ただし dev 環境だけは本番 Bluesky への誤投稿
@@ -117,7 +119,8 @@ export function BoardNew() {
   const validTitle = title.trim().length > 0 && title.length <= MAX_TITLE;
   const validBody = body.trim().length > 0 && body.length <= MAX_BODY;
   const validReward = Number.isInteger(rewardPoints) && rewardPoints >= 0;
-  const canSubmit = !busy && validTitle && validBody && validReward;
+  const validMax = Number.isInteger(maxAssignees) && maxAssignees >= 1 && maxAssignees <= MAX_ASSIGNEES_PER_QUEST;
+  const canSubmit = !busy && validTitle && validBody && validReward && validMax;
 
   return (
     <form onSubmit={onSubmit}>
@@ -200,6 +203,23 @@ export function BoardNew() {
         />
         <p style={{ fontSize: '0.75em', color: 'var(--color-muted)', margin: '0.2em 0 0' }}>
           あなたの名前のポイントを {rewardPoints} pt 発行します (合算されない、発行上限なし)。
+        </p>
+      </Field>
+
+      <Field label={`受託できる人数 (1〜${MAX_ASSIGNEES_PER_QUEST} 人)`}>
+        <input
+          type="number"
+          value={maxAssignees}
+          onChange={(e) => setMaxAssignees(Math.max(1, Math.min(MAX_ASSIGNEES_PER_QUEST, parseInt(e.target.value, 10) || 1)))}
+          min={1}
+          max={MAX_ASSIGNEES_PER_QUEST}
+          step={1}
+          style={{ width: '12em' }}
+        />
+        <p style={{ fontSize: '0.75em', color: 'var(--color-muted)', margin: '0.2em 0 0' }}>
+          {maxAssignees > 1
+            ? `最大 ${maxAssignees} 人まで受託者に指定できます。報酬は承認した受託者それぞれに ${rewardPoints} pt ずつ発行します。`
+            : '1 人だけが受託します。2 人以上にすると複数人で取り組めます。'}
         </p>
       </Field>
 

--- a/apps/web/src/routes/portfolio.tsx
+++ b/apps/web/src/routes/portfolio.tsx
@@ -17,6 +17,7 @@ import {
   distinctRecipients,
   distinctRequesters,
   questXpScalar,
+  questAssignees,
   type UserQuest,
   type OutcomeSummary,
 } from '@aozoraquest/core';
@@ -95,7 +96,7 @@ function PortfolioView({ did, agent, isSelf, signedIn }: PortfolioViewProps) {
         for (const u of questUris) {
           try {
             const q = await getQuest(agent, u);
-            if (q && q.assignee === did) fetched.push(q);
+            if (q && questAssignees(q).includes(did)) fetched.push(q);
           } catch (e) {
             console.warn('[portfolio] resolve received quest failed', u, e);
           }


### PR DESCRIPTION
## 背景
クエスト複数人受託の **段階3a (workflow UI)**。段階1(core #226)+段階2(api #227)の上に UI を載せ、end-to-end で使えるようにする。

## 変更
- **board-new**: 「受託できる人数 (1〜MAX)」入力。
- **board-detail**: 受託者表示/報告/承認を **per-assignee** に。受託者ごとに状態表示、本人は自分ぶん報告、発注者は受託者ごとに個別承認/やり直し (targetAssignee 指定)。応募/応募者一覧は空き枠 (hasOpenSlot) がある間表示。
- **board-shared / quest-actionable / portfolio**: questAssignees 経由へ全面移行、summaryToQuest 転写、per-assignee 状態。
- `quest.assignee` 直読み 12 箇所を questAssignees 経由へ。

## Review (§1.5 3並列: 設計 / 実装 / UX)
- **★★★ なし**。typecheck/unit(222)/build green を実装レビューで確認。
- **★★ (設計) 発注者の編集/キャンセルが open 固定** → hasOpenSlot ベースに修正 (commit 845a0d8)。
- **★★ (UX) 募集継続中も「受託中」表示で矛盾** → openSlot のとき「募集中」表示 (845a0d8)。
- **★★ (UX) 満枠時に応募導線が無言で消える** → 「受託枠が埋まりました」明示 (845a0d8)。
- **★★ (UX/実装) 承認操作中の行ハイライト不足** → actionTarget 行を accent 枠 (845a0d8)。
- **★★ 承認フォーム切替で書きかけコメント消失** → issue #229 に切り出し。
- ★ 未使用 import 削除・絵文字を世界観グリフ (受託 N/M・✓) へ (845a0d8)。
- **段階3b (別 PR)**: portfolio/me/spirit の XP/holdings を per-assignee 承認 (completions) ベースへ配線。それまでは「一部承認・quest 未完了」の間、承認済み受託者の XP が quest 完了まで計上されない (status fallback)。3 段階すべて dev に揃えてから dev→main リリースするので本番には不整合状態を出さない。

後方互換: 単数クエストは従来どおり (questMaxAssignees=1 ガードで複数受託 UI 非表示、legacy assignee ミラー)。