### PR TITLE
feat(post): 引用投稿 (bsky.app リンクのぶら下げ) をインライン表示

### DIFF
--- a/apps/web/src/components/post-article.tsx
+++ b/apps/web/src/components/post-article.tsx
@@ -10,7 +10,7 @@ import { RepeatIcon } from './icons';
 import { CognitiveTriggerIcon, CognitiveScores } from './post-cognitive-badge';
 import { useCognitiveAnalysis } from '@/lib/post-cognitive';
 import { displayWidth } from '@/lib/text-width';
-import { extractPostExternal, extractPostImages, extractPostVideo } from '@/lib/post-embed';
+import { extractPostExternal, extractPostImages, extractPostQuote, extractPostVideo } from '@/lib/post-embed';
 
 /** 名前がこの表示幅を超えたら、タイムラインでは @handle を畳む (折り返し防止)。 */
 const HANDLE_HIDE_WIDTH = 18;
@@ -147,6 +147,7 @@ export function PostArticle({
         images={extractPostImages(post)}
         external={extractPostExternal(post)}
         video={extractPostVideo(post)}
+        quote={extractPostQuote(post)}
         postUri={post.uri}
         {...(record.langs ? { langs: record.langs } : {})}
       />

--- a/apps/web/src/components/post-body.tsx
+++ b/apps/web/src/components/post-body.tsx
@@ -1,8 +1,9 @@
 import { useState, type CSSProperties } from 'react';
-import type { PostExternal, PostImage, PostVideo } from '@/lib/post-embed';
+import type { PostExternal, PostImage, PostQuote, PostVideo } from '@/lib/post-embed';
 import { PostText, type Facet } from './post-text';
 import { PostImages } from './post-images';
 import { PostExternalCard } from './post-external';
+import { PostQuoteCard } from './post-quote';
 import { PostVideoCard } from './post-video';
 import { YoutubeEmbed } from './youtube-embed';
 import { youtubeId } from '@/lib/youtube';
@@ -24,6 +25,8 @@ export interface PostBodyProps {
   images?: PostImage[] | undefined;
   external?: PostExternal | null | undefined;
   video?: PostVideo | null | undefined;
+  /** 引用投稿 (app.bsky.embed.record#view 相当)。あれば本文下にカード表示。 */
+  quote?: PostQuote | null | undefined;
   /** 翻訳キャッシュのキー兼有無判定に使う。profile の RecentPosts など
    *  URI が無い場面では翻訳機能を無効化する。 */
   postUri?: string | undefined;
@@ -33,7 +36,7 @@ export interface PostBodyProps {
   topMargin?: CSSProperties['marginTop'];
 }
 
-export function PostBody({ text, facets, images, external, video, postUri, langs, topMargin = '0.45em' }: PostBodyProps) {
+export function PostBody({ text, facets, images, external, video, quote, postUri, langs, topMargin = '0.45em' }: PostBodyProps) {
   const hasImages = images && images.length > 0;
   const { state, translated, error, triggerTranslate, retranslate, isNonJapanese } = useTranslation(postUri, text, langs);
   const [showOriginal, setShowOriginal] = useState(false);
@@ -84,6 +87,7 @@ export function PostBody({ text, facets, images, external, video, postUri, langs
         <YoutubeEmbed id={ytId} {...(external.title ? { title: external.title } : {})} {...(external.thumb ? { thumb: external.thumb } : {})} />
       )}
       {external && !ytId && <PostExternalCard external={external} />}
+      {quote && <PostQuoteCard quote={quote} />}
     </>
   );
 }

--- a/apps/web/src/components/post-quote.tsx
+++ b/apps/web/src/components/post-quote.tsx
@@ -1,0 +1,100 @@
+import type { CSSProperties } from 'react';
+import { useNavigate } from 'react-router-dom';
+import type { PostQuote } from '@/lib/post-embed';
+import { didFromUri, postDetailPath } from '@/lib/uri';
+import { Avatar } from './avatar';
+import { PostText } from './post-text';
+
+/**
+ * 引用投稿カード (Bluesky 本家の「ぶら下げ」表示相当)。
+ *
+ * カード全体をタップすると引用先投稿へ**内部遷移**する。ただし外側を `<a>`/`<Link>`
+ * で包むと、本文中の mention/リンク (これも `<a>`) が入れ子アンカーになり不正 HTML に
+ * なるため、`<div onClick>` + useNavigate で遷移する (本文中リンクは自前の
+ * stopPropagation で個別に効く)。closest('a,button') ガードは保険。
+ */
+export function PostQuoteCard({ quote }: { quote: PostQuote }) {
+  const navigate = useNavigate();
+
+  const box: CSSProperties = {
+    marginTop: '0.5em',
+    padding: 8,
+    border: '1px solid var(--color-border)',
+    borderRadius: 8,
+    background: 'var(--color-overlay-soft)',
+  };
+
+  if (quote.kind === 'unavailable') {
+    const label =
+      quote.reason === 'notFound'
+        ? '引用先の投稿が見つかりません'
+        : quote.reason === 'blocked'
+          ? 'ブロックされた投稿'
+          : '引用が取り消されました';
+    return (
+      <div style={{ ...box, color: 'var(--color-muted)', fontSize: '0.85em' }} onClick={(e) => e.stopPropagation()}>
+        {label}
+      </div>
+    );
+  }
+
+  if (quote.kind === 'other') {
+    return (
+      <div style={{ ...box, color: 'var(--color-muted)', fontSize: '0.85em' }} onClick={(e) => e.stopPropagation()}>
+        {quote.label}
+      </div>
+    );
+  }
+
+  // handle があれば /profile/<handle>/post/<rkey>、無ければ at-uri の DID で代替
+  // (profile ルートは DID をそのまま解決できる)。/post/<uri> 素通しは未登録ルートなので避ける。
+  const to = postDetailPath(quote.author.handle || didFromUri(quote.uri), quote.uri);
+  const onClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    // 親投稿カードのクリックには伝播させない (引用先へ飛ぶのが意図)。
+    e.stopPropagation();
+    // 本文中リンク/ボタンを踏んだときはカード遷移しない (二重遷移を避ける)。
+    if ((e.target as HTMLElement).closest('a,button')) return;
+    navigate(to);
+  };
+
+  return (
+    <div style={{ ...box, cursor: 'pointer' }} onClick={onClick}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.4em',
+          fontSize: '0.85em',
+          color: 'var(--color-muted)',
+        }}
+      >
+        <Avatar src={quote.author.avatar} size={20} archetype={null} />
+        <strong style={{ color: 'var(--color-fg)' }}>
+          {quote.author.displayName || quote.author.handle || '(不明)'}
+        </strong>
+        {quote.author.handle && <span>@{quote.author.handle}</span>}
+      </div>
+      {quote.text && (
+        <PostText
+          text={quote.text}
+          facets={quote.facets}
+          style={{ marginTop: '0.3em', fontSize: '0.95em', lineHeight: 1.5 }}
+        />
+      )}
+      {quote.images.length > 0 && (
+        <div style={{ marginTop: '0.4em', display: 'flex', gap: 4, flexWrap: 'wrap' }}>
+          {quote.images.slice(0, 4).map((img, i) => (
+            <img
+              key={i}
+              src={img.thumb}
+              alt={img.alt}
+              loading="lazy"
+              decoding="async"
+              style={{ width: 64, height: 64, objectFit: 'cover', borderRadius: 4, flexShrink: 0, background: '#000' }}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/post-quote.tsx
+++ b/apps/web/src/components/post-quote.tsx
@@ -8,10 +8,10 @@ import { PostText } from './post-text';
 /**
  * 引用投稿カード (Bluesky 本家の「ぶら下げ」表示相当)。
  *
- * カード全体をタップすると引用先投稿へ**内部遷移**する。ただし外側を `<a>`/`<Link>`
- * で包むと、本文中の mention/リンク (これも `<a>`) が入れ子アンカーになり不正 HTML に
- * なるため、`<div onClick>` + useNavigate で遷移する (本文中リンクは自前の
- * stopPropagation で個別に効く)。closest('a,button') ガードは保険。
+ * カード全体をタップ / Enter・Space で引用先投稿へ**内部遷移**する。外側を
+ * `<a>`/`<Link>` で包むと本文中の mention/リンク (これも `<a>`) が入れ子アンカーになり
+ * 不正 HTML になるため、`<div role="link" tabIndex>` + useNavigate で遷移する
+ * (本文中リンクは自前の stopPropagation で個別に効く。closest('a,button') ガードは保険)。
  */
 export function PostQuoteCard({ quote }: { quote: PostQuote }) {
   const navigate = useNavigate();
@@ -20,7 +20,7 @@ export function PostQuoteCard({ quote }: { quote: PostQuote }) {
     marginTop: '0.5em',
     padding: 8,
     border: '1px solid var(--color-border)',
-    borderRadius: 8,
+    borderRadius: 6,
     background: 'var(--color-overlay-soft)',
   };
 
@@ -29,8 +29,8 @@ export function PostQuoteCard({ quote }: { quote: PostQuote }) {
       quote.reason === 'notFound'
         ? '引用先の投稿が見つかりません'
         : quote.reason === 'blocked'
-          ? 'ブロックされた投稿'
-          : '引用が取り消されました';
+          ? 'ブロックされた投稿です'
+          : '引用元により引用が解除されました';
     return (
       <div style={{ ...box, color: 'var(--color-muted)', fontSize: '0.85em' }} onClick={(e) => e.stopPropagation()}>
         {label}
@@ -49,16 +49,35 @@ export function PostQuoteCard({ quote }: { quote: PostQuote }) {
   // handle があれば /profile/<handle>/post/<rkey>、無ければ at-uri の DID で代替
   // (profile ルートは DID をそのまま解決できる)。/post/<uri> 素通しは未登録ルートなので避ける。
   const to = postDetailPath(quote.author.handle || didFromUri(quote.uri), quote.uri);
+  const go = () => navigate(to);
   const onClick = (e: React.MouseEvent<HTMLDivElement>) => {
     // 親投稿カードのクリックには伝播させない (引用先へ飛ぶのが意図)。
     e.stopPropagation();
     // 本文中リンク/ボタンを踏んだときはカード遷移しない (二重遷移を避ける)。
     if ((e.target as HTMLElement).closest('a,button')) return;
-    navigate(to);
+    go();
+  };
+  const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    // カード自身にフォーカスがある時のみ (内部リンクにフォーカス中は素通し)。
+    if (e.target !== e.currentTarget) return;
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      go();
+    }
   };
 
+  const authorName = quote.author.displayName || quote.author.handle || '名称不明';
+
   return (
-    <div style={{ ...box, cursor: 'pointer' }} onClick={onClick}>
+    <div
+      className="dq-quote-card"
+      style={{ ...box, cursor: 'pointer' }}
+      onClick={onClick}
+      onKeyDown={onKeyDown}
+      role="link"
+      tabIndex={0}
+      aria-label={`引用先の投稿を開く: ${authorName}`}
+    >
       <div
         style={{
           display: 'flex',
@@ -69,20 +88,27 @@ export function PostQuoteCard({ quote }: { quote: PostQuote }) {
         }}
       >
         <Avatar src={quote.author.avatar} size={20} archetype={null} />
-        <strong style={{ color: 'var(--color-fg)' }}>
-          {quote.author.displayName || quote.author.handle || '(不明)'}
-        </strong>
+        <strong style={{ color: 'var(--color-fg)' }}>{authorName}</strong>
         {quote.author.handle && <span>@{quote.author.handle}</span>}
       </div>
       {quote.text && (
         <PostText
           text={quote.text}
           facets={quote.facets}
-          style={{ marginTop: '0.3em', fontSize: '0.95em', lineHeight: 1.5 }}
+          style={{
+            marginTop: '0.3em',
+            fontSize: '0.95em',
+            lineHeight: 1.5,
+            // 長い引用でタイムラインが膨れないよう本文を最大 6 行にクランプ (本家同様)。
+            display: '-webkit-box',
+            WebkitLineClamp: 6,
+            WebkitBoxOrient: 'vertical',
+            overflow: 'hidden',
+          }}
         />
       )}
       {quote.images.length > 0 && (
-        <div style={{ marginTop: '0.4em', display: 'flex', gap: 4, flexWrap: 'wrap' }}>
+        <div style={{ marginTop: '0.4em', display: 'flex', gap: 4 }}>
           {quote.images.slice(0, 4).map((img, i) => (
             <img
               key={i}
@@ -90,7 +116,16 @@ export function PostQuoteCard({ quote }: { quote: PostQuote }) {
               alt={img.alt}
               loading="lazy"
               decoding="async"
-              style={{ width: 64, height: 64, objectFit: 'cover', borderRadius: 4, flexShrink: 0, background: '#000' }}
+              // 枚数に応じて等分 (狭幅でもはみ出さない)。単独時に巨大化しないよう上限。
+              style={{
+                flex: '1 1 0',
+                minWidth: 0,
+                maxWidth: 88,
+                aspectRatio: '1 / 1',
+                objectFit: 'cover',
+                borderRadius: 4,
+                background: '#000',
+              }}
             />
           ))}
         </div>

--- a/apps/web/src/components/post-text.tsx
+++ b/apps/web/src/components/post-text.tsx
@@ -1,17 +1,9 @@
 import type { CSSProperties, ReactNode } from 'react';
 import { Link } from 'react-router-dom';
+import type { Facet, FacetFeature } from '@/lib/facet';
 
-export interface FacetFeature {
-  $type?: string;
-  uri?: string;
-  did?: string;
-  tag?: string;
-}
-
-export interface Facet {
-  index: { byteStart: number; byteEnd: number };
-  features?: FacetFeature[];
-}
+// 従来 post-text から Facet 型を import していた箇所 (post-body 等) の後方互換のため再エクスポート。
+export type { Facet, FacetFeature } from '@/lib/facet';
 
 interface PostTextProps {
   text: string;

--- a/apps/web/src/lib/facet.ts
+++ b/apps/web/src/lib/facet.ts
@@ -1,0 +1,17 @@
+/**
+ * AT Protocol リッチテキスト facet の最小型 (app.bsky.richtext.facet)。
+ * 描画側 (components/post-text) と埋め込み抽出側 (lib/post-embed) の双方が参照するため、
+ * どちらにも依存しない leaf モジュールに置く (lib → components の逆流依存を避ける)。
+ */
+
+export interface FacetFeature {
+  $type?: string;
+  uri?: string;
+  did?: string;
+  tag?: string;
+}
+
+export interface Facet {
+  index: { byteStart: number; byteEnd: number };
+  features?: FacetFeature[];
+}

--- a/apps/web/src/lib/post-embed.test.ts
+++ b/apps/web/src/lib/post-embed.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import type { AppBskyFeedDefs } from '@atproto/api';
+import { extractPostQuote, extractPostImages } from './post-embed';
+
+/** テスト用に post.embed だけ差し替えた最小の PostView を作る。 */
+function postWithEmbed(embed: unknown): AppBskyFeedDefs.PostView {
+  return {
+    uri: 'at://did:plc:me/app.bsky.feed.post/self',
+    cid: 'cid',
+    author: { did: 'did:plc:me', handle: 'me.example', viewer: {}, labels: [] },
+    record: { text: '本文', $type: 'app.bsky.feed.post' },
+    indexedAt: '2026-07-10T00:00:00.000Z',
+    ...(embed ? { embed: embed as AppBskyFeedDefs.PostView['embed'] } : {}),
+  } as AppBskyFeedDefs.PostView;
+}
+
+const viewRecord = {
+  $type: 'app.bsky.embed.record#viewRecord',
+  uri: 'at://did:plc:nao/app.bsky.feed.post/abc',
+  cid: 'qcid',
+  author: { did: 'did:plc:nao', handle: 'nao774.bsky.social', displayName: 'nao' },
+  value: {
+    $type: 'app.bsky.feed.post',
+    text: 'でもそれはそれとして公式が本筋として…',
+    createdAt: '2026-07-10T13:00:00.000Z',
+    facets: [
+      {
+        index: { byteStart: 0, byteEnd: 4 },
+        features: [{ $type: 'app.bsky.richtext.facet#link', uri: 'https://example.com' }],
+      },
+    ],
+  },
+  embeds: [],
+};
+
+describe('extractPostQuote', () => {
+  it('embed が無ければ null', () => {
+    expect(extractPostQuote(postWithEmbed(null))).toBeNull();
+  });
+
+  it('画像だけの embed は引用ではないので null', () => {
+    const embed = { $type: 'app.bsky.embed.images#view', images: [] };
+    expect(extractPostQuote(postWithEmbed(embed))).toBeNull();
+  });
+
+  it('record#view の viewRecord を post として抽出 (author/text/facets)', () => {
+    const embed = { $type: 'app.bsky.embed.record#view', record: viewRecord };
+    const q = extractPostQuote(postWithEmbed(embed));
+    expect(q?.kind).toBe('post');
+    if (q?.kind !== 'post') throw new Error('expected post');
+    expect(q.uri).toBe('at://did:plc:nao/app.bsky.feed.post/abc');
+    expect(q.author.handle).toBe('nao774.bsky.social');
+    expect(q.author.displayName).toBe('nao');
+    expect(q.text).toContain('公式が本筋');
+    expect(q.facets?.length).toBe(1);
+    expect(q.images).toEqual([]);
+    expect(q.createdAt).toBe('2026-07-10T13:00:00.000Z');
+  });
+
+  it('recordWithMedia#view は record.record を辿って引用を抽出しつつ、media 画像は extractPostImages で拾える', () => {
+    const embed = {
+      $type: 'app.bsky.embed.recordWithMedia#view',
+      record: { $type: 'app.bsky.embed.record#view', record: viewRecord },
+      media: {
+        $type: 'app.bsky.embed.images#view',
+        images: [{ thumb: 't', fullsize: 'f', alt: 'a' }],
+      },
+    };
+    const post = postWithEmbed(embed);
+    const q = extractPostQuote(post);
+    expect(q?.kind).toBe('post');
+    // media 側の画像は「この投稿自身の画像」として拾われる (引用カードではなく本体グリッド)
+    expect(extractPostImages(post)).toHaveLength(1);
+  });
+
+  it('引用先が自前で持つ画像 (embeds) はサムネとして拾う', () => {
+    const embed = {
+      $type: 'app.bsky.embed.record#view',
+      record: {
+        ...viewRecord,
+        embeds: [
+          { $type: 'app.bsky.embed.images#view', images: [{ thumb: 't', fullsize: 'f', alt: '' }] },
+        ],
+      },
+    };
+    const q = extractPostQuote(postWithEmbed(embed));
+    if (q?.kind !== 'post') throw new Error('expected post');
+    expect(q.images).toHaveLength(1);
+  });
+
+  it('未取得系 (notFound/blocked/detached) は unavailable', () => {
+    const mk = (t: string) => ({ $type: 'app.bsky.embed.record#view', record: { $type: t, uri: 'at://x/y/z' } });
+    expect(extractPostQuote(postWithEmbed(mk('app.bsky.embed.record#viewNotFound')))).toEqual({
+      kind: 'unavailable',
+      reason: 'notFound',
+    });
+    expect(extractPostQuote(postWithEmbed(mk('app.bsky.embed.record#viewBlocked')))).toEqual({
+      kind: 'unavailable',
+      reason: 'blocked',
+    });
+    expect(extractPostQuote(postWithEmbed(mk('app.bsky.embed.record#viewDetached')))).toEqual({
+      kind: 'unavailable',
+      reason: 'detached',
+    });
+  });
+
+  it('フィード / リスト埋め込みは other (ラベル付き)', () => {
+    const feed = {
+      $type: 'app.bsky.embed.record#view',
+      record: { $type: 'app.bsky.feed.defs#generatorView', displayName: 'みんなのフィード' },
+    };
+    const q = extractPostQuote(postWithEmbed(feed));
+    expect(q?.kind).toBe('other');
+    if (q?.kind !== 'other') throw new Error('expected other');
+    expect(q.label).toContain('みんなのフィード');
+
+    const list = {
+      $type: 'app.bsky.embed.record#view',
+      record: { $type: 'app.bsky.graph.defs#listView', name: '仲間リスト' },
+    };
+    const ql = extractPostQuote(postWithEmbed(list));
+    expect(ql?.kind).toBe('other');
+    if (ql?.kind !== 'other') throw new Error('expected other');
+    expect(ql.label).toContain('仲間リスト');
+  });
+
+  it('未知の record union $type は null (壊さない)', () => {
+    const embed = { $type: 'app.bsky.embed.record#view', record: { $type: 'com.example.unknown#view' } };
+    expect(extractPostQuote(postWithEmbed(embed))).toBeNull();
+  });
+
+  it('uri が無い viewRecord は null (壊れたデータ)', () => {
+    const embed = {
+      $type: 'app.bsky.embed.record#view',
+      record: { $type: 'app.bsky.embed.record#viewRecord', author: {}, value: {} },
+    };
+    expect(extractPostQuote(postWithEmbed(embed))).toBeNull();
+  });
+});

--- a/apps/web/src/lib/post-embed.ts
+++ b/apps/web/src/lib/post-embed.ts
@@ -1,5 +1,5 @@
 import type { AppBskyFeedDefs } from '@atproto/api';
-import type { Facet } from '@/components/post-text';
+import type { Facet } from '@/lib/facet';
 
 /** 投稿カード / ライトボックスで使う 1 枚分の画像。 */
 export interface PostImage {

--- a/apps/web/src/lib/post-embed.ts
+++ b/apps/web/src/lib/post-embed.ts
@@ -1,4 +1,5 @@
 import type { AppBskyFeedDefs } from '@atproto/api';
+import type { Facet } from '@/components/post-text';
 
 /** 投稿カード / ライトボックスで使う 1 枚分の画像。 */
 export interface PostImage {
@@ -7,6 +8,26 @@ export interface PostImage {
   alt: string;
   aspectRatio?: { width: number; height: number };
 }
+
+/**
+ * 引用投稿 (app.bsky.embed.record#view / recordWithMedia#view の record 部)。
+ * Bluesky 本家がリンク先投稿を「ぶら下げ」表示するのと同じ埋め込みデータ。
+ * - kind='post': 通常の投稿を引用 (viewRecord)。カード表示 + タップで内部遷移。
+ * - kind='unavailable': 未検出 / ブロック / 引用解除 (viewNotFound/Blocked/Detached)。
+ * - kind='other': フィード / リスト / スターターパック等、投稿以外の埋め込み。
+ */
+export type PostQuote =
+  | {
+      kind: 'post';
+      uri: string;
+      author: { handle: string; displayName: string; avatar?: string };
+      text: string;
+      facets?: Facet[];
+      images: PostImage[];
+      createdAt?: string;
+    }
+  | { kind: 'unavailable'; reason: 'notFound' | 'blocked' | 'detached' }
+  | { kind: 'other'; label: string };
 
 /** 外部リンクカード (app.bsky.embed.external#view)。 */
 export interface PostExternal {
@@ -82,16 +103,8 @@ interface EmbedShape {
   };
 }
 
-/**
- * post.embed から画像配列を安全に抽出する。
- * - app.bsky.embed.images#view: 単純な画像添付
- * - app.bsky.embed.recordWithMedia#view: 引用投稿 + メディア (media 側が images)
- * どちらも拾う。どれにも該当しないときは空配列を返す。
- */
-export function extractPostImages(post: AppBskyFeedDefs.PostView): PostImage[] {
-  const embed = post.embed as EmbedShape | undefined;
+function imagesFromEmbed(embed: EmbedShape | undefined): PostImage[] {
   if (!embed) return [];
-
   const fromList = (list: ViewImageShape[] | undefined): PostImage[] => {
     if (!Array.isArray(list)) return [];
     const out: PostImage[] = [];
@@ -101,7 +114,6 @@ export function extractPostImages(post: AppBskyFeedDefs.PostView): PostImage[] {
     }
     return out;
   };
-
   if (embed.$type === 'app.bsky.embed.images#view') {
     return fromList(embed.images);
   }
@@ -109,6 +121,101 @@ export function extractPostImages(post: AppBskyFeedDefs.PostView): PostImage[] {
     return fromList(embed.media.images);
   }
   return [];
+}
+
+/**
+ * post.embed から画像配列を安全に抽出する。
+ * - app.bsky.embed.images#view: 単純な画像添付
+ * - app.bsky.embed.recordWithMedia#view: 引用投稿 + メディア (media 側が images)
+ * どちらも拾う。どれにも該当しないときは空配列を返す。
+ */
+export function extractPostImages(post: AppBskyFeedDefs.PostView): PostImage[] {
+  return imagesFromEmbed(post.embed as EmbedShape | undefined);
+}
+
+/** 引用埋め込みの record union (viewRecord 等) の shape。実体は AT Protocol の union。 */
+interface ViewRecordShape {
+  $type?: string;
+  uri?: unknown;
+  author?: { handle?: unknown; displayName?: unknown; avatar?: unknown };
+  value?: { text?: unknown; facets?: unknown; createdAt?: unknown };
+  embeds?: EmbedShape[];
+}
+
+function toQuotePost(r: ViewRecordShape): PostQuote | null {
+  if (typeof r.uri !== 'string') return null;
+  const a = r.author ?? {};
+  const v = r.value ?? {};
+  // 引用先が自前で持つ添付画像 (embeds は複数種類の埋め込みビュー配列)。最初に
+  // 画像を含む埋め込みだけサムネ表示に使う (引用カードは軽量表示に留める)。
+  let images: PostImage[] = [];
+  for (const e of r.embeds ?? []) {
+    const imgs = imagesFromEmbed(e);
+    if (imgs.length) {
+      images = imgs;
+      break;
+    }
+  }
+  return {
+    kind: 'post',
+    uri: r.uri,
+    author: {
+      handle: typeof a.handle === 'string' ? a.handle : '',
+      displayName: typeof a.displayName === 'string' ? a.displayName : '',
+      ...(typeof a.avatar === 'string' ? { avatar: a.avatar } : {}),
+    },
+    text: typeof v.text === 'string' ? v.text : '',
+    ...(Array.isArray(v.facets) ? { facets: v.facets as Facet[] } : {}),
+    images,
+    ...(typeof v.createdAt === 'string' ? { createdAt: v.createdAt } : {}),
+  };
+}
+
+/**
+ * post.embed から引用投稿を抽出する。
+ * - app.bsky.embed.record#view: 純粋な引用 (record 単体)
+ * - app.bsky.embed.recordWithMedia#view: 引用 + メディア (record.record が union)
+ * record union の $type を見て post / 未取得系 / それ以外 (フィード等) に振り分ける。
+ * どれにも該当しなければ null (= 引用なし)。
+ */
+export function extractPostQuote(post: AppBskyFeedDefs.PostView): PostQuote | null {
+  const embed = post.embed as
+    | (EmbedShape & { record?: unknown })
+    | undefined;
+  if (!embed) return null;
+
+  let recordUnion: unknown = null;
+  if (embed.$type === 'app.bsky.embed.record#view') {
+    recordUnion = (embed as { record?: unknown }).record;
+  } else if (embed.$type === 'app.bsky.embed.recordWithMedia#view') {
+    // recordWithMedia は record ラッパを一段挟む: { record: { record: <union> }, media }
+    const wrapper = (embed as { record?: { record?: unknown } }).record;
+    recordUnion = wrapper?.record;
+  }
+  if (!recordUnion || typeof recordUnion !== 'object') return null;
+
+  const str = (x: unknown): string => (typeof x === 'string' ? x : '');
+  const r = recordUnion as { $type?: string; displayName?: unknown; name?: unknown };
+  switch (r.$type) {
+    case 'app.bsky.embed.record#viewRecord':
+      return toQuotePost(r as ViewRecordShape);
+    case 'app.bsky.embed.record#viewNotFound':
+      return { kind: 'unavailable', reason: 'notFound' };
+    case 'app.bsky.embed.record#viewBlocked':
+      return { kind: 'unavailable', reason: 'blocked' };
+    case 'app.bsky.embed.record#viewDetached':
+      return { kind: 'unavailable', reason: 'detached' };
+    case 'app.bsky.feed.defs#generatorView':
+      return { kind: 'other', label: `フィード: ${str(r.displayName) || '(名称不明)'}` };
+    case 'app.bsky.graph.defs#listView':
+      return { kind: 'other', label: `リスト: ${str(r.name) || '(名称不明)'}` };
+    case 'app.bsky.graph.defs#starterPackViewBasic':
+      return { kind: 'other', label: 'スターターパック' };
+    case 'app.bsky.labeler.defs#labelerView':
+      return { kind: 'other', label: 'ラベラー' };
+    default:
+      return null;
+  }
 }
 
 /**

--- a/apps/web/src/lib/uri.test.ts
+++ b/apps/web/src/lib/uri.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { didFromUri, rkeyFromUri, postDetailPath } from './uri';
+
+describe('didFromUri', () => {
+  it('通常の at-uri から authority (did) を取る', () => {
+    expect(didFromUri('at://did:plc:abc/app.bsky.feed.post/xyz')).toBe('did:plc:abc');
+  });
+  it('collection/rkey が無くても authority を取る', () => {
+    expect(didFromUri('at://did:plc:abc')).toBe('did:plc:abc');
+  });
+  it('handle authority でも取れる', () => {
+    expect(didFromUri('at://alice.example/app.bsky.feed.post/1')).toBe('alice.example');
+  });
+  it('at:// でない / 壊れた文字列は空文字', () => {
+    expect(didFromUri('https://bsky.app/profile/x')).toBe('');
+    expect(didFromUri('')).toBe('');
+    expect(didFromUri('nonsense')).toBe('');
+  });
+});
+
+describe('postDetailPath + didFromUri の合わせ技', () => {
+  it('handle 欠落時に DID で /profile/<did>/post/<rkey> を組める', () => {
+    const uri = 'at://did:plc:nao/app.bsky.feed.post/abc';
+    expect(postDetailPath(didFromUri(uri), uri)).toBe('/profile/did:plc:nao/post/abc');
+    expect(rkeyFromUri(uri)).toBe('abc');
+  });
+});

--- a/apps/web/src/lib/uri.ts
+++ b/apps/web/src/lib/uri.ts
@@ -7,9 +7,10 @@ export function rkeyFromUri(uri: string): string {
   return uri.split('/').pop() ?? '';
 }
 
-/** at://<did>/<collection>/<rkey> から <did> (authority) を取り出す。取れなければ空文字。 */
+/** at://<did>/<collection>/<rkey> から <did> (authority) を取り出す。取れなければ空文字。
+ *  collection/rkey が無い (末尾スラッシュ無し) at-uri でも authority だけは拾う。 */
 export function didFromUri(uri: string): string {
-  const m = /^at:\/\/([^/]+)\//.exec(uri);
+  const m = /^at:\/\/([^/]+)/.exec(uri);
   return m ? m[1]! : '';
 }
 

--- a/apps/web/src/lib/uri.ts
+++ b/apps/web/src/lib/uri.ts
@@ -7,6 +7,12 @@ export function rkeyFromUri(uri: string): string {
   return uri.split('/').pop() ?? '';
 }
 
+/** at://<did>/<collection>/<rkey> から <did> (authority) を取り出す。取れなければ空文字。 */
+export function didFromUri(uri: string): string {
+  const m = /^at:\/\/([^/]+)\//.exec(uri);
+  return m ? m[1]! : '';
+}
+
 export function postUri(did: string, rkey: string): string {
   return `at://${did}/app.bsky.feed.post/${rkey}`;
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -959,6 +959,24 @@ p { margin: 0.4em 0; }
   transition: background-color 80ms ease, color 80ms ease, border-color 80ms ease, transform 60ms ease;
   -webkit-tap-highlight-color: transparent;
 }
+/* 引用投稿カード (post-quote.tsx)。カード全体がタップ可能なので、初動の視覚
+   フィードバック (ホバー着色 + 押下の沈み) とキーボードフォーカスリングを付ける。 */
+.dq-quote-card {
+  transition:
+    background-color 0.12s ease,
+    transform 0.08s ease;
+}
+.dq-quote-card:hover {
+  background: var(--color-window-bg-alt);
+}
+.dq-quote-card:active {
+  transform: translateY(1px) scale(0.99);
+}
+.dq-quote-card:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
 .dq-tab:hover {
   color: #ffffff;
   border-color: #ffffff;


### PR DESCRIPTION
## 概要
本文に貼られた Bluesky 投稿リンク (bsky.app/profile/…/post/…) の参照先を、公式クライアント同様に**引用カード**としてインライン表示する。

これまであおぞらは `app.bsky.embed.record#view` / `recordWithMedia#view` の record 部を**一切描画していなかった**ため、参照先投稿が出ず「リンクだけ」に見えていた。埋め込みデータ自体は投稿に既に載っているので、描画を足すだけで本家の「ぶら下げ」表示に揃う。

## 変更
- `lib/post-embed.ts`: `extractPostQuote()` + `PostQuote` 型を追加。画像抽出を `imagesFromEmbed()` に共通化。record#view / recordWithMedia#view を辿り、viewRecord=post / notFound・blocked・detached=unavailable / feed・list 等=other に振り分け。
- `components/post-quote.tsx` (新規): 引用カード。アバター+表示名+本文 (PostText)+画像サムネ。**カード全体タップ / Enter・Space で内部の投稿詳細へ遷移** (role=link + tabIndex + aria-label)。外側を `<a>` で包むと本文中 mention/リンクが入れ子アンカーになるため `div`+`onClick`+`useNavigate`。
- `components/post-body.tsx` / `post-article.tsx`: `quote` prop を結線 (全表示経路が PostArticle 経由なので TL/スレッド/通知/検索/プロフィールで一貫表示)。
- `lib/facet.ts` (新規): Facet 型を leaf モジュールへ分離 (lib→components の逆流依存を解消)。
- `lib/uri.ts`: `didFromUri()` 追加。handle 欠落時に at-uri の DID で内部遷移。
- `styles.css`: `.dq-quote-card` に hover/active/focus フィードバック。

## テスト
- `post-embed.test.ts` (9) + `uri.test.ts` (5) 追加。web unit 236 passed。typecheck + build green。

## Review (§1.5 3並列: 設計 / 実装 / UX)
**★★★ (必須対応・全て本PR内で修正済み)**
- [UX] 長い引用本文が未クランプ→TL膨れ: 本文を **line-clamp 6 行** に (94e1f84)
- [UX] `div onClick` にキーボード/ARIA 無し→操作不能: **role=link + tabIndex + onKeyDown(Enter/Space) + aria-label** 付与 (94e1f84)

**★★ (本PR内で対応、1件のみ issue 化)**
- [設計] `viewDetached` の文言が意味的に不正確: 「引用元により引用が解除されました」に修正 + unavailable 文言統一 (94e1f84)
- [設計] `lib→components` の Facet 型逆流依存: `lib/facet.ts` へ分離して解消 (94e1f84)
- [UX] タップ初動フィードバック無し (DESIGN.md 違反): `.dq-quote-card` に hover/active/focus 追加 (94e1f84)
- [UX] border-radius 8→**6** で OG カードと統一 (94e1f84)
- [UX] タップ可能性の視覚アフォーダンス強化 → **#250** に切り出し (hover/active で一次対応済み)

**★ (対応 or 据え置き)**
- [実装] `didFromUri` が末尾スラッシュ無し at-uri で空→正規表現を堅牢化 + テスト追加 (94e1f84)
- [UX] 狭幅での画像サムネはみ出し→flex 等分 + 上限で対応 (94e1f84)
- [UX] JP 文言の並列性→unavailable を です形に統一、"名称不明" で統一 (94e1f84)
- [実装] card の stopPropagation ガードは現状 inert (親に click ハンドラ無し) だが防御的に維持
- [UX] recordWithMedia (自前画像+引用) の密なケースは dev で実機目視予定

## スコープ外 (別 PR)
- 本文中 bsky.app リンクを外部ではなく**内部で開く**トグル + 設定 (Part B) は次 PR。
- 素の bsky.app リンクのみの投稿への fetch→引用生成は将来検討。