### PR TITLE
fix(workspace): カラムのスクロール位置を保存/復元 (戻ると先頭に飛ぶのを解消)

### DIFF
--- a/apps/web/src/components/workspace.tsx
+++ b/apps/web/src/components/workspace.tsx
@@ -11,7 +11,7 @@
  * body 要素を ColumnScrollContext で配って内部の VirtualFeed が
  * 「カラム内スクロール」モードで動けるようにする。
  */
-import { Fragment, useEffect, useRef, useState, type CSSProperties, type PointerEvent as ReactPointerEvent, type ReactNode } from 'react';
+import { Fragment, useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type PointerEvent as ReactPointerEvent, type ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 import { useSession } from '@/lib/session';
 import {
@@ -354,18 +354,26 @@ function ColumnView({ column, canMoveLeft, canMoveRight, onMoveLeft, onMoveRight
   // され先頭に戻ってしまうため、body の scrollTop を kind+param 単位で sessionStorage に
   // 控えて復元する。復元はコンテンツ高さ (IDB キャッシュ描画) が保存位置に届くまで rAF で
   // 待つ。届く前の scroll=0 で保存を上書きしないよう restored フラグでゲートする。
+  // 復元完了まで body を隠して「一瞬先頭に見えてからジャンプ」を避ける (useLayoutEffect で
+  // 初回ペイント前に opacity=0 を当てる)。仮想リストは estimate 高さベースなので mobile では
+  // 位置は近似 (desktop の FlowFeed は実寸で正確)。
   const scrollKey = columnScrollKey(column);
-  useEffect(() => {
+  useLayoutEffect(() => {
     const el = bodyEl;
     if (!el) return;
     const saved = readColumnScroll(scrollKey);
     let restored = saved <= 0;
+    if (!restored) el.style.opacity = '0'; // 復元まで隠す
+    const finishRestore = () => {
+      restored = true;
+      el.style.opacity = '';
+    };
     let restoreRaf = 0;
     let frames = 0;
     const tryRestore = () => {
       if (el.scrollHeight - el.clientHeight >= saved - 4) {
         el.scrollTop = saved;
-        restored = true;
+        finishRestore();
         return;
       }
       if (++frames < 60) {
@@ -373,25 +381,28 @@ function ColumnView({ column, canMoveLeft, canMoveRight, onMoveLeft, onMoveRight
       } else {
         // 高さが届かなくても (キャッシュ未満のページ数など) 近い位置へ寄せて打ち切る
         el.scrollTop = Math.min(saved, Math.max(0, el.scrollHeight - el.clientHeight));
-        restored = true;
+        finishRestore();
       }
     };
     if (!restored) restoreRaf = requestAnimationFrame(tryRestore);
 
-    let saveRaf = 0;
+    // 保存は 200ms トレイルデバウンス。モバイルの momentum scroll で毎フレーム
+    // sessionStorage に書くのを避ける (最終位置は cleanup でも保存)。
+    let saveTimer = 0;
     const onScroll = () => {
       if (!restored) return; // 復元完了前は保存しない (0 上書き防止)
-      if (saveRaf) return;
-      saveRaf = requestAnimationFrame(() => {
-        saveRaf = 0;
+      if (saveTimer) return;
+      saveTimer = window.setTimeout(() => {
+        saveTimer = 0;
         writeColumnScroll(scrollKey, el.scrollTop);
-      });
+      }, 200);
     };
     el.addEventListener('scroll', onScroll, { passive: true });
     return () => {
       if (restoreRaf) cancelAnimationFrame(restoreRaf);
-      if (saveRaf) cancelAnimationFrame(saveRaf);
+      if (saveTimer) clearTimeout(saveTimer);
       el.removeEventListener('scroll', onScroll);
+      el.style.opacity = ''; // 隠したまま剥がれないよう必ず戻す
       if (restored) writeColumnScroll(scrollKey, el.scrollTop); // route away 時の最終保存
     };
   }, [bodyEl, scrollKey]);
@@ -402,6 +413,10 @@ function ColumnView({ column, canMoveLeft, canMoveRight, onMoveLeft, onMoveRight
   const [spinning, setSpinning] = useState(false);
   function triggerRefresh() {
     onRefresh();
+    // 明示更新は先頭から見せる。保存位置も破棄して「高さ collapse 依存で先頭に戻る」
+    // レースをやめ、意図を明示する。
+    writeColumnScroll(scrollKey, 0);
+    bodyEl?.scrollTo({ top: 0 });
     setSpinning(true);
     setTimeout(() => setSpinning(false), 600);
   }
@@ -488,6 +503,8 @@ function ColumnView({ column, canMoveLeft, canMoveRight, onMoveLeft, onMoveRight
             // JS の behavior 指定に勝てないため JS 側で分岐)
             const reduce = typeof window !== 'undefined'
               && window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches;
+            // 保存位置を即座に破棄 (smooth 中に別ルートへ抜けても先頭起点を保つ)
+            writeColumnScroll(scrollKey, 0);
             bodyEl?.scrollTo({ top: 0, behavior: reduce ? 'auto' : 'smooth' });
           }}
         >

--- a/apps/web/src/components/workspace.tsx
+++ b/apps/web/src/components/workspace.tsx
@@ -27,6 +27,7 @@ import {
   type AppColumnKind,
 } from '@/lib/app-columns';
 import { urlForColumn } from '@/lib/column-router';
+import { columnScrollKey, readColumnScroll, writeColumnScroll } from '@/lib/column-scroll';
 import { publishVisibleColumn } from '@/lib/visible-column';
 import { ColumnScrollContext } from '@/components/column-scroll-context';
 import { ColumnContent } from '@/components/column-content';
@@ -348,6 +349,53 @@ function ColumnView({ column, canMoveLeft, canMoveRight, onMoveLeft, onMoveRight
   // body 要素を state で持つ (callback ref)。要素の出現が props 変化として
   // 子に伝わり、VirtualFeed がカラム内スクロールへ自然に切り替わる。
   const [bodyEl, setBodyEl] = useState<HTMLElement | null>(null);
+
+  // スクロール位置の保存/復元。投稿詳細等の別ルートから戻ると ColumnView が再マウント
+  // され先頭に戻ってしまうため、body の scrollTop を kind+param 単位で sessionStorage に
+  // 控えて復元する。復元はコンテンツ高さ (IDB キャッシュ描画) が保存位置に届くまで rAF で
+  // 待つ。届く前の scroll=0 で保存を上書きしないよう restored フラグでゲートする。
+  const scrollKey = columnScrollKey(column);
+  useEffect(() => {
+    const el = bodyEl;
+    if (!el) return;
+    const saved = readColumnScroll(scrollKey);
+    let restored = saved <= 0;
+    let restoreRaf = 0;
+    let frames = 0;
+    const tryRestore = () => {
+      if (el.scrollHeight - el.clientHeight >= saved - 4) {
+        el.scrollTop = saved;
+        restored = true;
+        return;
+      }
+      if (++frames < 60) {
+        restoreRaf = requestAnimationFrame(tryRestore);
+      } else {
+        // 高さが届かなくても (キャッシュ未満のページ数など) 近い位置へ寄せて打ち切る
+        el.scrollTop = Math.min(saved, Math.max(0, el.scrollHeight - el.clientHeight));
+        restored = true;
+      }
+    };
+    if (!restored) restoreRaf = requestAnimationFrame(tryRestore);
+
+    let saveRaf = 0;
+    const onScroll = () => {
+      if (!restored) return; // 復元完了前は保存しない (0 上書き防止)
+      if (saveRaf) return;
+      saveRaf = requestAnimationFrame(() => {
+        saveRaf = 0;
+        writeColumnScroll(scrollKey, el.scrollTop);
+      });
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => {
+      if (restoreRaf) cancelAnimationFrame(restoreRaf);
+      if (saveRaf) cancelAnimationFrame(saveRaf);
+      el.removeEventListener('scroll', onScroll);
+      if (restored) writeColumnScroll(scrollKey, el.scrollTop); // route away 時の最終保存
+    };
+  }, [bodyEl, scrollKey]);
+
   const [menuOpen, setMenuOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   // 押下フィードバック (↻ を一瞬回す) 用

--- a/apps/web/src/lib/column-scroll.test.ts
+++ b/apps/web/src/lib/column-scroll.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { columnScrollKey, readColumnScroll, writeColumnScroll } from './column-scroll';
+import type { AppColumn } from './app-columns';
+
+// vitest 環境は 'node' (DOM 無し) なので sessionStorage を最小ポリフィル (prefs.test と同様)。
+beforeAll(() => {
+  if (typeof globalThis.sessionStorage === 'undefined') {
+    const store = new Map<string, string>();
+    globalThis.sessionStorage = {
+      getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+      setItem: (k: string, v: string) => void store.set(k, String(v)),
+      removeItem: (k: string) => void store.delete(k),
+      clear: () => store.clear(),
+      key: (i: number) => Array.from(store.keys())[i] ?? null,
+      get length() {
+        return store.size;
+      },
+    } as Storage;
+  }
+});
+
+const col = (c: Partial<AppColumn> & { kind: AppColumn['kind'] }): AppColumn =>
+  ({ id: 'x', ...c }) as AppColumn;
+
+describe('columnScrollKey', () => {
+  it('kind ごとに安定キー (id に依存しない)', () => {
+    expect(columnScrollKey(col({ kind: 'home' }))).toBe('home');
+    expect(columnScrollKey(col({ kind: 'bar' }))).toBe('bar');
+    expect(columnScrollKey(col({ kind: 'notifications' }))).toBe('notifications');
+    expect(columnScrollKey(col({ kind: 'board' }))).toBe('board');
+  });
+
+  it('search / profile は param を含めて区別', () => {
+    expect(columnScrollKey(col({ kind: 'search', param: 'foo', mode: 'posts' }))).toBe('search:posts:foo');
+    expect(columnScrollKey(col({ kind: 'profile', param: 'a.example', section: 'posts' }))).toBe(
+      'profile:posts:a.example',
+    );
+  });
+
+  it('同じ id でも kind が違えば別キー / 違う id でも同じ kind なら同キー', () => {
+    expect(columnScrollKey(col({ id: 'A', kind: 'home' }))).toBe(columnScrollKey(col({ id: 'B', kind: 'home' })));
+  });
+});
+
+describe('read/writeColumnScroll', () => {
+  beforeEach(() => sessionStorage.clear());
+
+  it('保存した値を読み戻す', () => {
+    writeColumnScroll('home', 1234);
+    expect(readColumnScroll('home')).toBe(1234);
+  });
+
+  it('丸めて保存', () => {
+    writeColumnScroll('home', 1234.7);
+    expect(readColumnScroll('home')).toBe(1235);
+  });
+
+  it('0 以下は保存せず削除 (先頭 = 保存なし扱い)', () => {
+    writeColumnScroll('home', 500);
+    writeColumnScroll('home', 0);
+    expect(readColumnScroll('home')).toBe(0);
+    expect(sessionStorage.getItem('aozoraquest:scroll:home')).toBeNull();
+  });
+
+  it('未保存キーは 0', () => {
+    expect(readColumnScroll('never')).toBe(0);
+  });
+});

--- a/apps/web/src/lib/column-scroll.ts
+++ b/apps/web/src/lib/column-scroll.ts
@@ -1,0 +1,51 @@
+/**
+ * カラム body のスクロール位置を保存/復元する (sessionStorage)。
+ *
+ * 投稿詳細やプロフィールは Workspace とは別ルートなので、そこへ遷移すると Workspace が
+ * アンマウントされ、戻ると各カラムが再マウントされて先頭に戻ってしまう。仮想リスト
+ * (VirtualFeed) は内側コンテナのスクロールなので、ブラウザ標準のスクロール復元も効かない。
+ * そこで body の scrollTop を「カラム種別 (+param)」ごとに sessionStorage に控え、戻って
+ * 来た時に復元する。key は col.id ではなく kind+param にする (id は再マウントで再生成
+ * されるため安定しない)。sessionStorage なのでタブを閉じれば消える。
+ */
+import type { AppColumn } from './app-columns';
+
+const PREFIX = 'aozoraquest:scroll:';
+
+/** カラムの安定スクロールキー (kind + 主要 param)。 */
+export function columnScrollKey(c: AppColumn): string {
+  switch (c.kind) {
+    case 'home':
+      return 'home';
+    case 'bar':
+      return 'bar';
+    case 'notifications':
+      return 'notifications';
+    case 'board':
+      return 'board';
+    case 'search':
+      return `search:${c.mode ?? ''}:${c.param ?? ''}`;
+    case 'profile':
+      return `profile:${c.section ?? ''}:${c.param ?? ''}`;
+  }
+}
+
+export function readColumnScroll(key: string): number {
+  try {
+    const v = sessionStorage.getItem(PREFIX + key);
+    if (v == null) return 0;
+    const n = parseInt(v, 10);
+    return Number.isFinite(n) && n > 0 ? n : 0;
+  } catch {
+    return 0;
+  }
+}
+
+export function writeColumnScroll(key: string, top: number): void {
+  try {
+    if (top > 0) sessionStorage.setItem(PREFIX + key, String(Math.round(top)));
+    else sessionStorage.removeItem(PREFIX + key); // 先頭は「保存なし」と同義にして肥大化を防ぐ
+  } catch {
+    /* no-op */
+  }
+}


### PR DESCRIPTION
## 問題
#252 で投稿詳細の「戻る」を `navigate(-1)` にしたが、実機では**依然としてタイムラインが先頭に飛んでいた**。原因: 投稿詳細は Workspace とは別ルートで、戻ると Workspace が再マウントされ各カラムが先頭に戻る。VirtualFeed は内側コンテナ (`.workspace-column-body`) のスクロールなので、pop 遷移でもブラウザ標準のスクロール復元が効かない。

## 修正
ColumnView の body `scrollTop` を **kind+param 単位** で sessionStorage に保存し、再マウント時に復元する。
- 復元は**コンテンツ高さ (IDB SWR キャッシュ描画) が保存位置に届くまで rAF で待つ** (最大60フレーム、届かなければ近い位置へ寄せて打ち切り)。
- **復元完了まで body を opacity:0 でマスク**し「一瞬先頭→ジャンプ」を回避。
- 保存は **200ms トレイルデバウンス** (モバイル momentum scroll での毎フレーム書き込み削減、最終位置は cleanup でも保存)。
- refresh / 最上部ボタンは**保存位置を即 0 破棄**して先頭起点を明示 (高さ collapse レース依存をやめる)。
- key は `col.id` でなく `kind+param` (id は再マウントで再生成され不安定)。
- sessionStorage なのでタブを閉じれば消える。

## 既知の挙動 (意図的)
- **mobile は近似復元**: 仮想リストは estimate 高さベースなので数行ずれることがある (desktop FlowFeed は実寸で正確)。→ 精度向上は #254。
- **same-session reload では復元される**: sessionStorage が残るため。cold load は空なので先頭。

## テスト
- `column-scroll.test.ts` (7): kind別安定キー / param区別 / id非依存 / 保存読み戻し / 丸め / 0削除 / 未保存0。web unit 257 passed。typecheck + build green。

## Review (§1.5 実装 / UX レビュー)
**★★★** — なし (rAF リーク・無限ループ・メモリリークなし、restored ゲート・closure capture・cleanup 正当性を確認)。

**★★ (本PR内で対応)**
- [UX] 復元前の「一瞬先頭→ジャンプ」がマスクされていない → **opacity マスク** (00f8aeb)。
- [impl] refresh が高さ collapse レース依存で先頭に戻る (不確実) → **明示リセット** writeColumnScroll(0)+scrollTo(0) (00f8aeb)。
- [impl] 最上部ボタンが smooth 中 navigate で中途位置を保存 → **即 0 破棄** (00f8aeb、主要経路。smooth 途中で即別ルートへ抜ける超短時間の残余は軽微)。

**★★ (issue 化)**
- [UX/impl] サマリ/アコーディオンの遅延高さ変化・新着・estimate で復元位置がずれる → **#254** (投稿URIアンカー方式へ)。
- [impl] 低速端末で rAF 予算超過時に末尾寄り着地・以降補正なし → **#255**。

**★ (対応 or issue)**
- [impl] momentum scroll で毎フレーム保存 → **200ms デバウンス化** (00f8aeb)。
- [impl] board サブタブ間でスクロール共有 → **#255**。
- [挙動] same-session reload 復元は意図的 (上記「既知の挙動」)。