### PR TITLE
feat(post): 投稿の共有ボタンを追加 (公開 bsky.app リンク)

### DIFF
--- a/apps/web/src/components/post-metrics.tsx
+++ b/apps/web/src/components/post-metrics.tsx
@@ -2,10 +2,10 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import type { AppBskyFeedDefs } from '@atproto/api';
 import { useSession } from '@/lib/session';
-import { HeartIcon, RepeatIcon, ReplyIcon } from './icons';
+import { HeartIcon, RepeatIcon, ReplyIcon, ShareIcon } from './icons';
 import { useCompose } from './compose-modal';
 import { formatDateTime } from '@/lib/format-datetime';
-import { postDetailPath } from '@/lib/uri';
+import { postDetailPath, rkeyFromUri } from '@/lib/uri';
 import { useColumnNav } from './column-detail';
 import type { PostRecordShape } from './post-article';
 
@@ -116,6 +116,29 @@ export function PostMetrics({ post, onToggleThread, threadExpanded }: PostMetric
   const ts = (post.record as PostRecordShape).createdAt ?? post.indexedAt;
   const detailPath = postDetailPath(post.author.handle, post.uri);
 
+  const [copied, setCopied] = useState(false);
+  // 投稿を共有する。公開リンク (bsky.app) を使い、誰でも開ける URL にする。
+  // モバイルは OS の共有シート (navigator.share)、無ければクリップボードにコピー。
+  async function onShare(e: React.MouseEvent) {
+    e.stopPropagation();
+    const url = `https://bsky.app/profile/${post.author.handle}/post/${rkeyFromUri(post.uri)}`;
+    if (typeof navigator !== 'undefined' && navigator.share) {
+      try {
+        await navigator.share({ url });
+      } catch {
+        /* キャンセル/失敗時は何もしない (誤コピーを避ける) */
+      }
+      return;
+    }
+    try {
+      await navigator.clipboard?.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* no-op */
+    }
+  }
+
   return (
     <div style={{ marginTop: '0.5em' }}>
       {/* アクション行: リプ/リポスト/いいね + 右端に日時 (小さく右揃え)。
@@ -129,6 +152,9 @@ export function PostMetrics({ post, onToggleThread, threadExpanded }: PostMetric
         </MetricButton>
         <MetricButton onClick={toggleLike} ariaLabel={liked ? 'いいね解除' : 'いいね'} count={likeCount} active={liked} activeColor="#ff6b9a">
           <HeartIcon size={15} />
+        </MetricButton>
+        <MetricButton onClick={onShare} ariaLabel="共有" {...(copied ? { count: '✓' } : {})} active={copied} activeColor="#4caf7d">
+          <ShareIcon size={15} />
         </MetricButton>
         <Link
           to={detailPath}
@@ -200,7 +226,8 @@ function MetricButton({
 }: {
   onClick: (e: React.MouseEvent) => void;
   ariaLabel: string;
-  count: number;
+  /** 数値カウント / 短い文字 (共有ボタンのコピー完了 ✓ 等)。未指定なら数字を出さない。 */
+  count?: number | string;
   children: React.ReactNode;
   active?: boolean;
   activeColor?: string;
@@ -231,7 +258,7 @@ function MetricButton({
       onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = 'transparent')}
     >
       {children}
-      <span>{count}</span>
+      {count !== undefined && count !== '' && <span>{count}</span>}
     </button>
   );
 }

--- a/apps/web/src/components/post-metrics.tsx
+++ b/apps/web/src/components/post-metrics.tsx
@@ -1,11 +1,11 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import type { AppBskyFeedDefs } from '@atproto/api';
 import { useSession } from '@/lib/session';
 import { HeartIcon, RepeatIcon, ReplyIcon, ShareIcon } from './icons';
 import { useCompose } from './compose-modal';
 import { formatDateTime } from '@/lib/format-datetime';
-import { postDetailPath, rkeyFromUri } from '@/lib/uri';
+import { didFromUri, postDetailPath, rkeyFromUri } from '@/lib/uri';
 import { useColumnNav } from './column-detail';
 import type { PostRecordShape } from './post-article';
 
@@ -117,11 +117,19 @@ export function PostMetrics({ post, onToggleThread, threadExpanded }: PostMetric
   const detailPath = postDetailPath(post.author.handle, post.uri);
 
   const [copied, setCopied] = useState(false);
+  const copiedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // 行が仮想フィードでアンマウントされても、遅延した setCopied(false) が走らないよう掃除。
+  useEffect(() => () => { if (copiedTimer.current) clearTimeout(copiedTimer.current); }, []);
+
   // 投稿を共有する。公開リンク (bsky.app) を使い、誰でも開ける URL にする。
   // モバイルは OS の共有シート (navigator.share)、無ければクリップボードにコピー。
   async function onShare(e: React.MouseEvent) {
     e.stopPropagation();
-    const url = `https://bsky.app/profile/${post.author.handle}/post/${rkeyFromUri(post.uri)}`;
+    // handle.invalid (未解決アカウント) は bsky.app で開けないので DID を使う。
+    // bsky.app は /profile/<did>/post/<rkey> も解決する。
+    const handle = post.author.handle;
+    const actor = handle && handle !== 'handle.invalid' ? handle : didFromUri(post.uri);
+    const url = `https://bsky.app/profile/${actor}/post/${rkeyFromUri(post.uri)}`;
     if (typeof navigator !== 'undefined' && navigator.share) {
       try {
         await navigator.share({ url });
@@ -133,7 +141,8 @@ export function PostMetrics({ post, onToggleThread, threadExpanded }: PostMetric
     try {
       await navigator.clipboard?.writeText(url);
       setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
+      if (copiedTimer.current) clearTimeout(copiedTimer.current);
+      copiedTimer.current = setTimeout(() => setCopied(false), 1500);
     } catch {
       /* no-op */
     }


### PR DESCRIPTION
## 要望
投稿をシェアする機能がない。

## 実装
アクション行 (返信/リポスト/いいね の隣) に**共有ボタン**。共有するのは公開リンク `https://bsky.app/profile/<actor>/post/<rkey>`。
- **モバイル**: OS 共有シート (`navigator.share`)。キャンセルは何もしない。
- **デスクトップ / 共有 API 無し**: クリップボードにコピー → ✓ を一瞬表示。
- `MetricButton` の `count` を optional 化 (数字なし共有ボタン・✓ 表示に流用、数値系は従来どおり)。
- 共有先が Bluesky 未使用でも開けるよう公式 (bsky.app) URL を使用。

## テスト
web unit 254 passed / typecheck / build green。

## Review (§1.5 焦点: 実装 + UX)
**★★★** — なし。

**★★ (本PR内で対応)**
- [実装] `handle.invalid` (未解決アカウント) で壊れた共有 URL → **DID フォールバック** (bsky.app は /profile/<did>/... も解決)。
- [実装] コピー完了 ✓ の setTimeout が仮想フィードのアンマウント後に発火しうる → **ref + cleanup で clearTimeout**。

**★★ (実機確認項目)**
- [UX] 狭カラムで 4 ボタン + カウント + 日時が nowrap のため行あふれの恐れ → 共有ボタンは数字なしで幅節約。dev 実機 (多カラム狭幅) で目視確認 (§3)。

**★ (据え置き / 判断)**
- [UX] デスクトップのコピー成功は 1.5s の緑 ✓ (トーストにするかは好み) / 共有失敗時のフィードバック無し。
- [設計] 共有は bsky.app 公開 URL + URL のみ (本文は付けない) の意図的既定。
- [実装] count=0 は描画される (guard は undefined/'' のみ除外) / stopPropagation 維持を確認済み。