### PR TITLE
release: 2026.07.08-1 — 今日のクエストをアコーディオンで畳める

### DIFF
--- a/apps/web/src/components/home-summary.tsx
+++ b/apps/web/src/components/home-summary.tsx
@@ -8,6 +8,7 @@ import { PersonIcon, ScrollIcon } from './icons';
 import { SpiritBubble } from './spirit-bubble';
 import { useOnPosted } from './compose-modal';
 import { ensureTodayQuestLog, loadTodayQuestLog, type ActivityEntry, type QuestLogRecord } from '@/lib/post-processor';
+import { getDailyQuestsOpen, setDailyQuestsOpen } from '@/lib/prefs';
 import { formatTime } from '@/lib/format-datetime';
 
 interface HomeSummaryProps {
@@ -31,6 +32,10 @@ interface HomeSummaryProps {
  */
 export function HomeSummary({ agent, diag, userDid, targetStats }: HomeSummaryProps) {
   const [open, setOpen] = useState(false);
+  // 「今日のクエスト」アコーディオンの開閉。localStorage に永続化し次回もその状態で開く。
+  const [questsOpen, setQuestsOpen] = useState(getDailyQuestsOpen);
+  // setState の updater 内で副作用を呼ばない (StrictMode 二重実行対策)。現在値から反転する。
+  const toggleQuests = () => { const nv = !questsOpen; setQuestsOpen(nv); setDailyQuestsOpen(nv); };
   const [questLog, setQuestLog] = useState<QuestLogRecord | null>(null);
 
   const generatedQuests: Quest[] = useMemo(() => {
@@ -153,8 +158,9 @@ export function HomeSummary({ agent, diag, userDid, targetStats }: HomeSummaryPr
         )}
       </div>
 
-      {/* 動的: 今日のクエスト。常に全件表示する (折り畳み時はコンパクト 1 行、
-          展開時はカード表示)。クエスト内容を隠さないのがオーナー方針。 */}
+      {/* 動的: 今日のクエスト。見出しのアコーディオンで完全に畳める (開閉は永続化)。
+          展開時は静的サマリの開閉 (open) に応じてコンパクト 1 行 / カード表示。
+          畳むのはユーザーの明示操作のみで、既定は展開 (= 内容を勝手に隠さない)。 */}
       {!targetStats ? (
         <div style={{ fontSize: '0.85em' }}>
           <p style={{ margin: '0 0 0.3em' }}>
@@ -168,19 +174,46 @@ export function HomeSummary({ agent, diag, userDid, targetStats }: HomeSummaryPr
           const visible = [...incomplete, ...done];
           return (
             <div>
-              <div style={{ fontSize: '0.8em', color: 'var(--color-muted)', marginBottom: '0.3em', display: 'flex', gap: '0.6em' }}>
+              {/* 今日のクエストのアコーディオン見出し (タップで完全に畳む / 開く、状態は永続化)。 */}
+              <button
+                type="button"
+                onClick={toggleQuests}
+                aria-expanded={questsOpen}
+                aria-controls="daily-quests-panel"
+                style={{
+                  width: '100%',
+                  background: 'transparent',
+                  border: 'none',
+                  padding: '0.1em 0',
+                  font: 'inherit',
+                  color: 'var(--color-muted)',
+                  cursor: 'pointer',
+                  boxShadow: 'none',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '0.6em',
+                  fontSize: '0.8em',
+                }}
+              >
                 <span>今日のクエスト</span>
-                {done.length > 0 && (
-                  <span style={{ color: 'var(--color-accent)' }}>達成 {done.length}/{quests.length}</span>
+                {/* 進捗サマリ: 展開時は達成があるときだけ、畳み時は常に「達成 X/Y」を出して
+                    開かなくても状況が分かるようにする (達成0でも 0/Y を表示 = 左右対称)。 */}
+                {(done.length > 0 || !questsOpen) && (
+                  <span style={{ color: done.length > 0 ? 'var(--color-accent)' : 'var(--color-muted)' }}>
+                    達成 {done.length}/{quests.length}
+                  </span>
                 )}
-              </div>
-              <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: open ? '0.35em' : '0.2em' }}>
-                {visible.map((q, i) => (
-                  <li key={q.id}>
-                    <QuestRow quest={q} showIcon={i === 0} compact={!open} />
-                  </li>
-                ))}
-              </ul>
+                <span style={{ marginLeft: 'auto' }}>{questsOpen ? '▾' : '▸'}</span>
+              </button>
+              {questsOpen && (
+                <ul id="daily-quests-panel" style={{ listStyle: 'none', padding: 0, margin: '0.3em 0 0', display: 'flex', flexDirection: 'column', gap: open ? '0.35em' : '0.2em' }}>
+                  {visible.map((q, i) => (
+                    <li key={q.id}>
+                      <QuestRow quest={q} showIcon={i === 0} compact={!open} />
+                    </li>
+                  ))}
+                </ul>
+              )}
             </div>
           );
         })() : null}

--- a/apps/web/src/lib/app-version.ts
+++ b/apps/web/src/lib/app-version.ts
@@ -12,7 +12,7 @@
  *   3. 同じ値で git tag を打つ:
  *        git tag v2026.06.14-1 && git push origin v2026.06.14-1
  */
-export const APP_VERSION = '2026.07.07-1';
+export const APP_VERSION = '2026.07.08-1';
 
 /** APP_VERSION が `YYYY.MM.DD-N` 形式かを検証する (テスト/CI で形式崩れを検出)。
  *  月 01-12 / 日 01-31 のゼロ詰め 2 桁、枝番は先頭ゼロ不可の 1 以上まで一本でガードする。 */

--- a/apps/web/src/lib/prefs.ts
+++ b/apps/web/src/lib/prefs.ts
@@ -59,6 +59,27 @@ export function setHideReposts(v: boolean): void {
   }
 }
 
+const KEY_DAILY_QUESTS_OPEN = 'aozoraquest:dailyQuestsOpen';
+
+/** ホームの「今日のクエスト」を展開表示するか。デフォルト ON (= 従来どおり表示)。
+ *  ユーザーがアコーディオンで畳んだら false を覚え、次回もその状態で開く。 */
+export function getDailyQuestsOpen(): boolean {
+  try {
+    // 未設定 (null) は既定の true。明示的に 'false' のときだけ畳む。
+    return localStorage.getItem(KEY_DAILY_QUESTS_OPEN) !== 'false';
+  } catch {
+    return true;
+  }
+}
+
+export function setDailyQuestsOpen(v: boolean): void {
+  try {
+    localStorage.setItem(KEY_DAILY_QUESTS_OPEN, String(v));
+  } catch {
+    /* no-op */
+  }
+}
+
 const KEY_FONT_SCALE = 'aozoraquest:fontScale';
 export const FONT_SCALE_MIN = 50;
 export const FONT_SCALE_MAX = 150;


### PR DESCRIPTION
## リリース 2026.07.08-1

### 内容 (#241)
ホーム上部の「今日のクエスト」を**アコーディオンで完全に畳める**ように + **開閉状態を localStorage で永続化**。畳み時は見出しに「達成 X/Y」を表示。既定は展開 (従来どおり)。

### §1.5 レビュー
focused (実装+UX) ★★★ なし、★★2件(矛盾コメント/aria-controls)+★2件を PR 内対応。後方互換 (未設定ユーザーは展開のまま)。

### リリース後の確認
- APP_VERSION 2026.07.08-1
- ホームで「今日のクエスト」見出しタップ → 完全に畳める・リロードしても開閉が記憶される