### PR TITLE
fix(spirit): 敗北文の視点 / /me に HP・MP / 難易度自動化

### DIFF
--- a/apps/web/src/components/trial-arena.tsx
+++ b/apps/web/src/components/trial-arena.tsx
@@ -6,6 +6,7 @@ import {
   MONSTERS_BY_ID,
   SKILL_KIND_LABELS,
   earnedTitles,
+  pickTrialTier,
   resolveTurn,
   rollDrops,
   startBattle,
@@ -84,12 +85,15 @@ export function TrialArena({
   useEffect(() => { refreshStats(); }, [refreshStats]);
 
   const begin = useCallback(
-    async (tier: 1 | 2 | 3) => {
+    async (fixedTier?: 1 | 2 | 3) => {
       if (points.balance < BATTLE_TUNING.powerCost) return;
       setErr(null);
-      setPhase({ kind: 'starting', tier });
       // 32bit seed (Math.random で十分。決定性はエンジン側の性質)
       const seed = Math.floor(Math.random() * 0xffffffff) >>> 0;
+      // 難易度は選ばせない: 初挑戦はやさしい敵、以降はレベルに応じて自動抽選。
+      // (再戦 = fixedTier は同じ tier でもう一度)
+      const tier = fixedTier ?? pickTrialTier(seed, playerLevel, stats?.total ?? 0);
+      setPhase({ kind: 'starting', tier });
       // やくそうは在庫から最大 herbCarryMax 個持ち込む (使用分は battle レコードで差し引く)
       const herbs = Math.min(BATTLE_TUNING.herbCarryMax, stats?.materials['herb'] ?? 0);
       const state = startBattle(archetype, jobLevel, playerLevel, playerName, tier, seed, herbs);
@@ -210,29 +214,24 @@ export function TrialArena({
           あおぞらパワー: <strong style={{ color: 'var(--color-fg)' }}>{points.balance}</strong>
           (投稿すると増える)
         </div>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.6em', marginTop: '0.6em' }}>
-          {([1, 2, 3] as const).map((tier) => (
-            <button
-              key={tier}
-              type="button"
-              disabled={!canPlay || starting}
-              onClick={() => void begin(tier)}
-              style={{
-                padding: '0.9em 1em',
-                fontSize: '1em',
-                textAlign: 'left',
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItems: 'center',
-                opacity: canPlay && !starting ? 1 : 0.55,
-              }}
-            >
-              <span>
-                {starting && phase.tier === tier ? '呼び出している…' : `${'★'.repeat(tier)} ${TIER_LABELS[tier].name}`}
-              </span>
-              <span style={{ fontSize: '0.75em', color: 'var(--color-muted)' }}>{TIER_LABELS[tier].hint}</span>
-            </button>
-          ))}
+        <div style={{ marginTop: '0.6em', textAlign: 'center' }}>
+          <button
+            type="button"
+            disabled={!canPlay || starting}
+            onClick={() => void begin()}
+            style={{
+              padding: '0.9em 2em',
+              fontSize: '1.05em',
+              opacity: canPlay && !starting ? 1 : 0.55,
+            }}
+          >
+            {starting ? '呼び出している…' : '試練に挑む'}
+          </button>
+          <p style={{ fontSize: '0.75em', color: 'var(--color-muted)', marginTop: '0.4em' }}>
+            {(stats?.total ?? 0) === 0
+              ? 'はじめての試練は、やさしい相手を呼んでもらえる。'
+              : '相手はブルスコンが選ぶ。強くなるほど手強いのが来る。'}
+          </p>
         </div>
         <p style={{ fontSize: '0.75em', color: 'var(--color-muted)', marginTop: '0.5em' }}>
           ※ 試練の途中でやめる (画面を閉じる) と敗北あつかいになるよ。
@@ -257,6 +256,9 @@ export function TrialArena({
         {/* 敵エリア。key=turn で再マウントして被弾シェイクを毎ターン再生する
             (class 文字列が同じままだと CSS アニメは再始動しない)。 */}
         <div style={{ textAlign: 'center', paddingTop: '0.4em' }}>
+          <div style={{ fontSize: '0.75em', color: 'var(--color-muted)' }}>
+            {'★'.repeat(phase.tier)} {TIER_LABELS[phase.tier].name}
+          </div>
           <div
             key={state.turn}
             style={{ display: 'inline-block' }}

--- a/apps/web/src/routes/me.tsx
+++ b/apps/web/src/routes/me.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { AtpAgent } from '@atproto/api';
 import type { Archetype, DiagnosisResult } from '@aozoraquest/core';
-import { ARCHETYPES, DIAGNOSIS_MIN_POST_COUNT, JOBS_BY_ID, archetypePairRelation, jobDisplayName, jobLevelFromXp, jobTagline, jobXpToNextLevel, playerLevelFromXp, playerXpToNextLevel, questXpScalar } from '@aozoraquest/core';
+import { ARCHETYPES, DIAGNOSIS_MIN_POST_COUNT, JOBS_BY_ID, archetypePairRelation, jobDisplayName, jobLevelFromXp, jobTagline, jobXpToNextLevel, playerCombatant, playerLevelFromXp, playerXpToNextLevel, questXpScalar } from '@aozoraquest/core';
 import { useSession } from '@/lib/session';
 import { runDiagnosis } from '@/lib/diagnosis-flow';
 import { listReceivedQuests, loadCompletionsByUri } from '@/lib/quest-api';
@@ -167,6 +167,22 @@ export function MyProfile() {
               <span>全体:</span>{' '}
               <span style={{ fontFamily: 'ui-monospace, monospace' }}>LV{myPlayerLv}</span>
               <span style={{ marginLeft: '0.5em', opacity: 0.8 }}>(累計 {myPlayerXp} XP)</span>
+            </p>
+          )}
+          {state.status === 'done' && myArchetype && (
+            // 試練 (docs/18) と同じ導出で戦闘値の HP/MP を表示。バトル外でも自分の
+            // 強さが分かるように (ジョブ/レベルから決まる値で、消耗状態ではない)。
+            <p style={{ margin: '0.15em 0 0', fontSize: '0.8em', color: 'var(--color-muted)' }}>
+              {(() => {
+                const c = playerCombatant(myArchetype, myJobLv, myPlayerLv, '');
+                return (
+                  <>
+                    <span style={{ fontFamily: 'ui-monospace, monospace' }}>HP {c.maxHp}</span>
+                    <span style={{ marginLeft: '0.6em', fontFamily: 'ui-monospace, monospace' }}>MP {c.maxMp}</span>
+                    <span style={{ marginLeft: '0.6em', opacity: 0.8 }}>(ブルスコンの試練の戦闘値)</span>
+                  </>
+                );
+              })()}
             </p>
           )}
           <p style={{ margin: '0.15em 0 0', fontSize: '0.85em', color: 'var(--color-muted)' }}>

--- a/packages/core/src/__tests__/battle.test.ts
+++ b/packages/core/src/__tests__/battle.test.ts
@@ -7,6 +7,7 @@ import {
   JOB_SKILL_NAMES,
   playerCombatant,
   summonMonster,
+  pickTrialTier,
   startBattle,
   resolveTurn,
   rollDrops,
@@ -363,6 +364,25 @@ describe('resolveTurn', () => {
       if (s.outcome === 'win') guardOnlyWins++;
     }
     expect(wins).toBeGreaterThan(guardOnlyWins);
+  });
+});
+
+describe('pickTrialTier', () => {
+  it('初挑戦 (戦績 0) は必ず tier1', () => {
+    for (let seed = 0; seed < 30; seed++) {
+      expect(pickTrialTier(seed, 50, 0)).toBe(1);
+    }
+  });
+  it('低レベル (LV<5) には tier3 が出ない', () => {
+    for (let seed = 0; seed < 200; seed++) {
+      expect(pickTrialTier(seed, 3, 10)).toBeLessThanOrEqual(2);
+    }
+  });
+  it('高レベルでは全 tier が出る (決定的)', () => {
+    const seen = new Set<number>();
+    for (let seed = 0; seed < 200; seed++) seen.add(pickTrialTier(seed, 20, 10));
+    expect(seen).toEqual(new Set([1, 2, 3]));
+    expect(pickTrialTier(7, 20, 10)).toBe(pickTrialTier(7, 20, 10));
   });
 });
 

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -276,6 +276,20 @@ export const MONSTERS_BY_ID: Record<string, MonsterDef> = Object.fromEntries(
   MONSTERS.map((m) => [m.id, m]),
 );
 
+/**
+ * 挑戦する試練の tier を自動で決める (UI に難易度選択は出さない)。
+ * - 初挑戦 (戦績 0) は必ず tier1 (手習い) = やさしい敵。
+ * - 以降は seed から決定的に抽選。プレイヤーレベルが低いうちは tier3 が出ない。
+ */
+export function pickTrialTier(seed: number, playerLevel: number, totalBattles: number): 1 | 2 | 3 {
+  if (totalBattles <= 0) return 1;
+  const r = createRng((seed ^ 0x7f4a7c15) >>> 0)();
+  if (playerLevel < 5) return r < 0.6 ? 1 : 2;
+  if (r < 0.25) return 1;
+  if (r < 0.65) return 2;
+  return 3;
+}
+
 /** tier に応じたモンスター強化倍率。プレイヤーのレベル補正と釣り合いを取る。 */
 function monsterLevelFactor(tier: 1 | 2 | 3, playerLevel: number): number {
   const t = BATTLE_TUNING;
@@ -406,9 +420,16 @@ function doAttack(
   const final = Math.max(1, Math.round(dmg));
   defender.hp = Math.max(0, defender.hp - final);
   const fatal = defender.hp === 0;
+  // 決着文はプレイヤー視点: 敵を倒した =「◯◯をたおした!」、自分が倒れた =
+  // 「◯◯はちからつきた!」(プレイヤーが「たおされる」対象になる文は視点が転倒する)。
+  const fatalText = fatal
+    ? actor === 'player'
+      ? `。${defender.name}をたおした!`
+      : `。${defender.name}はちからつきた…!`
+    : '';
   events.push({
     actor,
-    text: `${label}${crit ? ' 会心の一撃!!' : ''} ${defender.name}に ${final} のダメージ${fatal ? '。' + defender.name + 'をたおした!' : ''}`,
+    text: `${label}${crit ? ' 会心の一撃!!' : ''} ${defender.name}に ${final} のダメージ${fatalText}`,
     damage: final,
     ...(fatal ? { fatal: true } : {}),
   });


### PR DESCRIPTION
## オーナー指摘 3 点への対応
1. **敗北文の視点**: 「◯◯のこうげき! kojira に 36 のダメージ。kojiraをたおした!」→ 自分が倒れた時は「**kojiraはちからつきた…!**」。敵撃破は従来どおり「たおした!」。
2. **/me に HP/MP**: レベル表示の下に試練の戦闘値 (ジョブ + LV から導出した maxHP/maxMP) を表示。
3. **難易度 3 択を廃止**: 「試練に挑む」1 ボタン。初挑戦は必ずやさしい敵 (tier1)、以降は自動抽選 (LV<5 は tier3 なし)。`pickTrialTier` を core に置きテスト 3 件で固定。バトル画面に tier バッジ。

## テスト
core 218 / web 269 / typecheck / build green。

## Review
UI 文言 + 小ロジック。core の抽選はテストで固定済み。§1.5 軽量 (1 観点) 相当。