### PR TITLE
release: 2026.06.30-2 — X 風画像グリッド + スワイプカルーセル

### DIFF
--- a/apps/web/src/components/image-lightbox.tsx
+++ b/apps/web/src/components/image-lightbox.tsx
@@ -6,11 +6,18 @@ import type { PostImage } from '@/lib/post-embed';
  * 投稿画像のフルスクリーンビューア。
  *
  * - ESC / 背景クリック / 閉じるボタンで閉じる
- * - 複数枚: ← → キー、左右ボタン、スワイプで前後移動
- * - 端まで来たら止まる (ループしない)
- * - 次の画像を new Image().src でプリロード
+ * - 複数枚: ← → キー、左右ボタン、**横スワイプ (指追従カルーセル)** で前後移動
+ * - 端まで来たら止まる (ループしない。端ではドラッグに抵抗をかける)
+ * - 次/前の画像を new Image().src でプリロード
  * - body のスクロールを掴んだままにしない
+ *
+ * スワイプは横カルーセル方式: 全スライドを横一列に並べ translateX で動かす。
+ * `touch-action: none` でブラウザの縦スクロール/パンに**ジェスチャを奪われない**ようにし、
+ * touchmove で指に追従、touchend で閾値を超えたら次/前へスナップ (transition でスライドイン)。
  */
