### PR TITLE
fix(notifications): 通知を見ても赤ポッチが消えない問題を修正

### DIFF
--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -8,6 +8,7 @@ import { useSession } from '@/lib/session';
 import { getUnreadNotificationCount } from '@/lib/atproto';
 import { useVisibleColumn } from '@/lib/visible-column';
 import { useQuestActionableCount, computeQuestActionableCount, setQuestActionableCount } from '@/lib/quest-actionable';
+import { subscribeNotificationsSeen } from '@/lib/notification-seen';
 import { useRuntimeConfig } from '@/components/config-provider';
 import type { AppColumnKind } from '@/lib/app-columns';
 
@@ -140,12 +141,17 @@ export function AppShell() {
     };
   }, [session.status, session.agent, session.did, directoryKey]);
 
-  // 通知タブを開いた瞬間にバッジを消す
+  // 通知タブ (ルート) を開いた瞬間にバッジを消す
   useEffect(() => {
     if (location.pathname === '/notifications' && unread > 0) {
       setUnread(0);
     }
   }, [location.pathname, unread]);
+
+  // 通知を既読化した瞬間 (NotificationsFeed が updateSeen を撃ったとき) にバッジを消す。
+  // モバイルはカラム (swipe, pathname='/') で通知を見るのでルート判定だけでは消えず、
+  // 60 秒 poll まで赤ポッチが残っていた。既読化イベントに直結させて即消す。
+  useEffect(() => subscribeNotificationsSeen(() => setUnread(0)), []);
 
   const onWorkspace = location.pathname === '/';
   // 投稿 FAB は、入力フォーム/認証系などタイムラインでない画面では出さない

--- a/apps/web/src/lib/atproto.ts
+++ b/apps/web/src/lib/atproto.ts
@@ -197,15 +197,19 @@ export async function getUnreadNotificationCount(agent: Agent): Promise<number> 
   }
 }
 
-/** 通知を見たことをサーバーに通知 (これで getUnreadCount が 0 に戻る)。 */
+/** 通知を見たことをサーバーに通知 (これで getUnreadCount が 0 に戻る)。
+ *  成功したら true。呼び出し側はこれを見て未読バッジの楽観クリアを成功時に限定できる
+ *  (失敗時にクリアすると次の poll でサーバの未読を拾い直しバッジが復活してしまうため)。 */
 export async function updateNotificationsSeen(
   agent: Agent,
   seenAt: string = new Date().toISOString(),
-): Promise<void> {
+): Promise<boolean> {
   try {
     await agent.app.bsky.notification.updateSeen({ seenAt });
+    return true;
   } catch (e) {
     console.warn('[notifications] updateSeen failed', e);
+    return false;
   }
 }
 

--- a/apps/web/src/lib/notification-seen.ts
+++ b/apps/web/src/lib/notification-seen.ts
@@ -1,0 +1,23 @@
+/**
+ * 「通知を既読化した」ことを app 全体に知らせる軽量シグナル (visible-column と同じ pattern)。
+ *
+ * NotificationsFeed が updateSeen を撃った (= 実際にサーバへ既読を送った、dwell 判定済み) 直後に
+ * publish し、AppShell が subscribe して未読バッジ (赤ポッチ) を即 0 にする。
+ *
+ * これが無いと、モバイルで通知を**カラム (swipe, pathname は '/')** で見たとき、AppShell の
+ * ローカル未読は `/notifications` ルートでしか消えず、次の 60 秒 poll まで赤ポッチが残る
+ * (= 「見ても消えない」体感)。ルートに依らずカラム閲覧でも即消すためのイベント。
+ */
+const subscribers = new Set<() => void>();
+
+/** 既読化した (updateSeen 済み)。購読者 (AppShell) にバッジ 0 を促す。 */
+export function publishNotificationsSeen(): void {
+  for (const fn of subscribers) {
+    try { fn(); } catch { /* no-op */ }
+  }
+}
+
+export function subscribeNotificationsSeen(cb: () => void): () => void {
+  subscribers.add(cb);
+  return () => { subscribers.delete(cb); };
+}

