### PR TITLE
feat(power): ブルスコンの試練の消費配線 (PR②)

### DIFF
--- a/apps/web/src/lib/battle-log.test.ts
+++ b/apps/web/src/lib/battle-log.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test, vi } from 'vitest';
+import { loadBattleStats, countBattles } from './battle-log';
+
+/** battle レコード列 (新しい順 = listRecords の返却順) を返す mock agent。 */
+function makeAgent(records: Array<{ outcome?: string; tier?: number; drops?: unknown }>): any {
+  const listRecords = vi.fn(async ({ cursor }: { collection: string; cursor?: string }) => {
+    if (cursor) return { data: { records: [] } };
+    return {
+      data: {
+        records: records.map((v, i) => ({ uri: `at://did:test/battle/${i}`, cid: `c${i}`, value: v })),
+      },
+    };
+  });
+  return { com: { atproto: { repo: { listRecords } } } };
+}
+
+describe('loadBattleStats', () => {
+  test('空: 全部 0', async () => {
+    const s = await loadBattleStats(makeAgent([]), 'did:test');
+    expect(s).toEqual({ wins: 0, losses: 0, bestStreak: 0, tier3Wins: 0, materials: {}, currentStreak: 0, total: 0 });
+  });
+
+  test('勝敗と tier3 勝利のカウント', async () => {
+    const s = await loadBattleStats(
+      makeAgent([
+        { outcome: 'win', tier: 3 },
+        { outcome: 'lose', tier: 1 },
+        { outcome: 'win', tier: 1 },
+        { outcome: 'win', tier: 3 },
+      ]),
+      'did:test',
+    );
+    expect(s.wins).toBe(3);
+    expect(s.losses).toBe(1);
+    expect(s.tier3Wins).toBe(2);
+    expect(s.total).toBe(4);
+  });
+
+  test('currentStreak は先頭 (新しい順) からの連続勝利', async () => {
+    // 新しい順: win, win, lose, win → 現在 2 連勝
+    const s = await loadBattleStats(
+      makeAgent([
+        { outcome: 'win', tier: 1 },
+        { outcome: 'win', tier: 1 },
+        { outcome: 'lose', tier: 1 },
+        { outcome: 'win', tier: 1 },
+      ]),
+      'did:test',
+    );
+    expect(s.currentStreak).toBe(2);
+  });
+
+  test('bestStreak は時系列の最長連勝 (向きに依存しない)', async () => {
+    // 新しい順: lose, win, win, win, lose, win → 最長 3
+    const s = await loadBattleStats(
+      makeAgent([
+        { outcome: 'lose', tier: 1 },
+        { outcome: 'win', tier: 1 },
+        { outcome: 'win', tier: 1 },
+        { outcome: 'win', tier: 1 },
+        { outcome: 'lose', tier: 1 },
+        { outcome: 'win', tier: 1 },
+      ]),
+      'did:test',
+    );
+    expect(s.bestStreak).toBe(3);
+    expect(s.currentStreak).toBe(0);
+  });
+
+  test('draw は連勝を切るが敗北には数えない', async () => {
+    const s = await loadBattleStats(
+      makeAgent([
+        { outcome: 'draw', tier: 1 },
+        { outcome: 'win', tier: 1 },
+      ]),
+      'did:test',
+    );
+    expect(s.losses).toBe(0);
+    expect(s.wins).toBe(1);
+    expect(s.currentStreak).toBe(0); // 先頭が draw なので現在連勝は 0
+  });
+
+  test('素材は勝利分だけ集計、壊れた drops は無視', async () => {
+    const s = await loadBattleStats(
+      makeAgent([
+        { outcome: 'win', tier: 1, drops: ['slime-drop', 'slime-drop'] },
+        { outcome: 'win', tier: 2, drops: ['golem-core', 42, null] },
+        { outcome: 'lose', tier: 1, drops: ['oni-horn'] }, // 敗北の drops は数えない (勝利時のみ書かれる)
+        { outcome: 'win', tier: 1, drops: 'not-an-array' },
+      ]),
+      'did:test',
+    );
+    expect(s.materials).toEqual({ 'slime-drop': 2, 'golem-core': 1 });
+  });
+
+  test('outcome 欠落は lose 扱い (中断された仮レコード = 棄権)', async () => {
+    const s = await loadBattleStats(makeAgent([{ tier: 1 }]), 'did:test');
+    expect(s.losses).toBe(1);
+  });
+
+  test('listRecords がエラーでも空 stats を返す (未作成コレクション)', async () => {
+    const agent = {
+      com: { atproto: { repo: { listRecords: vi.fn(async () => { throw new Error('nope'); }) } } },
+    } as any;
+    const s = await loadBattleStats(agent, 'did:test');
+    expect(s.total).toBe(0);
+  });
+});
+
+describe('countBattles', () => {
+  test('件数を数える / エラー時は途中まで', async () => {
+    expect(await countBattles(makeAgent([{ outcome: 'win' }, { outcome: 'lose' }]), 'did:test')).toBe(2);
+    const err = { com: { atproto: { repo: { listRecords: vi.fn(async () => { throw new Error('x'); }) } } } } as any;
+    expect(await countBattles(err, 'did:test')).toBe(0);
+  });
+});

