### PR TITLE
feat(world): あおぞらワールドの散歩プレビュー UI (PR-W2)

### DIFF
--- a/apps/web/src/components/world-tiles.tsx
+++ b/apps/web/src/components/world-tiles.tsx
@@ -1,0 +1,92 @@
+import type { ReactElement } from 'react';
+import type { Terrain } from '@aozoraquest/core';
+
+/**
+ * あおぞらワールドのタイル SVG (docs/19-overworld.md / オーナー承認済み
+ * docs/overworld-drafts/tiles.html v2 の React 化)。
+ * 各タイルは 32x32 viewBox の SVG 断片。マップは <g transform> で並べる。
+ */
+
+const PLAINS = (
+  <>
+    <rect width="32" height="32" fill="#9dd07f" />
+    <path d="M6 22 l2 -4 l2 4 M20 12 l2 -4 l2 4" stroke="#7db95f" strokeWidth="1.6" fill="none" strokeLinecap="round" />
+    <circle cx="26" cy="24" r="1.2" fill="#b8e29a" />
+    <circle cx="12" cy="8" r="1.2" fill="#b8e29a" />
+  </>
+);
+
+export const TERRAIN_TILES: Record<Terrain, ReactElement> = {
+  plains: PLAINS,
+  grove: (
+    <>
+      <rect width="32" height="32" fill="#8cc46f" />
+      <ellipse cx="10" cy="14" rx="6" ry="7" fill="#4f9e4a" />
+      <rect x="9" y="19" width="2.4" height="5" fill="#7a5a3a" />
+      <ellipse cx="23" cy="21" rx="5" ry="6" fill="#5cab54" />
+      <rect x="22" y="25" width="2.2" height="4" fill="#7a5a3a" />
+    </>
+  ),
+  forest: (
+    <>
+      <rect width="32" height="32" fill="#4f8f4a" />
+      <path d="M8 20 L13 8 L18 20 Z" fill="#2f6e35" />
+      <path d="M17 24 L22 12 L27 24 Z" fill="#255d2c" />
+      <path d="M3 27 L8 16 L13 27 Z" fill="#2a6631" />
+      <rect x="12" y="20" width="2" height="5" fill="#5d4630" />
+      <rect x="21" y="24" width="2" height="4" fill="#5d4630" />
+    </>
+  ),
+  pond: (
+    <>
+      <rect width="32" height="32" fill="#9dd07f" />
+      <ellipse cx="16" cy="17" rx="11" ry="8.5" fill="#57b7ee" />
+      <ellipse cx="16" cy="17" rx="11" ry="8.5" fill="none" stroke="#3e94c9" strokeWidth="1.6" />
+      <path d="M10 16 q3 -2 6 0 M14 20 q3 -2 6 0" stroke="#bfe6ff" strokeWidth="1.4" fill="none" strokeLinecap="round" />
+    </>
+  ),
+  water: (
+    <>
+      <rect width="32" height="32" fill="#57b7ee" />
+      <path
+        d="M2 10 q4 -3 8 0 t8 0 t8 0 t8 0 M-2 20 q4 -3 8 0 t8 0 t8 0 t8 0 M2 30 q4 -3 8 0 t8 0 t8 0"
+        stroke="#bfe6ff"
+        strokeWidth="1.6"
+        fill="none"
+        strokeLinecap="round"
+      />
+    </>
+  ),
+  bridge: (
+    <>
+      <rect width="32" height="32" fill="#57b7ee" />
+      <path d="M2 10 q4 -3 8 0 t8 0 t8 0 t8 0 M2 30 q4 -3 8 0 t8 0 t8 0" stroke="#bfe6ff" strokeWidth="1.4" fill="none" strokeLinecap="round" />
+      <rect x="0" y="12" width="32" height="9" fill="#b08a5c" />
+      <path d="M0 12 h32 M0 21 h32" stroke="#8a6a42" strokeWidth="1.6" />
+      <path d="M4 12 v9 M10 12 v9 M16 12 v9 M22 12 v9 M28 12 v9" stroke="#8a6a42" strokeWidth="1.2" />
+      <path d="M0 11 h32 M0 22 h32" stroke="#6e5334" strokeWidth="1" />
+    </>
+  ),
+  mountain: (
+    <>
+      <rect width="32" height="32" fill="#8cc46f" />
+      <path d="M2 28 L12 8 L20 28 Z" fill="#8a7f74" />
+      <path d="M12 8 L15.5 15 L12.5 15 L16 22 L20 28 L12 28 Z" fill="#6e655c" opacity=".55" />
+      <path d="M9.5 13 L12 8 L14.5 13 L12.8 12 L12 13.6 L11 12 Z" fill="#f2f5f7" />
+      <path d="M14 28 L23 12 L31 28 Z" fill="#9b8f83" />
+      <path d="M20.8 16 L23 12 L25.2 16 L23.7 15 L23 16.4 L22 15 Z" fill="#f2f5f7" />
+    </>
+  ),
+  town: (
+    <>
+      {PLAINS}
+      <rect x="5" y="15" width="9" height="9" fill="#f0e6d2" />
+      <path d="M3.5 15.5 L9.5 8.5 L15.5 15.5 Z" fill="#c9564a" />
+      <rect x="8" y="19" width="3" height="5" fill="#7a5a3a" />
+      <rect x="18" y="17" width="9" height="8" fill="#f0e6d2" />
+      <path d="M16.5 17.5 L22.5 11.5 L28.5 17.5 Z" fill="#4a7fc9" />
+      <rect x="20" y="19.5" width="2.4" height="2.4" fill="#57b7ee" />
+      <rect x="24" y="19.5" width="2.4" height="2.4" fill="#57b7ee" />
+    </>
+  ),
+};

