### PR TITLE
release: 2026.07.10-1 — 初回表示の体感高速化

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -7,6 +7,27 @@
        を有効化して iOS ホームインジケータと被らないようにするため (footer の padding-bottom 参照)。 -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="theme-color" content="#378ADD">
+
+  <!-- 初回データ/画像取得先へ preconnect (DNS+TCP+TLS を JS パースと並行で前倒し)。
+       公開 AppView・画像 CDN・多数派 PDS ホスト。ユーザーの PDS が別ホストでも無害。 -->
+  <link rel="preconnect" href="https://public.api.bsky.app" crossorigin>
+  <link rel="preconnect" href="https://cdn.bsky.app" crossorigin>
+  <link rel="preconnect" href="https://bsky.social" crossorigin>
+
+  <!-- 即時スプラッシュ: JS バンドル (~2MB) のパース完了まで #root は空でブランクになる。
+       ここに軽量 splash を置くと「開いた瞬間に何か出る」体感になる。
+       splash は #root の兄弟 (下記) なので createRoot では消えない。lib/splash.ts の
+       removeSplash() が session 復元完了時 (AppShell) にフェード除去する。 -->
+  <style>
+    #app-splash { position: fixed; inset: 0; z-index: 9999; display: flex; flex-direction: column;
+      align-items: center; justify-content: center; gap: 1.1em;
+      background: linear-gradient(to bottom, #4aa6e2 0%, #7cc7ea 40%, #bee3f1 62%, #9dd07f 63%, #6fb052 82%, #3f7a32 100%);
+      color: #fff; font-family: 'Hiragino Maru Gothic ProN', 'Hiragino Maru Gothic Pro', 'Noto Sans JP', sans-serif; }
+    #app-splash .t { font-size: 1.55em; font-weight: 700; letter-spacing: .01em; text-shadow: 2px 2px 0 rgba(10,20,60,.35); }
+    #app-splash .s { width: 26px; height: 26px; border: 3px solid rgba(255,255,255,.4); border-top-color: #fff;
+      border-radius: 50%; animation: aq-spin .8s linear infinite; }
+    @keyframes aq-spin { to { transform: rotate(360deg); } }
+  </style>
   <title>あおぞらくえすと</title>
   <meta name="description" content="Bluesky の投稿から、今のあなたをジョブとステータスで可視化。毎日のクエストで、目指す姿へ。" />
 
@@ -50,6 +71,11 @@
 </head>
 <body>
   <div id="root"></div>
+  <!-- #root の兄弟に置き、React マウント後 main.tsx が除去する (createRoot は空の #root に描画)。 -->
+  <div id="app-splash">
+    <div class="t">あおぞらくえすと</div>
+    <div class="s"></div>
+  </div>
   <script type="module" src="/src/main.tsx"></script>
 </body>
 </html>