+const SWIPE_THRESHOLD_RATIO = 0.18; // ビューポート幅のこの割合を超えたらページ送り
+const SWIPE_THRESHOLD_MAX = 60;     // ただし最低でもこの px を超えれば送る
+
 export function ImageLightbox({
   images,
   initialIndex,
@@ -21,7 +28,14 @@ export function ImageLightbox({
   onClose: () => void;
 }) {
   const [idx, setIdx] = useState(initialIndex);
-  const touchStartX = useRef<number | null>(null);
+  const [drag, setDrag] = useState(0);
+  const [dragging, setDragging] = useState(false);
+
+  const startX = useRef(0);
+  const startY = useRef(0);
+  const axis = useRef<'h' | 'v' | null>(null);
+  const vpRef = useRef<HTMLDivElement>(null);
+  const vpW = useRef(0);
 
   const go = useCallback(
     (delta: number) => {
@@ -50,26 +64,67 @@ export function ImageLightbox({
     };
   }, [onClose, go]);
 
-  // 次の画像をプリロード
+  // 前後の画像をプリロード
   useEffect(() => {
-    const next = images[idx + 1];
-    if (next) {
-      const img = new Image();
-      img.src = next.fullsize;
-    }
-    const prev = images[idx - 1];
-    if (prev) {
-      const img = new Image();
-      img.src = prev.fullsize;
+    for (const j of [idx + 1, idx - 1]) {
+      const im = images[j];
+      if (im) { const pre = new Image(); pre.src = im.fullsize; }
     }
   }, [idx, images]);
 
-  const current = images[idx];
-  if (!current) return null;
-
+  const multi = images.length > 1;
   const hasPrev = idx > 0;
   const hasNext = idx < images.length - 1;
-  const multi = images.length > 1;
+
+  // 指が外れた / ジェスチャ中断時に drag が途中値で固定されないよう確実にリセットする。
+  function resetDrag() {
+    setDragging(false);
+    setDrag(0);
+    axis.current = null;
+  }
+
+  function onTouchStart(e: React.TouchEvent) {
+    // 2 本目以降 (ピンチ等) は基準点がぶれるのでカルーセルを開始しない。
+    if (e.touches.length > 1) { resetDrag(); return; }
+    const t = e.touches[0];
+    if (!t) return;
+    startX.current = t.clientX;
+    startY.current = t.clientY;
+    axis.current = null;
+    vpW.current = vpRef.current?.clientWidth ?? window.innerWidth;
+    setDragging(true);
+  }
+
+  function onTouchMove(e: React.TouchEvent) {
+    if (e.touches.length > 1) return; // マルチタッチ中は drag を更新しない
+    const t = e.touches[0];
+    if (!t) return;
+    const dx = t.clientX - startX.current;
+    const dy = t.clientY - startY.current;
+    // 最初の十分な移動で軸を確定 (横なら以後カルーセル、縦なら無視)。
+    if (axis.current === null && (Math.abs(dx) > 8 || Math.abs(dy) > 8)) {
+      axis.current = Math.abs(dx) >= Math.abs(dy) ? 'h' : 'v';
+    }
+    if (axis.current === 'h') {
+      // 端ではドラッグに抵抗 (1/3) をかけ、これ以上めくれない感を出す。
+      const atEdge = (idx === 0 && dx > 0) || (idx === images.length - 1 && dx < 0);
+      setDrag(atEdge ? dx / 3 : dx);
+    }
+  }
+
+  function onTouchEnd(e: React.TouchEvent) {
+    setDragging(false);
+    const a = axis.current;
+    axis.current = null;
+    if (a !== 'h') { setDrag(0); return; }
+    const endX = e.changedTouches[0]?.clientX ?? startX.current;
+    const dx = endX - startX.current;
+    const threshold = Math.min(SWIPE_THRESHOLD_MAX, vpW.current * SWIPE_THRESHOLD_RATIO);
+    if (Math.abs(dx) > threshold) go(dx < 0 ? 1 : -1);
+    setDrag(0); // idx 変化 + drag 0 + transition で新しい位置へスライドイン
+  }
+
+  if (!images[idx]) return null;
 
   return createPortal(
     <div
@@ -85,33 +140,55 @@ export function ImageLightbox({
         justifyContent: 'center',
         padding: '2vh 2vw',
       }}
-      onTouchStart={(e) => {
-        touchStartX.current = e.touches[0]?.clientX ?? null;
-      }}
-      onTouchEnd={(e) => {
-        const startX = touchStartX.current;
-        touchStartX.current = null;
-        if (startX === null) return;
-        const endX = e.changedTouches[0]?.clientX ?? startX;
-        const dx = endX - startX;
-        if (Math.abs(dx) < 50) return;
-        if (dx < 0) go(1);
-        else go(-1);
-      }}
     >
-      {/* 画像エリア (残りの高さいっぱい。ボタンは画像に重ねない) */}
-      <div style={{ flex: 1, minHeight: 0, width: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-        <img
-          src={current.fullsize}
-          alt={current.alt}
-          onClick={(e) => e.stopPropagation()}
+      {/* 画像エリア = 横カルーセル。touch-action:none でブラウザの縦スクロール/パンに
+          スワイプを奪われないようにする (= 指追従が安定)。 */}
+      <div
+        ref={vpRef}
+        onTouchStart={onTouchStart}
+        onTouchMove={onTouchMove}
+        onTouchEnd={onTouchEnd}
+        onTouchCancel={resetDrag}
+        // 画像エリア (レターボックス余白含む) のタップで誤って閉じない。閉じるのは
+        // 背景余白 / ✕ ボタン / ESC のみ (スワイプ後のタップ誤爆も防ぐ)。
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          flex: 1,
+          minHeight: 0,
+          width: '100%',
+          overflow: 'hidden',
+          touchAction: 'none',
+        }}
+      >
+        <div
           style={{
-            maxWidth: '100%',
-            maxHeight: '100%',
-            objectFit: 'contain',
-            userSelect: 'none',
+            display: 'flex',
+            height: '100%',
+            transform: `translateX(calc(${-idx * 100}% + ${drag}px))`,
+            transition: dragging ? 'none' : 'transform 0.28s cubic-bezier(0.22, 0.61, 0.36, 1)',
+            willChange: 'transform',
           }}
-        />
+        >
+          {images.map((im, i) => (
+            <div
+              key={i}
+              style={{ flex: '0 0 100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+            >
+              <img
+                src={im.fullsize}
+                alt={im.alt}
+                onClick={(e) => e.stopPropagation()}
+                draggable={false}
+                style={{
+                  maxWidth: '100%',
+                  maxHeight: '100%',
+                  objectFit: 'contain',
+                  userSelect: 'none',
+                }}
+              />
+            </div>
+          ))}
+        </div>
       </div>
 
       {/* 下部コントロール: 親指で届く位置に。前後 ‹›・カウンタは画像の下、
@@ -131,8 +208,8 @@ export function ImageLightbox({
           fontSize: 13,
         }}
       >
-        {current.alt && (
-          <span style={{ maxWidth: 720, textAlign: 'center', lineHeight: 1.5, padding: '0 16px' }}>{current.alt}</span>
+        {images[idx]!.alt && (
+          <span style={{ maxWidth: 720, textAlign: 'center', lineHeight: 1.5, padding: '0 16px' }}>{images[idx]!.alt}</span>
         )}
 
         {multi && (

--- a/apps/web/src/components/post-body.tsx
+++ b/apps/web/src/components/post-body.tsx
@@ -11,9 +11,9 @@ import { useTranslation } from '@/lib/translate';
 /**
  * 投稿本文 (テキスト + 画像 + 外部リンクカード) の共通レイアウト。
  *
- * 画像が 0 枚: テキストのみ。1 枚以上: 画像を float:left して**テキストを回り込ませる**
- * (画像の横に最初の数行、画像の下からは全幅)。末尾 clear:both で float を閉じる。
- * 外部リンクカード / 動画は回り込みを clear した後にフル幅で追加。
+ * 画像が 0 枚: テキストのみ。1 枚以上: X (Twitter) 風に **テキストを上・画像をその下に
+ * フル幅**で並べる (枚数別グリッドは PostImages 側)。外部リンクカード / 動画はさらに下に
+ * フル幅で続く。
  *
  * `postUri` が渡されると、非日本語投稿に対してローカル LLM による翻訳を
  * オンデマンドで表示 (自動翻訳設定 ON ならロード時に自動開始)。
@@ -60,21 +60,17 @@ export function PostBody({ text, facets, images, external, video, postUri, langs
     </div>
   );
 
-  // 画像ありのときは画像を float: left してテキストを回り込ませる
-  // (画像の横に最初の数行、画像の下からは全幅)。旧 flex 横並びだとテキストが
-  // 画像の高さ全体にわたって狭い列に押し込まれ縦長になっていた。
-  // 末尾の clear:both で、テキストが短くても親が画像高さまで伸び、後続
-  // (翻訳コントロール・metrics) が float に巻き込まれないようにする。
-  const textBlock = hasImages ? (
+  // X 風: テキストを上に、画像をその下にフル幅で並べる (枚数でレイアウトが変わる
+  // グリッドは PostImages 側)。aspect-ratio で形が確定するのでロード時の高さジャンプは無い。
+  const textBlock = (
     <div style={{ marginTop: topMargin }}>
-      <div style={{ float: 'left', marginRight: '0.6em', marginBottom: '0.3em' }}>
-        <PostImages images={images} />
-      </div>
       {textNode}
-      <div style={{ clear: 'both' }} />
+      {hasImages && (
+        <div style={{ marginTop: '0.5em' }}>
+          <PostImages images={images} />
+        </div>
+      )}
     </div>
-  ) : (
-    <div style={{ marginTop: topMargin }}>{textNode}</div>
   );
 
   // 外部リンクが YouTube なら iframe 埋め込み、それ以外なら OG カード

--- a/apps/web/src/components/post-images.tsx
+++ b/apps/web/src/components/post-images.tsx
@@ -1,73 +1,110 @@
-import { useState, type CSSProperties } from 'react';
+import { useState, type CSSProperties, type ReactNode } from 'react';
 import type { PostImage } from '@/lib/post-embed';
 import { ImageLightbox } from './image-lightbox';
 
 /**
- * 投稿に添付された 1〜4 枚の画像を **正方形タイル** で表示する
- * 固定幅の小さなグリッド。post-body 側で float:left され、テキストが回り込む。
+ * 投稿に添付された 1〜4 枚の画像を **X (Twitter) 風のフル幅グリッド**で表示する。
+ * 枚数でレイアウトが変わる:
+ *   1 枚: 画像の自然比 (縦長〜横長にクランプ) で 1 枚。
+ *   2 枚: 左右 2 分割。
+ *   3 枚: 左 1 枚を縦長 + 右に 2 枚を縦積み。
+ *   4 枚: 2×2。
  *
- * レイアウト (総幅 COL_W = 140px):
- *   1 枚: 140×140 (単独)
- *   2 枚: 140×68 (2 列 × 1 行、各タイル 68×68)
- *   3 枚: 140×140 (2×2 で 1 枚分空き、各タイル 68×68)
- *   4 枚: 140×140 (2×2、各タイル 68×68)
- *
- * 画像ロードで高さがジャンプしないよう `aspect-ratio: 1 / 1` で
- * タイル形状を CSS 側で確定させる。画像本体は `object-fit: cover`。
+ * 各グリッドは `aspect-ratio` で形を CSS 側に確定させるので、画像ロードで高さが
+ * ジャンプしない (仮想スクロールの帳尻ズレも防ぐ)。画像本体は object-fit: cover。
+ * 外周だけ角丸 (overflow:hidden)、セル間は 2px gap。
  */
-const COL_W = 140;
 const GAP = 2;
+// DESIGN.md (Shapes): 角丸は 8px 上限。X 風でも世界観に合わせ 8px に収める。
+const RADIUS = 8;
+/** 1 枚表示の最大高さ (縦長画像が極端に縦に伸びないようキャップ)。 */
+const SINGLE_MAX_H = 510;
+// PC のカラム幅は最大 760px までドラッグ可能 (COLUMN_MAX_WIDTH)。画像がそのまま追従して
+// 巨大化しないよう、グリッド全体の最大幅もキャップする (X の本文カラム幅相当)。
+const MAX_W = 510;
 
-function gridStyle(n: 1 | 2 | 3 | 4): CSSProperties {
-  const cols = n === 1 ? 1 : 2;
-  return {
-    display: 'grid',
-    gridTemplateColumns: `repeat(${cols}, 1fr)`,
-    gap: GAP,
-    width: COL_W,
-    flexShrink: 0,
-  };
+/** 1 枚画像の表示アスペクト比 (= width/height)。自然比を縦長 0.75〜横長 1.78 にクランプ。 */
+function singleAspect(img: PostImage): number {
+  const ar = img.aspectRatio;
+  if (!ar || ar.width <= 0 || ar.height <= 0) return 16 / 9;
+  const r = ar.width / ar.height;
+  return Math.max(0.75, Math.min(16 / 9, r));
 }
 
 export function PostImages({ images }: { images: PostImage[] }) {
   const [openIdx, setOpenIdx] = useState<number | null>(null);
   if (images.length === 0) return null;
   const slice = images.slice(0, 4);
-  const n = slice.length as 1 | 2 | 3 | 4;
+  const n = slice.length;
+
+  const cell = (i: number, extra?: CSSProperties) => {
+    const img = slice[i]!;
+    return (
+      <button
+        key={i}
+        type="button"
+        onClick={() => setOpenIdx(i)}
+        style={{
+          // all:unset は使わない (global の button:focus-visible アウトラインを潰すため)。
+          // 必要なリセットだけ明示し、フォーカスリング (a11y) は global ルールに任せる。
+          border: 'none',
+          padding: 0,
+          margin: 0,
+          font: 'inherit',
+          cursor: 'zoom-in',
+          display: 'block',
+          width: '100%',
+          height: '100%',
+          overflow: 'hidden',
+          background: '#000',
+          ...extra,
+        }}
+      >
+        <img
+          src={img.thumb}
+          alt={img.alt}
+          loading="lazy"
+          decoding="async"
+          style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
+        />
+      </button>
+    );
+  };
+
+  let containerStyle: CSSProperties;
+  let inner: ReactNode;
+
+  if (n === 1) {
+    containerStyle = { aspectRatio: String(singleAspect(slice[0]!)), maxHeight: SINGLE_MAX_H };
+    inner = cell(0);
+  } else if (n === 2) {
+    containerStyle = { aspectRatio: '16 / 9', display: 'grid', gridTemplateColumns: '1fr 1fr', gap: GAP };
+    inner = (<>{cell(0)}{cell(1)}</>);
+  } else if (n === 3) {
+    containerStyle = {
+      aspectRatio: '16 / 9',
+      display: 'grid',
+      gridTemplateColumns: '1fr 1fr',
+      gridTemplateRows: '1fr 1fr',
+      gap: GAP,
+    };
+    // 左 1 枚を 2 行ぶん (縦長) + 右に 2 枚を縦積み
+    inner = (<>{cell(0, { gridRow: '1 / 3', height: '100%' })}{cell(1)}{cell(2)}</>);
+  } else {
+    containerStyle = {
+      aspectRatio: '16 / 9',
+      display: 'grid',
+      gridTemplateColumns: '1fr 1fr',
+      gridTemplateRows: '1fr 1fr',
+      gap: GAP,
+    };
+    inner = (<>{cell(0)}{cell(1)}{cell(2)}{cell(3)}</>);
+  }
 
   return (
     <>
-      <div style={gridStyle(n)}>
-        {slice.map((img, i) => (
-          <button
-            key={i}
-            type="button"
-            onClick={() => setOpenIdx(i)}
-            style={{
-              all: 'unset',
-              cursor: 'zoom-in',
-              display: 'block',
-              width: '100%',
-              aspectRatio: '1 / 1',
-              overflow: 'hidden',
-              borderRadius: 4,
-              background: '#000',
-            }}
-          >
-            <img
-              src={img.thumb}
-              alt={img.alt}
-              loading="lazy"
-              decoding="async"
-              style={{
-                width: '100%',
-                height: '100%',
-                objectFit: 'cover',
-                display: 'block',
-              }}
-            />
-          </button>
-        ))}
+      <div style={{ width: '100%', maxWidth: MAX_W, borderRadius: RADIUS, overflow: 'hidden', ...containerStyle }}>
+        {inner}
       </div>
       {openIdx !== null && (
         <ImageLightbox images={slice} initialIndex={openIdx} onClose={() => setOpenIdx(null)} />

--- a/apps/web/src/lib/app-version.ts
+++ b/apps/web/src/lib/app-version.ts
@@ -12,7 +12,7 @@
  *   3. 同じ値で git tag を打つ:
  *        git tag v2026.06.14-1 && git push origin v2026.06.14-1
  */
-export const APP_VERSION = '2026.06.30-1';
+export const APP_VERSION = '2026.06.30-2';
 
 /** APP_VERSION が `YYYY.MM.DD-N` 形式かを検証する (テスト/CI で形式崩れを検出)。
  *  月 01-12 / 日 01-31 のゼロ詰め 2 桁、枝番は先頭ゼロ不可の 1 以上まで一本でガードする。 */


### PR DESCRIPTION
## リリース 2026.06.30-2

### 内容 (#235)
投稿画像を X (Twitter) 風に刷新:
- **枚数別フル幅グリッド**: 1枚=自然比 / 2枚=左右 / 3枚=左大+右2縦 / 4枚=2×2。aspect-ratio で高さ確定 (ロード時のガタつき無し)、最大幅510px、角丸8px。
- **ライトボックス指追従カルーセル**: touch-action:none で縦スクロールにスワイプを奪われず、指追従でスライドイン。

### §1.5 レビュー
X グリッド 2並列 (実装/UX) + カルーセル focused、★★★ ゼロ・★★ 全対応。実機 (dev) 確認済み。

### リリース後の確認
- APP_VERSION 2026.06.30-2
- 画像1〜4枚の表示、スワイプ (スクロールに奪われない)、PC で画像が巨大化しない