--- a/apps/web/src/routes/notifications.tsx
+++ b/apps/web/src/routes/notifications.tsx
@@ -103,7 +103,8 @@ export function NotificationsFeed({ markSeen = false }: { markSeen?: boolean }) 
     // 無ければ updateNotificationsSeen 既定の now に落ちる。既読化できたら app 全体へ通知して
     // 未読バッジを即クリアする (モバイルのカラム閲覧でも消えるように)。
     const latest = feed.items[0]?.indexedAt;
-    void updateNotificationsSeen(agent, latest).then(() => publishNotificationsSeen());
+    // 成功時のみ publish (= サーバ反映後だけ楽観クリア。失敗時にクリアすると poll で復活する)。
+    void updateNotificationsSeen(agent, latest).then((ok) => { if (ok) publishNotificationsSeen(); });
   }, [shouldMarkSeen, agent, feed.items.length, feed.done]);
 
   const groups = useMemo(() => groupNotifications(feed.items), [feed.items]);

--- a/apps/web/src/routes/notifications.tsx
+++ b/apps/web/src/routes/notifications.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import type { AppBskyFeedDefs } from '@atproto/api';
 import { useSession } from '@/lib/session';
 import { fetchPosts, listNotifications, updateNotificationsSeen } from '@/lib/atproto';
+import { publishNotificationsSeen } from '@/lib/notification-seen';
 import { useInfiniteFeed } from '@/lib/use-infinite-feed';
 import { VirtualFeed } from '@/components/virtual-feed';
 import { NotificationItem } from '@/components/notification-item';
@@ -97,7 +98,12 @@ export function NotificationsFeed({ markSeen = false }: { markSeen?: boolean }) 
     if (seenSent.current) return;
     if (feed.items.length === 0 && !feed.done) return;
     seenSent.current = true;
-    void updateNotificationsSeen(agent);
+    // seenAt は最新通知の indexedAt (サーバ時刻) を使い、client 時計ズレで直近通知が
+    // 未読のまま残る (getUnreadCount が拾い続ける) のを防ぐ。items は新しい順なので [0] が最新。
+    // 無ければ updateNotificationsSeen 既定の now に落ちる。既読化できたら app 全体へ通知して
+    // 未読バッジを即クリアする (モバイルのカラム閲覧でも消えるように)。
+    const latest = feed.items[0]?.indexedAt;
+    void updateNotificationsSeen(agent, latest).then(() => publishNotificationsSeen());
   }, [shouldMarkSeen, agent, feed.items.length, feed.done]);
 
   const groups = useMemo(() => groupNotifications(feed.items), [feed.items]);


### PR DESCRIPTION
## 背景
「通知を見ても赤ポッチが消えないことが結構ある」報告。

## 原因
1. app-shell のローカル未読は **`/notifications` ルートでしか消えていなかった**。モバイルは通知をカラム (swipe, pathname='/') で見るため消えず、次の 60 秒 poll 待ちで残っていた。
2. `updateSeen` が client の `new Date()` を seenAt にしていたため、端末の時計がサーバより遅れていると直近通知が `indexedAt > seenAt` で未読のまま残り poll で復活していた。

## 修正
- `notification-seen.ts` (pub/sub) 新設。NotificationsFeed が updateSeen 成功後に publish → app-shell が subscribe して未読バッジを即 0 に (ルート/カラムどちらの閲覧でも消える)。
- updateSeen の seenAt に**最新通知の indexedAt (サーバ時刻)** を渡し時計ズレを解消。
- updateNotificationsSeen を Promise<boolean> にし、**成功時 (サーバ反映後) のみ楽観クリア**。失敗時はクリアせず poll に委ねる。

## Review (§1.5 focused: 実装・正確性)
- **★★★/★★ なし** (最終)。seenAt=最新indexedAt の境界 (`>` 排他で最新は既読・新着は未読)、pub/sub の購読解除、seenSent ガードと両経路(ルート/カラム600ms dwell)での publish、二重クリアの冪等性、後方互換 (updateNotificationsSeen の呼び出しは1箇所) を確認。
- ★★ (楽観クリアが失敗時も走る) → updateNotificationsSeen を boolean 化し成功時のみ publish に修正 (commit 7c0a146)。
- typecheck + unit(222) + build green。dev デプロイ済み。