--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type MouseEvent } from 'react';
+import { Suspense, useEffect, useRef, useState, type MouseEvent } from 'react';
 import { NavLink, Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { openComposePane, toggleComposePane, useComposePaneOpen } from '@/lib/compose-pane';
 import { BellIcon, BrusukonIcon, ComposeIcon, HomeIcon, PersonIcon, ScrollIcon, SearchIcon, SettingsIcon } from './icons';
@@ -7,6 +7,7 @@ import { composeFabAllowedOnPath } from '@/lib/compose-fab';
 import { useSession } from '@/lib/session';
 import { getUnreadNotificationCount } from '@/lib/atproto';
 import { useVisibleColumn } from '@/lib/visible-column';
+import { removeSplash } from '@/lib/splash';
 import { useQuestActionableCount, computeQuestActionableCount, setQuestActionableCount } from '@/lib/quest-actionable';
 import { subscribeNotificationsSeen } from '@/lib/notification-seen';
 import { useRuntimeConfig } from '@/components/config-provider';
@@ -49,6 +50,12 @@ export function AppShell() {
   // 自分のアクション待ちクエスト件数 (承認待ち + 完了報告待ち)。クエストタブに赤カウント表示。
   const questActionable = useQuestActionableCount();
   const runtimeConfig = useRuntimeConfig();
+
+  // セッション復元が終わって実コンテンツを描画できる状態になったら、即時スプラッシュを
+  // 滑らかに除去する (JS パース + 復元の間は 1 枚のまま維持し「準備しています…」を挟まない)。
+  useEffect(() => {
+    if (session.status !== 'loading') removeSplash();
+  }, [session.status]);
   const visibleKind = useVisibleColumn();
   const headerRef = useRef<HTMLElement>(null);
   const footerRef = useRef<HTMLElement>(null);
@@ -189,7 +196,10 @@ export function AppShell() {
         <strong>あおぞらくえすと</strong>
       </header>
       <main className="content">
-        <Outlet />
+        {/* ルートは lazy 分割 (main.tsx)。チャンク取得中の簡素なフォールバック。 */}
+        <Suspense fallback={<div style={{ padding: '1em', fontSize: '0.85em', color: 'var(--color-muted)' }}>読み込み中…</div>}>
+          <Outlet />
+        </Suspense>
       </main>
       {showComposeFab && (
         <button

--- a/apps/web/src/components/column-content/index.tsx
+++ b/apps/web/src/components/column-content/index.tsx
@@ -5,13 +5,19 @@
  *  - PR 3: notifications / search / profile
  *  - PR 4: board (本 PR で全 kind 実装完了)
  */
+import { lazy, Suspense } from 'react';
 import type { AppColumn } from '@/lib/app-columns';
 import { HomeColumn } from './home-column';
 import { BarColumn } from './bar-column';
-import { BoardColumn } from './board-column';
-import { NotificationsFeed } from '@/routes/notifications';
-import { SearchPanel } from '@/routes/search';
-import { ProfileView } from '@/routes/profile';
+// 初回表示はホームが主役。非ホームカラム (board/通知/検索/profile) は lazy 分割して
+// 初期チャンクから外し、ホームの feed 描画がこれらのコードを待たないようにする。
+// (ルート側 main.tsx と同じモジュールを指すので chunk は共有 = 二重取得しない)
+const BoardColumn = lazy(() => import('./board-column').then((m) => ({ default: m.BoardColumn })));
+const NotificationsFeed = lazy(() => import('@/routes/notifications').then((m) => ({ default: m.NotificationsFeed })));
+const SearchPanel = lazy(() => import('@/routes/search').then((m) => ({ default: m.SearchPanel })));
+const ProfileView = lazy(() => import('@/routes/profile').then((m) => ({ default: m.ProfileView })));
+
+const COL_FALLBACK = <div style={{ padding: '1em', fontSize: '0.85em', color: 'var(--color-muted)' }}>読み込み中…</div>;
 
 export function ColumnContent({
   column,
@@ -30,31 +36,35 @@ export function ColumnContent({
     case 'notifications':
       // markSeen は渡さない (= カラム表示では既読化しない。通知ページを
       // 開いたときだけ既読化する。可視判定ベースは PR 5)
-      return <NotificationsFeed />;
+      return <Suspense fallback={COL_FALLBACK}><NotificationsFeed /></Suspense>;
     case 'search':
       return (
         // key は column.id のみ (param を含めると検索のたび remount して
         // 結果がチラつく)。カラム内の再検索は onSearch → onPatch で
         // column.param に書き戻し、ヘッダータイトルが追従する (issue #35)
-        <SearchPanel
-          key={column.id}
-          {...(column.param !== undefined ? { initialQuery: column.param } : {})}
-          {...(column.mode !== undefined ? { initialMode: column.mode } : {})}
-          {...(onPatch
-            ? { onSearch: (q: string, mode: 'posts' | 'users') => onPatch({ param: q, mode } as Partial<AppColumn>) }
-            : {})}
-        />
+        <Suspense fallback={COL_FALLBACK}>
+          <SearchPanel
+            key={column.id}
+            {...(column.param !== undefined ? { initialQuery: column.param } : {})}
+            {...(column.mode !== undefined ? { initialMode: column.mode } : {})}
+            {...(onPatch
+              ? { onSearch: (q: string, mode: 'posts' | 'users') => onPatch({ param: q, mode } as Partial<AppColumn>) }
+              : {})}
+          />
+        </Suspense>
       );
     case 'profile':
       return column.param ? (
         // profile はカラム内で actor を変える UI がないため、外部編集 =
         // remount でよい (key に param を含める)
-        <ProfileView key={`${column.id}:${column.param}`} actor={column.param} />
+        <Suspense fallback={COL_FALLBACK}>
+          <ProfileView key={`${column.id}:${column.param}`} actor={column.param} />
+        </Suspense>
       ) : (
         <MissingParam label="プロフィール" hint="表示するユーザーの指定がありません。「＋ カラムを追加」からハンドルを指定して追加し直してください。" />
       );
     case 'board':
-      return <BoardColumn inner={column.inner} />;
+      return <Suspense fallback={COL_FALLBACK}><BoardColumn inner={column.inner} /></Suspense>;
   }
 }
 

--- a/apps/web/src/lib/app-version.ts
+++ b/apps/web/src/lib/app-version.ts
@@ -12,7 +12,7 @@
  *   3. 同じ値で git tag を打つ:
  *        git tag v2026.06.14-1 && git push origin v2026.06.14-1
  */
-export const APP_VERSION = '2026.07.08-2';
+export const APP_VERSION = '2026.07.10-1';
 
 /** APP_VERSION が `YYYY.MM.DD-N` 形式かを検証する (テスト/CI で形式崩れを検出)。
  *  月 01-12 / 日 01-31 のゼロ詰め 2 桁、枝番は先頭ゼロ不可の 1 以上まで一本でガードする。 */

--- a/apps/web/src/lib/session.ts
+++ b/apps/web/src/lib/session.ts
@@ -118,14 +118,23 @@ async function setStateFromSession(
   }
   if (isCancelled()) return;
 
+  // ハンドル取得 (getProfile) は**表示に必須でない**ので待たない。先に signed-in にして
+  // workspace を描画させ (= 「準備しています」を早く抜けフィード/キャッシュを出す)、handle は
+  // バックグラウンドで取得して来たら足す。これで初回表示のブロッキングから 1 往復ぶん外れる。
   const next: SessionState = { status: 'signed-in', did, agent };
-  // 公開 AppView から引く: PDS 経由の getProfile は初期化直後に 401 が出ることがある
-  try {
-    const publicAgent = new AtpAgent({ service: PUBLIC_APPVIEW });
-    const profile = await publicAgent.getProfile({ actor: did });
-    if (profile.data.handle) next.handle = profile.data.handle;
-  } catch (e) {
-    console.warn('getProfile failed', e);
-  }
   if (!isCancelled()) setState(next);
+
+  void (async () => {
+    try {
+      // 公開 AppView から引く: PDS 経由の getProfile は初期化直後に 401 が出ることがある
+      const publicAgent = new AtpAgent({ service: PUBLIC_APPVIEW });
+      const profile = await publicAgent.getProfile({ actor: did });
+      if (!isCancelled() && profile.data.handle) {
+        // agent は同一 instance のまま handle だけ足して更新 (下流の再 fetch は起きない)。
+        setState({ ...next, handle: profile.data.handle });
+      }
+    } catch (e) {
+      console.warn('getProfile failed', e);
+    }
+  })();
 }

--- a/apps/web/src/lib/splash.ts
+++ b/apps/web/src/lib/splash.ts
@@ -1,0 +1,17 @@
+/**
+ * index.html の即時スプラッシュ (#app-splash) を滑らかにフェードして除去する。
+ *
+ * 呼ぶタイミングは「アプリが実際に表示できる状態になったとき」(= session.status が
+ * loading を抜けたとき、AppShell から)。これで JS パース + セッション復元の間ずっと
+ * 1 枚のスプラッシュが出続け、「準備しています…」のちらつき (二重ローディング) を避ける。
+ * main.tsx はハング保険として最大待ち時間後に強制除去する。二重呼び出しは data 属性でガード。
+ */
+export function removeSplash(): void {
+  const el = document.getElementById('app-splash');
+  if (!el || el.dataset.removing) return;
+  el.dataset.removing = '1';
+  el.style.transition = 'opacity 0.32s ease';
+  el.style.opacity = '0';
+  el.style.pointerEvents = 'none';
+  window.setTimeout(() => el.remove(), 340);
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,34 +1,39 @@
-import { StrictMode } from 'react';
+import { StrictMode, lazy } from 'react';
 import { createRoot } from 'react-dom/client';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import { Workspace } from '@/components/workspace';
-import { Profile } from '@/routes/profile';
-import { MyProfile } from '@/routes/me';
-import { Friends } from '@/routes/friends';
-import { Card } from '@/routes/card';
-import { PostDetail } from '@/routes/post-detail';
-import { Notifications } from '@/routes/notifications';
-import { Quests } from '@/routes/quests';
-import { Search } from '@/routes/search';
-import { Settings } from '@/routes/settings';
-import { Spirit } from '@/routes/spirit';
-import { Onboarding } from '@/routes/onboarding';
-import { OAuthCallback } from '@/routes/oauth-callback';
-import { Tos } from '@/routes/tos';
-import { Privacy } from '@/routes/privacy';
-import { Board } from '@/routes/board';
-import { BoardNew } from '@/routes/board-new';
-import { BoardDetail, BoardDetailLegacyRedirect } from '@/routes/board-detail';
-import { Portfolio, PublicPortfolio } from '@/routes/portfolio';
-import { DebugCard } from '@/routes/debug-card';
-import { DebugRadar } from '@/routes/debug-radar';
-import { DebugMe } from '@/routes/debug-me';
+// 初回に必要な shell + workspace(ホーム) だけ eager。それ以外のルートは lazy 分割して
+// 初期バンドルから外す (初回表示の JS を軽くする)。named export を default に写す。
+const Profile = lazy(() => import('@/routes/profile').then(m => ({ default: m.Profile })));
+const MyProfile = lazy(() => import('@/routes/me').then(m => ({ default: m.MyProfile })));
+const Friends = lazy(() => import('@/routes/friends').then(m => ({ default: m.Friends })));
+const Card = lazy(() => import('@/routes/card').then(m => ({ default: m.Card })));
+const PostDetail = lazy(() => import('@/routes/post-detail').then(m => ({ default: m.PostDetail })));
+const Notifications = lazy(() => import('@/routes/notifications').then(m => ({ default: m.Notifications })));
+const Quests = lazy(() => import('@/routes/quests').then(m => ({ default: m.Quests })));
+const Search = lazy(() => import('@/routes/search').then(m => ({ default: m.Search })));
+const Settings = lazy(() => import('@/routes/settings').then(m => ({ default: m.Settings })));
+const Spirit = lazy(() => import('@/routes/spirit').then(m => ({ default: m.Spirit })));
+const Onboarding = lazy(() => import('@/routes/onboarding').then(m => ({ default: m.Onboarding })));
+const OAuthCallback = lazy(() => import('@/routes/oauth-callback').then(m => ({ default: m.OAuthCallback })));
+const Tos = lazy(() => import('@/routes/tos').then(m => ({ default: m.Tos })));
+const Privacy = lazy(() => import('@/routes/privacy').then(m => ({ default: m.Privacy })));
+const Board = lazy(() => import('@/routes/board').then(m => ({ default: m.Board })));
+const BoardNew = lazy(() => import('@/routes/board-new').then(m => ({ default: m.BoardNew })));
+const BoardDetail = lazy(() => import('@/routes/board-detail').then(m => ({ default: m.BoardDetail })));
+const BoardDetailLegacyRedirect = lazy(() => import('@/routes/board-detail').then(m => ({ default: m.BoardDetailLegacyRedirect })));
+const Portfolio = lazy(() => import('@/routes/portfolio').then(m => ({ default: m.Portfolio })));
+const PublicPortfolio = lazy(() => import('@/routes/portfolio').then(m => ({ default: m.PublicPortfolio })));
+const DebugCard = lazy(() => import('@/routes/debug-card').then(m => ({ default: m.DebugCard })));
+const DebugRadar = lazy(() => import('@/routes/debug-radar').then(m => ({ default: m.DebugRadar })));
+const DebugMe = lazy(() => import('@/routes/debug-me').then(m => ({ default: m.DebugMe })));
 import { AppShell } from '@/components/app-shell';
 import { SessionProvider } from '@/components/session-provider';
 import { ConfigProvider } from '@/components/config-provider';
 import { ComposeProvider } from '@/components/compose-modal';
 import { initFontScale } from '@/lib/font-scale';
 import { initTheme } from '@/lib/theme';
+import { removeSplash } from '@/lib/splash';
 import '@/styles.css';
 
 initFontScale();
@@ -94,3 +99,8 @@ createRoot(document.getElementById('root')!).render(
     </ConfigProvider>
   </StrictMode>,
 );
+
+// スプラッシュ (index.html) は通常 AppShell が session 復元完了時に除去する
+// (JS パース + 復元の間ずっと 1 枚出続け、「準備しています…」のちらつきを避ける)。
+// ここはハング保険: 復元が異常に長い/失敗しても最大 12s でスプラッシュを剥がす。
+setTimeout(removeSplash, 12000);

--- a/apps/web/src/routes/card.tsx
+++ b/apps/web/src/routes/card.tsx
@@ -168,7 +168,12 @@ export function Card() {
       }
     })();
     return () => { cancelled = true; };
-  }, [session.status, session.agent, session.did, session.handle]);
+    // session.handle は effect 内で profile?.handle のフォールバック表示にしか使わない。
+    // dep に入れると、handle が signed-in の後に背景取得で届いたとき (session.ts の
+    // getProfile 非ブロッキング化) にカードの全ロード (~500 posts scan 含む) が再発火して
+    // しまうため、意図的に dep から外す。表示 handle は effect 自身が引く profile が主。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [session.status, session.agent, session.did]);
 
   const result = load.status === 'ready' ? load.result : null;
   const profile = load.status === 'ready' ? load.profile : null;

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -60,5 +60,26 @@ export default defineConfig({
     outDir: 'dist',
     target: 'es2022',
     sourcemap: true,
+    rollupOptions: {
+      output: {
+        // 変化の少ない大物ライブラリを安定した vendor チャンクに分離する。
+        // これで app コードだけ変えてデプロイしたとき、返ってきたユーザーは巨大な
+        // @atproto/api (Bluesky lexicon 一式) を再ダウンロードせずキャッシュを使える
+        // (=頻繁なデプロイでも表示が速い)。/assets/* は immutable キャッシュ済み。
+        manualChunks(id) {
+          if (!id.includes('node_modules')) return undefined;
+          if (id.includes('@atproto')) return 'vendor-atproto';
+          if (
+            id.includes('/react-dom/') ||
+            id.includes('/react/') ||
+            id.includes('/react-router') ||
+            id.includes('/scheduler/')
+          ) {
+            return 'vendor-react';
+          }
+          return undefined;
+        },
+      },
+    },
   },
 });


### PR DESCRIPTION
## リリース 2026.07.10-1

### 内容 (#247)
初回表示の体感高速化: ルート/カラム lazy 分割 + vendor 分離、即時スプラッシュ + preconnect、session 復元の getProfile 非ブロッキング化 (「準備しています」短縮)、二重ローディング解消 (スプラッシュ 1 枚 + 滑らかフェード)。

### §1.5
focused レビュー ★★★ なし。★★ (card 再フェッチ) / ★ (コメント) 対応済み。session boot・splash・lazy・CSP 確認。dev でオーナー体感確認済み。