--- a/apps/web/src/lib/collections.ts
+++ b/apps/web/src/lib/collections.ts
@@ -44,6 +44,9 @@ export const COL = {
   /** ブルスコンの試練の戦闘記録 (docs/18-brusukon-trial.md)。1 戦 1 レコード。
    *  パワー消費の監査 + 戦績/称号/素材の集計ソース。 */
   battle: `${USER_PREFIX}.battle`,
+  /** あおぞらワールドの状態 (docs/19-overworld.md)。rkey='self'。位置・乗り物・
+   *  解禁リージョン。PR-W3 以降は Worker (DO) が正で、これは表示キャッシュ + 監査線。 */
+  world: `${USER_PREFIX}.world`,
   /** 依頼クエスト (docs/15-user-quest.md)。tid key。発注者の PDS に書く。 */
   userQuest: `${USER_PREFIX}.userQuest`,
   /** 応募 (docs/15-user-quest.md)。tid key。応募者の PDS に書く。 */

--- a/apps/web/src/lib/world-preview.ts
+++ b/apps/web/src/lib/world-preview.ts
@@ -1,0 +1,9 @@
+/**
+ * あおぞらワールドのプレビューゲート (docs/19-overworld.md §7 PR-W2)。
+ *
+ * 散歩プレビューは「dev だけで確認」する段階のため、本番 (VITE_NSID_ENV 未指定) では
+ * 入口ボタンも /world 画面も出さない。dev 環境 (dev.aozoraquest.app) とローカル開発
+ * でのみ有効。PR-W3 (消費・遭遇の配線) が本番に出せる段階になったらこのゲートを外す。
+ */
+export const WORLD_PREVIEW_ENABLED =
+  import.meta.env.DEV || (import.meta.env.VITE_NSID_ENV as string | undefined)?.trim() === 'dev';

--- a/apps/web/src/lib/world-state.test.ts
+++ b/apps/web/src/lib/world-state.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test, vi } from 'vitest';
+import { worldOverlay } from '@aozoraquest/core';
+import { loadWorldState } from './world-state';
+
+function agentWithGetRecord(impl: () => Promise<unknown>): any {
+  return { com: { atproto: { repo: { getRecord: vi.fn(impl) } } } };
+}
+
+describe('loadWorldState', () => {
+  test('レコードがあれば wrap した座標を返す', async () => {
+    const agent = agentWithGetRecord(async () => ({
+      data: { value: { x: 1030, y: -2, updatedAt: '2026-07-17T00:00:00.000Z' } },
+    }));
+    const s = await loadWorldState(agent, 'did:test');
+    expect(s.x).toBe(6); // 1030 mod 1024
+    expect(s.y).toBe(1022);
+  });
+
+  test('レコード未作成 (RecordNotFound) は spawn を返す', async () => {
+    const agent = agentWithGetRecord(async () => {
+      const e = new Error('Could not locate record') as Error & { error?: string };
+      e.error = 'RecordNotFound';
+      throw e;
+    });
+    const s = await loadWorldState(agent, 'did:test');
+    const spawn = worldOverlay().spawn;
+    expect(s.x).toBe(spawn.x);
+    expect(s.y).toBe(spawn.y);
+  });
+
+  test('一時的な読み込み失敗は throw する (spawn に倒すと位置の上書き事故になる)', async () => {
+    const agent = agentWithGetRecord(async () => {
+      throw new Error('network down');
+    });
+    await expect(loadWorldState(agent, 'did:test')).rejects.toThrow();
+  });
+
+  test('壊れたレコード (x/y が数値でない) は spawn を返す', async () => {
+    const agent = agentWithGetRecord(async () => ({ data: { value: { x: 'a', y: null } } }));
+    const s = await loadWorldState(agent, 'did:test');
+    const spawn = worldOverlay().spawn;
+    expect(s.x).toBe(spawn.x);
+    expect(s.y).toBe(spawn.y);
+  });
+});

--- a/apps/web/src/lib/world-state.ts
+++ b/apps/web/src/lib/world-state.ts
@@ -17,17 +17,18 @@ export interface WorldState {
   updatedAt: string;
 }
 