--- a/apps/web/src/lib/battle-log.ts
+++ b/apps/web/src/lib/battle-log.ts
@@ -1,0 +1,148 @@
+/**
+ * ブルスコンの試練の戦闘記録 (docs/18-brusukon-trial.md)。
+ *
+ * 1 戦 = 1 レコードを `COL.battle` に書く。パワー消費の監査であり、
+ * 戦績 (勝敗/連勝/称号) と素材ドロップの集計ソースでもある。
+ * cardDraw と同じく端末には保存しない (端末を変えても整合する)。
+ */
+
+import type { Agent } from '@atproto/api';
+import type { BattleOutcome, BattleRecordSummary } from '@aozoraquest/core';
+import { VIA } from './atproto';
+import { COL } from './collections';
+
+export interface BattleLogRecord {
+  $type: string;
+  /** バトルの seed (決定的エンジンの再現用) */
+  seed: number;
+  tier: 1 | 2 | 3;
+  monsterId: string;
+  outcome: Exclude<BattleOutcome, 'ongoing'>;
+  /** 決着までのターン数 */
+  turns: number;
+  /** ドロップした素材 ID (勝利時のみ非空) */
+  drops: string[];
+  at: string;
+  via: string;
+}
+
+/** 1 戦の結果を記録する (PDS に 1 レコード作成)。 */
+export async function recordBattle(
+  agent: Agent,
+  input: Omit<BattleLogRecord, '$type' | 'at' | 'via'>,
+): Promise<void> {
+  const did = agent.assertDid;
+  const rkey = `b-${Date.now().toString(36)}-${Math.floor(Math.random() * 1e6).toString(36)}`;
+  await agent.com.atproto.repo.createRecord({
+    repo: did,
+    collection: COL.battle,
+    rkey,
+    record: {
+      $type: COL.battle,
+      ...input,
+      at: new Date().toISOString(),
+      via: VIA,
+    } satisfies BattleLogRecord,
+  });
+}
+
+/** 戦闘レコード数を数える (パワー再スキャン用。cardDraw と同じ最大 500 件)。 */
+export async function countBattles(agent: Agent, did: string): Promise<number> {
+  let cursor: string | undefined;
+  let count = 0;
+  for (let page = 0; page < 5; page++) {
+    try {
+      const res = await agent.com.atproto.repo.listRecords({
+        repo: did,
+        collection: COL.battle,
+        limit: 100,
+        ...(cursor !== undefined ? { cursor } : {}),
+      });
+      count += res.data.records.length;
+      const next = res.data.cursor;
+      if (!next || next === cursor) break;
+      cursor = next;
+    } catch (e) {
+      // レコード未作成時はエラーが返ることがあるのでそのまま返す
+      console.info('battle listRecords:', (e as Error)?.message);
+      return count;
+    }
+  }
+  return count;
+}
+
+export interface BattleStats extends BattleRecordSummary {
+  /** 集めた素材 (素材 ID → 個数) */
+  materials: Record<string, number>;
+  /** 現在の連勝数 (直近から遡って連続勝利) */
+  currentStreak: number;
+  total: number;
+}
+
+/**
+ * 戦績を集計する (称号 / 素材在庫 / 連勝の計算ソース)。
+ * listRecords は新しい順に返る前提で currentStreak を出す。最大 500 件。
+ */
+export async function loadBattleStats(agent: Agent, did: string): Promise<BattleStats> {
+  const stats: BattleStats = {
+    wins: 0,
+    losses: 0,
+    bestStreak: 0,
+    tier3Wins: 0,
+    materials: {},
+    currentStreak: 0,
+    total: 0,
+  };
+  const outcomes: { outcome: string; tier: number; drops: string[] }[] = [];
+  let cursor: string | undefined;
+  for (let page = 0; page < 5; page++) {
+    let res;
+    try {
+      res = await agent.com.atproto.repo.listRecords({
+        repo: did,
+        collection: COL.battle,
+        limit: 100,
+        ...(cursor !== undefined ? { cursor } : {}),
+      });
+    } catch {
+      break; // 未作成
+    }
+    for (const r of res.data.records) {
+      const v = r.value as Partial<BattleLogRecord>;
+      outcomes.push({
+        outcome: typeof v.outcome === 'string' ? v.outcome : 'lose',
+        tier: typeof v.tier === 'number' ? v.tier : 1,
+        drops: Array.isArray(v.drops) ? v.drops.filter((d): d is string => typeof d === 'string') : [],
+      });
+    }
+    const next = res.data.cursor;
+    if (!next || next === cursor) break;
+    cursor = next;
+  }
+
+  stats.total = outcomes.length;
+  // outcomes は新しい順。currentStreak は先頭からの連続勝利。
+  let counting = true;
+  // bestStreak は古い順で数える
+  let running = 0;
+  for (const o of outcomes) {
+    if (o.outcome === 'win') {
+      stats.wins++;
+      if (o.tier === 3) stats.tier3Wins++;
+      for (const d of o.drops) stats.materials[d] = (stats.materials[d] ?? 0) + 1;
+      if (counting) stats.currentStreak++;
+    } else {
+      if (o.outcome === 'lose') stats.losses++;
+      counting = false;
+    }
+  }
+  for (let i = outcomes.length - 1; i >= 0; i--) {
+    if (outcomes[i]!.outcome === 'win') {
+      running++;
+      if (running > stats.bestStreak) stats.bestStreak = running;
+    } else {
+      running = 0;
+    }
+  }
+  return stats;
+}

