### PR TITLE
feat(lightbox): 画像のピンチズーム + パン + ダブルタップ切替

### DIFF
--- a/apps/web/src/components/image-lightbox.tsx
+++ b/apps/web/src/components/image-lightbox.tsx
@@ -20,8 +20,9 @@ import type { PostImage } from '@/lib/post-embed';
 const SWIPE_THRESHOLD_RATIO = 0.18; // ビューポート幅のこの割合を超えたらページ送り
 const SWIPE_THRESHOLD_MAX = 60;     // ただし最低でもこの px を超えれば送る
 const MAX_SCALE = 5;                // ピンチ/ダブルタップの最大倍率
-const DOUBLE_TAP_SCALE = 2.5;       // ダブルタップ時に飛ぶ倍率
+const DOUBLE_TAP_SCALE = 3;         // ダブルタップ時に飛ぶ倍率 (スクショの小文字も読める程度)
 const DOUBLE_TAP_MS = 300;          // ダブルタップ判定の間隔
+const TAP_MOVE_TOL = 10;            // これ未満の移動はタップ扱い (ダブルタップ検出)
 
 interface Zoom {
   scale: number;
@@ -59,6 +60,8 @@ export function ImageLightbox({
   // ピンチ (2 本指) / パン (ズーム中 1 本指) のジェスチャ追跡。
   const pinch = useRef<{ dist: number; midX: number; midY: number } | null>(null);
   const pan = useRef<{ x: number; y: number } | null>(null);
+  // 単指タッチの開始点 (タップ判定用)。ピンチからの引き継ぎパンでは付けない (= タップ扱いしない)。
+  const panStart = useRef<{ x: number; y: number } | null>(null);
   const lastTap = useRef(0);
 
   const go = useCallback(
@@ -135,6 +138,7 @@ export function ImageLightbox({
     axis.current = null;
     pinch.current = null;
     pan.current = null;
+    panStart.current = null;
     setGesturing(false);
   }
 
@@ -158,6 +162,17 @@ export function ImageLightbox({
     return Math.hypot(b.clientX - a.clientX, b.clientY - a.clientY);
   }
 
+  // タップ (= ダブルタップ) 判定。ズーム中/等倍どちらの経路からも呼べる。
+  function handleTapAt(x: number, y: number) {
+    const now = Date.now();
+    if (now - lastTap.current < DOUBLE_TAP_MS) {
+      lastTap.current = 0;
+      zoomTo(zoomRef.current.scale > 1 ? 1 : DOUBLE_TAP_SCALE, x, y);
+    } else {
+      lastTap.current = now;
+    }
+  }
+
   function onTouchStart(e: React.TouchEvent) {
     if (e.touches.length >= 2) {
       // ピンチ開始。カルーセルドラッグはキャンセル。
@@ -174,8 +189,9 @@ export function ImageLightbox({
     const t = e.touches[0];
     if (!t) return;
     if (zoomRef.current.scale > 1) {
-      // ズーム中の 1 本指 = パン。
+      // ズーム中の 1 本指 = パン。開始点を控えて (ほぼ動かなければ) ダブルタップも拾えるように。
       pan.current = { x: t.clientX, y: t.clientY };
+      panStart.current = { x: t.clientX, y: t.clientY };
       setGesturing(true);
       return;
     }
@@ -244,8 +260,19 @@ export function ImageLightbox({
     if (pinch.current || pan.current) {
       if (e.touches.length === 0) {
         setGesturing(false);
+        const wasTapCandidate = panStart.current;
         pinch.current = null;
         pan.current = null;
+        panStart.current = null;
+        // ズーム中に (ほぼ動かさず) タップした = ダブルタップでズームアウトできるように拾う。
+        if (wasTapCandidate) {
+          const ex = e.changedTouches[0]?.clientX ?? wasTapCandidate.x;
+          const ey = e.changedTouches[0]?.clientY ?? wasTapCandidate.y;
+          if (Math.abs(ex - wasTapCandidate.x) < TAP_MOVE_TOL && Math.abs(ey - wasTapCandidate.y) < TAP_MOVE_TOL) {
+            handleTapAt(ex, ey);
+            return;
+          }
+        }
         const z = zoomRef.current;
         if (z.scale <= 1.02) applyZoom(IDENTITY);
         else {
@@ -254,9 +281,10 @@ export function ImageLightbox({
         }
       } else if (e.touches.length === 1) {
         // 2 本指の片方が離れた → 残り 1 本指でパンに引き継ぐ (急に飛ばないよう基準点を取り直す)。
+        // 引き継ぎパンはタップ候補にしない (panStart は付けない)。
         pinch.current = null;
         const t = e.touches[0];
-        if (t && zoomRef.current.scale > 1) {
+        if (t && zoomRef.current.scale > 1.02) {
           pan.current = { x: t.clientX, y: t.clientY };
         } else {
           pan.current = null;
@@ -272,25 +300,40 @@ export function ImageLightbox({
     const endX = e.changedTouches[0]?.clientX ?? startX.current;
     const endY = e.changedTouches[0]?.clientY ?? startY.current;
     const dx = endX - startX.current;
-    if (a === null && Math.abs(dx) < 10) {
-      // 軸が立たない微小移動 = タップ。ダブルタップならズームトグル。
-      const now = Date.now();
-      if (now - lastTap.current < DOUBLE_TAP_MS) {
-        lastTap.current = 0;
-        zoomTo(zoomRef.current.scale > 1 ? 1 : DOUBLE_TAP_SCALE, endX, endY);
-      } else {
-        lastTap.current = now;
-      }
+    const dy = endY - startY.current;
+    // 軸が立たない微小移動 = タップ (ダブルタップならズームトグル)。
+    if (a === null && Math.abs(dx) < TAP_MOVE_TOL && Math.abs(dy) < TAP_MOVE_TOL) {
+      handleTapAt(endX, endY);
       setDrag(0);
       return;
     }
-    if (a !== 'h') {
+    // 横スワイプ判定: axis が 'h' で確定、または高速フリックで axis 未確定でも終端デルタが
+    // 横優勢なら横送り扱いにする (サンプルが少ない速い指で送りが死ぬのを防ぐ)。
+    const horizontal = a === 'h' || (a === null && Math.abs(dx) > Math.abs(dy));
+    if (!horizontal) {
       setDrag(0);
       return;
     }
     const threshold = Math.min(SWIPE_THRESHOLD_MAX, vpW.current * SWIPE_THRESHOLD_RATIO);
     if (Math.abs(dx) > threshold) go(dx < 0 ? 1 : -1);
     setDrag(0);
+  }
+
+  // デスクトップ: ホイールでカーソル位置を固定してズーム。
+  function onWheel(e: React.WheelEvent) {
+    e.stopPropagation();
+    const { cx, cy, w, h } = viewport();
+    const prev = zoomRef.current;
+    const factor = e.deltaY < 0 ? 1.15 : 1 / 1.15;
+    const scale = Math.max(1, Math.min(MAX_SCALE, prev.scale * factor));
+    if (scale <= 1.001) {
+      applyZoom(IDENTITY);
+      return;
+    }
+    const ratio = scale / prev.scale;
+    const mrx = e.clientX - cx;
+    const mry = e.clientY - cy;
+    applyZoom(clampZoom({ scale, tx: mrx - ratio * (mrx - prev.tx), ty: mry - ratio * (mry - prev.ty) }, w, h));
   }
 
   // デスクトップ: ダブルクリックでズームトグル。
@@ -324,6 +367,7 @@ export function ImageLightbox({
         onTouchMove={onTouchMove}
         onTouchEnd={onTouchEnd}
         onTouchCancel={resetDrag}
+        onWheel={onWheel}
         // 画像エリア (レターボックス余白含む) のタップで誤って閉じない。閉じるのは
         // 背景余白 / ✕ ボタン / ESC のみ (スワイプ後のタップ誤爆も防ぐ)。
         onClick={(e) => e.stopPropagation()}
@@ -366,7 +410,7 @@ export function ImageLightbox({
                     transform: isCurrent ? `translate(${zoom.tx}px, ${zoom.ty}px) scale(${zoom.scale})` : undefined,
                     transformOrigin: 'center center',
                     transition: isCurrent && !gesturing ? 'transform 0.2s ease' : 'none',
-                    cursor: isCurrent && zoom.scale > 1 ? 'grab' : 'zoom-in',
+                    cursor: isCurrent && zoom.scale > 1 ? (gesturing ? 'grabbing' : 'grab') : 'zoom-in',
                     touchAction: 'none',
                   }}
                 />

--- a/apps/web/src/components/image-lightbox.tsx
+++ b/apps/web/src/components/image-lightbox.tsx
@@ -7,16 +7,28 @@ import type { PostImage } from '@/lib/post-embed';
  *
  * - ESC / 背景クリック / 閉じるボタンで閉じる
  * - 複数枚: ← → キー、左右ボタン、**横スワイプ (指追従カルーセル)** で前後移動
+ * - **ピンチイン/アウトでズーム**、ズーム中は 1 本指ドラッグでパン、ダブルタップ /
+ *   ダブルクリックでズーム↔等倍トグル。ズーム中は横スワイプはページ送りにせずパンにする。
  * - 端まで来たら止まる (ループしない。端ではドラッグに抵抗をかける)
  * - 次/前の画像を new Image().src でプリロード
  * - body のスクロールを掴んだままにしない
  *
  * スワイプは横カルーセル方式: 全スライドを横一列に並べ translateX で動かす。
- * `touch-action: none` でブラウザの縦スクロール/パンに**ジェスチャを奪われない**ようにし、
+ * `touch-action: none` でブラウザの縦スクロール/パン/ピンチにジェスチャを奪われないようにし、
  * touchmove で指に追従、touchend で閾値を超えたら次/前へスナップ (transition でスライドイン)。
  */
 const SWIPE_THRESHOLD_RATIO = 0.18; // ビューポート幅のこの割合を超えたらページ送り
 const SWIPE_THRESHOLD_MAX = 60;     // ただし最低でもこの px を超えれば送る
+const MAX_SCALE = 5;                // ピンチ/ダブルタップの最大倍率
+const DOUBLE_TAP_SCALE = 2.5;       // ダブルタップ時に飛ぶ倍率
+const DOUBLE_TAP_MS = 300;          // ダブルタップ判定の間隔
+
+interface Zoom {
+  scale: number;
+  tx: number;
+  ty: number;
+}
+const IDENTITY: Zoom = { scale: 1, tx: 0, ty: 0 };
 
 export function ImageLightbox({
   images,
@@ -30,12 +42,24 @@ export function ImageLightbox({
   const [idx, setIdx] = useState(initialIndex);
   const [drag, setDrag] = useState(0);
   const [dragging, setDragging] = useState(false);
+  // 現在画像のズーム状態。ref を即時ソースにし state は描画反映用 (gesture 中の stale 読み回避)。
+  const [zoom, setZoom] = useState<Zoom>(IDENTITY);
+  const zoomRef = useRef<Zoom>(IDENTITY);
+  const [gesturing, setGesturing] = useState(false);
+  const applyZoom = useCallback((z: Zoom) => {
+    zoomRef.current = z;
+    setZoom(z);
+  }, []);
 
   const startX = useRef(0);
   const startY = useRef(0);
   const axis = useRef<'h' | 'v' | null>(null);
   const vpRef = useRef<HTMLDivElement>(null);
   const vpW = useRef(0);
+  // ピンチ (2 本指) / パン (ズーム中 1 本指) のジェスチャ追跡。
+  const pinch = useRef<{ dist: number; midX: number; midY: number } | null>(null);
+  const pan = useRef<{ x: number; y: number } | null>(null);
+  const lastTap = useRef(0);
 
   const go = useCallback(
     (delta: number) => {
@@ -47,6 +71,11 @@ export function ImageLightbox({
     },
     [images.length],
   );
+
+  // 画像を切り替えたらズームを等倍にリセット (前の画像の拡大状態を持ち越さない)。
+  useEffect(() => {
+    applyZoom(IDENTITY);
+  }, [idx, applyZoom]);
 
   // keyboard + body scroll lock
   useEffect(() => {
@@ -76,18 +105,81 @@ export function ImageLightbox({
   const hasPrev = idx > 0;
   const hasNext = idx < images.length - 1;
 
+  // ビューポート中心と実寸 (ピンチのアンカー計算・パン境界に使う)。
+  const viewport = useCallback(() => {
+    const el = vpRef.current;
+    if (!el) {
+      const w = window.innerWidth;
+      const h = window.innerHeight;
+      return { cx: w / 2, cy: h / 2, w, h };
+    }
+    const r = el.getBoundingClientRect();
+    return { cx: r.left + r.width / 2, cy: r.top + r.height / 2, w: r.width, h: r.height };
+  }, []);
+
+  // translate を「画像がビューポートから出過ぎない」範囲に丸める。
+  const clampZoom = useCallback((z: Zoom, w: number, h: number): Zoom => {
+    const maxX = Math.max(0, ((z.scale - 1) * w) / 2);
+    const maxY = Math.max(0, ((z.scale - 1) * h) / 2);
+    return {
+      scale: z.scale,
+      tx: Math.max(-maxX, Math.min(maxX, z.tx)),
+      ty: Math.max(-maxY, Math.min(maxY, z.ty)),
+    };
+  }, []);
+
   // 指が外れた / ジェスチャ中断時に drag が途中値で固定されないよう確実にリセットする。
   function resetDrag() {
     setDragging(false);
     setDrag(0);
     axis.current = null;
+    pinch.current = null;
+    pan.current = null;
+    setGesturing(false);
+  }
+
+  const zoomTo = useCallback(
+    (targetScale: number, screenX: number, screenY: number) => {
+      const { cx, cy, w, h } = viewport();
+      if (targetScale <= 1.001) {
+        applyZoom(IDENTITY);
+        return;
+      }
+      // 等倍 (tx=ty=0) からアンカー点を固定して targetScale へ。
+      const mrx = screenX - cx;
+      const mry = screenY - cy;
+      const next = clampZoom({ scale: targetScale, tx: mrx * (1 - targetScale), ty: mry * (1 - targetScale) }, w, h);
+      applyZoom(next);
+    },
+    [viewport, clampZoom, applyZoom],
+  );
+
+  function twoTouchDist(a: React.Touch, b: React.Touch): number {
+    return Math.hypot(b.clientX - a.clientX, b.clientY - a.clientY);
   }
 
   function onTouchStart(e: React.TouchEvent) {
-    // 2 本目以降 (ピンチ等) は基準点がぶれるのでカルーセルを開始しない。
-    if (e.touches.length > 1) { resetDrag(); return; }
+    if (e.touches.length >= 2) {
+      // ピンチ開始。カルーセルドラッグはキャンセル。
+      const a = e.touches[0]!;
+      const b = e.touches[1]!;
+      pinch.current = { dist: twoTouchDist(a, b), midX: (a.clientX + b.clientX) / 2, midY: (a.clientY + b.clientY) / 2 };
+      pan.current = null;
+      setDragging(false);
+      setDrag(0);
+      axis.current = null;
+      setGesturing(true);
+      return;
+    }
     const t = e.touches[0];
     if (!t) return;
+    if (zoomRef.current.scale > 1) {
+      // ズーム中の 1 本指 = パン。
+      pan.current = { x: t.clientX, y: t.clientY };
+      setGesturing(true);
+      return;
+    }
+    // 等倍 = 従来のカルーセルスワイプ。
     startX.current = t.clientX;
     startY.current = t.clientY;
     axis.current = null;
@@ -96,32 +188,115 @@ export function ImageLightbox({
   }
 
   function onTouchMove(e: React.TouchEvent) {
-    if (e.touches.length > 1) return; // マルチタッチ中は drag を更新しない
+    // ── ピンチ ──
+    if (pinch.current && e.touches.length >= 2) {
+      const a = e.touches[0]!;
+      const b = e.touches[1]!;
+      const nd = twoTouchDist(a, b);
+      const nmx = (a.clientX + b.clientX) / 2;
+      const nmy = (a.clientY + b.clientY) / 2;
+      const { cx, cy } = viewport();
+      const prev = zoomRef.current;
+      const scale = Math.max(1, Math.min(MAX_SCALE, (prev.scale * nd) / (pinch.current.dist || nd)));
+      const ratio = scale / prev.scale;
+      // 2 本指の移動ぶんパン → 現在の中点を固定してズーム。
+      let tx = prev.tx + (nmx - pinch.current.midX);
+      let ty = prev.ty + (nmy - pinch.current.midY);
+      const mrx = nmx - cx;
+      const mry = nmy - cy;
+      tx = mrx - ratio * (mrx - tx);
+      ty = mry - ratio * (mry - ty);
+      applyZoom({ scale, tx, ty });
+      pinch.current = { dist: nd, midX: nmx, midY: nmy };
+      return;
+    }
+    // ── パン (ズーム中) ──
+    if (pan.current && e.touches.length === 1) {
+      const t = e.touches[0]!;
+      const prev = zoomRef.current;
+      const { w, h } = viewport();
+      const next = clampZoom(
+        { scale: prev.scale, tx: prev.tx + (t.clientX - pan.current.x), ty: prev.ty + (t.clientY - pan.current.y) },
+        w,
+        h,
+      );
+      applyZoom(next);
+      pan.current = { x: t.clientX, y: t.clientY };
+      return;
+    }
+    // ── カルーセル (等倍) ──
+    if (e.touches.length > 1) return;
     const t = e.touches[0];
     if (!t) return;
     const dx = t.clientX - startX.current;
     const dy = t.clientY - startY.current;
-    // 最初の十分な移動で軸を確定 (横なら以後カルーセル、縦なら無視)。
     if (axis.current === null && (Math.abs(dx) > 8 || Math.abs(dy) > 8)) {
       axis.current = Math.abs(dx) >= Math.abs(dy) ? 'h' : 'v';
     }
     if (axis.current === 'h') {
-      // 端ではドラッグに抵抗 (1/3) をかけ、これ以上めくれない感を出す。
       const atEdge = (idx === 0 && dx > 0) || (idx === images.length - 1 && dx < 0);
       setDrag(atEdge ? dx / 3 : dx);
     }
   }
 
   function onTouchEnd(e: React.TouchEvent) {
+    // ── ピンチ/パンの終了 ──
+    if (pinch.current || pan.current) {
+      if (e.touches.length === 0) {
+        setGesturing(false);
+        pinch.current = null;
+        pan.current = null;
+        const z = zoomRef.current;
+        if (z.scale <= 1.02) applyZoom(IDENTITY);
+        else {
+          const { w, h } = viewport();
+          applyZoom(clampZoom(z, w, h));
+        }
+      } else if (e.touches.length === 1) {
+        // 2 本指の片方が離れた → 残り 1 本指でパンに引き継ぐ (急に飛ばないよう基準点を取り直す)。
+        pinch.current = null;
+        const t = e.touches[0];
+        if (t && zoomRef.current.scale > 1) {
+          pan.current = { x: t.clientX, y: t.clientY };
+        } else {
+          pan.current = null;
+          setGesturing(false);
+        }
+      }
+      return;
+    }
+    // ── カルーセルの終了 (タップ判定 = ダブルタップも拾う) ──
     setDragging(false);
     const a = axis.current;
     axis.current = null;
-    if (a !== 'h') { setDrag(0); return; }
     const endX = e.changedTouches[0]?.clientX ?? startX.current;
+    const endY = e.changedTouches[0]?.clientY ?? startY.current;
     const dx = endX - startX.current;
+    if (a === null && Math.abs(dx) < 10) {
+      // 軸が立たない微小移動 = タップ。ダブルタップならズームトグル。
+      const now = Date.now();
+      if (now - lastTap.current < DOUBLE_TAP_MS) {
+        lastTap.current = 0;
+        zoomTo(zoomRef.current.scale > 1 ? 1 : DOUBLE_TAP_SCALE, endX, endY);
+      } else {
+        lastTap.current = now;
+      }
+      setDrag(0);
+      return;
+    }
+    if (a !== 'h') {
+      setDrag(0);
+      return;
+    }
     const threshold = Math.min(SWIPE_THRESHOLD_MAX, vpW.current * SWIPE_THRESHOLD_RATIO);
     if (Math.abs(dx) > threshold) go(dx < 0 ? 1 : -1);
-    setDrag(0); // idx 変化 + drag 0 + transition で新しい位置へスライドイン
+    setDrag(0);
+  }
+
+  // デスクトップ: ダブルクリックでズームトグル。
+  function onDoubleClick(e: React.MouseEvent) {
+    e.stopPropagation();
+    zoomTo(zoomRef.current.scale > 1 ? 1 : DOUBLE_TAP_SCALE, e.clientX, e.clientY);
   }
 
   if (!images[idx]) return null;
@@ -141,8 +316,8 @@ export function ImageLightbox({
         padding: '2vh 2vw',
       }}
     >
-      {/* 画像エリア = 横カルーセル。touch-action:none でブラウザの縦スクロール/パンに
-          スワイプを奪われないようにする (= 指追従が安定)。 */}
+      {/* 画像エリア = 横カルーセル。touch-action:none でブラウザの縦スクロール/パン/ピンチに
+          ジェスチャを奪われないようにする (= 指追従が安定)。 */}
       <div
         ref={vpRef}
         onTouchStart={onTouchStart}
@@ -169,25 +344,35 @@ export function ImageLightbox({
             willChange: 'transform',
           }}
         >
-          {images.map((im, i) => (
-            <div
-              key={i}
-              style={{ flex: '0 0 100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
-            >
-              <img
-                src={im.fullsize}
-                alt={im.alt}
-                onClick={(e) => e.stopPropagation()}
-                draggable={false}
-                style={{
-                  maxWidth: '100%',
-                  maxHeight: '100%',
-                  objectFit: 'contain',
-                  userSelect: 'none',
-                }}
-              />
-            </div>
-          ))}
+          {images.map((im, i) => {
+            const isCurrent = i === idx;
+            return (
+              <div
+                key={i}
+                style={{ flex: '0 0 100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+              >
+                <img
+                  src={im.fullsize}
+                  alt={im.alt}
+                  onClick={(e) => e.stopPropagation()}
+                  onDoubleClick={onDoubleClick}
+                  draggable={false}
+                  style={{
+                    maxWidth: '100%',
+                    maxHeight: '100%',
+                    objectFit: 'contain',
+                    userSelect: 'none',
+                    // ズーム変形は現在表示中の画像だけに適用。
+                    transform: isCurrent ? `translate(${zoom.tx}px, ${zoom.ty}px) scale(${zoom.scale})` : undefined,
+                    transformOrigin: 'center center',
+                    transition: isCurrent && !gesturing ? 'transform 0.2s ease' : 'none',
+                    cursor: isCurrent && zoom.scale > 1 ? 'grab' : 'zoom-in',
+                    touchAction: 'none',
+                  }}
+                />
+              </div>
+            );
+          })}
         </div>
       </div>
 


### PR DESCRIPTION
## 要望
ライトボックスに表示された画像をピンチイン/アウトでズームできるようにしてほしい。

## 実装
- **ピンチズーム** (2 本指): 等倍〜5倍、中点固定。中点の移動でパンも追従。
- **パン** (ズーム中 1 本指): 境界クランプ。
- **ダブルタップ / ダブルクリック**: 3 倍 ↔ 等倍トグル、点固定。**ズーム中/等倍どちらからも両方向に効く**。
- **デスクトップ wheel**: カーソル位置固定ズーム。
- ズーム中は横スワイプをパンに切替。画像送り (idx 変化) で等倍リセット。高速フリックの横送りも維持。

## テスト
web unit 254 passed / typecheck / build green。ジェスチャは実機確認前提 (§3)。

## Review (§1.5 実装 + UX)
**★★★** — なし (焦点固定の数式は正しいと検証済み、ref 同期・遷移カバレッジ OK)。

**★★ (本PR内で対応)**
- [UX] ズーム中にダブルタップでズームアウトできない (pan 経路で早期 return) → panStart を控えて pan 終了時もタップ判定 → 両方向トグル (この commit)。
- [実装] 高速フリックで axis 未確定だと横送りが死ぬ → 終端デルタが横優勢なら送る (この commit)。
- [UX] ダブルタップ倍率 2.5→3。

**★ (対応 or 据え置き)**
- [実装] 2→1 handoff の dead-zone → 閾値 >1.02 で緩和 (この commit)。
- [UX] デスクトップ wheel ズーム + grabbing カーソル追加 (この commit)。
- [実装] clampZoom の pan 境界は viewport 幅ベース (contain 画像の実寸でない) → 縦長画像で端が中央まで寄れる。実用上許容、将来 naturalWidth で精緻化可 (据え置き)。
- [UX] ズームインジケータ無し / キーボードズーム無し → 標準ジェスチャで代替、据え置き。