-/** 位置を読み込む。未作成なら spawn (そらみの街) を返す。 */
+/**
+ * 位置を読み込む。**レコード未作成** (getRecord が null) のときだけ spawn を返す。
+ * 一時的な読み込み失敗は throw する — ここで握りつぶして spawn を返すと、
+ * 電波の悪い端末で「spawn にテレポート → その位置で上書き保存」というデータ損失が
+ * 起きる (レビュー指摘)。呼び出し側はエラー表示 + リトライにすること。
+ */
 export async function loadWorldState(agent: Agent, did: string): Promise<WorldState> {
-  const spawn = worldOverlay().spawn;
-  try {
-    const rec = await getRecord<Partial<WorldState>>(agent, did, COL.world, 'self');
-    if (rec && typeof rec.x === 'number' && typeof rec.y === 'number') {
-      return { x: wrap(rec.x), y: wrap(rec.y), updatedAt: rec.updatedAt ?? '' };
-    }
-  } catch {
-    /* 未作成 */
+  const rec = await getRecord<Partial<WorldState>>(agent, did, COL.world, 'self');
+  if (rec && typeof rec.x === 'number' && typeof rec.y === 'number') {
+    return { x: wrap(rec.x), y: wrap(rec.y), updatedAt: rec.updatedAt ?? '' };
   }
+  const spawn = worldOverlay().spawn;
   return { x: spawn.x, y: spawn.y, updatedAt: '' };
 }
 

--- a/apps/web/src/lib/world-state.ts
+++ b/apps/web/src/lib/world-state.ts
@@ -1,0 +1,45 @@
+/**
+ * あおぞらワールドのプレイヤー状態 (docs/19-overworld.md §5)。
+ *
+ * PR-W2 (散歩プレビュー) 時点ではクライアントが位置を読み書きする。
+ * PR-W3 以降は Worker (Durable Object) が位置の正となり、このレコードは
+ * 「表示キャッシュ + 監査線」に格下げされる (書き込み元が DO 応答になる)。
+ */
+
+import type { Agent } from '@atproto/api';
+import { worldOverlay, wrap } from '@aozoraquest/core';
+import { getRecord, putRecord } from './atproto';
+import { COL } from './collections';
+
+export interface WorldState {
+  x: number;
+  y: number;
+  updatedAt: string;
+}
+
+/** 位置を読み込む。未作成なら spawn (そらみの街) を返す。 */
+export async function loadWorldState(agent: Agent, did: string): Promise<WorldState> {
+  const spawn = worldOverlay().spawn;
+  try {
+    const rec = await getRecord<Partial<WorldState>>(agent, did, COL.world, 'self');
+    if (rec && typeof rec.x === 'number' && typeof rec.y === 'number') {
+      return { x: wrap(rec.x), y: wrap(rec.y), updatedAt: rec.updatedAt ?? '' };
+    }
+  } catch {
+    /* 未作成 */
+  }
+  return { x: spawn.x, y: spawn.y, updatedAt: '' };
+}
+
+/** 位置を保存する。失敗は warn して swallow (歩行体験を止めない)。 */
+export async function saveWorldState(agent: Agent, x: number, y: number): Promise<void> {
+  try {
+    await putRecord(agent, COL.world, 'self', {
+      x: wrap(x),
+      y: wrap(y),
+      updatedAt: new Date().toISOString(),
+    });
+  } catch (e) {
+    console.warn('[world] state save failed', e);
+  }
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -14,6 +14,7 @@ const Quests = lazy(() => import('@/routes/quests').then(m => ({ default: m.Ques
 const Search = lazy(() => import('@/routes/search').then(m => ({ default: m.Search })));
 const Settings = lazy(() => import('@/routes/settings').then(m => ({ default: m.Settings })));
 const Spirit = lazy(() => import('@/routes/spirit').then(m => ({ default: m.Spirit })));
+const World = lazy(() => import('@/routes/world').then(m => ({ default: m.World })));
 const Onboarding = lazy(() => import('@/routes/onboarding').then(m => ({ default: m.Onboarding })));
 const OAuthCallback = lazy(() => import('@/routes/oauth-callback').then(m => ({ default: m.OAuthCallback })));
 const Tos = lazy(() => import('@/routes/tos').then(m => ({ default: m.Tos })));
@@ -67,6 +68,7 @@ const router = createBrowserRouter([
       { path: 'search', element: <Search /> },
       { path: 'settings', element: <Settings /> },
       { path: 'spirit', element: <Spirit /> },
+      { path: 'world', element: <World /> },
       { path: 'onboarding', element: <Onboarding /> },
       { path: 'oauth/callback', element: <OAuthCallback /> },
       { path: 'tos', element: <Tos /> },

--- a/apps/web/src/routes/spirit.tsx
+++ b/apps/web/src/routes/spirit.tsx
@@ -22,6 +22,7 @@ import { useOnPosted } from '@/components/compose-modal';
 import { useRuntimeConfig } from '@/components/config-provider';
 import { applyPromptTemplate } from '@/lib/prompt-template';
 import { bumpPower, loadPointsState, SUMMON_THRESHOLD, type PointsState } from '@/lib/points';
+import { WORLD_PREVIEW_ENABLED } from '@/lib/world-preview';
 
 /**
  * 精霊ブルスコンのページ (docs/18-brusukon-trial.md)。
@@ -257,14 +258,16 @@ export function Spirit() {
             )}
           </section>
 
-          {/* あおぞらワールド (docs/19) の入口。PR-W2 の散歩プレビュー段階。 */}
-          <section style={{ marginTop: '1.2em', textAlign: 'center' }}>
-            <Link to="/world">
-              <button type="button" style={{ padding: '0.6em 1.4em' }}>
-                🗺 あおぞらワールドを歩く (プレビュー)
-              </button>
-            </Link>
-          </section>
+          {/* あおぞらワールド (docs/19) の入口。散歩プレビュー段階 = dev 環境限定。 */}
+          {WORLD_PREVIEW_ENABLED && (
+            <section style={{ marginTop: '1.2em', textAlign: 'center' }}>
+              <Link to="/world">
+                <button type="button" style={{ padding: '0.6em 1.4em' }}>
+                  🗺 あおぞらワールドを歩く (プレビュー)
+                </button>
+              </Link>
+            </section>
+          )}
         </>
       )}
 

--- a/apps/web/src/routes/spirit.tsx
+++ b/apps/web/src/routes/spirit.tsx
@@ -256,6 +256,15 @@ export function Spirit() {
               </div>
             )}
           </section>
+
+          {/* あおぞらワールド (docs/19) の入口。PR-W2 の散歩プレビュー段階。 */}
+          <section style={{ marginTop: '1.2em', textAlign: 'center' }}>
+            <Link to="/world">
+              <button type="button" style={{ padding: '0.6em 1.4em' }}>
+                🗺 あおぞらワールドを歩く (プレビュー)
+              </button>
+            </Link>
+          </section>
         </>
       )}
 

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -13,6 +13,7 @@ import { useSession } from '@/lib/session';
 import { getRecord } from '@/lib/atproto';
 import { COL } from '@/lib/collections';
 import { loadWorldState, saveWorldState } from '@/lib/world-state';
+import { WORLD_PREVIEW_ENABLED } from '@/lib/world-preview';
 import { Avatar } from '@/components/avatar';
 import { TERRAIN_TILES } from '@/components/world-tiles';
 
@@ -21,7 +22,10 @@ import { TERRAIN_TILES } from '@/components/world-tiles';
  *
  * 16×16 ビューポートでプレイヤー中央固定、1 タップ 1 マス移動。トーラス wrap。
  * この段階では**パワー消費なし・遭遇なし** (消費と判定は PR-W3 で Worker に移る)。
- * 位置は PDS (world/self) に保存 (デバウンス)。
+ * 位置は PDS (world/self) に保存 (デバウンス)。dev 環境限定 (world-preview.ts)。
+ *
+ * プレイヤーのアバターは SVG の foreignObject ではなく **HTML オーバーレイ**で描く
+ * (foreignObject は overflow:hidden でジョブ装備が切れる + iOS Safari の位置ズレ quirk)。
  */
 
 const VIEW = 16; // ビューポートの一辺 (タイル数)
@@ -29,11 +33,11 @@ const HALF = VIEW / 2;
 const TILE = 32; // SVG 内の 1 タイルサイズ (表示は width 100% で縮尺)
 
 type Dir = 'up' | 'down' | 'left' | 'right';
-const DIRS: Record<Dir, { dx: number; dy: number; label: string }> = {
-  up: { dx: 0, dy: -1, label: '↑' },
-  down: { dx: 0, dy: 1, label: '↓' },
-  left: { dx: -1, dy: 0, label: '←' },
-  right: { dx: 1, dy: 0, label: '→' },
+const DIRS: Record<Dir, { dx: number; dy: number; glyph: string; label: string }> = {
+  up: { dx: 0, dy: -1, glyph: '↑', label: '上に移動' },
+  down: { dx: 0, dy: 1, glyph: '↓', label: '下に移動' },
+  left: { dx: -1, dy: 0, glyph: '←', label: '左に移動' },
+  right: { dx: 1, dy: 0, glyph: '→', label: '右に移動' },
 };
 
 const DANGER_LABELS = ['おだやか', 'すこし危険', '危険', 'とても危険'] as const;
@@ -43,27 +47,53 @@ export function World() {
   const agent = session.agent ?? null;
   const did = session.did ?? null;
   const [pos, setPos] = useState<{ x: number; y: number } | null>(null);
+  const [loadErr, setLoadErr] = useState(false);
+  const [retryNonce, setRetryNonce] = useState(0);
+  const [blocked, setBlocked] = useState(false);
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
   const [archetype, setArchetype] = useState<DiagnosisResult['archetype'] | null>(null);
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // タイルの実表示サイズ (px)。アバターオーバーレイの寸法に使う。
+  const mapRef = useRef<HTMLDivElement>(null);
+  const [tilePx, setTilePx] = useState(24);
 
-  // 初期ロード: 位置 + アバター + ジョブ
+  // 初期ロード: 位置 + アバター + ジョブ。位置の読み込み失敗はエラー表示 + リトライ
+  // (spawn に倒すと「テレポート → 上書き保存」のデータ損失になるため倒さない)。
   useEffect(() => {
     if (session.status !== 'signed-in' || !agent || !did) return;
     let cancelled = false;
+    setLoadErr(false);
     (async () => {
-      const [state, profile, diag] = await Promise.all([
-        loadWorldState(agent, did),
+      try {
+        const state = await loadWorldState(agent, did);
+        if (cancelled) return;
+        setPos({ x: state.x, y: state.y });
+      } catch (e) {
+        console.warn('[world] load failed', e);
+        if (!cancelled) setLoadErr(true);
+        return;
+      }
+      const [profile, diag] = await Promise.all([
         agent.getProfile({ actor: did }).catch(() => null),
         getRecord<DiagnosisResult>(agent, did, COL.analysis, 'self').catch(() => null),
       ]);
       if (cancelled) return;
-      setPos({ x: state.x, y: state.y });
       setAvatarUrl(profile?.data.avatar ?? null);
       setArchetype(diag?.archetype ?? null);
     })();
     return () => { cancelled = true; };
-  }, [session.status, agent, did]);
+  }, [session.status, agent, did, retryNonce]);
+
+  // タイル実寸の追従 (アバターオーバーレイ用)
+  useEffect(() => {
+    const el = mapRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+    const update = () => setTilePx(el.clientWidth / VIEW);
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [pos === null]);
 
   // 位置保存 (2 秒デバウンス + unmount 時に確定)
   const posRef = useRef(pos);
@@ -87,22 +117,27 @@ export function World() {
 
   const move = useCallback(
     (dir: Dir) => {
-      setPos((p) => {
-        if (!p) return p;
-        const { dx, dy } = DIRS[dir];
-        const nx = wrap(p.x + dx);
-        const ny = wrap(p.y + dy);
-        if (!isWalkable(terrainAt(nx, ny))) return p; // 通行不能
-        return { x: nx, y: ny };
-      });
+      const p = posRef.current;
+      if (!p) return;
+      const { dx, dy } = DIRS[dir];
+      const nx = wrap(p.x + dx);
+      const ny = wrap(p.y + dy);
+      if (!isWalkable(terrainAt(nx, ny))) {
+        setBlocked(true); // 「そっちには進めない」フィードバック
+        return; // 位置不変なので保存もしない
+      }
+      setBlocked(false);
+      setPos({ x: nx, y: ny });
       scheduleSave();
     },
     [scheduleSave],
   );
 
-  // キーボード (PC)
+  // キーボード (PC)。修飾キー付き (Cmd+← のブラウザ戻る等) は奪わない。
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
+      if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return;
+      if (!posRef.current) return;
       const map: Record<string, Dir> = { ArrowUp: 'up', ArrowDown: 'down', ArrowLeft: 'left', ArrowRight: 'right' };
       const dir = map[e.key];
       if (dir) {
@@ -114,6 +149,15 @@ export function World() {
     return () => window.removeEventListener('keydown', onKey);
   }, [move]);
 
+  if (!WORLD_PREVIEW_ENABLED) {
+    return (
+      <div>
+        <h2>あおぞらワールド</h2>
+        <p style={{ color: 'var(--color-muted)' }}>じゅんびちゅう… もうすこし待っててね。</p>
+        <Link to="/spirit">← ブルスコンのところへ戻る</Link>
+      </div>
+    );
+  }
   if (session.status === 'loading') return <p>読み込み中…</p>;
   if (session.status === 'signed-out') {
     return (
@@ -121,6 +165,15 @@ export function World() {
         <h2>あおぞらワールド</h2>
         <p>ログインすると世界を歩けます。</p>
         <Link to="/onboarding"><button>ログイン</button></Link>
+      </div>
+    );
+  }
+  if (loadErr) {
+    return (
+      <div>
+        <h2>あおぞらワールド</h2>
+        <p style={{ color: 'var(--color-danger)' }}>現在地を読み込めなかった。通信を確認してもう一度どうぞ。</p>
+        <button type="button" onClick={() => setRetryNonce((n) => n + 1)}>再読み込み</button>
       </div>
     );
   }
@@ -144,6 +197,8 @@ export function World() {
     }
   }
 
+  const avatarSize = Math.max(16, Math.round(tilePx * 1.15));
+
   return (
     <div style={{ maxWidth: 560, margin: '0 auto' }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', flexWrap: 'wrap', gap: '0.3em' }}>
@@ -153,7 +208,9 @@ export function World() {
         </span>
       </div>
       <p style={{ margin: '0.2em 0 0.5em', fontSize: '0.8em', color: 'var(--color-muted)' }}>
-        {town ? (
+        {blocked ? (
+          <strong style={{ color: 'var(--color-fg)' }}>そっちには進めない!</strong>
+        ) : town ? (
           <strong style={{ color: 'var(--color-fg)' }}>🏘 {town.name}</strong>
         ) : (
           <>このあたり: {DANGER_LABELS[danger]}{here === 'forest' ? ' / 深い森…' : ''}</>
@@ -161,25 +218,39 @@ export function World() {
         <span style={{ marginLeft: '0.6em', opacity: 0.8 }}>※ プレビュー中はパワー消費・遭遇なし</span>
       </p>
 
-      {/* マップ本体 */}
+      {/* マップ本体。アバターは SVG 外の HTML オーバーレイ (装備が枠外に出るため)。 */}
       <div className="dq-window" style={{ padding: 4 }}>
-        <svg
-          viewBox={`0 0 ${VIEW * TILE} ${VIEW * TILE}`}
-          style={{ display: 'block', width: '100%', imageRendering: 'pixelated' }}
-          aria-label="ワールドマップ"
-        >
-          {tiles}
-          {/* プレイヤー (中央): 実アバター + 白リング */}
-          <g transform={`translate(${HALF * TILE},${HALF * TILE})`}>
-            <circle cx={TILE / 2} cy={TILE / 2} r={TILE / 2 - 1} fill="rgba(0,0,0,0.25)" />
-            <foreignObject x={2} y={2} width={TILE - 4} height={TILE - 4}>
-              <div style={{ width: '100%', height: '100%' }}>
-                <Avatar src={avatarUrl ?? undefined} size={TILE - 4} archetype={archetype} />
-              </div>
-            </foreignObject>
-            <circle cx={TILE / 2} cy={TILE / 2} r={TILE / 2 - 2} fill="none" stroke="#ffffff" strokeWidth={2} />
-          </g>
-        </svg>
+        <div ref={mapRef} style={{ position: 'relative' }}>
+          <svg
+            viewBox={`0 0 ${VIEW * TILE} ${VIEW * TILE}`}
+            style={{ display: 'block', width: '100%' }}
+            aria-label="ワールドマップ"
+          >
+            {tiles}
+            {/* プレイヤーの足元の影 */}
+            <ellipse
+              cx={HALF * TILE + TILE / 2}
+              cy={HALF * TILE + TILE * 0.8}
+              rx={TILE * 0.34}
+              ry={TILE * 0.14}
+              fill="rgba(0,0,0,0.3)"
+            />
+          </svg>
+          <div
+            style={{
+              position: 'absolute',
+              left: `${((HALF + 0.5) / VIEW) * 100}%`,
+              top: `${((HALF + 0.5) / VIEW) * 100}%`,
+              transform: 'translate(-50%, -55%)',
+              width: avatarSize,
+              height: avatarSize,
+              pointerEvents: 'none',
+              filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.4))',
+            }}
+          >
+            <Avatar src={avatarUrl ?? undefined} size={avatarSize} archetype={archetype} />
+          </div>
+        </div>
       </div>
 
       {/* 十字キー (親指ゾーン) */}
@@ -202,11 +273,17 @@ function DirButton({ dir, onMove }: { dir: Dir; onMove: (d: Dir) => void }) {
   return (
     <button
       type="button"
-      aria-label={`${DIRS[dir].label} に移動`}
+      aria-label={DIRS[dir].label}
       onClick={() => onMove(dir)}
-      style={{ height: 56, fontSize: '1.4em', padding: 0 }}
+      style={{
+        height: 56,
+        fontSize: '1.4em',
+        padding: 0,
+        // 連打でダブルタップズームを誘発しない (iOS)
+        touchAction: 'manipulation',
+      }}
     >
-      {DIRS[dir].label}
+      {DIRS[dir].glyph}
     </button>
   );
 }

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -1,0 +1,212 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+import type { DiagnosisResult } from '@aozoraquest/core';
+import {
+  isWalkable,
+  regionDanger,
+  regionOf,
+  terrainAt,
+  townAt,
+  wrap,
+} from '@aozoraquest/core';
+import { useSession } from '@/lib/session';
+import { getRecord } from '@/lib/atproto';
+import { COL } from '@/lib/collections';
+import { loadWorldState, saveWorldState } from '@/lib/world-state';
+import { Avatar } from '@/components/avatar';
+import { TERRAIN_TILES } from '@/components/world-tiles';
+
+/**
+ * あおぞらワールド (docs/19-overworld.md) — PR-W2: 散歩プレビュー。
+ *
+ * 16×16 ビューポートでプレイヤー中央固定、1 タップ 1 マス移動。トーラス wrap。
+ * この段階では**パワー消費なし・遭遇なし** (消費と判定は PR-W3 で Worker に移る)。
+ * 位置は PDS (world/self) に保存 (デバウンス)。
+ */
+
+const VIEW = 16; // ビューポートの一辺 (タイル数)
+const HALF = VIEW / 2;
+const TILE = 32; // SVG 内の 1 タイルサイズ (表示は width 100% で縮尺)
+
+type Dir = 'up' | 'down' | 'left' | 'right';
+const DIRS: Record<Dir, { dx: number; dy: number; label: string }> = {
+  up: { dx: 0, dy: -1, label: '↑' },
+  down: { dx: 0, dy: 1, label: '↓' },
+  left: { dx: -1, dy: 0, label: '←' },
+  right: { dx: 1, dy: 0, label: '→' },
+};
+
+const DANGER_LABELS = ['おだやか', 'すこし危険', '危険', 'とても危険'] as const;
+
+export function World() {
+  const session = useSession();
+  const agent = session.agent ?? null;
+  const did = session.did ?? null;
+  const [pos, setPos] = useState<{ x: number; y: number } | null>(null);
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
+  const [archetype, setArchetype] = useState<DiagnosisResult['archetype'] | null>(null);
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // 初期ロード: 位置 + アバター + ジョブ
+  useEffect(() => {
+    if (session.status !== 'signed-in' || !agent || !did) return;
+    let cancelled = false;
+    (async () => {
+      const [state, profile, diag] = await Promise.all([
+        loadWorldState(agent, did),
+        agent.getProfile({ actor: did }).catch(() => null),
+        getRecord<DiagnosisResult>(agent, did, COL.analysis, 'self').catch(() => null),
+      ]);
+      if (cancelled) return;
+      setPos({ x: state.x, y: state.y });
+      setAvatarUrl(profile?.data.avatar ?? null);
+      setArchetype(diag?.archetype ?? null);
+    })();
+    return () => { cancelled = true; };
+  }, [session.status, agent, did]);
+
+  // 位置保存 (2 秒デバウンス + unmount 時に確定)
+  const posRef = useRef(pos);
+  posRef.current = pos;
+  const scheduleSave = useCallback(() => {
+    if (!agent) return;
+    if (saveTimer.current) clearTimeout(saveTimer.current);
+    saveTimer.current = setTimeout(() => {
+      saveTimer.current = null;
+      const p = posRef.current;
+      if (p) void saveWorldState(agent, p.x, p.y);
+    }, 2000);
+  }, [agent]);
+  useEffect(() => () => {
+    if (saveTimer.current) {
+      clearTimeout(saveTimer.current);
+      const p = posRef.current;
+      if (agent && p) void saveWorldState(agent, p.x, p.y);
+    }
+  }, [agent]);
+
+  const move = useCallback(
+    (dir: Dir) => {
+      setPos((p) => {
+        if (!p) return p;
+        const { dx, dy } = DIRS[dir];
+        const nx = wrap(p.x + dx);
+        const ny = wrap(p.y + dy);
+        if (!isWalkable(terrainAt(nx, ny))) return p; // 通行不能
+        return { x: nx, y: ny };
+      });
+      scheduleSave();
+    },
+    [scheduleSave],
+  );
+
+  // キーボード (PC)
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const map: Record<string, Dir> = { ArrowUp: 'up', ArrowDown: 'down', ArrowLeft: 'left', ArrowRight: 'right' };
+      const dir = map[e.key];
+      if (dir) {
+        e.preventDefault();
+        move(dir);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [move]);
+
+  if (session.status === 'loading') return <p>読み込み中…</p>;
+  if (session.status === 'signed-out') {
+    return (
+      <div>
+        <h2>あおぞらワールド</h2>
+        <p>ログインすると世界を歩けます。</p>
+        <Link to="/onboarding"><button>ログイン</button></Link>
+      </div>
+    );
+  }
+  if (!pos) return <p>世界を読み込んでいる…</p>;
+
+  const town = townAt(pos.x, pos.y);
+  const here = terrainAt(pos.x, pos.y);
+  const danger = regionDanger(regionOf(pos.x, pos.y));
+
+  // ビューポートのタイル列 (プレイヤー中央固定)
+  const tiles = [];
+  for (let vy = 0; vy < VIEW; vy++) {
+    for (let vx = 0; vx < VIEW; vx++) {
+      const x = wrap(pos.x - HALF + vx);
+      const y = wrap(pos.y - HALF + vy);
+      tiles.push(
+        <g key={`${vx}-${vy}`} transform={`translate(${vx * TILE},${vy * TILE})`}>
+          {TERRAIN_TILES[terrainAt(x, y)]}
+        </g>,
+      );
+    }
+  }
+
+  return (
+    <div style={{ maxWidth: 560, margin: '0 auto' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', flexWrap: 'wrap', gap: '0.3em' }}>
+        <h2 style={{ margin: 0 }}>あおぞらワールド <span style={{ fontSize: '0.6em', color: 'var(--color-muted)' }}>(散歩プレビュー)</span></h2>
+        <span style={{ fontSize: '0.75em', color: 'var(--color-muted)', fontFamily: 'ui-monospace, monospace' }}>
+          ({pos.x}, {pos.y})
+        </span>
+      </div>
+      <p style={{ margin: '0.2em 0 0.5em', fontSize: '0.8em', color: 'var(--color-muted)' }}>
+        {town ? (
+          <strong style={{ color: 'var(--color-fg)' }}>🏘 {town.name}</strong>
+        ) : (
+          <>このあたり: {DANGER_LABELS[danger]}{here === 'forest' ? ' / 深い森…' : ''}</>
+        )}
+        <span style={{ marginLeft: '0.6em', opacity: 0.8 }}>※ プレビュー中はパワー消費・遭遇なし</span>
+      </p>
+
+      {/* マップ本体 */}
+      <div className="dq-window" style={{ padding: 4 }}>
+        <svg
+          viewBox={`0 0 ${VIEW * TILE} ${VIEW * TILE}`}
+          style={{ display: 'block', width: '100%', imageRendering: 'pixelated' }}
+          aria-label="ワールドマップ"
+        >
+          {tiles}
+          {/* プレイヤー (中央): 実アバター + 白リング */}
+          <g transform={`translate(${HALF * TILE},${HALF * TILE})`}>
+            <circle cx={TILE / 2} cy={TILE / 2} r={TILE / 2 - 1} fill="rgba(0,0,0,0.25)" />
+            <foreignObject x={2} y={2} width={TILE - 4} height={TILE - 4}>
+              <div style={{ width: '100%', height: '100%' }}>
+                <Avatar src={avatarUrl ?? undefined} size={TILE - 4} archetype={archetype} />
+              </div>
+            </foreignObject>
+            <circle cx={TILE / 2} cy={TILE / 2} r={TILE / 2 - 2} fill="none" stroke="#ffffff" strokeWidth={2} />
+          </g>
+        </svg>
+      </div>
+
+      {/* 十字キー (親指ゾーン) */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 64px)', gap: 6, justifyContent: 'center', marginTop: '0.8em' }}>
+        <span />
+        <DirButton dir="up" onMove={move} />
+        <span />
+        <DirButton dir="left" onMove={move} />
+        <DirButton dir="down" onMove={move} />
+        <DirButton dir="right" onMove={move} />
+      </div>
+      <p style={{ textAlign: 'center', fontSize: '0.72em', color: 'var(--color-muted)', marginTop: '0.4em' }}>
+        PC は矢印キーでも移動できます。池・川・海・山は今は通れません。
+      </p>
+    </div>
+  );
+}
+
+function DirButton({ dir, onMove }: { dir: Dir; onMove: (d: Dir) => void }) {
+  return (
+    <button
+      type="button"
+      aria-label={`${DIRS[dir].label} に移動`}
+      onClick={() => onMove(dir)}
+      style={{ height: 56, fontSize: '1.4em', padding: 0 }}
+    >
+      {DIRS[dir].label}
+    </button>
+  );
+}


### PR DESCRIPTION
## 概要
docs/19-overworld.md の **PR-W2**。承認済みタイルで 16×16 ビューポートを描画し、そらみの街から世界を歩ける「散歩プレビュー」。**パワー消費・遭遇はまだ無し** (PR-W3 で Worker 権威に配線)。**dev 環境限定** (WORLD_PREVIEW_ENABLED ゲート — 本番では入口も画面も出ない)。

## 実装
- **/world**: プレイヤー中央固定ビューポート (SVG)。十字キー + PC 矢印キーで 1 マス移動、トーラス wrap、通行判定 + 「そっちには進めない!」フィードバック。街の上で街名 / 圏外でリージョン危険度を表示。プレイヤーは**実アバター + ジョブ装備を HTML オーバーレイ**で描画 (装備が枠外に出るため foreignObject 不採用)。
- タイルは承認済み tiles.html v2 の React 化 (world-tiles.tsx)。
- 位置は PDS `world/self` に保存 (2 秒デバウンス + unmount 確定)。W3 以降は DO が正。
- 入口: ブルスコンページ (召喚済み) の試練の下 (dev のみ表示)。

## テスト
web 273 (world-state 4 追加) / typecheck / build green。/world ルートのスモーク済み。歩行体験は dev 実機確認 (§3)。

## Review (§1.5 レビュー: 実装 + UX)
**★★★** — なし。

**★★ (本PR内で対応 — 4183b25)**
- 位置読み込みの一時失敗→spawn 上書きの**データ損失経路** → 失敗は throw + エラー表示/リトライ、保存は成功ロード後のみ。テスト 4 件で固定。
- foreignObject のアバターは**ジョブ装備が overflow:hidden で切れる** + iOS Safari quirk → HTML オーバーレイ化 (実寸 ResizeObserver 追従)。
- d-pad の連打が iOS ダブルタップズームを誘発 → touch-action: manipulation。
- docs/19「dev だけで確認」のゲート欠如 (次のリリース列車で本番に出る) → WORLD_PREVIEW_ENABLED (dev/ローカルのみ)。

**★ (対応)**
- 修飾キー付き矢印 (Cmd+← 戻る等) を奪わない / ブロック移動は保存しない / aria-label 自然化 / ブロック時フィードバック。
- [確認済み] unmount 保存 (posRef+LWW) / トーラス表示計算 / SE 320px で崩れなし / 256 タイル再描画は現規模で許容 (W3 のアニメ時に defs/use 化検討)。

## dev 確認ポイント
- そらみの街から歩く: タイルの見え方・移動の手触り・通行判定
- iPhone 実機: アバター + 装備の表示 (オーバーレイ化後)・d-pad 連打でズームしないこと
- 別端末で開くと同じ位置から再開すること