--- a/apps/web/src/lib/battle-log.ts
+++ b/apps/web/src/lib/battle-log.ts
@@ -81,7 +81,10 @@ export interface BattleStats extends BattleRecordSummary {
 
 /**
  * 戦績を集計する (称号 / 素材在庫 / 連勝の計算ソース)。
- * listRecords は新しい順に返る前提で currentStreak を出す。最大 500 件。
+ * listRecords は新しい順 (rkey 降順) に返る前提で currentStreak を出す。これは参照
+ * PDS の既定挙動で lexicon 上の保証ではないが、万一順序が変わっても影響は
+ * currentStreak の表示のみ (bestStreak/称号は向きに依存しない)。最大 500 件。
+ * draw は連勝を切るが敗北には数えない。outcome 欠落 = 中断された仮レコード = 敗北扱い。
  */
 export async function loadBattleStats(agent: Agent, did: string): Promise<BattleStats> {
   const stats: BattleStats = {

--- a/apps/web/src/lib/collections.ts
+++ b/apps/web/src/lib/collections.ts
@@ -41,6 +41,9 @@ export const COL = {
   /** あおぞらパワーの累積カウンタ (rkey='self')。アクションごとに増分する。
    *  初回読み取り時に旧データから一度だけスキャン → 書き込みでマイグレーション。 */
   power: `${USER_PREFIX}.power`,
+  /** ブルスコンの試練の戦闘記録 (docs/18-brusukon-trial.md)。1 戦 1 レコード。
+   *  パワー消費の監査 + 戦績/称号/素材の集計ソース。 */
+  battle: `${USER_PREFIX}.battle`,
   /** 依頼クエスト (docs/15-user-quest.md)。tid key。発注者の PDS に書く。 */
   userQuest: `${USER_PREFIX}.userQuest`,
   /** 応募 (docs/15-user-quest.md)。tid key。応募者の PDS に書く。 */

--- a/apps/web/src/lib/points.test.ts
+++ b/apps/web/src/lib/points.test.ts
@@ -44,10 +44,38 @@ describe('loadPointsState', () => {
       viaPosts: 0,
       userMessages: 0,
       cardDraws: 0,
+      battles: 0,
       summoned: false,
       balance: 0,
       toSummon: SUMMON_THRESHOLD,
     });
+  });
+
+  test('battle レコードは 1 件 1 パワー消費として balance から引かれる', async () => {
+    const agent = makeAgent({
+      posts: Array(10).fill({ via: 'AozoraQuest' }),
+      spiritChat: [],
+    });
+    // battle collection にレコード 4 件 (勝敗は消費量に関係しない)
+    const orig = agent.com.atproto.repo.listRecords;
+    agent.com.atproto.repo.listRecords = vi.fn(async (args: { collection: string; cursor?: string }) => {
+      if (args.collection.endsWith('.battle')) {
+        if (args.cursor) return { data: { records: [] } };
+        return {
+          data: {
+            records: Array.from({ length: 4 }, (_, i) => ({
+              uri: `at://did:test/battle/${i}`,
+              cid: `c${i}`,
+              value: { outcome: i % 2 ? 'win' : 'lose' },
+            })),
+          },
+        };
+      }
+      return orig(args);
+    });
+    const p = await loadPointsState(agent, 'did:test');
+    expect(p.battles).toBe(4);
+    expect(p.balance).toBe(10 - 4);
   });
 
   test('via 投稿 3 件 + チャットなし → toSummon 7', async () => {

--- a/apps/web/src/lib/points.ts
+++ b/apps/web/src/lib/points.ts
@@ -27,6 +27,7 @@ import {
 import { VIA, getRecord, putRecord } from './atproto';
 import { COL } from './collections';
 import { countCardDraws } from './card-power';
+import { countBattles } from './battle-log';
 
 export const SUMMON_THRESHOLD = CORE_SUMMON_THRESHOLD;
 const POST_SCAN_PAGES = POINTS_SCAN_PAGES;
@@ -40,30 +41,36 @@ export interface PointsState {
   userMessages: number;
   /** カード引き直しで消費したパワー数 */
   cardDraws: number;
+  /** ブルスコンの試練で消費したパワー数 (docs/18-brusukon-trial.md) */
+  battles: number;
   /** 召喚済みか (spiritChat レコードが 1 件でもあるか) */
   summoned: boolean;
-  /** 残あおぞらパワー = max(0, viaPosts - userMessages - cardDraws) */
+  /** 残あおぞらパワー = max(0, viaPosts - userMessages - cardDraws - battles) */
   balance: number;
   /** 召喚に必要な残り投稿数 = max(0, SUMMON_THRESHOLD - viaPosts) */
   toSummon: number;
 }
 
-/** PDS に保存する累積カウンタ。`app.aozoraquest.power/self`。 */
+/** PDS に保存する累積カウンタ。`app.aozoraquest.power/self`。
+ *  battles は後付けフィールド (docs/18) — 旧レコードには無いので欠落 = 0 として読む。 */
 interface PowerRecord {
   viaPosts: number;
   userMessages: number;
   cardDraws: number;
+  battles?: number;
   summoned: boolean;
   updatedAt: string;
 }
 
 function deriveState(rec: PowerRecord): PointsState {
-  const balance = Math.max(0, rec.viaPosts - rec.userMessages - rec.cardDraws);
+  const battles = rec.battles ?? 0;
+  const balance = Math.max(0, rec.viaPosts - rec.userMessages - rec.cardDraws - battles);
   const toSummon = Math.max(0, SUMMON_THRESHOLD - rec.viaPosts);
   return {
     viaPosts: rec.viaPosts,
     userMessages: rec.userMessages,
     cardDraws: rec.cardDraws,
+    battles,
     summoned: rec.summoned,
     balance,
     toSummon,
@@ -83,17 +90,19 @@ async function writePowerRecord(agent: Agent, base: Omit<PowerRecord, 'updatedAt
 /** 旧方式: PDS の post / spiritChat / cardDraw を実際に走査して計算する。
  *  loadPointsState のマイグレーション用 + power レコード破損時の復旧用に残す。 */
 async function scanFullPoints(agent: Agent, did: string): Promise<PointsState> {
-  const [viaPosts, { userMessages, hasAnySpiritChat }, cardDraws] = await Promise.all([
+  const [viaPosts, { userMessages, hasAnySpiritChat }, cardDraws, battles] = await Promise.all([
     countViaPosts(agent, did),
     countSpiritChat(agent, did),
     countCardDraws(agent, did),
+    countBattles(agent, did),
   ]);
-  const balance = Math.max(0, viaPosts - userMessages - cardDraws);
+  const balance = Math.max(0, viaPosts - userMessages - cardDraws - battles);
   const toSummon = Math.max(0, SUMMON_THRESHOLD - viaPosts);
   return {
     viaPosts,
     userMessages,
     cardDraws,
+    battles,
     summoned: hasAnySpiritChat,
     balance,
     toSummon,
@@ -114,6 +123,7 @@ export async function loadPointsState(agent: Agent, did: string): Promise<Points
     viaPosts: scanned.viaPosts,
     userMessages: scanned.userMessages,
     cardDraws: scanned.cardDraws,
+    battles: scanned.battles,
     summoned: scanned.summoned,
   };
   try {
@@ -130,6 +140,7 @@ export interface PowerDelta {
   viaPosts?: number;
   userMessages?: number;
   cardDraws?: number;
+  battles?: number;
   /** 召喚状態を強制 true に立てるとき指定。下げる用途は今のところ無し。 */
   summoned?: true;
 }
@@ -143,6 +154,7 @@ export async function bumpPower(agent: Agent, did: string, delta: PowerDelta): P
         viaPosts: scanned.viaPosts,
         userMessages: scanned.userMessages,
         cardDraws: scanned.cardDraws,
+        battles: scanned.battles,
         summoned: scanned.summoned,
         updatedAt: new Date().toISOString(),
       };
@@ -151,6 +163,7 @@ export async function bumpPower(agent: Agent, did: string, delta: PowerDelta): P
       viaPosts: cur.viaPosts + (delta.viaPosts ?? 0),
       userMessages: cur.userMessages + (delta.userMessages ?? 0),
       cardDraws: cur.cardDraws + (delta.cardDraws ?? 0),
+      battles: (cur.battles ?? 0) + (delta.battles ?? 0),
       summoned: delta.summoned ?? cur.summoned,
     };
     await writePowerRecord(agent, next);


### PR DESCRIPTION
## 概要
docs/18-brusukon-trial.md の PR②。パワー消費の配線のみ — **UI はまだ無く、既存ユーザーの残高も変わらない** (battles は旧レコード欠落 → 0 として読む後方互換)。

## 変更
- パワー残高式を `viaPosts − userMessages − cardDraws − battles` に拡張 (points.ts)。PowerRecord の `battles` は後付け optional。
- `COL.battle` (1 戦 1 レコード) 追加。`battle-log.ts`: recordBattle / countBattles / loadBattleStats (勝敗・現在/最高連勝・tier3 勝利・素材在庫)。
- points.test に battles 消費ケース、battle-log.test に集計 9 ケース。

## テスト
web unit 264 passed / typecheck / build green。

## Review (§1.5 実装レビュー)
**★★★** — なし (後方互換は全読経路で battles欠落→0 と確認、既存残高不変)。

**★★ (対応)**
- loadBattleStats のテスト欠落 → **battle-log.test.ts 9 ケース追加** (02678b6): 連勝の向き / draw は連勝を切るが敗北に数えない / 素材集計 / 壊れレコード耐性 / outcome 欠落=棄権敗北。
- 旧バンドルの stale クライアントが bumpPower すると battles フィールドが落ち balance が膨らむ → **既知の許容ドリフト** (points.ts の設計方針どおり)。battle レコードが真実なのでレスキャンで復旧可能。リリース順は #268 が UI (PR③) より先に main へ届く形にする。

**★ (記録)**
- listRecords 新しい順は参照 PDS の既定で lexicon 保証でない → コメント明記 (影響は currentStreak 表示のみ、称号は向き非依存)。
- outcome 欠落→lose は PR③ の仮レコード (棄権=敗北) 方式と整合する意図的挙動。
- countBattles / loadBattleStats のページングループ重複は cardDraw 前例に合わせ許容 (将来共通化余地)。

## 後続
PR③ (UI) がスタック済み — 挑戦開始時に仮レコード + 支払い、決着時に確定 (途中離脱=棄権=敗北でスカム防止)。