### PR TITLE
fix(workspace): ドリルダウン詳細の横スクロール抑止 + 読み込み高速化

### DIFF
--- a/apps/web/src/components/column-detail.tsx
+++ b/apps/web/src/components/column-detail.tsx
@@ -138,7 +138,7 @@ export function ColumnDetailView({
         <ColumnScrollContext.Provider value={bodyEl}>
           <Suspense fallback={DETAIL_FALLBACK}>
             {entry.kind === 'post' ? (
-              <PostThread handle={entry.handle} rkey={entry.rkey} />
+              <PostThread handle={entry.handle} rkey={entry.rkey} uri={entry.uri} />
             ) : (
               <ProfileView actor={entry.actor} />
             )}

--- a/apps/web/src/components/post-thread.tsx
+++ b/apps/web/src/components/post-thread.tsx
@@ -17,8 +17,12 @@ type LoadState =
  * handle + rkey から投稿スレッドをロードして表示する。
  * ルート (routes/post-detail.tsx の全画面表示) とカラム内ドリルダウン
  * (column-detail.tsx のオーバーレイ) の両方から使い回す。
+ *
+ * uri (at://did:.../) が渡され DID 形式なら、handle→DID 解決 (getProfile 1 往復) を
+ * 省いて即スレッド取得する (タイムラインからのタップは post.uri を持っているので速い)。
+ * uri が無い/handle 形式のとき (共有 URL 直開き・bsky.app リンク等) だけ解決する。
  */
-export function PostThread({ handle, rkey }: { handle: string; rkey: string }) {
+export function PostThread({ handle, rkey, uri: uriProp }: { handle: string; rkey: string; uri?: string }) {
   const session = useSession();
   const [state, setState] = useState<LoadState>({ status: 'loading' });
 
@@ -32,13 +36,16 @@ export function PostThread({ handle, rkey }: { handle: string; rkey: string }) {
     let cancelled = false;
     (async () => {
       try {
-        const did = await resolveHandleToDid(agent, handle);
-        if (cancelled) return;
-        if (!did) {
-          setState({ status: 'error', message: `ユーザー "@${handle}" が見つかりません。` });
-          return;
+        let uri = uriProp && uriProp.startsWith('at://did:') ? uriProp : null;
+        if (!uri) {
+          const did = await resolveHandleToDid(agent, handle);
+          if (cancelled) return;
+          if (!did) {
+            setState({ status: 'error', message: `ユーザー "@${handle}" が見つかりません。` });
+            return;
+          }
+          uri = postUri(did, rkey);
         }
-        const uri = postUri(did, rkey);
         const thread = await fetchPostThread(agent, uri, { depth: 6, parentHeight: 10 });
         if (cancelled) return;
         if (FeedDefs.isThreadViewPost(thread)) {
@@ -56,7 +63,7 @@ export function PostThread({ handle, rkey }: { handle: string; rkey: string }) {
       }
     })();
     return () => { cancelled = true; };
-  }, [handle, rkey, session.status, session.agent]);
+  }, [handle, rkey, uriProp, session.status, session.agent]);
 
   return (
     <>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -407,6 +407,7 @@ p { margin: 0.4em 0; }
   z-index: 6;
   display: flex;
   flex-direction: column;
+  min-width: 0;
   /* 不透明にして下のフィードを完全に隠す (半透明 window-bg だと透ける)。 */
   background: var(--color-window-solid);
   overflow: hidden;
@@ -442,9 +443,13 @@ p { margin: 0.4em 0; }
 .workspace-column-detail-back:active { transform: translateY(1px); }
 .workspace-column-detail-body {
   flex: 1 1 auto;
+  min-width: 0;                   /* 中身で横に膨らませない (column-body と同様) */
+  overflow-wrap: anywhere;        /* 長い URL/連続文字を折り返す */
   overflow-y: auto;
+  overflow-x: hidden;             /* 詳細は横スクロールさせない (カラム送りとも切り離す) */
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;
+  touch-action: pan-y;            /* 縦スクロールのみ (横スワイプでカラム送りに漏れない) */
   padding: 0.5em;
 }
 


### PR DESCRIPTION
## 報告 (実機)
カラム内ドリルダウン (#256) で: (1) 投稿によっては詳細が左右スクロールできてしまう、(2) ポストをタップしてからの読み込みが遅い。

## 修正
1. **横スクロール**: `.workspace-column-detail-body` に既存 `.workspace-column-body` と同じ制約 (`min-width:0` / `overflow-wrap:anywhere` / `overflow-x:hidden` / `touch-action:pan-y`) が抜けていた。付与して縦スクロールのみに (親 `.workspace-column-detail` にも min-width:0)。
2. **遅い**: `PostThread` が handle→DID (getProfile 1 往復) を毎回挟んでからスレッド取得していた。TL タップは `post.uri` (`at://did:.../`) を持つので、DID 形式 uri が渡れば解決を省いて即取得。共有 URL 直開き / bsky.app リンク (handle 形式) のみ従来どおり解決。

## テスト
web unit 254 passed / typecheck / build green。

## Review (§1.5 焦点レビュー: 実装 + UX/レイアウト)
**★★★ / ★★** — なし。
- uri-skip は健全: openPost は authoritative な post.uri (DID 形式) を渡すので即取得で正しいスレッド。openPostByParts で actor が handle のときは `at://<handle>/` になり `at://did:` gate に掛からず従来解決へフォールバック (handle が DID を騙ることは不可)。共有 URL 直開き (uri 無し) も従来経路。notFound/blocked は fetchPostThread の判定で従来どおり。effect deps に uriProp 追加は正当。
- overflow 修正は feed の column-body と同一の実績ある組み合わせ。画像/埋め込み/引用カードは min-width:0 で縮み、クリップされない。touch-action:pan-y は詳細をカラム送りに参加させない意図的差分。VirtualFeed (overflow-y:auto ベース) に影響なし。

**★ (据え置き)**
- [実装] openPost で handle 省略時に entry.handle が DID になる整合 nit → DID 形式 uri が fast path を勝つため未使用・無害。