### PR TITLE
fix(post-detail): 「ホームに戻る」を履歴 pop の「戻る」に

### DIFF
--- a/apps/web/src/routes/post-detail.tsx
+++ b/apps/web/src/routes/post-detail.tsx
@@ -26,10 +26,13 @@ export function PostDetail() {
   const [state, setState] = useState<LoadState>({ status: 'loading' });
 
   // 投稿詳細は Workspace とは別ルートなので、戻り先は「直前に居た場所」(TL の途中・
-  // プロフィール・通知など) であるべきで、常にホーム先頭ではない。アプリ内履歴が
-  // あれば history を pop する (navigate(-1))。pop 遷移はブラウザ標準のスクロール復元が
-  // 効くうえ、home カラムは IDB キャッシュから即描画されるので TL の位置が保たれる。
-  // 履歴が無い場合 (共有 URL の直開き等) のみホームへのリンクにフォールバックする。
+  // プロフィール・通知など) であるべきで、常にホーム先頭ではない。
+  // location.key は、この document 読み込み後に 1 回でも app 内 navigation が
+  // push されていれば非 'default' になる (RR 7 は index 0 のエントリだけ 'default')。
+  // その場合は history を pop する (navigate(-1))。pop で戻ると home カラムは IDB
+  // キャッシュから即描画されるため以前の位置付近が保たれやすい (仮想リストなので
+  // 厳密なピクセル単位の復元までは保証しない。少なくとも毎回先頭リセットは避けられる)。
+  // 履歴が無い場合 (共有 URL の直開き等) はホームへのリンクにフォールバックする。
   const canGoBack = location.key !== 'default';
 
   useEffect(() => {

--- a/apps/web/src/routes/post-detail.tsx
+++ b/apps/web/src/routes/post-detail.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
 import type { AppBskyFeedDefs, Agent } from '@atproto/api';
 import { AppBskyFeedDefs as FeedDefs } from '@atproto/api';
 import { useSession } from '@/lib/session';
@@ -21,7 +21,16 @@ type LoadState =
 export function PostDetail() {
   const { handle, rkey } = useParams<{ handle: string; rkey: string }>();
   const session = useSession();
+  const navigate = useNavigate();
+  const location = useLocation();
   const [state, setState] = useState<LoadState>({ status: 'loading' });
+
+  // 投稿詳細は Workspace とは別ルートなので、戻り先は「直前に居た場所」(TL の途中・
+  // プロフィール・通知など) であるべきで、常にホーム先頭ではない。アプリ内履歴が
+  // あれば history を pop する (navigate(-1))。pop 遷移はブラウザ標準のスクロール復元が
+  // 効くうえ、home カラムは IDB キャッシュから即描画されるので TL の位置が保たれる。
+  // 履歴が無い場合 (共有 URL の直開き等) のみホームへのリンクにフォールバックする。
+  const canGoBack = location.key !== 'default';
 
   useEffect(() => {
     if (session.status !== 'signed-in' || !session.agent) return;
@@ -62,7 +71,25 @@ export function PostDetail() {
   return (
     <div>
       <div style={{ marginBottom: '0.6em' }}>
-        <Link to="/">← ホームに戻る</Link>
+        {canGoBack ? (
+          <button
+            type="button"
+            onClick={() => navigate(-1)}
+            style={{
+              background: 'transparent',
+              border: 'none',
+              padding: 0,
+              color: 'var(--color-accent)',
+              cursor: 'pointer',
+              font: 'inherit',
+              textDecoration: 'underline',
+            }}
+          >
+            ← 戻る
+          </button>
+        ) : (
+          <Link to="/">← ホームへ</Link>
+        )}
       </div>
       {state.status === 'loading' && <p>読み込み中…</p>}
       {state.status === 'not-found' && (


### PR DESCRIPTION
## 問題
投稿詳細ページ (`/profile/:handle/post/:rkey`) の上部リンクが `<Link to="/">← ホームに戻る</Link>` 固定だった。投稿詳細は Workspace とは別ルートなので、引用カード (#249) やリンク内部化 (#251) でどこから来ても**常にホーム先頭へ**飛び、Workspace 再マウントで**タイムラインが再読み込み**されていた。表現としても来た場所に関わらず「ホームに戻る」は不正確。（ユーザー報告 + スクショで確認）

## 修正
- アプリ内履歴があれば (`location.key !== 'default'`) `navigate(-1)` で history を **pop**。戻り先は直前に居た場所。
- pop で戻ると home カラムは **IDB SWR キャッシュから即描画**され、以前の位置付近が保たれやすい (毎回先頭リセットを回避)。
- 履歴が無い場合 (共有 URL 直開き、`key === 'default'`) のみ `<Link to="/">← ホームへ` にフォールバック。
- ラベルを「← 戻る」に。

## 確認
typecheck / unit 250 / build 緑。

## Review (§1.5 実装レビュー / 小規模ナビゲーション修正)
**★★★** — なし。

**★★ (本PR内で対応)**
- [実装] コメントが `navigate(-1)` の in-app 保証・ブラウザ標準スクロール復元を断定しすぎ → **コメントを正確化** (location.key の実意味、仮想リストは厳密復元を保証しない旨)。挙動は全 real flow で正しいとレビュー確認済み (in-app back / 引用ネスト連鎖 / 直開きフォールバック)。

**★ (確認のみ・変更なし)**
- [実装] `<button>` を back アクションに使うのは link より意味的に正確、キーボード操作可。
- ネスト (home→A→引用でB→戻る) は B→A→home の単一 pop 連鎖で double-pop なし。
- 直開き時は label 変更のみ (ホームに戻る→ホームへ)、挙動同一。