### PR TITLE
feat(quest): 受託上限 50 + listCompletionsFor 並列化

### DIFF
--- a/apps/web/src/lib/quest-api.ts
+++ b/apps/web/src/lib/quest-api.ts
@@ -707,8 +707,10 @@ export async function listCompletionsFor(
   // 全受託者の PDS から completion を読む (複数受託では各自が自分の PDS に報告を書く)。
   for (const a of questAssignees(quest)) dids.add(a);
 
-  const out: QuestCompletion[] = [];
-  for (const did of dids) {
+  // 各 DID の PDS read を並列化する (複数受託で受託者が増えても read 時間が伸びにくい。
+  // 1 DID の失敗は他に波及させず空配列に倒す)。
+  const perDid = await Promise.all([...dids].map(async (did) => {
+    const acc: QuestCompletion[] = [];
     try {
       // 各 DID の PDS から公開 read (自分の PDS 経由だと別ホストの repo を読めない)
       const res = await listRecordsForDid(did, COL.questCompletion, 100);
@@ -722,13 +724,15 @@ export async function listCompletionsFor(
           console.warn('[quest-api] dropping invalid completion (owner mismatch)', r.uri, c.role);
           continue;
         }
-        out.push(c);
+        acc.push(c);
       }
     } catch (err) {
       console.warn('[quest-api] listCompletions fetch failed', did, err);
     }
-  }
-  return out.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+    return acc;
+  }));
+  // createdAt 昇順で安定ソート (並列なので順序を明示的に確定させる)。
+  return perDid.flat().sort((a, b) => a.createdAt.localeCompare(b.createdAt));
 }
 
 /**

--- a/packages/core/src/__tests__/user-quest.test.ts
+++ b/packages/core/src/__tests__/user-quest.test.ts
@@ -559,8 +559,8 @@ describe('複数受託 (multi-assignee)', () => {
     expect(questAssignees({ assignees: [], assignee: A })).toEqual([A]);
   });
 
-  it('MAX_ASSIGNEES_PER_QUEST = 20 (確定値)', () => {
-    expect(MAX_ASSIGNEES_PER_QUEST).toBe(20);
+  it('MAX_ASSIGNEES_PER_QUEST = 50 (確定値)', () => {
+    expect(MAX_ASSIGNEES_PER_QUEST).toBe(50);
   });
 });
 

--- a/packages/core/src/user-quest.ts
+++ b/packages/core/src/user-quest.ts
@@ -88,7 +88,7 @@ export interface QuestCompletion {
 // ─── 受託者集合の正規化 (新旧形式を吸収する読み取りの単一窓口) ─────
 
 /** 受託上限。未指定 legacy は 1 (旧 = 単数受託)。 */
-export const MAX_ASSIGNEES_PER_QUEST = 20;
+export const MAX_ASSIGNEES_PER_QUEST = 50;
 export const MIN_ASSIGNEES_PER_QUEST = 1;
 
 /** quest の受託者 DID を新旧両形式から正規化する。書き込み済み record を壊さない読み取りの窓口。 */


### PR DESCRIPTION
## 背景
オーナー要望: 受託上限 20 → 50。大人数受託でも遅くならないよう completion 読み取りを並列化 (issue #231 close)。

## 変更
- `MAX_ASSIGNEES_PER_QUEST`: 20 → 50 (定数1つで上限表示・addAssignee チェック・clamp すべてに反映)。
- `listCompletionsFor`: 発注者+全受託者の PDS read を直列 for → Promise.all 並列。1 DID 失敗は空配列に倒し波及させない。createdAt 昇順ソート維持で結果同値。

## Review (§1.5 focused: 実装・正確性)
- **★★★/★★ なし**。並列化は旧直列版と挙動等価 (収集集合・順序ともソートで確定)、偽造防止 (isValidCompletion 全 record 適用)・エラー隔離 (各 thunk が内部 catch で必ず resolve)・定数50の全経路反映・後方互換 (呼び出し側は順序非依存) を確認。
- ★ (将来): 満員クエストで最大50並列 fetch、loadCompletionsByUri と重なると (クエスト数×50) の同時 fetch があり得る → 将来 p-limit 等で並列度を絞る余地 (現状ブロッカーでない)。
- core 174 / web 222 test + typecheck green。

Closes #231