### PR TITLE
release: 2026.06.30-1 — 複数人受託クエスト

### DIFF
--- a/apps/web/e2e/quest-flow-api.test.ts
+++ b/apps/web/e2e/quest-flow-api.test.ts
@@ -5,6 +5,10 @@ import { fileURLToPath } from 'node:url';
 import { AtpAgent } from '@atproto/api';
 import {
   effectiveState,
+  effectiveStateForAssignee,
+  questLevelState,
+  questAssignees,
+  rewardForMe,
   isCompleted,
   questXpScalar,
   type UserQuest,
@@ -15,6 +19,7 @@ import {
   applyToQuest,
   listApplicationsFor,
   setAssignee,
+  addAssignee,
   reportCompletion,
   approveCompletion,
   listCompletionsFor,
@@ -136,9 +141,9 @@ describe.skipIf(!HAS_CREDS)('依頼クエスト 2 アカウント フル E2E (AP
     const apps = await listApplicationsFor(undefined, quest.uri, idxA1);
     expect(apps.some(a => a.did === didB && !a.withdrawn)).toBe(true);
 
-    // 5) A が B を受託者に指定
+    // 5) A が B を受託者に指定 (setAssignee は addAssignee の alias。新形式 assignees に入る)
     const assigned = await setAssignee(agentA, quest, didB);
-    expect(assigned.assignee).toBe(didB);
+    expect(questAssignees(assigned)).toContain(didB);
 
     // 6) B の「受託中」フィルタにクエストが出る (#126: 消えるバグの回帰)
     const idxB2 = await buildQuestIndexFromDirectory(agentB, dids);
@@ -165,5 +170,39 @@ describe.skipIf(!HAS_CREDS)('依頼クエスト 2 アカウント フル E2E (AP
     // 11) 報酬: B が受託完了した分の経験値 (固定 100 XP/件)。全体/現職 LV に加算される。
     const xp = questXpScalar([finalQuest], didB);
     expect(xp).toBe(100); // 完了 1 件 × XP_REWARDS.questComplete
+  });
+
+  it('複数受託 (maxAssignees=2): 1人承認しても空き枠があれば quest は assigned のまま・報酬は per-assignee で確定', async () => {
+    const dids = [didA, didB];
+
+    // A が「最大2人」のクエストを発行
+    const quest = await createQuest(agentA, didA, {
+      title: `E2E複数受託 ${Date.now()}`, body: 'multi', tags: ['code'], rewardPoints: 200, maxAssignees: 2,
+    });
+    expect(quest.maxAssignees).toBe(2);
+
+    // B が応募 → A が B を受託者に追加 (1/2、空き枠が残る)
+    await applyToQuest(agentB, didB, quest.uri, 'やります (multi)');
+    const idxA = await buildQuestIndexFromDirectory(agentA, dids);
+    const apps = await listApplicationsFor(undefined, quest.uri, idxA);
+    expect(apps.some(a => a.did === didB)).toBe(true);
+    const assigned = await addAssignee(agentA, quest, didB);
+    expect(questAssignees(assigned)).toEqual([didB]);
+    expect(assigned.status).toBe('assigned');
+
+    // B が報告 → A が B を承認 (targetAssignee=didB)
+    await reportCompletion(agentB, didB, assigned, '成果物 (multi)');
+    const { updatedQuest } = await approveCompletion(agentA, didA, assigned, 'OK (multi)', didB);
+
+    // 空き枠が残る (1/2) ので quest 全体 status は completed にならない (assigned 据え置き)
+    expect(updatedQuest.status).toBe('assigned');
+
+    // PDS から読み直し: B は per-assignee で COMPLETED・報酬確定、quest 全体は ASSIGNED
+    const finalQuest = await getQuest(undefined, quest.uri) as UserQuest;
+    const comps = await listCompletionsFor(undefined, finalQuest);
+    expect(effectiveStateForAssignee(finalQuest, comps, didB)).toBe('COMPLETED');
+    expect(questLevelState(finalQuest, comps)).toBe('ASSIGNED'); // 空き枠 1 残り
+    expect(rewardForMe(finalQuest, didB, comps)).toBe(200); // B に満額
+    expect(questXpScalar([finalQuest], didB, new Map([[finalQuest.uri, comps]]))).toBe(100);
   });
 });

--- a/apps/web/src/components/column-content/board-shared.tsx
+++ b/apps/web/src/components/column-content/board-shared.tsx
@@ -9,7 +9,7 @@ import { Link } from 'react-router-dom';
 import type { QuestIndex, QuestIndexSummary } from '@/lib/quest-api';
 import { listIssuedQuests, listMyApplications, listCompletionsFor, buildQuestIndexViaDiscovery, questPath } from '@/lib/quest-api';
 import { getQuestIndexCached } from '@/lib/quest-index-cache';
-import { needsRequesterApproval, effectiveState, type EffectiveState, type UserQuest } from '@aozoraquest/core';
+import { needsRequesterApproval, effectiveStateForAssignee, questAssignees, questMaxAssignees, type EffectiveState, type UserQuest } from '@aozoraquest/core';
 import { setQuestActionableCount } from '@/lib/quest-actionable';
 import { useSession } from '@/lib/session';
 import { useRuntimeConfig } from '@/components/config-provider';
@@ -69,7 +69,7 @@ export function useBoardData() {
       setReportPending([]);
       return;
     }
