### PR TITLE
feat(quest-rewards): XP/holdings を per-assignee 承認ベースへ (段階3b/3)

### DIFF
--- a/apps/web/src/lib/quest-api.ts
+++ b/apps/web/src/lib/quest-api.ts
@@ -731,6 +731,26 @@ export async function listCompletionsFor(
   return out.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
 }
 
+/**
+ * 報酬/XP 集計を per-assignee 承認ベースで正しく出すための completion マップを作る。
+ *
+ * **multi かつ未完了 (status が completed/cancelled でない) のクエストだけ** completion を読む。
+ * 単数クエストや全員承認済み (status='completed') のクエストは status fallback が実値と一致する
+ * ため取得しない (= 無駄な PDS read を避ける)。複数受託で「一部だけ承認・quest 未完了」のときに
+ * 承認済み受託者の報酬を計上するのが目的。
+ */
+export async function loadCompletionsByUri(quests: UserQuest[]): Promise<Map<AtUri, QuestCompletion[]>> {
+  const map = new Map<AtUri, QuestCompletion[]>();
+  const targets = quests.filter(
+    q => questMaxAssignees(q) > 1 && q.status !== 'completed' && q.status !== 'cancelled',
+  );
+  await Promise.all(targets.map(async (q) => {
+    try { map.set(q.uri, await listCompletionsFor(undefined, q)); }
+    catch (e) { console.warn('[quest-api] loadCompletionsByUri', q.uri, e); }
+  }));
+  return map;
+}
+
 async function notifyEdgeApplication(_agent: Agent, app: QuestApplication): Promise<void> {
   if (!EDGE_URL) {
     mockIndex.addApplication({

--- a/apps/web/src/lib/quest-api.ts
+++ b/apps/web/src/lib/quest-api.ts
@@ -734,16 +734,15 @@ export async function listCompletionsFor(
 /**
  * 報酬/XP 集計を per-assignee 承認ベースで正しく出すための completion マップを作る。
  *
- * **multi かつ未完了 (status が completed/cancelled でない) のクエストだけ** completion を読む。
- * 単数クエストや全員承認済み (status='completed') のクエストは status fallback が実値と一致する
- * ため取得しない (= 無駄な PDS read を避ける)。複数受託で「一部だけ承認・quest 未完了」のときに
- * 承認済み受託者の報酬を計上するのが目的。
+ * **複数受託 (maxAssignees > 1) のクエストだけ** completion を読む。複数受託では報酬の真実は
+ * 受託者ごとの承認 record (sticky) であって quest.status ではないため、status に関わらず取得して
+ * per-assignee で集計する (例: 全員未承認なのに発注者が completed にした / 一部承認済みで
+ * cancelled になった、でも正しく承認済みの人だけ計上)。単数クエストは status fallback が実値と
+ * 一致するので取得しない (= 無駄な PDS read を避ける。本番の既存データは全件これ)。
  */
 export async function loadCompletionsByUri(quests: UserQuest[]): Promise<Map<AtUri, QuestCompletion[]>> {
   const map = new Map<AtUri, QuestCompletion[]>();
-  const targets = quests.filter(
-    q => questMaxAssignees(q) > 1 && q.status !== 'completed' && q.status !== 'cancelled',
-  );
+  const targets = quests.filter(q => questMaxAssignees(q) > 1);
   await Promise.all(targets.map(async (q) => {
     try { map.set(q.uri, await listCompletionsFor(undefined, q)); }
     catch (e) { console.warn('[quest-api] loadCompletionsByUri', q.uri, e); }

--- a/apps/web/src/routes/me.tsx
+++ b/apps/web/src/routes/me.tsx
@@ -5,7 +5,7 @@ import type { Archetype, DiagnosisResult } from '@aozoraquest/core';
 import { ARCHETYPES, DIAGNOSIS_MIN_POST_COUNT, JOBS_BY_ID, archetypePairRelation, jobDisplayName, jobLevelFromXp, jobTagline, jobXpToNextLevel, playerLevelFromXp, playerXpToNextLevel, questXpScalar } from '@aozoraquest/core';
 import { useSession } from '@/lib/session';
 import { runDiagnosis } from '@/lib/diagnosis-flow';
-import { listReceivedQuests } from '@/lib/quest-api';
+import { listReceivedQuests, loadCompletionsByUri } from '@/lib/quest-api';
 import { getRecord } from '@/lib/atproto';
 import { COL } from '@/lib/collections';
 import { JOB_CHANGE_STREAK_THRESHOLD, confirmJobChange, dismissPendingArchetype } from '@/lib/post-processor';
@@ -96,7 +96,9 @@ export function MyProfile() {
     (async () => {
       try {
         const received = await listReceivedQuests(agent, did);
-        if (!cancelled) setQuestXp(questXpScalar(received, did));
+        // 複数受託で一部だけ承認 (quest 未完了) のときも、自分が承認済みなら XP に計上する。
+        const compMap = await loadCompletionsByUri(received);
+        if (!cancelled) setQuestXp(questXpScalar(received, did, compMap));
       } catch (e) {
         console.warn('quest xp load failed', e);
       }

--- a/apps/web/src/routes/portfolio.tsx
+++ b/apps/web/src/routes/portfolio.tsx
@@ -18,7 +18,11 @@ import {
   distinctRequesters,
   questXpScalar,
   questAssignees,
+  rewardForMe,
+  totalIssued,
   type UserQuest,
+  type QuestCompletion,
+  type AtUri,
   type OutcomeSummary,
 } from '@aozoraquest/core';
 import { useSession } from '@/lib/session';
@@ -26,6 +30,7 @@ import {
   listIssuedQuests,
   listMyApplications,
   getQuest,
+  loadCompletionsByUri,
   questPath,
 } from '@/lib/quest-api';
 import { Handle, RewardPoints } from '@/components/handle';
@@ -79,6 +84,8 @@ interface PortfolioViewProps {
 function PortfolioView({ did, agent, isSelf, signedIn }: PortfolioViewProps) {
   const [issued, setIssued] = useState<UserQuest[] | null>(null);
   const [received, setReceived] = useState<UserQuest[] | null>(null);
+  // 複数受託で一部だけ承認 (quest 未完了) のクエストの completion (per-assignee 報酬集計用)。
+  const [compMap, setCompMap] = useState<Map<AtUri, QuestCompletion[]>>(new Map());
   const [err, setErr] = useState<string | null>(null);
 
   useEffect(() => {
@@ -102,6 +109,9 @@ function PortfolioView({ did, agent, isSelf, signedIn }: PortfolioViewProps) {
           }
         }
         if (!cancelled) setReceived(fetched);
+        // multi かつ未完了のクエストだけ completion を読み、per-assignee 承認の報酬を計上する。
+        const m = await loadCompletionsByUri([...myIssued, ...fetched]);
+        if (!cancelled) setCompMap(m);
       } catch (e) {
         if (!cancelled) setErr(String((e as Error)?.message ?? e));
       }
@@ -112,24 +122,32 @@ function PortfolioView({ did, agent, isSelf, signedIn }: PortfolioViewProps) {
   const issuedSummary: OutcomeSummary | null = issued ? summarize(issued) : null;
   const receivedSummary: OutcomeSummary | null = received ? summarize(received) : null;
 
-  const completedIssued = useMemo(() => (issued ?? []).filter(q => q.status === 'completed'), [issued]);
-  const completedReceived = useMemo(() => (received ?? []).filter(q => q.status === 'completed'), [received]);
-  // 受託して完了したクエストから得た累計経験値 (完了集合からの派生 = 二重加算なし)。
-  // 全体 LV と現職 LV の両方に加算される (固定 100 XP/件)。
-  const questXpTotal = useMemo(() => questXpScalar(completedReceived, did ?? ''), [completedReceived, did]);
+  // 「完了」= per-assignee 承認ベース。複数受託で quest 全体が未完了でも、自分が承認された
+  // 受託 / 誰かを承認した発注は「完了」履歴に含める (compMap が無い単数/完了は status fallback)。
+  const completedIssued = useMemo(
+    () => (issued ?? []).filter(q => totalIssued([q], compMap) > 0),
+    [issued, compMap],
+  );
+  const completedReceived = useMemo(
+    () => (received ?? []).filter(q => rewardForMe(q, did ?? '', compMap.get(q.uri)) > 0),
+    [received, compMap, did],
+  );
+  // 受託して承認された分の累計経験値 (固定 100 XP/件)。全体 LV と現職 LV の両方に加算。
+  const questXpTotal = useMemo(() => questXpScalar(received ?? [], did ?? '', compMap), [received, compMap, did]);
 
-  /** 受託者視点: 発注者 DID → 獲得 pt の合計 */
+  /** 受託者視点: 発注者 DID → 獲得 pt の合計 (per-assignee 承認ベース) */
   const receivedByIssuer = useMemo(() => {
     const map = new Map<string, number>();
-    for (const q of completedReceived) {
-      map.set(q.did, (map.get(q.did) ?? 0) + q.rewardPoints);
+    for (const q of received ?? []) {
+      const r = rewardForMe(q, did ?? '', compMap.get(q.uri));
+      if (r > 0) map.set(q.did, (map.get(q.did) ?? 0) + r);
     }
     return Array.from(map.entries()).sort((a, b) => b[1] - a[1]);
-  }, [completedReceived]);
+  }, [received, compMap, did]);
 
   const totalIssuedPower = useMemo(
-    () => completedIssued.reduce((s, q) => s + q.rewardPoints, 0),
-    [completedIssued],
+    () => totalIssued(issued ?? [], compMap),
+    [issued, compMap],
   );
 
   if (isSelf && !signedIn) {
@@ -156,7 +174,7 @@ function PortfolioView({ did, agent, isSelf, signedIn }: PortfolioViewProps) {
         )}
         {issued && (
           <p style={{ fontSize: '0.85em', marginTop: '0.6em' }}>
-            完了したクエストで <strong>{distinctRecipients(issued)} 人</strong> に
+            完了したクエストで <strong>{distinctRecipients(issued, compMap)} 人</strong> に
             自分発行ポイントを渡しました (累計{' '}
             <span style={{ fontFamily: 'ui-monospace, monospace', color: 'var(--color-accent)' }}>
               {totalIssuedPower.toLocaleString()} pt

--- a/apps/web/src/routes/spirit.tsx
+++ b/apps/web/src/routes/spirit.tsx
@@ -5,7 +5,7 @@ import type { DiagnosisResult } from '@aozoraquest/core';
 import { GREETING_HOUR_BOUNDARIES, SPIRIT_CHAT_HISTORY_TURNS, SPIRIT_INPUT_MAX_LENGTH, jobDisplayName, jobLevelFromXp, pickSpiritLine, questXpScalar, type SpiritSituation } from '@aozoraquest/core';
 import { useSession } from '@/lib/session';
 import { getRecord } from '@/lib/atproto';
-import { listReceivedQuests } from '@/lib/quest-api';
+import { listReceivedQuests, loadCompletionsByUri } from '@/lib/quest-api';
 import { COL } from '@/lib/collections';
 import { SpiritIcon } from '@/components/spirit-icon';
 import { SpiritBubble } from '@/components/spirit-bubble';
@@ -110,7 +110,7 @@ export function Spirit() {
           getRecord<DiagnosisResult>(agent, did, COL.analysis, 'self').catch(() => null),
           loadPointsState(agent, did),
           loadChatHistory(agent, did),
-          listReceivedQuests(agent, did).then((qs) => questXpScalar(qs, did)).catch(() => 0),
+          listReceivedQuests(agent, did).then(async (qs) => questXpScalar(qs, did, await loadCompletionsByUri(qs))).catch(() => 0),
         ]);
         if (cancelled) return;
         setDiag(r);


### PR DESCRIPTION
## 背景
クエスト複数人受託の **段階3b (最終、報酬集計)**。段階3a で残課題とした「複数受託で一部だけ承認・quest 未完了の間、承認済み受託者の報酬/XP が計上されない」を解消。

## 変更
- `quest-api.loadCompletionsByUri`: **複数受託 (maxAssignees>1) のクエストだけ** completion を読む (status を問わず per-assignee で集計。単数は fallback、本番は全件単数なので不変)。
- `me`/`spirit`: questXpScalar に completionsByUri を渡す。
- `portfolio`: questXp / 発注者別獲得pt (rewardForMe) / 総発行 (totalIssued) / 受取人数 (distinctRecipients) / 完了履歴を per-assignee 承認ベースへ。「報酬発行済み表示 vs 数値未反映」(§1.5 ★★ #228) を解消。

## Review (§1.5 2並列: 実装+報酬正確性 / 後方互換)
- **★★★/★★ なし**(両レビュー)。二重計上・取りこぼし・後方互換いずれも健全。status 書き込み条件 (allApproved && !hasOpenSlot) により completed multi = 全員承認で fallback と一致することを確認。
- **★★ (後方互換) multi の status=completed/cancelled で fallback が乖離しうる edge** → loadCompletionsByUri を「multi は status 問わず取得」に簡素化して解消 (commit 208ec2b)。
- ★ (perf) listCompletionsFor の受託者 PDS 直列 read → issue 化。
- ★ spirit.tsx の可読性 → 機能問題なし、据え置き。
- 本番影響: 既存データは全件単数 → fallback で従来と厳密一致 (数値変化なし) を確認。