-    const mine = index.quests.filter((q) => q.assignee === selfDid && q.status === 'assigned');
+    const mine = index.quests.filter((q) => questAssignees(q).includes(selfDid) && q.status === 'assigned');
     if (mine.length === 0) {
       setAssigneeStates(new Map());
       setReportPending([]);
@@ -83,7 +83,8 @@ export function useBoardData() {
         const q = summaryToQuest(s);
         try {
           const comps = await listCompletionsFor(undefined, q);
-          const st = effectiveState(q, comps);
+          // 複数受託: 自分ぶんの状態だけを見る (他の受託者の進行は無関係)。
+          const st = effectiveStateForAssignee(q, comps, selfDid);
           states.set(q.uri, st);
           if (st === 'IN_PROGRESS' || st === 'REVISION_REQUESTED') pend.push(q);
         } catch (e) {
@@ -160,6 +161,8 @@ function summaryToQuest(s: QuestIndexSummary): UserQuest {
     updatedAt: s.createdAt,
   };
   if (s.assignee !== undefined) q.assignee = s.assignee;
+  if (s.assignees !== undefined) q.assignees = s.assignees;
+  if (s.maxAssignees !== undefined) q.maxAssignees = s.maxAssignees;
   if (s.deadline !== undefined) q.deadline = s.deadline;
   return q;
 }
@@ -181,7 +184,7 @@ export function filterForBoard(
     // 抜ける)。これが無いと受託者は受託後にクエストを見失い完了報告に到達できない。
     if (!index) return null;
     if (!selfDid) return [];
-    return index.quests.filter(q => q.assignee === selfDid && q.status === 'assigned');
+    return index.quests.filter(q => questAssignees(q).includes(selfDid) && q.status === 'assigned');
   }
   if (c.kind === 'mine') {
     if (!myQuests) return null;
@@ -269,6 +272,10 @@ export function QuestCard({ summary, expired, needsApproval, assigneeState }: { 
         </div>
         <div style={{ display: 'flex', gap: '0.5em', flexWrap: 'wrap', fontSize: '0.72em', color: 'var(--color-muted)', marginTop: '0.3em' }}>
           {summary.tags.slice(0, 3).map(t => <span key={t}>#{t.replace(/^#/, '')}</span>)}
+          {questMaxAssignees(summary) > 1 && (
+            // 複数受託クエスト: 確定済み人数 / 上限を示す (募集枠の埋まり具合)
+            <span title="受託者数 / 上限">受託 {questAssignees(summary).length}/{questMaxAssignees(summary)}</span>
+          )}
           <span style={{ marginLeft: 'auto' }}>
             {expired ? '期限切れ' : summary.deadline ? `〆 ${formatDate(summary.deadline)}` : ''}
             {/* needsApproval / assignee バッジが状態を示すときは muted ラベルを重複させない */}

--- a/apps/web/src/lib/app-version.ts
+++ b/apps/web/src/lib/app-version.ts
@@ -12,7 +12,7 @@
  *   3. 同じ値で git tag を打つ:
  *        git tag v2026.06.14-1 && git push origin v2026.06.14-1
  */
-export const APP_VERSION = '2026.06.29-1';
+export const APP_VERSION = '2026.06.30-1';
 
 /** APP_VERSION が `YYYY.MM.DD-N` 形式かを検証する (テスト/CI で形式崩れを検出)。
  *  月 01-12 / 日 01-31 のゼロ詰め 2 桁、枝番は先頭ゼロ不可の 1 以上まで一本でガードする。 */

--- a/apps/web/src/lib/quest-actionable.ts
+++ b/apps/web/src/lib/quest-actionable.ts
@@ -18,7 +18,7 @@
 import { useSyncExternalStore } from 'react';
 import { listIssuedQuests, listCompletionsFor, buildQuestIndexViaDiscovery, type QuestIndexSummary } from './quest-api';
 import { getQuestIndexCached } from './quest-index-cache';
-import { effectiveState, needsRequesterApproval, type UserQuest } from '@aozoraquest/core';
+import { effectiveStateForAssignee, needsRequesterApproval, questAssignees, type UserQuest } from '@aozoraquest/core';
 
 type Agent = Parameters<typeof buildQuestIndexViaDiscovery>[0];
 type Did = Parameters<typeof buildQuestIndexViaDiscovery>[1][number];
@@ -65,6 +65,8 @@ function summaryToQuest(s: QuestIndexSummary): UserQuest {
     updatedAt: s.createdAt,
   };
   if (s.assignee !== undefined) q.assignee = s.assignee;
+  if (s.assignees !== undefined) q.assignees = s.assignees;
+  if (s.maxAssignees !== undefined) q.maxAssignees = s.maxAssignees;
   if (s.deadline !== undefined) q.deadline = s.deadline;
   return q;
 }
@@ -84,12 +86,13 @@ export async function computeQuestActionableCount(
   let reportPending = 0;
   try {
     const idx = await getQuestIndexCached(() => buildQuestIndexViaDiscovery(agent, directoryDids, did));
-    const mine = idx.quests.filter((q) => q.assignee === did && q.status === 'assigned');
+    const mine = idx.quests.filter((q) => questAssignees(q).includes(did) && q.status === 'assigned');
     await Promise.all(mine.map(async (s) => {
       const q = summaryToQuest(s);
       try {
         const comps = await listCompletionsFor(undefined, q);
-        const st = effectiveState(q, comps);
+        // 複数受託: 自分ぶんの状態だけ見る (他受託者の進行は無関係)。
+        const st = effectiveStateForAssignee(q, comps, did);
         if (st === 'IN_PROGRESS' || st === 'REVISION_REQUESTED') reportPending += 1;
       } catch {
         // 失敗時は「報告する番」に倒す (見落とすより出して気づかせる。useBoardData と対称)

--- a/apps/web/src/lib/quest-api.ts
+++ b/apps/web/src/lib/quest-api.ts
@@ -731,6 +731,25 @@ export async function listCompletionsFor(
   return out.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
 }
 
+/**
+ * 報酬/XP 集計を per-assignee 承認ベースで正しく出すための completion マップを作る。
+ *
+ * **複数受託 (maxAssignees > 1) のクエストだけ** completion を読む。複数受託では報酬の真実は
+ * 受託者ごとの承認 record (sticky) であって quest.status ではないため、status に関わらず取得して
+ * per-assignee で集計する (例: 全員未承認なのに発注者が completed にした / 一部承認済みで
+ * cancelled になった、でも正しく承認済みの人だけ計上)。単数クエストは status fallback が実値と
+ * 一致するので取得しない (= 無駄な PDS read を避ける。本番の既存データは全件これ)。
+ */
+export async function loadCompletionsByUri(quests: UserQuest[]): Promise<Map<AtUri, QuestCompletion[]>> {
+  const map = new Map<AtUri, QuestCompletion[]>();
+  const targets = quests.filter(q => questMaxAssignees(q) > 1);
+  await Promise.all(targets.map(async (q) => {
+    try { map.set(q.uri, await listCompletionsFor(undefined, q)); }
+    catch (e) { console.warn('[quest-api] loadCompletionsByUri', q.uri, e); }
+  }));
+  return map;
+}
+
 async function notifyEdgeApplication(_agent: Agent, app: QuestApplication): Promise<void> {
   if (!EDGE_URL) {
     mockIndex.addApplication({

--- a/apps/web/src/lib/quest-api.ts
+++ b/apps/web/src/lib/quest-api.ts
@@ -16,7 +16,15 @@ import type {
   AtUri,
   Did,
 } from '@aozoraquest/core';
-import { isValidCompletion, isCompleted } from '@aozoraquest/core';
+import {
+  isValidCompletion,
+  isCompletedForAssignee,
+  questAssignees,
+  questMaxAssignees,
+  hasOpenSlot,
+  completionTarget,
+  MAX_ASSIGNEES_PER_QUEST,
+} from '@aozoraquest/core';
 import { putRecord, getRecord } from './atproto';
 import { listRecordsForDid, getRecordForDid } from './repo-read';
 import { COL } from './collections';
@@ -42,6 +50,8 @@ export interface NewQuestInput {
   deadline?: string;
   rewardPoints: number;
   blueskyPostUri?: AtUri;
+  /** 受託上限人数 (1〜MAX_ASSIGNEES_PER_QUEST)。未指定は 1 (単数受託)。 */
+  maxAssignees?: number;
 }
 
 /** クエストを発行する: tid 生成 → putRecord → index 同期 */
@@ -68,6 +78,11 @@ export async function createQuest(
   if (input.targetJob !== undefined) quest.targetJob = input.targetJob;
   if (input.deadline !== undefined) quest.deadline = input.deadline;
   if (input.blueskyPostUri !== undefined) quest.blueskyPostUri = input.blueskyPostUri;
+  // 2 人以上募集のときだけ maxAssignees を書く (1 は legacy と同義なので省略)。
+  // 整数化 + [2, MAX] に clamp (UI 配線時の不正値で巨大ループ等が起きないよう API でも防御)。
+  if (input.maxAssignees !== undefined && input.maxAssignees > 1) {
+    quest.maxAssignees = Math.min(Math.floor(input.maxAssignees), MAX_ASSIGNEES_PER_QUEST);
+  }
 
   await putRecord(agent, COL.userQuest, rkey, toRecord(quest, COL.userQuest));
   await notifyEdgeQuest(agent, quest);
@@ -126,8 +141,12 @@ export interface QuestIndexSummary {
   rewardPoints: number;
   deadline?: string;
   status: string;
-  /** 受託者 DID (status>=assigned)。受託者が「自分が受けたクエスト」を一覧で判定するのに使う。 */
+  /** @deprecated 旧・単数受託者 DID。読み取りは questAssignees(summary) を通すこと。 */
   assignee?: Did;
+  /** 受託者 DID 群 (新形式)。受託者が「自分が受けたクエスト」を一覧で判定するのに使う。 */
+  assignees?: Did[];
+  /** 受託上限人数 (未指定は 1)。「空き枠あり」判定 (募集中表示) に使う。 */
+  maxAssignees?: number;
   createdAt: string;
 }
 
@@ -154,7 +173,10 @@ function questToSummary(q: UserQuest): QuestIndexSummary {
     rewardPoints: q.rewardPoints,
     ...(q.deadline ? { deadline: q.deadline } : {}),
     status: q.status,
+    // legacy 単数 assignee も併載 (旧クライアント互換)。新形式は assignees。
     ...(q.assignee ? { assignee: q.assignee } : {}),
+    ...(q.assignees && q.assignees.length > 0 ? { assignees: q.assignees } : {}),
+    ...(q.maxAssignees !== undefined ? { maxAssignees: q.maxAssignees } : {}),
     createdAt: q.createdAt,
   };
 }
@@ -476,7 +498,7 @@ export async function listReceivedQuests(agent: Agent, did: Did): Promise<UserQu
   for (const u of questUris) {
     try {
       const q = await getQuest(agent, u);
-      if (q && q.assignee === did) out.push(q);
+      if (q && questAssignees(q).includes(did)) out.push(q);
     } catch (e) {
       console.warn('[quest-api] resolve received quest failed', u, e);
     }
@@ -496,21 +518,71 @@ export async function listMyApplications(_agent: Agent, did: Did, limit = 100): 
 
 // ─── Phase 2: 受託者指定 (発注者が quest record を更新) ───
 
+/**
+ * 書き込み record の legacy `assignee` を新形式 `assignees` に同期する (in-place)。
+ * **単数 (assignees が 1 名) のうちは legacy `assignee` も併記** する。これは段階3 未改修の
+ * UI (board-detail / board-shared / quest-actionable / portfolio が `quest.assignee` を直読み)
+ * が単数受託で壊れないための後方互換措置。複数 (2 名以上) は単数フィールドで表せないので外す
+ * (複数受託は段階3 の UI 配線が揃ってから作成可能になる)。
+ */
+function syncLegacyAssignee(q: UserQuest): void {
+  const list = q.assignees ?? [];
+  if (list.length === 1) q.assignee = list[0]!;
+  else delete q.assignee;
+}
+
+/** 受託者を 1 名追加する (発注者操作)。上限超過は拒否、重複は no-op。
+ *  書き込みは新形式 `assignees` に寄せる (単数のうちは legacy assignee も併記 = 後方互換)。 */
+export async function addAssignee(
+  agent: Agent,
+  quest: UserQuest,
+  assignee: Did,
+): Promise<UserQuest> {
+  const list = questAssignees(quest);
+  if (list.includes(assignee)) return quest; // 冪等 (重複追加は何もしない)
+  if (list.length >= questMaxAssignees(quest)) {
+    throw new Error('受託上限に達しています');
+  }
+  const { rkey } = parseAtUri(quest.uri);
+  const updated: UserQuest = {
+    ...quest,
+    assignees: [...list, assignee],
+    status: 'assigned',
+    updatedAt: new Date().toISOString(),
+  };
+  syncLegacyAssignee(updated);
+  await putRecord(agent, COL.userQuest, rkey, toRecord(updated, COL.userQuest));
+  await notifyEdgeQuest(agent, updated);
+  return updated;
+}
+
+/** 受託者を 1 名外す (発注者操作)。全員外れたら status を open に戻す。 */
+export async function removeAssignee(
+  agent: Agent,
+  quest: UserQuest,
+  assignee: Did,
+): Promise<UserQuest> {
+  const assignees = questAssignees(quest).filter(d => d !== assignee);
+  const { rkey } = parseAtUri(quest.uri);
+  const updated: UserQuest = {
+    ...quest,
+    assignees,
+    status: assignees.length === 0 ? 'open' : 'assigned',
+    updatedAt: new Date().toISOString(),
+  };
+  syncLegacyAssignee(updated);
+  await putRecord(agent, COL.userQuest, rkey, toRecord(updated, COL.userQuest));
+  await notifyEdgeQuest(agent, updated);
+  return updated;
+}
+
+/** @deprecated `addAssignee` を使う。単数指定の後方互換 alias。 */
 export async function setAssignee(
   agent: Agent,
   quest: UserQuest,
   assignee: Did,
 ): Promise<UserQuest> {
-  const { rkey } = parseAtUri(quest.uri);
-  const updated: UserQuest = {
-    ...quest,
-    assignee,
-    status: 'assigned',
-    updatedAt: new Date().toISOString(),
-  };
-  await putRecord(agent, COL.userQuest, rkey, toRecord(updated, COL.userQuest));
-  await notifyEdgeQuest(agent, updated);
-  return updated;
+  return addAssignee(agent, quest, assignee);
 }
 
 // ─── Phase 2: 完了報告 / 承認 / やり直し ─────────────
@@ -521,6 +593,7 @@ async function writeCompletion(
   questUri: AtUri,
   role: QuestCompletion['role'],
   comment?: string,
+  targetAssignee?: Did,
 ): Promise<QuestCompletion> {
   const rkey = makeRkey();
   const now = new Date().toISOString();
@@ -532,6 +605,8 @@ async function writeCompletion(
     createdAt: now,
   };
   if (comment !== undefined) c.comment = comment;
+  // approval / revision は「どの受託者向けか」を必ず記録する (複数受託の per-assignee 判定用)。
+  if (targetAssignee !== undefined) c.targetAssignee = targetAssignee;
   await putRecord(agent, COL.questCompletion, rkey, toRecord(c, COL.questCompletion));
   return c;
 }
@@ -559,44 +634,66 @@ export async function approveCompletion(
   requesterDid: Did,
   quest: UserQuest,
   comment?: string,
+  targetAssignee?: Did,
 ): Promise<{ completion: QuestCompletion; updatedQuest: UserQuest }> {
-  // 冪等性: 既に承認済みなら二重 approval record を書かない (= 二重発行防止)。
-  // 報酬 (ポイント/XP) は完了集合からの派生なので record が 1 つでも複数でも結果は同じだが、
-  // 余計な record を増やさないため既存 approval を返して no-op にする。
+  // targetAssignee 省略時は唯一の受託者に解決 (単数 quest の後方互換)。
+  const target = targetAssignee ?? questAssignees(quest)[0];
+  if (!target) throw new Error('受託者がいません');
+  // 書き込み前ガード: target が受託者集合内であること (読み取り時 isValidCompletion でも弾くが、
+  // ゴミ approval record を書かないよう書き込み側でも防御)。
+  if (!questAssignees(quest).includes(target)) throw new Error('指定した受託者はこのクエストの受託者ではありません');
+
   const existing = await listCompletionsFor(undefined, quest);
-  if (isCompleted(quest, existing)) {
-    const approval = existing.find(c => c.role === 'requesterApproval' && c.did === quest.did);
-    const updated: UserQuest = quest.status === 'completed'
-      ? quest
-      : { ...quest, status: 'completed', updatedAt: new Date().toISOString() };
-    if (approval) return { completion: approval, updatedQuest: updated };
-    // status は completed だが approval record が見当たらない稀ケースは通常経路で書く
+  // 冪等性: **この受託者向け**の承認が既にあれば二重 approval を書かない (= 二重発行防止)。
+  // 複数受託では「他の受託者が承認済み」でもこの受託者は未承認なので、per-assignee で判定する。
+  if (isCompletedForAssignee(quest, existing, target)) {
+    const approval = existing.find(
+      c => c.role === 'requesterApproval' && completionTarget(c, quest) === target,
+    );
+    if (approval) return { completion: approval, updatedQuest: quest };
   }
-  // 順序: (A) approval record → (B) quest status → (C) index 同期。
-  // (A) が真実、B-C は派生 (docs/15-user-quest.md §耐故障性)。
-  const completion = await writeCompletion(agent, requesterDid, quest.uri, 'requesterApproval', comment);
-  const { rkey } = parseAtUri(quest.uri);
-  const updated: UserQuest = { ...quest, status: 'completed', updatedAt: new Date().toISOString() };
-  await putRecord(agent, COL.userQuest, rkey, toRecord(updated, COL.userQuest));
-  // (B) 成功後にのみ index と mock を更新する。B 失敗時は次回 reconciliation で
-  // 自分の approval record から完了済みと判定される (= eventual consistency)。
-  mockIndex.updateQuestStatus(quest.uri, 'completed');
+  // 順序: (A) approval record → (B) quest status → (C) index 同期。(A) が真実 (docs/15 §耐故障性)。
+  const completion = await writeCompletion(
+    agent, requesterDid, quest.uri, 'requesterApproval', comment, target,
+  );
+  // quest 全体 status を completed にするのは「全受託者が承認済み かつ 空き枠なし」のときだけ。
+  // 途中 (一部だけ承認 / まだ募集枠が残る) は assigned のまま据え置き、報酬は per-assignee で確定。
+  const after = [...existing, completion];
+  const allApproved = questAssignees(quest).every(d => isCompletedForAssignee(quest, after, d));
+  let updated = quest;
+  if (allApproved && !hasOpenSlot(quest)) {
+    const { rkey } = parseAtUri(quest.uri);
+    updated = { ...quest, status: 'completed', updatedAt: new Date().toISOString() };
+    await putRecord(agent, COL.userQuest, rkey, toRecord(updated, COL.userQuest));
+    mockIndex.updateQuestStatus(quest.uri, 'completed');
+  }
   await notifyEdgeQuest(agent, updated);
   return { completion, updatedQuest: updated };
 }
 
-/** 発注者が「やり直し」を依頼。元 quest の status を assigned に戻す。 */
+/** 発注者が特定の受託者に「やり直し」を依頼。quest 全体 status は assigned のまま
+ *  (他の受託者が進行中の可能性があるため、status は据え置き = per-assignee で管理)。 */
 export async function requestRevision(
   agent: Agent,
   requesterDid: Did,
   quest: UserQuest,
   comment: string,
+  targetAssignee?: Did,
 ): Promise<{ completion: QuestCompletion; updatedQuest: UserQuest }> {
-  const completion = await writeCompletion(agent, requesterDid, quest.uri, 'requesterRevision', comment);
-  const { rkey } = parseAtUri(quest.uri);
-  const updated: UserQuest = { ...quest, status: 'assigned', updatedAt: new Date().toISOString() };
-  await putRecord(agent, COL.userQuest, rkey, toRecord(updated, COL.userQuest));
-  mockIndex.updateQuestStatus(quest.uri, 'assigned');
+  const target = targetAssignee ?? questAssignees(quest)[0];
+  if (!target) throw new Error('受託者がいません');
+  if (!questAssignees(quest).includes(target)) throw new Error('指定した受託者はこのクエストの受託者ではありません');
+  const completion = await writeCompletion(
+    agent, requesterDid, quest.uri, 'requesterRevision', comment, target,
+  );
+  // status は assigned に揃える (completed/reported から戻す)。複数受託では元々 assigned。
+  let updated = quest;
+  if (quest.status !== 'assigned') {
+    const { rkey } = parseAtUri(quest.uri);
+    updated = { ...quest, status: 'assigned', updatedAt: new Date().toISOString() };
+    await putRecord(agent, COL.userQuest, rkey, toRecord(updated, COL.userQuest));
+    mockIndex.updateQuestStatus(quest.uri, 'assigned');
+  }
   return { completion, updatedQuest: updated };
 }
 
@@ -607,7 +704,8 @@ export async function listCompletionsFor(
 ): Promise<QuestCompletion[]> {
   const dids = new Set<Did>();
   dids.add(quest.did);
-  if (quest.assignee) dids.add(quest.assignee);
+  // 全受託者の PDS から completion を読む (複数受託では各自が自分の PDS に報告を書く)。
+  for (const a of questAssignees(quest)) dids.add(a);
 
   const out: QuestCompletion[] = [];
   for (const did of dids) {

--- a/apps/web/src/lib/quest-api.ts
+++ b/apps/web/src/lib/quest-api.ts
@@ -707,8 +707,10 @@ export async function listCompletionsFor(
   // 全受託者の PDS から completion を読む (複数受託では各自が自分の PDS に報告を書く)。
   for (const a of questAssignees(quest)) dids.add(a);
 
-  const out: QuestCompletion[] = [];
-  for (const did of dids) {
+  // 各 DID の PDS read を並列化する (複数受託で受託者が増えても read 時間が伸びにくい。
+  // 1 DID の失敗は他に波及させず空配列に倒す)。
+  const perDid = await Promise.all([...dids].map(async (did) => {
+    const acc: QuestCompletion[] = [];
     try {
       // 各 DID の PDS から公開 read (自分の PDS 経由だと別ホストの repo を読めない)
       const res = await listRecordsForDid(did, COL.questCompletion, 100);
@@ -722,13 +724,15 @@ export async function listCompletionsFor(
           console.warn('[quest-api] dropping invalid completion (owner mismatch)', r.uri, c.role);
           continue;
         }
-        out.push(c);
+        acc.push(c);
       }
     } catch (err) {
       console.warn('[quest-api] listCompletions fetch failed', did, err);
     }
-  }
-  return out.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+    return acc;
+  }));
+  // createdAt 昇順で安定ソート (並列なので順序を明示的に確定させる)。
+  return perDid.flat().sort((a, b) => a.createdAt.localeCompare(b.createdAt));
 }
 
 /**

--- a/apps/web/src/lib/quest-mock.ts
+++ b/apps/web/src/lib/quest-mock.ts
@@ -46,6 +46,11 @@ function toSummary(q: UserQuest): QuestIndexSummary {
     createdAt: q.createdAt,
   };
   if (q.deadline !== undefined) base.deadline = q.deadline;
+  // 受託者情報を summary に載せる (これが無いと mock fallback 時に「受託中」判定や
+  // 複数受託の表示が消える)。legacy 単数 assignee と新形式 assignees の両方を運ぶ。
+  if (q.assignee !== undefined) base.assignee = q.assignee;
+  if (q.assignees !== undefined) base.assignees = q.assignees;
+  if (q.maxAssignees !== undefined) base.maxAssignees = q.maxAssignees;
   return base;
 }
 

--- a/apps/web/src/routes/board-detail.tsx
+++ b/apps/web/src/routes/board-detail.tsx
@@ -17,7 +17,7 @@ import {
   applyToQuest,
   withdrawApplication,
   listApplicationsFor,
-  setAssignee,
+  addAssignee,
   reportCompletion,
   approveCompletion,
   requestRevision,
@@ -38,8 +38,13 @@ import { isoToLocalInput } from '@/lib/datetime';
 import { resolveHandle } from '@/lib/handle-cache';
 import {
   isExpired,
-  effectiveState,
-  type EffectiveState,
+  effectiveStateForAssignee,
+  questLevelState,
+  questAssignees,
+  questMaxAssignees,
+  hasOpenSlot,
+  type AssigneeState,
+  type QuestLevelState,
   formatNotificationPost,
   type NotificationAction,
   type UserQuest,
@@ -66,6 +71,8 @@ export function BoardDetail() {
   const [revisionForm, setRevisionForm] = useState<{ open: boolean; message: string }>({ open: false, message: '' });
   /** 受託者指定の確認: applicant did を保持 (= 確認 UI を開いている対象) */
   const [pendingAssign, setPendingAssign] = useState<string | null>(null);
+  /** 承認/やり直しフォームの対象受託者 did (複数受託で「誰を」承認/差し戻すか)。 */
+  const [actionTarget, setActionTarget] = useState<string | null>(null);
 
   // URI 変更 (= 別 quest へ遷移) 時に inline form の state を初期化する。
   // 第三者レビューの指摘 (UI: form 持ち越し)。
@@ -77,6 +84,7 @@ export function BoardDetail() {
     setApproveForm({ open: false, message: '' });
     setRevisionForm({ open: false, message: '' });
     setPendingAssign(null);
+    setActionTarget(null);
     setErr(null);
     setBusy(false);
   }, [uri]);
@@ -132,14 +140,20 @@ export function BoardDetail() {
 
   const expired = isExpired(quest);
   const isOwner = session.did === quest.did;
-  const isAssignee = session.did === quest.assignee;
+  const assignees = questAssignees(quest);
+  const isAssignee = !!session.did && assignees.includes(session.did);
+  const openSlot = hasOpenSlot(quest);
   // 自分の応募の中で、取り下げてないものを最新順で先頭から (= 複数応募していても
   // 最新のアクティブ応募を「自分の応募」として扱う)。
   const myApp = applications
     ?.filter(a => a.did === session.did && !a.withdrawn)
     .sort((a, b) => b.createdAt.localeCompare(a.createdAt))[0] ?? null;
-  // 全状態・操作の gate は effectiveState を唯一の真実に (status は受託者の報告を反映しない)。
-  const state = effectiveState(quest, completions ?? []);
+  // quest 全体状態と、受託者ごとの状態 (複数受託では受託者ごとに独立進行)。status は信じず
+  // completion record から導出する (status は受託者の報告を反映しないため)。
+  const qState: QuestLevelState = questLevelState(quest, completions ?? []);
+  const comps = completions ?? [];
+  const stateOf = (did: string): AssigneeState => effectiveStateForAssignee(quest, comps, did);
+  const myState: AssigneeState | null = isAssignee && session.did ? stateOf(session.did) : null;
 
   async function cancelQuest() {
     if (!session.agent || !quest || !isOwner) return;
@@ -235,7 +249,7 @@ export function BoardDetail() {
     if (!session.agent || !quest || !isOwner) return;
     setBusy(true);
     try {
-      await setAssignee(session.agent, quest, applicantDid);
+      await addAssignee(session.agent, quest, applicantDid);
       await notifyBluesky('assigned', applicantDid);
       setPendingAssign(null);
       await refresh();
@@ -263,13 +277,14 @@ export function BoardDetail() {
   }
 
   async function submitApprove() {
-    if (!session.agent || !session.did || !quest || !isOwner) return;
+    if (!session.agent || !session.did || !quest || !isOwner || !actionTarget) return;
     setBusy(true);
     try {
       const comment = approveForm.message.trim();
-      await approveCompletion(session.agent, session.did, quest, comment || undefined);
-      if (quest.assignee) await notifyBluesky('approved', quest.assignee);
+      await approveCompletion(session.agent, session.did, quest, comment || undefined, actionTarget);
+      await notifyBluesky('approved', actionTarget);
       setApproveForm({ open: false, message: '' });
+      setActionTarget(null);
       await refresh();
     } catch (e) {
       setErr(String((e as Error)?.message ?? e));
@@ -279,14 +294,15 @@ export function BoardDetail() {
   }
 
   async function submitRevision() {
-    if (!session.agent || !session.did || !quest || !isOwner) return;
+    if (!session.agent || !session.did || !quest || !isOwner || !actionTarget) return;
     const comment = revisionForm.message.trim();
     if (!comment) return;
     setBusy(true);
     try {
-      await requestRevision(session.agent, session.did, quest, comment);
-      if (quest.assignee) await notifyBluesky('revisionRequested', quest.assignee);
+      await requestRevision(session.agent, session.did, quest, comment, actionTarget);
+      await notifyBluesky('revisionRequested', actionTarget);
       setRevisionForm({ open: false, message: '' });
+      setActionTarget(null);
       await refresh();
     } catch (e) {
       setErr(String((e as Error)?.message ?? e));
@@ -308,7 +324,14 @@ export function BoardDetail() {
         <span style={{ color: 'var(--color-accent)' }}>
           <RewardPoints did={quest.did} points={quest.rewardPoints} />
         </span>
-        <span style={{ marginLeft: 'auto' }}>{statusLabel(state)}</span>
+        {/* 空き枠が残る間は「受託中」でなく「募集中」と出す (複数受託で 1 人確定済みでも
+            まだ応募を受け付けているため。👥 N/M で確定済み人数も併記)。 */}
+        <span style={{ marginLeft: 'auto' }}>
+          {qState === 'ASSIGNED' && openSlot ? '募集中' : questLevelLabel(qState)}
+        </span>
+        {questMaxAssignees(quest) > 1 && (
+          <span title="受託者数 / 上限">受託 {assignees.length}/{questMaxAssignees(quest)}</span>
+        )}
       </div>
 
       <div style={{ marginTop: '0.6em', whiteSpace: 'pre-wrap', lineHeight: 1.6 }}>{quest.body}</div>
@@ -323,8 +346,10 @@ export function BoardDetail() {
         </p>
       )}
 
-      {/* 発注者向け: 期限変更 / キャンセル (open 中のみ) */}
-      {isOwner && quest.status === 'open' && (
+      {/* 発注者向け: 期限変更 / キャンセル (募集枠が残る間 = まだ受付中のクエストのみ)。
+          複数受託では 1 人確定後 (status=assigned) でも空き枠がある間は募集継続なので操作可。
+          単数 (満枠 1/1) や完了/キャンセル後は従来どおり非表示。 */}
+      {isOwner && openSlot && qState !== 'CANCELLED' && qState !== 'COMPLETED' && (
         <div style={{ marginTop: '1em' }}>
           <div style={{ display: 'flex', gap: '0.6em' }}>
             <button onClick={() => {
@@ -354,8 +379,9 @@ export function BoardDetail() {
         </div>
       )}
 
-      {/* 応募者向け: 応募フォーム / 自分の応募表示 */}
-      {!isOwner && session.status === 'signed-in' && quest.status === 'open' && !expired && (
+      {/* 応募者向け: 応募フォーム / 自分の応募表示。複数受託では空き枠がある間 (assigned でも) 応募可。 */}
+      {!isOwner && session.status === 'signed-in' && !isAssignee && openSlot
+        && qState !== 'CANCELLED' && qState !== 'COMPLETED' && !expired && (
         <div style={{ marginTop: '1em' }}>
           {!myApp ? (
             !applyForm.open ? (
@@ -388,12 +414,23 @@ export function BoardDetail() {
         </div>
       )}
 
-      {/* 発注者向け応募者一覧 (open のとき): withdrawn は除外 */}
-      {isOwner && quest.status === 'open' && (() => {
-        const activeApps = applications?.filter(a => !a.withdrawn) ?? null;
+      {/* 満枠 (空き枠なし・未完了) のとき、非受託の訪問者に「もう応募できない理由」を明示する
+          (無言で応募導線が消えると認知ギャップになる、UX レビュー指摘)。 */}
+      {!isOwner && !isAssignee && !openSlot && qState === 'ASSIGNED' && questMaxAssignees(quest) > 1 && (
+        <p style={{ marginTop: '1em', fontSize: '0.85em', color: 'var(--color-muted)' }}>
+          受託枠が埋まりました ({assignees.length}/{questMaxAssignees(quest)} 人)。
+        </p>
+      )}
+
+      {/* 発注者向け応募者一覧: 空き枠がある間表示。withdrawn と確定済み受託者は除外 */}
+      {isOwner && openSlot && qState !== 'CANCELLED' && qState !== 'COMPLETED' && (() => {
+        const activeApps = applications?.filter(a => !a.withdrawn && !assignees.includes(a.did)) ?? null;
         return (
           <section style={{ marginTop: '1.4em' }}>
-            <h3 style={{ fontSize: '0.95em' }}>応募者 ({activeApps?.length ?? 0})</h3>
+            <h3 style={{ fontSize: '0.95em' }}>
+              応募者 ({activeApps?.length ?? 0})
+              {questMaxAssignees(quest) > 1 && <span style={{ fontSize: '0.8em', color: 'var(--color-muted)', fontWeight: 400 }}> ・受託 {assignees.length}/{questMaxAssignees(quest)} 人</span>}
+            </h3>
             {!activeApps && <p style={{ fontSize: '0.85em', color: 'var(--color-muted)' }}>読み込み中...</p>}
             {activeApps && activeApps.length === 0 && (
               <p style={{ fontSize: '0.85em', color: 'var(--color-muted)' }}>まだ応募がありません。</p>
@@ -409,7 +446,9 @@ export function BoardDetail() {
                     <p style={{ margin: '0 0 0.4em', fontSize: '0.85em' }}>
                       <strong><Handle did={a.did} /></strong> を受託者に指定しますか?<br />
                       <span style={{ fontSize: '0.78em', color: 'var(--color-muted)' }}>
-                        他の応募者には自動通知は送られませんが、ステータスが「受託中」に変わり追加応募は受け付けられなくなります。
+                        {questMaxAssignees(quest) > 1
+                          ? `この人が受託者に加わります (受託 ${assignees.length + 1}/${questMaxAssignees(quest)} 人)。空き枠がある間は他の人も追加できます。`
+                          : '他の応募者には自動通知は送られませんが、ステータスが「受託中」に変わり追加応募は受け付けられなくなります。'}
                       </span>
                     </p>
                     <div style={{ display: 'flex', gap: '0.5em' }}>
@@ -426,99 +465,82 @@ export function BoardDetail() {
         );
       })()}
 
-      {/* 受託確定〜完了前: 受託者の表示 + 受託者の完了報告フォーム (state は completion 由来) */}
-      {(state === 'IN_PROGRESS' || state === 'AWAITING_APPROVAL' || state === 'REVISION_REQUESTED') && quest.assignee && (
+      {/* 受託者一覧: 受託者ごとに状態を表示。受託者は自分ぶんを報告でき、発注者は受託者ごとに
+          個別に承認/やり直しできる (複数受託対応)。状態は completion record から導出 (status 非依存)。 */}
+      {assignees.length > 0 && (
         <section style={{ marginTop: '1.4em' }}>
-          <p style={{ fontSize: '0.85em' }}>
-            受託者: <strong><Handle did={quest.assignee} /></strong>
-            {state === 'AWAITING_APPROVAL' && ' (完了報告済み、承認待ち)'}
-            {state === 'REVISION_REQUESTED' && ' (やり直し依頼中)'}
-          </p>
-          {/* 受託者は作業中(未報告) と 差し戻し中 のとき報告できる。報告後(承認待ち)は隠す。
-              completions ロード中 (null) は state が IN_PROGRESS に見えるため、確定するまで
-              報告ボタンを出さない (ちらつき + 報告済みなのに再報告で二重 report を防ぐ)。 */}
-          {isAssignee && completions !== null && (state === 'IN_PROGRESS' || state === 'REVISION_REQUESTED') && (
-            !reportForm.open ? (
-              <button onClick={() => setReportForm({ open: true, message: '' })} disabled={busy}>完了を報告する</button>
-            ) : (
-              <div className="dq-window compact">
-                <h4 style={{ margin: '0 0 0.4em', fontSize: '0.9em' }}>完了を報告する</h4>
-                <label htmlFor="report-msg" style={{ display: 'block', fontSize: '0.8em', color: 'var(--color-muted)', marginBottom: '0.3em' }}>成果物の URL・一言コメント (任意)</label>
-                <textarea
-                  id="report-msg"
-                  value={reportForm.message}
-                  onChange={(e) => setReportForm({ ...reportForm, message: e.target.value })}
-                  rows={4}
-                  autoFocus
-                  placeholder="例: https://example.com/illust.png&#10;こんな感じになりました!"
-                  style={{ width: '100%' }}
-                />
-                <div style={{ display: 'flex', gap: '0.5em', marginTop: '0.5em' }}>
-                  <button onClick={submitReport} disabled={busy}>完了を報告する</button>
-                  <button className="secondary" onClick={() => setReportForm({ open: false, message: '' })} disabled={busy}>キャンセル</button>
-                </div>
-              </div>
-            )
-          )}
-          {isOwner && state === 'AWAITING_APPROVAL' && (
-            <div style={{ marginTop: '0.4em' }}>
-              {!approveForm.open && !revisionForm.open && (
-                <div style={{ display: 'flex', gap: '0.6em' }}>
-                  <button onClick={() => setApproveForm({ open: true, message: '' })} disabled={busy}>承認する (報酬を発行)</button>
-                  <button onClick={() => setRevisionForm({ open: true, message: '' })} disabled={busy} className="secondary">やり直しを依頼</button>
-                </div>
-              )}
-              {approveForm.open && (
-                <div className="dq-window compact">
-                  <h4 style={{ margin: '0 0 0.4em', fontSize: '0.9em' }}>完了を承認する (報酬を発行)</h4>
-                  <label htmlFor="approve-msg" style={{ display: 'block', fontSize: '0.8em', color: 'var(--color-muted)', marginBottom: '0.3em' }}>承認コメント (任意)</label>
-                  <textarea
-                    id="approve-msg"
-                    value={approveForm.message}
-                    onChange={(e) => setApproveForm({ ...approveForm, message: e.target.value })}
-                    rows={3}
-                    autoFocus
-                    style={{ width: '100%' }}
-                  />
-                  <div style={{ display: 'flex', gap: '0.5em', marginTop: '0.5em' }}>
-                    <button onClick={submitApprove} disabled={busy}>承認する</button>
-                    <button className="secondary" onClick={() => setApproveForm({ open: false, message: '' })} disabled={busy}>戻る</button>
-                  </div>
-                </div>
-              )}
-              {revisionForm.open && (
-                <div className="dq-window compact">
-                  <h4 style={{ margin: '0 0 0.4em', fontSize: '0.9em' }}>やり直しを依頼する</h4>
-                  <label htmlFor="revision-msg" style={{ display: 'block', fontSize: '0.8em', color: 'var(--color-muted)', marginBottom: '0.3em' }}>依頼する理由 (必須)</label>
-                  <textarea
-                    id="revision-msg"
-                    value={revisionForm.message}
-                    onChange={(e) => setRevisionForm({ ...revisionForm, message: e.target.value })}
-                    rows={4}
-                    autoFocus
-                    style={{ width: '100%' }}
-                  />
-                  <div style={{ display: 'flex', gap: '0.5em', marginTop: '0.5em' }}>
-                    <button onClick={submitRevision} disabled={busy || !revisionForm.message.trim()}>送信する</button>
-                    <button className="secondary" onClick={() => setRevisionForm({ open: false, message: '' })} disabled={busy}>戻る</button>
-                  </div>
-                </div>
-              )}
-            </div>
-          )}
-        </section>
-      )}
+          <h3 style={{ fontSize: '0.95em' }}>
+            受託者{questMaxAssignees(quest) > 1 ? ` (${assignees.length}/${questMaxAssignees(quest)})` : ''}
+          </h3>
+          {assignees.map((aDid) => {
+            const st = stateOf(aDid);
+            const meRow = session.did === aDid;
+            return (
+              <div key={aDid} className="dq-window compact" style={{ marginTop: '0.4em', borderColor: actionTarget === aDid ? 'var(--color-accent)' : undefined }}>
+                <p style={{ margin: 0, fontSize: '0.85em' }}>
+                  <strong><Handle did={aDid} /></strong>
+                  <span style={{ marginLeft: '0.5em', fontSize: '0.85em', color: st === 'COMPLETED' ? 'var(--color-accent)' : 'var(--color-muted)' }}>
+                    {assigneeStateLabel(st)}
+                  </span>
+                </p>
 
-      {/* 完了済み: 報酬表示 */}
-      {state === 'COMPLETED' && (
-        <section style={{ marginTop: '1.4em' }} className="dq-window">
-          <p style={{ margin: 0, fontSize: '0.9em' }}>
-            完了! 受託者 <strong>{quest.assignee ? <Handle did={quest.assignee} /> : '—'}</strong> に{' '}
-            <span style={{ color: 'var(--color-accent)' }}>
-              <RewardPoints did={quest.did} points={quest.rewardPoints} />
-            </span>{' '}
-            が発行されました。
-          </p>
+                {/* この受託者本人: 報告 (作業中 / やり直し中、completions ロード後のみ) */}
+                {meRow && completions !== null && (st === 'IN_PROGRESS' || st === 'REVISION_REQUESTED') && (
+                  !reportForm.open ? (
+                    <button style={{ marginTop: '0.4em' }} onClick={() => setReportForm({ open: true, message: '' })} disabled={busy}>完了を報告する</button>
+                  ) : (
+                    <div style={{ marginTop: '0.4em' }}>
+                      <label htmlFor="report-msg" style={{ display: 'block', fontSize: '0.8em', color: 'var(--color-muted)', marginBottom: '0.3em' }}>成果物の URL・一言コメント (任意)</label>
+                      <textarea id="report-msg" value={reportForm.message} onChange={(e) => setReportForm({ ...reportForm, message: e.target.value })} rows={4} autoFocus placeholder="例: https://example.com/illust.png&#10;こんな感じになりました!" style={{ width: '100%' }} />
+                      <div style={{ display: 'flex', gap: '0.5em', marginTop: '0.5em' }}>
+                        <button onClick={submitReport} disabled={busy}>完了を報告する</button>
+                        <button className="secondary" onClick={() => setReportForm({ open: false, message: '' })} disabled={busy}>キャンセル</button>
+                      </div>
+                    </div>
+                  )
+                )}
+
+                {/* 発注者: この受託者が承認待ちなら、この受託者を対象に承認/やり直し */}
+                {isOwner && st === 'AWAITING_APPROVAL' && (
+                  <div style={{ marginTop: '0.4em' }}>
+                    {actionTarget !== aDid && (
+                      <div style={{ display: 'flex', gap: '0.6em' }}>
+                        <button onClick={() => { setActionTarget(aDid); setApproveForm({ open: true, message: '' }); setRevisionForm({ open: false, message: '' }); }} disabled={busy}>承認する (報酬を発行)</button>
+                        <button className="secondary" onClick={() => { setActionTarget(aDid); setRevisionForm({ open: true, message: '' }); setApproveForm({ open: false, message: '' }); }} disabled={busy}>やり直しを依頼</button>
+                      </div>
+                    )}
+                    {actionTarget === aDid && approveForm.open && (
+                      <div style={{ marginTop: '0.4em' }}>
+                        <label htmlFor="approve-msg" style={{ display: 'block', fontSize: '0.8em', color: 'var(--color-muted)', marginBottom: '0.3em' }}>承認コメント (任意)</label>
+                        <textarea id="approve-msg" value={approveForm.message} onChange={(e) => setApproveForm({ ...approveForm, message: e.target.value })} rows={3} autoFocus style={{ width: '100%' }} />
+                        <div style={{ display: 'flex', gap: '0.5em', marginTop: '0.5em' }}>
+                          <button onClick={submitApprove} disabled={busy}>承認する</button>
+                          <button className="secondary" onClick={() => { setApproveForm({ open: false, message: '' }); setActionTarget(null); }} disabled={busy}>戻る</button>
+                        </div>
+                      </div>
+                    )}
+                    {actionTarget === aDid && revisionForm.open && (
+                      <div style={{ marginTop: '0.4em' }}>
+                        <label htmlFor="revision-msg" style={{ display: 'block', fontSize: '0.8em', color: 'var(--color-muted)', marginBottom: '0.3em' }}>依頼する理由 (必須)</label>
+                        <textarea id="revision-msg" value={revisionForm.message} onChange={(e) => setRevisionForm({ ...revisionForm, message: e.target.value })} rows={4} autoFocus style={{ width: '100%' }} />
+                        <div style={{ display: 'flex', gap: '0.5em', marginTop: '0.5em' }}>
+                          <button onClick={submitRevision} disabled={busy || !revisionForm.message.trim()}>送信する</button>
+                          <button className="secondary" onClick={() => { setRevisionForm({ open: false, message: '' }); setActionTarget(null); }} disabled={busy}>戻る</button>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {/* この受託者が承認済み: 報酬発行を表示 */}
+                {st === 'COMPLETED' && (
+                  <p style={{ margin: '0.3em 0 0', fontSize: '0.82em', color: 'var(--color-accent)' }}>
+                    ✓ <RewardPoints did={quest.did} points={quest.rewardPoints} /> を発行しました。
+                  </p>
+                )}
+              </div>
+            );
+          })}
         </section>
       )}
 
@@ -542,15 +564,22 @@ export function BoardDetail() {
   );
 }
 
-function statusLabel(state: EffectiveState): string {
+function questLevelLabel(state: QuestLevelState): string {
   switch (state) {
-    case 'COMPLETED':          return '完了';
-    case 'EXPIRED':            return '期限切れ';
-    case 'OPEN':               return '募集中';
-    case 'IN_PROGRESS':        return '受託中';
-    case 'AWAITING_APPROVAL':  return '完了報告中 (承認待ち)';
+    case 'COMPLETED': return '完了';
+    case 'EXPIRED':   return '期限切れ';
+    case 'OPEN':      return '募集中';
+    case 'ASSIGNED':  return '受託中';
+    case 'CANCELLED': return 'キャンセル';
+  }
+}
+
+function assigneeStateLabel(state: AssigneeState): string {
+  switch (state) {
+    case 'IN_PROGRESS':        return '作業中';
+    case 'AWAITING_APPROVAL':  return '完了報告済み (承認待ち)';
     case 'REVISION_REQUESTED': return 'やり直し対応中';
-    case 'CANCELLED':          return 'キャンセル';
+    case 'COMPLETED':          return '✓ 完了 (承認済み)';
   }
 }
 

--- a/apps/web/src/routes/board-new.tsx
+++ b/apps/web/src/routes/board-new.tsx
@@ -7,7 +7,7 @@
  */
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ARCHETYPES, JOBS_BY_ID, jobDisplayName, formatQuestAnnouncement, checkIssuanceLimits } from '@aozoraquest/core';
+import { ARCHETYPES, JOBS_BY_ID, jobDisplayName, formatQuestAnnouncement, checkIssuanceLimits, MAX_ASSIGNEES_PER_QUEST } from '@aozoraquest/core';
 import { useSession } from '@/lib/session';
 import { createQuest, listIssuedQuests, questUrlOf, questPath } from '@/lib/quest-api';
 import { refreshQuestIndex } from '@/lib/quest-index-cache';
@@ -29,6 +29,7 @@ export function BoardNew() {
   const [targetJob, setTargetJob] = useState<string>('');
   const [deadline, setDeadline] = useState('');
   const [rewardPoints, setRewardPoints] = useState(100);
+  const [maxAssignees, setMaxAssignees] = useState(1);
   const [announceText, setAnnounceText] = useState('');
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
@@ -83,6 +84,7 @@ export function BoardNew() {
         ...(targetJob ? { targetJob } : {}),
         ...(deadline ? { deadline: new Date(deadline).toISOString() } : {}),
         rewardPoints,
+        maxAssignees,
       });
       // Bluesky 告知は常時 ON (= 掲示板で他人に見えるために必須。発行者が
       // off にできる導線は廃止)。ただし dev 環境だけは本番 Bluesky への誤投稿
@@ -117,7 +119,8 @@ export function BoardNew() {
   const validTitle = title.trim().length > 0 && title.length <= MAX_TITLE;
   const validBody = body.trim().length > 0 && body.length <= MAX_BODY;
   const validReward = Number.isInteger(rewardPoints) && rewardPoints >= 0;
-  const canSubmit = !busy && validTitle && validBody && validReward;
+  const validMax = Number.isInteger(maxAssignees) && maxAssignees >= 1 && maxAssignees <= MAX_ASSIGNEES_PER_QUEST;
+  const canSubmit = !busy && validTitle && validBody && validReward && validMax;
 
   return (
     <form onSubmit={onSubmit}>
@@ -200,6 +203,23 @@ export function BoardNew() {
         />
         <p style={{ fontSize: '0.75em', color: 'var(--color-muted)', margin: '0.2em 0 0' }}>
           あなたの名前のポイントを {rewardPoints} pt 発行します (合算されない、発行上限なし)。
+        </p>
+      </Field>
+
+      <Field label={`受託できる人数 (1〜${MAX_ASSIGNEES_PER_QUEST} 人)`}>
+        <input
+          type="number"
+          value={maxAssignees}
+          onChange={(e) => setMaxAssignees(Math.max(1, Math.min(MAX_ASSIGNEES_PER_QUEST, parseInt(e.target.value, 10) || 1)))}
+          min={1}
+          max={MAX_ASSIGNEES_PER_QUEST}
+          step={1}
+          style={{ width: '12em' }}
+        />
+        <p style={{ fontSize: '0.75em', color: 'var(--color-muted)', margin: '0.2em 0 0' }}>
+          {maxAssignees > 1
+            ? `最大 ${maxAssignees} 人まで受託者に指定できます。報酬は承認した受託者それぞれに ${rewardPoints} pt ずつ発行します。`
+            : '1 人だけが受託します。2 人以上にすると複数人で取り組めます。'}
         </p>
       </Field>
 

--- a/apps/web/src/routes/me.tsx
+++ b/apps/web/src/routes/me.tsx
@@ -5,7 +5,7 @@ import type { Archetype, DiagnosisResult } from '@aozoraquest/core';
 import { ARCHETYPES, DIAGNOSIS_MIN_POST_COUNT, JOBS_BY_ID, archetypePairRelation, jobDisplayName, jobLevelFromXp, jobTagline, jobXpToNextLevel, playerLevelFromXp, playerXpToNextLevel, questXpScalar } from '@aozoraquest/core';
 import { useSession } from '@/lib/session';
 import { runDiagnosis } from '@/lib/diagnosis-flow';
-import { listReceivedQuests } from '@/lib/quest-api';
+import { listReceivedQuests, loadCompletionsByUri } from '@/lib/quest-api';
 import { getRecord } from '@/lib/atproto';
 import { COL } from '@/lib/collections';
 import { JOB_CHANGE_STREAK_THRESHOLD, confirmJobChange, dismissPendingArchetype } from '@/lib/post-processor';
@@ -96,7 +96,9 @@ export function MyProfile() {
     (async () => {
       try {
         const received = await listReceivedQuests(agent, did);
-        if (!cancelled) setQuestXp(questXpScalar(received, did));
+        // 複数受託で一部だけ承認 (quest 未完了) のときも、自分が承認済みなら XP に計上する。
+        const compMap = await loadCompletionsByUri(received);
+        if (!cancelled) setQuestXp(questXpScalar(received, did, compMap));
       } catch (e) {
         console.warn('quest xp load failed', e);
       }

--- a/apps/web/src/routes/portfolio.tsx
+++ b/apps/web/src/routes/portfolio.tsx
@@ -17,6 +17,7 @@ import {
   distinctRecipients,
   distinctRequesters,
   questXpScalar,
+  questAssignees,
   type UserQuest,
   type OutcomeSummary,
 } from '@aozoraquest/core';
@@ -95,7 +96,7 @@ function PortfolioView({ did, agent, isSelf, signedIn }: PortfolioViewProps) {
         for (const u of questUris) {
           try {
             const q = await getQuest(agent, u);
-            if (q && q.assignee === did) fetched.push(q);
+            if (q && questAssignees(q).includes(did)) fetched.push(q);
           } catch (e) {
             console.warn('[portfolio] resolve received quest failed', u, e);
           }

--- a/apps/web/src/routes/portfolio.tsx
+++ b/apps/web/src/routes/portfolio.tsx
@@ -18,7 +18,11 @@ import {
   distinctRequesters,
   questXpScalar,
   questAssignees,
+  rewardForMe,
+  totalIssued,
   type UserQuest,
+  type QuestCompletion,
+  type AtUri,
   type OutcomeSummary,
 } from '@aozoraquest/core';
 import { useSession } from '@/lib/session';
@@ -26,6 +30,7 @@ import {
   listIssuedQuests,
   listMyApplications,
   getQuest,
+  loadCompletionsByUri,
   questPath,
 } from '@/lib/quest-api';
 import { Handle, RewardPoints } from '@/components/handle';
@@ -79,6 +84,8 @@ interface PortfolioViewProps {
 function PortfolioView({ did, agent, isSelf, signedIn }: PortfolioViewProps) {
   const [issued, setIssued] = useState<UserQuest[] | null>(null);
   const [received, setReceived] = useState<UserQuest[] | null>(null);
+  // 複数受託で一部だけ承認 (quest 未完了) のクエストの completion (per-assignee 報酬集計用)。
+  const [compMap, setCompMap] = useState<Map<AtUri, QuestCompletion[]>>(new Map());
   const [err, setErr] = useState<string | null>(null);
 
   useEffect(() => {
@@ -102,6 +109,9 @@ function PortfolioView({ did, agent, isSelf, signedIn }: PortfolioViewProps) {
           }
         }
         if (!cancelled) setReceived(fetched);
+        // multi かつ未完了のクエストだけ completion を読み、per-assignee 承認の報酬を計上する。
+        const m = await loadCompletionsByUri([...myIssued, ...fetched]);
+        if (!cancelled) setCompMap(m);
       } catch (e) {
         if (!cancelled) setErr(String((e as Error)?.message ?? e));
       }
@@ -112,24 +122,32 @@ function PortfolioView({ did, agent, isSelf, signedIn }: PortfolioViewProps) {
   const issuedSummary: OutcomeSummary | null = issued ? summarize(issued) : null;
   const receivedSummary: OutcomeSummary | null = received ? summarize(received) : null;
 
-  const completedIssued = useMemo(() => (issued ?? []).filter(q => q.status === 'completed'), [issued]);
-  const completedReceived = useMemo(() => (received ?? []).filter(q => q.status === 'completed'), [received]);
-  // 受託して完了したクエストから得た累計経験値 (完了集合からの派生 = 二重加算なし)。
-  // 全体 LV と現職 LV の両方に加算される (固定 100 XP/件)。
-  const questXpTotal = useMemo(() => questXpScalar(completedReceived, did ?? ''), [completedReceived, did]);
+  // 「完了」= per-assignee 承認ベース。複数受託で quest 全体が未完了でも、自分が承認された
+  // 受託 / 誰かを承認した発注は「完了」履歴に含める (compMap が無い単数/完了は status fallback)。
+  const completedIssued = useMemo(
+    () => (issued ?? []).filter(q => totalIssued([q], compMap) > 0),
+    [issued, compMap],
+  );
+  const completedReceived = useMemo(
+    () => (received ?? []).filter(q => rewardForMe(q, did ?? '', compMap.get(q.uri)) > 0),
+    [received, compMap, did],
+  );
+  // 受託して承認された分の累計経験値 (固定 100 XP/件)。全体 LV と現職 LV の両方に加算。
+  const questXpTotal = useMemo(() => questXpScalar(received ?? [], did ?? '', compMap), [received, compMap, did]);
 
-  /** 受託者視点: 発注者 DID → 獲得 pt の合計 */
+  /** 受託者視点: 発注者 DID → 獲得 pt の合計 (per-assignee 承認ベース) */
   const receivedByIssuer = useMemo(() => {
     const map = new Map<string, number>();
-    for (const q of completedReceived) {
-      map.set(q.did, (map.get(q.did) ?? 0) + q.rewardPoints);
+    for (const q of received ?? []) {
+      const r = rewardForMe(q, did ?? '', compMap.get(q.uri));
+      if (r > 0) map.set(q.did, (map.get(q.did) ?? 0) + r);
     }
     return Array.from(map.entries()).sort((a, b) => b[1] - a[1]);
-  }, [completedReceived]);
+  }, [received, compMap, did]);
 
   const totalIssuedPower = useMemo(
-    () => completedIssued.reduce((s, q) => s + q.rewardPoints, 0),
-    [completedIssued],
+    () => totalIssued(issued ?? [], compMap),
+    [issued, compMap],
   );
 
   if (isSelf && !signedIn) {
@@ -156,7 +174,7 @@ function PortfolioView({ did, agent, isSelf, signedIn }: PortfolioViewProps) {
         )}
         {issued && (
           <p style={{ fontSize: '0.85em', marginTop: '0.6em' }}>
-            完了したクエストで <strong>{distinctRecipients(issued)} 人</strong> に
+            完了したクエストで <strong>{distinctRecipients(issued, compMap)} 人</strong> に
             自分発行ポイントを渡しました (累計{' '}
             <span style={{ fontFamily: 'ui-monospace, monospace', color: 'var(--color-accent)' }}>
               {totalIssuedPower.toLocaleString()} pt

--- a/apps/web/src/routes/spirit.tsx
+++ b/apps/web/src/routes/spirit.tsx
@@ -5,7 +5,7 @@ import type { DiagnosisResult } from '@aozoraquest/core';
 import { GREETING_HOUR_BOUNDARIES, SPIRIT_CHAT_HISTORY_TURNS, SPIRIT_INPUT_MAX_LENGTH, jobDisplayName, jobLevelFromXp, pickSpiritLine, questXpScalar, type SpiritSituation } from '@aozoraquest/core';
 import { useSession } from '@/lib/session';
 import { getRecord } from '@/lib/atproto';
-import { listReceivedQuests } from '@/lib/quest-api';
+import { listReceivedQuests, loadCompletionsByUri } from '@/lib/quest-api';
 import { COL } from '@/lib/collections';
 import { SpiritIcon } from '@/components/spirit-icon';
 import { SpiritBubble } from '@/components/spirit-bubble';
@@ -110,7 +110,7 @@ export function Spirit() {
           getRecord<DiagnosisResult>(agent, did, COL.analysis, 'self').catch(() => null),
           loadPointsState(agent, did),
           loadChatHistory(agent, did),
-          listReceivedQuests(agent, did).then((qs) => questXpScalar(qs, did)).catch(() => 0),
+          listReceivedQuests(agent, did).then(async (qs) => questXpScalar(qs, did, await loadCompletionsByUri(qs))).catch(() => 0),
         ]);
         if (cancelled) return;
         setDiag(r);

--- a/packages/core/src/__tests__/user-quest.test.ts
+++ b/packages/core/src/__tests__/user-quest.test.ts
@@ -5,6 +5,15 @@ import {
   isValidCompletion,
   needsRequesterApproval,
   effectiveState,
+  effectiveStateForAssignee,
+  questLevelState,
+  questAssignees,
+  questMaxAssignees,
+  hasOpenSlot,
+  completionTarget,
+  isCompletedForAssignee,
+  rewardForMe,
+  MAX_ASSIGNEES_PER_QUEST,
   questXpScalar,
   outcomeOf,
   holdings,
@@ -420,6 +429,138 @@ describe('checkIssuanceLimits', () => {
     const r = checkIssuanceLimits(qs, NOW);
     expect(r.ok).toBe(true);
     expect(r.todayCount).toBe(0);
+  });
+});
+
+describe('複数受託 (multi-assignee)', () => {
+  const owner = 'did:plc:owner';
+  const A = 'did:plc:alice';
+  const B = 'did:plc:bob';
+  const URI = 'at://did:plc:owner/app.aozoraquest.userQuest/multi';
+  const multi = (over: Partial<UserQuest> = {}): UserQuest =>
+    mk({ uri: URI, did: owner, status: 'assigned', assignees: [A, B], maxAssignees: 2, rewardPoints: 500, ...over });
+  const report = (who: string, at: string): QuestCompletion =>
+    ({ uri: `rep-${who}-${at}`, did: who, questUri: URI, role: 'assigneeReport', createdAt: at });
+  const approve = (target: string, at: string): QuestCompletion =>
+    ({ uri: `app-${target}-${at}`, did: owner, questUri: URI, role: 'requesterApproval', targetAssignee: target, createdAt: at });
+  const revise = (target: string, at: string): QuestCompletion =>
+    ({ uri: `rev-${target}-${at}`, did: owner, questUri: URI, role: 'requesterRevision', targetAssignee: target, createdAt: at });
+
+  describe('正規化ヘルパー', () => {
+    it('questAssignees: assignees 優先・無ければ legacy assignee・両方無しは空', () => {
+      expect(questAssignees(multi())).toEqual([A, B]);
+      expect(questAssignees(mk({ assignee: A }))).toEqual([A]);
+      expect(questAssignees(mk({}))).toEqual([]);
+    });
+    it('questMaxAssignees: 未指定 legacy は 1', () => {
+      expect(questMaxAssignees(multi())).toBe(2);
+      expect(questMaxAssignees(mk({}))).toBe(1);
+    });
+    it('hasOpenSlot: 空き枠の有無', () => {
+      expect(hasOpenSlot(multi({ assignees: [A], maxAssignees: 2 }))).toBe(true);
+      expect(hasOpenSlot(multi({ assignees: [A, B], maxAssignees: 2 }))).toBe(false);
+    });
+    it('completionTarget: targetAssignee → 唯一assignee → 複数で不明は null', () => {
+      expect(completionTarget(approve(A, 't'), multi())).toBe(A);
+      // legacy 単数: target 無し approval は唯一の assignee に解決
+      const legacy = mk({ assignee: A });
+      expect(completionTarget({ uri: 'x', did: owner, questUri: legacy.uri, role: 'requesterApproval', createdAt: 't' }, legacy)).toBe(A);
+      // 複数受託で target 無しは曖昧 → null
+      expect(completionTarget({ uri: 'x', did: owner, questUri: URI, role: 'requesterApproval', createdAt: 't' }, multi())).toBeNull();
+    });
+  });
+
+  it('受託者ごとに独立して進行する (A承認済み・B報告済み未承認)', () => {
+    const q = multi();
+    const comps = [report(A, '01'), approve(A, '02'), report(B, '03')];
+    expect(effectiveStateForAssignee(q, comps, A)).toBe('COMPLETED');
+    expect(effectiveStateForAssignee(q, comps, B)).toBe('AWAITING_APPROVAL');
+    expect(questLevelState(q, comps)).toBe('ASSIGNED'); // 全員 COMPLETED ではない
+    expect(needsRequesterApproval(q, comps)).toBe(true); // B が承認待ち
+  });
+
+  it('全員承認で questLevelState=COMPLETED', () => {
+    const q = multi();
+    const comps = [report(A, '01'), approve(A, '02'), report(B, '03'), approve(B, '04')];
+    expect(questLevelState(q, comps)).toBe('COMPLETED');
+    expect(needsRequesterApproval(q, comps)).toBe(false);
+  });
+
+  it('1人やり直し中・1人完了の混在', () => {
+    const q = multi();
+    const comps = [report(A, '01'), approve(A, '02'), report(B, '03'), revise(B, '04')];
+    expect(effectiveStateForAssignee(q, comps, A)).toBe('COMPLETED');
+    expect(effectiveStateForAssignee(q, comps, B)).toBe('REVISION_REQUESTED');
+    expect(questLevelState(q, comps)).toBe('ASSIGNED');
+  });
+
+  it('isValidCompletion: 各受託者の報告は本人なら正当 / target が集合外の承認は無効', () => {
+    const q = multi();
+    expect(isValidCompletion(report(A, 't'), q)).toBe(true);
+    expect(isValidCompletion(report(B, 't'), q)).toBe(true);
+    expect(isValidCompletion(report('did:plc:stranger', 't'), q)).toBe(false);
+    expect(isValidCompletion(approve(A, 't'), q)).toBe(true);
+    expect(isValidCompletion(approve('did:plc:stranger', 't'), q)).toBe(false); // target が assignees 外
+    // 複数受託で target 無し approval は曖昧 → 無効 (偽の一括完了防止)
+    expect(isValidCompletion({ uri: 'x', did: owner, questUri: URI, role: 'requesterApproval', createdAt: 't' }, q)).toBe(false);
+  });
+
+  it('報酬は承認された受託者それぞれに満額 (per-assignee 承認ベース)', () => {
+    const q = multi(); // rewardPoints: 500
+    const comps = [report(A, '01'), approve(A, '02'), report(B, '03')]; // A 承認, B 未承認
+    const byUri = new Map([[URI, comps]]);
+    expect(rewardForMe(q, A, comps)).toBe(500);
+    expect(rewardForMe(q, B, comps)).toBe(0);
+    expect(holdings([q], A, byUri)).toBe(500);
+    expect(holdings([q], B, byUri)).toBe(0);
+    expect(totalIssued([q], byUri)).toBe(500); // 承認済み 1 人ぶん
+    expect(distinctRecipients([q], byUri)).toBe(1);
+    // 全員承認後は 2 人ぶん発行
+    const comps2 = [...comps, approve(B, '04')];
+    const byUri2 = new Map([[URI, comps2]]);
+    expect(totalIssued([q], byUri2)).toBe(1000);
+    expect(distinctRecipients([q], byUri2)).toBe(2);
+    expect(questXpScalar([q], A, byUri2)).toBe(questXpScalar([q], B, byUri2)); // 各自 1 件ぶん
+  });
+
+  it('後方互換: legacy 単数 assignee + status=completed は従来どおり (completions 無し fallback)', () => {
+    const legacy = mk({ status: 'completed', assignee: A, rewardPoints: 300 });
+    expect(rewardForMe(legacy, A)).toBe(300);
+    expect(holdings([legacy], A)).toBe(300);
+    expect(effectiveState(legacy, [])).toBe('COMPLETED');
+    expect(questAssignees(legacy)).toEqual([A]);
+  });
+
+  it('ある受託者への承認は別の受託者の状態に漏れない (target フィルタの効き)', () => {
+    const q = multi();
+    const comps = [report(A, '01'), approve(A, '02')]; // A のみ報告+承認、B は何もしていない
+    expect(effectiveStateForAssignee(q, comps, A)).toBe('COMPLETED');
+    expect(effectiveStateForAssignee(q, comps, B)).toBe('IN_PROGRESS'); // B には漏れない
+    expect(isCompletedForAssignee(q, comps, A)).toBe(true);
+    expect(isCompletedForAssignee(q, comps, B)).toBe(false);
+  });
+
+  it('isCompletedForAssignee は受託者ごとに判定 (isCompleted の複数受託版)', () => {
+    const q = multi();
+    const comps = [report(A, '01'), approve(A, '02'), report(B, '03')];
+    expect(isCompletedForAssignee(q, comps, A)).toBe(true);
+    expect(isCompletedForAssignee(q, comps, B)).toBe(false); // B は報告のみ未承認
+  });
+
+  it('questAssignees: assignees の重複 DID は除去する (水増し防止)', () => {
+    expect(questAssignees(multi({ assignees: [A, A, B] }))).toEqual([A, B]);
+    // 重複 assignee でも totalIssued は承認された実人数ぶんに留まる
+    const q = multi({ assignees: [A, A], maxAssignees: 2, rewardPoints: 500 });
+    const byUri = new Map([[URI, [report(A, '01'), approve(A, '02')]]]);
+    expect(totalIssued([q], byUri)).toBe(500); // A 1 人ぶん (重複で 1000 にならない)
+  });
+
+  it('questAssignees: assignees:[] (明示空) は legacy assignee に fallback する', () => {
+    expect(questAssignees({ assignees: [], assignee: A })).toEqual([A]);
+  });
+
+  it('MAX_ASSIGNEES_PER_QUEST = 20 (確定値)', () => {
+    expect(MAX_ASSIGNEES_PER_QUEST).toBe(20);
   });
 });
 

--- a/packages/core/src/__tests__/user-quest.test.ts
+++ b/packages/core/src/__tests__/user-quest.test.ts
@@ -559,8 +559,8 @@ describe('複数受託 (multi-assignee)', () => {
     expect(questAssignees({ assignees: [], assignee: A })).toEqual([A]);
   });
 
-  it('MAX_ASSIGNEES_PER_QUEST = 20 (確定値)', () => {
-    expect(MAX_ASSIGNEES_PER_QUEST).toBe(20);
+  it('MAX_ASSIGNEES_PER_QUEST = 50 (確定値)', () => {
+    expect(MAX_ASSIGNEES_PER_QUEST).toBe(50);
   });
 });
 

--- a/packages/core/src/user-quest.ts
+++ b/packages/core/src/user-quest.ts
@@ -39,8 +39,16 @@ export interface UserQuest {
   deadline?: string;
   visibility: UserQuestVisibility;
   status: UserQuestStatus;
-  /** 受託者 DID (status >= assigned) */
+  /**
+   * @deprecated 旧・単数受託者 DID。後方互換のため **読み取り時のみ** 参照する
+   * (本番 PDS に既存 record があるため)。新規書き込みでは使わず `assignees` に寄せる。
+   * 読みは必ず `questAssignees(q)` を通すこと。
+   */
   assignee?: Did;
+  /** 受託者 DID 群 (新形式)。発注者が応募者から上限 `maxAssignees` まで個別に追加する。 */
+  assignees?: Did[];
+  /** 受託上限人数 (作成時に発注者が指定、1〜MAX_ASSIGNEES_PER_QUEST)。未指定の legacy は 1 とみなす。 */
+  maxAssignees?: number;
   /** 発注者が指定する報酬ポイント (= 発注者発行通貨での pt 数)。0 以上の整数 */
   rewardPoints: number;
   /** Bluesky 告知 post の at-uri (任意) */
@@ -64,10 +72,53 @@ export interface QuestCompletion {
   did: Did;
   questUri: AtUri;
   role: QuestCompletionRole;
+  /**
+   * `requesterApproval` / `requesterRevision` が **どの受託者向けか** を示す (複数受託対応)。
+   * `assigneeReport` では未使用 (書き手 `did` が受託者自身)。
+   * legacy (targetAssignee 無し) の approval/revision は「唯一の assignee 向け」と解釈する
+   * (`completionTarget` 参照)。
+   */
+  targetAssignee?: Did;
   /** rating は MVP 未使用 (将来用) */
   rating?: number;
   comment?: string;
   createdAt: string;
+}
+
+// ─── 受託者集合の正規化 (新旧形式を吸収する読み取りの単一窓口) ─────
+
+/** 受託上限。未指定 legacy は 1 (旧 = 単数受託)。 */
+export const MAX_ASSIGNEES_PER_QUEST = 20;
+export const MIN_ASSIGNEES_PER_QUEST = 1;
+
+/** quest の受託者 DID を新旧両形式から正規化する。書き込み済み record を壊さない読み取りの窓口。 */
+export function questAssignees(q: Pick<UserQuest, 'assignees' | 'assignee'>): Did[] {
+  // 重複 DID は除去する (集計の水増し防止 = 防御。書き込み側 addAssignee も重複拒否するが、
+  // 不正/壊れた record でも totalIssued 等が水増しされないよう読み取り窓口でも担保)。
+  if (q.assignees && q.assignees.length > 0) return [...new Set(q.assignees)];
+  return q.assignee ? [q.assignee] : [];
+}
+
+/** 受託上限人数 (未指定 legacy は 1)。 */
+export function questMaxAssignees(q: Pick<UserQuest, 'maxAssignees'>): number {
+  return q.maxAssignees ?? 1;
+}
+
+/** まだ受託者を追加できる空き枠があるか。 */
+export function hasOpenSlot(q: UserQuest): boolean {
+  return questAssignees(q).length < questMaxAssignees(q);
+}
+
+/**
+ * completion (approval/revision) が向けた受託者を正規化する。
+ * - `targetAssignee` があればそれ。
+ * - 無く、受託者が唯一なら その人 (= legacy 単数時代の record 互換)。
+ * - 無く、受託者が複数いて不明なら `null` (= 偽の一括完了を防ぐため無効扱い)。
+ */
+export function completionTarget(c: QuestCompletion, q: UserQuest): Did | null {
+  if (c.targetAssignee) return c.targetAssignee;
+  const list = questAssignees(q);
+  return list.length === 1 ? list[0]! : null;
 }
 
 // ─── 期限切れ判定 ──────────────────────────────────────────
@@ -96,13 +147,33 @@ export function isCompleted(q: UserQuest, completions: QuestCompletion[]): boole
   );
 }
 
+/**
+ * **複数受託では `isCompleted` を完了判定に使わないこと** (= owner の approval が 1 件でも
+ * あれば true を返すため、複数受託で「1 人承認 = quest 全体完了」に化ける)。
+ * 報酬・冪等性・per-assignee の完了は **この関数** (= その受託者向けの承認があるか) を使う。
+ * `isCompleted` は legacy 単数 / quest 全体の概況用に限定する。
+ */
+export function isCompletedForAssignee(
+  q: UserQuest,
+  completions: QuestCompletion[],
+  assigneeDid: Did,
+): boolean {
+  return effectiveStateForAssignee(q, completions, assigneeDid) === 'COMPLETED';
+}
+
 /** completion record の owner DID が role に対応する正当な書き手かを検証する。
  *  集計・表示の前に flooring すると、不正な record を排除できる。 */
 export function isValidCompletion(c: QuestCompletion, q: UserQuest): boolean {
   if (c.questUri !== q.uri) return false;
-  if (c.role === 'assigneeReport')      return q.assignee ? c.did === q.assignee : false;
-  if (c.role === 'requesterApproval')   return c.did === q.did;
-  if (c.role === 'requesterRevision')   return c.did === q.did;
+  const list = questAssignees(q);
+  // 受託者の報告: 書き手が受託者集合の誰か本人であること
+  if (c.role === 'assigneeReport') return list.includes(c.did);
+  // 発注者の承認/やり直し: 発注者本人が書き、向け先 (target) が受託者集合内であること
+  if (c.role === 'requesterApproval' || c.role === 'requesterRevision') {
+    if (c.did !== q.did) return false;
+    const t = completionTarget(c, q);
+    return t !== null && list.includes(t);
+  }
   return false;
 }
 
@@ -124,7 +195,11 @@ function latestCreatedAt(items: QuestCompletion[]): string | null {
  *  - 最後の報告 (assigneeReport) が最後の差し戻し (requesterRevision) より新しければ「承認待ち」。
  *    差し戻しの方が新しければ受託者の再報告待ちなので false。 */
 export function needsRequesterApproval(q: UserQuest, completions: QuestCompletion[]): boolean {
-  return effectiveState(q, completions) === 'AWAITING_APPROVAL';
+  if (q.status === 'completed' || q.status === 'cancelled') return false;
+  // 複数受託では「誰か 1 人でも報告済み・未承認」なら発注者の番。
+  return questAssignees(q).some(
+    d => effectiveStateForAssignee(q, completions, d) === 'AWAITING_APPROVAL',
+  );
 }
 
 /**
@@ -148,23 +223,70 @@ export type EffectiveState =
   | 'OPEN' | 'IN_PROGRESS' | 'AWAITING_APPROVAL' | 'REVISION_REQUESTED'
   | 'COMPLETED' | 'CANCELLED' | 'EXPIRED';
 
+/** 受託者 1 人ぶんの進行状態。複数受託では受託者ごとに独立して進む。 */
+export type AssigneeState = 'IN_PROGRESS' | 'AWAITING_APPROVAL' | 'REVISION_REQUESTED' | 'COMPLETED';
+
+/**
+ * **受託者 1 人ぶん**の実効状態を completion record から導出する (複数受託の真実)。
+ * その受託者の `assigneeReport` と、その人に向いた (targetAssignee 一致) `requesterApproval`
+ * / `requesterRevision` だけを見る。報酬・XP・「あなたの番」判定はこれが基準。
+ */
+export function effectiveStateForAssignee(
+  q: UserQuest,
+  completions: QuestCompletion[],
+  assigneeDid: Did,
+): AssigneeState {
+  const valid = completions.filter(c => isValidCompletion(c, q));
+  // この受託者向けの承認があれば確定 COMPLETED (status を信じない = 耐故障性)
+  const approved = valid.some(
+    c => c.role === 'requesterApproval' && completionTarget(c, q) === assigneeDid,
+  );
+  if (approved) return 'COMPLETED';
+  const lastReport = latestCreatedAt(
+    valid.filter(c => c.role === 'assigneeReport' && c.did === assigneeDid),
+  );
+  if (lastReport === null) return 'IN_PROGRESS';
+  const lastRevision = latestCreatedAt(
+    valid.filter(c => c.role === 'requesterRevision' && completionTarget(c, q) === assigneeDid),
+  );
+  if (lastRevision !== null && lastRevision > lastReport) return 'REVISION_REQUESTED';
+  return 'AWAITING_APPROVAL';
+}
+
+/** クエスト全体の状態 (募集枠・進行の概況)。報酬の真実は assignee 別状態を見ること。 */
+export type QuestLevelState = 'OPEN' | 'ASSIGNED' | 'COMPLETED' | 'CANCELLED' | 'EXPIRED';
+
+export function questLevelState(
+  q: UserQuest,
+  completions: QuestCompletion[],
+  now: Date = new Date(),
+): QuestLevelState {
+  if (q.status === 'cancelled') return 'CANCELLED';
+  if (q.status === 'completed') return 'COMPLETED'; // 発注者が明示クローズ
+  const list = questAssignees(q);
+  if (list.length === 0) return isExpired(q, now) ? 'EXPIRED' : 'OPEN';
+  if (list.every(d => effectiveStateForAssignee(q, completions, d) === 'COMPLETED')) return 'COMPLETED';
+  return 'ASSIGNED';
+}
+
+/**
+ * **後方互換ラッパ**。旧・単数受託前提の UI / 集計が引き続き動くよう、quest 全体に 1 つの
+ * EffectiveState を返す。受託者 0 人なら従来どおり OPEN/EXPIRED/CANCELLED/COMPLETED、
+ * 1 人以上なら「最初の (legacy では唯一の) 受託者の状態」を返す。
+ * 複数受託を正しく扱う新コードは `effectiveStateForAssignee` / `questLevelState` を直接使うこと。
+ */
 export function effectiveState(
   q: UserQuest,
   completions: QuestCompletion[],
   now: Date = new Date(),
 ): EffectiveState {
   if (q.status === 'cancelled') return 'CANCELLED';
-  if (isCompleted(q, completions)) return 'COMPLETED';
-  if (!q.assignee) {
+  if (q.status === 'completed') return 'COMPLETED';
+  const list = questAssignees(q);
+  if (list.length === 0) {
     return isExpired(q, now) ? 'EXPIRED' : 'OPEN';
   }
-  // 受託確定済み (assignee あり)。completion record から進行を判定する。
-  const valid = completions.filter(c => isValidCompletion(c, q));
-  const lastReport = latestCreatedAt(valid.filter(c => c.role === 'assigneeReport'));
-  if (lastReport === null) return 'IN_PROGRESS';
-  const lastRevision = latestCreatedAt(valid.filter(c => c.role === 'requesterRevision'));
-  if (lastRevision !== null && lastRevision > lastReport) return 'REVISION_REQUESTED';
-  return 'AWAITING_APPROVAL';
+  return effectiveStateForAssignee(q, completions, list[0]!);
 }
 
 // ─── 発注者視点: 成功 / 失敗 / キャンセル / 進行中 ─────────
@@ -173,39 +295,78 @@ export type Outcome = 'success' | 'failure' | 'cancelled' | 'inProgress';
 
 export function outcomeOf(q: UserQuest): Outcome {
   if (q.status === 'completed') return 'success';
-  if (q.status === 'cancelled') return q.assignee ? 'failure' : 'cancelled';
+  if (q.status === 'cancelled') return questAssignees(q).length > 0 ? 'failure' : 'cancelled';
   return 'inProgress';
 }
 
 // ─── ポイント集計 ──────────────────────────────────────────
+//
+// 複数受託では「各受託者が個別に承認された時点でそれぞれ満額」付与する (オーナー仕様)。
+// よって報酬は quest.status ではなく **受託者ごとの承認 (completion record)** が真実。
+// completions マップを渡すと per-assignee 承認ベースで判定し、省略時は従来の status ベースに
+// fallback する (legacy 単数クエストは status='completed' のままなので壊れない)。
 
-/** 「issuer (DID) が発注した完了済み quest のうち、me が受託したもの」のポイント合計 */
-export function holdings(issuerQuests: UserQuest[], me: Did): number {
-  return issuerQuests
-    .filter(q => q.status === 'completed' && q.assignee === me)
-    .reduce((sum, q) => sum + q.rewardPoints, 0);
+/** quest 1 件で me に確定した報酬。completions があれば per-assignee 承認で判定。 */
+export function rewardForMe(q: UserQuest, me: Did, completions?: QuestCompletion[]): number {
+  if (completions) {
+    return effectiveStateForAssignee(q, completions, me) === 'COMPLETED' ? q.rewardPoints : 0;
+  }
+  return q.status === 'completed' && questAssignees(q).includes(me) ? q.rewardPoints : 0;
 }
 
-/** 「issuer が発行した総ポイント (= 流通量)」 */
-export function totalIssued(issuerQuests: UserQuest[]): number {
-  return issuerQuests
-    .filter(q => q.status === 'completed')
-    .reduce((sum, q) => sum + q.rewardPoints, 0);
+/** 「issuer (DID) が発注した quest のうち、me が承認されたもの」のポイント合計 */
+export function holdings(
+  issuerQuests: UserQuest[],
+  me: Did,
+  completionsByUri?: Map<AtUri, QuestCompletion[]>,
+): number {
+  return issuerQuests.reduce(
+    (sum, q) => sum + rewardForMe(q, me, completionsByUri?.get(q.uri)),
+    0,
+  );
+}
+
+/** 「issuer が発行した総ポイント (= 流通量)」。複数受託では承認された人数ぶん発行される。 */
+export function totalIssued(
+  issuerQuests: UserQuest[],
+  completionsByUri?: Map<AtUri, QuestCompletion[]>,
+): number {
+  return issuerQuests.reduce((sum, q) => {
+    const comps = completionsByUri?.get(q.uri);
+    const completedCount = comps
+      ? questAssignees(q).filter(d => effectiveStateForAssignee(q, comps, d) === 'COMPLETED').length
+      : (q.status === 'completed' ? questAssignees(q).length || 1 : 0);
+    return sum + completedCount * q.rewardPoints;
+  }, 0);
 }
 
 /** 「me が持つ issuer ポイントの総発行に対するシェア % (0-100)」 */
-export function shareOf(issuerQuests: UserQuest[], me: Did): number {
-  const total = totalIssued(issuerQuests);
-  return total === 0 ? 0 : (holdings(issuerQuests, me) / total) * 100;
+export function shareOf(
+  issuerQuests: UserQuest[],
+  me: Did,
+  completionsByUri?: Map<AtUri, QuestCompletion[]>,
+): number {
+  const total = totalIssued(issuerQuests, completionsByUri);
+  return total === 0 ? 0 : (holdings(issuerQuests, me, completionsByUri) / total) * 100;
 }
 
 // ─── 関わった人数 ──────────────────────────────────────────
 
 /** 発注者視点: 完了済みクエストで実際に報酬を渡したユニーク受取人数 */
-export function distinctRecipients(myIssuedQuests: UserQuest[]): number {
+export function distinctRecipients(
+  myIssuedQuests: UserQuest[],
+  completionsByUri?: Map<AtUri, QuestCompletion[]>,
+): number {
   const set = new Set<Did>();
   for (const q of myIssuedQuests) {
-    if (q.status === 'completed' && q.assignee) set.add(q.assignee);
+    const comps = completionsByUri?.get(q.uri);
+    if (comps) {
+      for (const d of questAssignees(q)) {
+        if (effectiveStateForAssignee(q, comps, d) === 'COMPLETED') set.add(d);
+      }
+    } else if (q.status === 'completed') {
+      for (const d of questAssignees(q)) set.add(d);
+    }
   }
   return set.size;
 }
@@ -248,15 +409,21 @@ export function summarize(quests: UserQuest[]): OutcomeSummary {
  * 承認済み (`status==='completed'`) のクエストのみ対象。この XP は全体 LV (playerLevel) と
  * 現職 LV (jobLevel) の両方に乗せて表示する (= 冒険で確かにレベルが上がる)。
  *
- * 引数は `status` / `assignee` だけ見るので、完全な UserQuest でも questIndex の
- * summary でも渡せる。承認の真実は発注者 record の `status='completed'` (承認時に発注者が
- * 書く) で、受託者はそれを公開 read できる。
+ * 複数受託対応: completions マップを渡すと「me がその quest で承認された (per-assignee
+ * COMPLETED)」件数を数える。省略時は従来どおり `status==='completed'` かつ me が受託者集合に
+ * 含まれる件数に fallback する (legacy 単数クエストは status で完了が分かるので壊れない)。
  */
 export function questXpScalar(
-  receivedQuests: { status: string; assignee?: Did }[],
+  receivedQuests: UserQuest[],
   me: Did,
+  completionsByUri?: Map<AtUri, QuestCompletion[]>,
 ): number {
-  const n = receivedQuests.filter(q => q.status === 'completed' && q.assignee === me).length;
+  const n = receivedQuests.filter(q => {
+    const comps = completionsByUri?.get(q.uri);
+    return comps
+      ? effectiveStateForAssignee(q, comps, me) === 'COMPLETED'
+      : q.status === 'completed' && questAssignees(q).includes(me);
+  }).length;
   return n * XP_REWARDS.questComplete;
 }
 

--- a/packages/core/src/user-quest.ts
+++ b/packages/core/src/user-quest.ts
@@ -88,7 +88,7 @@ export interface QuestCompletion {
 // ─── 受託者集合の正規化 (新旧形式を吸収する読み取りの単一窓口) ─────
 
 /** 受託上限。未指定 legacy は 1 (旧 = 単数受託)。 */
-export const MAX_ASSIGNEES_PER_QUEST = 20;
+export const MAX_ASSIGNEES_PER_QUEST = 50;
 export const MIN_ASSIGNEES_PER_QUEST = 1;
 
 /** quest の受託者 DID を新旧両形式から正規化する。書き込み済み record を壊さない読み取りの窓口。 */


### PR DESCRIPTION
## リリース 2026.06.30-1

### 目玉: クエストを複数人で受託可能に
発注者がクエスト作成時に受託人数 (1〜50) を指定でき、複数人が同じクエストを受託・各自報告・発注者が個別承認、承認された各受託者に報酬を満額発行する。

### 含まれる PR (各 §1.5 3並列レビュー + テスト済み)
- **#226** core: 受託者別/quest全体の2層状態機械、後方互換正規化、報酬を per-assignee 承認ベースへ
- **#227** api: addAssignee/removeAssignee、targetAssignee 付き個別承認、listCompletionsFor 複数対応
- **#228** UI: 作成フォーム人数入力、受託者ごとの報告/承認 UI、募集継続/満枠表示、quest.assignee 直読み全廃
- **#230** 報酬集計: XP/holdings を per-assignee 承認ベースへ配線
- **#232** 上限 50 + listCompletionsFor 並列化
- **#233** APP_VERSION 2026.06.30-1

### 後方互換 (最重要)
本番の既存単数クエストは一切壊さない。読み取りは questAssignees で正規化、書き込みは単数のうち legacy assignee をミラー併記、報酬集計は単数/完了済みで status fallback (本番データは全件単数なので従来と厳密一致)。後方互換レビューで本番影響ゼロを確認済み。

### §1.5 レビュー
全 PR で実装/設計/UX/セキュリティ/後方互換の観点でレビュー済み。★★★ は各 PR 内で全対応。残 follow-up は issue #229 (承認フォームの書きかけ消失、軽微)。

### リリース後の確認
- APP_VERSION 2026.06.30-1
- 単数クエストが従来どおり動く / 複数受託の作成〜個別承認〜報酬反映