### PR TITLE
feat(battle): バトルのレベルアップに演出とテキスト

### DIFF
--- a/apps/web/src/components/level-up-overlay.tsx
+++ b/apps/web/src/components/level-up-overlay.tsx
@@ -63,7 +63,9 @@ export function LevelUpOverlay() {
         alignItems: 'center',
         justifyContent: 'center',
         pointerEvents: 'none',
-        zIndex: 500,
+        // エンカウントワイプ (encounter-wipe.tsx, 1000) より上 — 連続レベルアップの
+        // 2 発目が再戦のワイプに飲まれて見えなくなるのを防ぐ
+        zIndex: 1100,
       }}
     >
       <style>{LEVEL_UP_KEYFRAMES}</style>

--- a/apps/web/src/components/trial-arena.tsx
+++ b/apps/web/src/components/trial-arena.tsx
@@ -4,6 +4,7 @@ import {
   BATTLE_TUNING,
   ITEMS,
   MONSTERS_BY_ID,
+  jobDisplayName,
   earnedTitles,
   pickTrialTier,
   resolveTurn,
@@ -27,8 +28,10 @@ import {
   finishBattleRecord,
   loadBattleStats,
   startBattleRecord,
+  type BattleLevelUps,
   type BattleStats,
 } from '@/lib/battle-log';
+import { notifyLevelUp } from './level-up-overlay';
 
 /**
  * ブルスコンの試練 — アリーナ UI (docs/18-brusukon-trial.md)。
@@ -51,6 +54,8 @@ type Phase =
       newTitles: string[];
       finalEvents: TurnEvent[];
       saveFailed: boolean;
+      /** XP 加算で確定したレベルアップ (非同期に届くので optional) */
+      levelUps?: BattleLevelUps;
     };
 
 const TIER_LABELS: Record<1 | 2 | 3, { name: string; hint: string }> = {
@@ -67,6 +72,7 @@ export function TrialArena({
   playerLevel,
   playerName,
   rpgStats,
+  jobXpOffset = 0,
   points,
   onPointsChanged,
 }: {
@@ -78,6 +84,9 @@ export function TrialArena({
   playerName: string;
   /** プロフィールの個人 5 パラメータ (戦闘値の基底)。未診断はジョブ基準にフォールバック */
   rpgStats?: StatVector | null;
+  /** ジョブレベル表示に含まれるレコード外 XP (クエスト報酬 questXp)。レベルアップ
+   *  判定を画面表示と一致させるために渡す */
+  jobXpOffset?: number;
   points: PointsState;
   onPointsChanged: (next: PointsState) => void;
 }) {
@@ -171,7 +180,23 @@ export function TrialArena({
           saveFailed = true;
         }
       }
-      if (xp > 0) void awardBattleXp(agent, did, xp);
+      if (xp > 0) {
+        void awardBattleXp(agent, did, xp, { jobXpOffset }).then((ups) => {
+          if (!ups) return;
+          // 全画面演出 (LevelUpOverlay は app 全体に常時マウント済み)
+          if (ups.player) notifyLevelUp({ kind: 'player', from: ups.player.from, to: ups.player.to });
+          if (ups.job) {
+            notifyLevelUp({
+              kind: 'job',
+              from: ups.job.from,
+              to: ups.job.to,
+              jobName: jobDisplayName(ups.job.archetype as Archetype, 'default'),
+            });
+          }
+          // リザルトの文言にも残す (演出は 2 秒で消えるため)
+          setPhase((p) => (p.kind === 'result' ? { ...p, levelUps: ups } : p));
+        });
+      }
       // 称号の新規獲得判定 (確定前の stats と比較)。stats 未取得 (取得失敗) 時は
       // 称号トーストを出さないだけで戦績自体はレコードに残る。
       const before = stats ? earnedTitles(stats).map((t) => t.id) : [];
@@ -225,7 +250,7 @@ export function TrialArena({
       });
       refreshStats();
     },
-    [phase, agent, did, stats, refreshStats],
+    [phase, agent, did, stats, refreshStats, jobXpOffset],
   );
 
   // ワイプ進行: 覆い切った時点でバトル準備がまだなら hold でつなぐ
@@ -358,6 +383,16 @@ export function TrialArena({
       </SpiritBubble>
       <div style={{ margin: '0.8em 0', fontSize: '0.9em', display: 'flex', flexDirection: 'column', gap: '0.3em' }}>
         {xp > 0 && <div>経験値 +{xp}</div>}
+        {phase.levelUps?.player && (
+          <div style={{ color: 'var(--color-accent)', fontWeight: 700 }}>
+            レベルが {phase.levelUps.player.to} に あがった!
+          </div>
+        )}
+        {phase.levelUps?.job && (
+          <div style={{ color: 'var(--color-accent)', fontWeight: 700 }}>
+            {jobDisplayName(phase.levelUps.job.archetype as Archetype, 'default')}のジョブレベルが {phase.levelUps.job.to} に あがった!
+          </div>
+        )}
         {drops.length > 0 && (
           <div>
             素材を手に入れた: {drops.map((d) => ITEMS[d]?.name ?? d).join('、')}

--- a/apps/web/src/components/trial-arena.tsx
+++ b/apps/web/src/components/trial-arena.tsx
@@ -73,6 +73,7 @@ export function TrialArena({
   playerName,
   rpgStats,
   jobXpOffset = 0,
+  onXpAwarded,
   points,
   onPointsChanged,
 }: {
@@ -87,6 +88,8 @@ export function TrialArena({
   /** ジョブレベル表示に含まれるレコード外 XP (クエスト報酬 questXp)。レベルアップ
    *  判定を画面表示と一致させるために渡す */
   jobXpOffset?: number;
+  /** XP 加算が確定したとき呼ばれる (親は analysis を再取得して表示レベルを更新する) */
+  onXpAwarded?: () => void;
   points: PointsState;
   onPointsChanged: (next: PointsState) => void;
 }) {
@@ -183,18 +186,23 @@ export function TrialArena({
       if (xp > 0) {
         void awardBattleXp(agent, did, xp, { jobXpOffset }).then((ups) => {
           if (!ups) return;
-          // 全画面演出 (LevelUpOverlay は app 全体に常時マウント済み)
-          if (ups.player) notifyLevelUp({ kind: 'player', from: ups.player.from, to: ups.player.to });
+          // 親に XP 反映を通知 (diag 再取得)。演出だけ出して表示レベルが古いままだと
+          // 「LEVEL UP! と言われたのに次戦も LV5」の矛盾が見える (レビュー指摘)
+          onXpAwarded?.();
+          // 全画面演出 (LevelUpOverlay は app 全体に常時マウント済み)。
+          // 発火順は投稿フロー (compose-modal) と同じ job → player
           if (ups.job) {
             notifyLevelUp({
               kind: 'job',
               from: ups.job.from,
               to: ups.job.to,
-              jobName: jobDisplayName(ups.job.archetype as Archetype, 'default'),
+              jobName: jobDisplayName(ups.job.archetype, 'default'),
             });
           }
-          // リザルトの文言にも残す (演出は 2 秒で消えるため)
-          setPhase((p) => (p.kind === 'result' ? { ...p, levelUps: ups } : p));
+          if (ups.player) notifyLevelUp({ kind: 'player', from: ups.player.from, to: ups.player.to });
+          // リザルトの文言にも残す (演出は 2 秒で消えるため)。seed 照合で
+          // 再戦後の別リザルトに前戦の分を付けない (world 側と同じ防御)
+          setPhase((p) => (p.kind === 'result' && p.state.seed === next.seed ? { ...p, levelUps: ups } : p));
         });
       }
       // 称号の新規獲得判定 (確定前の stats と比較)。stats 未取得 (取得失敗) 時は
@@ -250,7 +258,7 @@ export function TrialArena({
       });
       refreshStats();
     },
-    [phase, agent, did, stats, refreshStats, jobXpOffset],
+    [phase, agent, did, stats, refreshStats, jobXpOffset, onXpAwarded],
   );
 
   // ワイプ進行: 覆い切った時点でバトル準備がまだなら hold でつなぐ
@@ -381,7 +389,7 @@ export function TrialArena({
               ? '引きぎわを知るのも強さのうちさ。また挑んでおいで。'
               : 'いい勝負だった。次は決着をつけよう。'}
       </SpiritBubble>
-      <div style={{ margin: '0.8em 0', fontSize: '0.9em', display: 'flex', flexDirection: 'column', gap: '0.3em' }}>
+      <div aria-live="polite" style={{ margin: '0.8em 0', fontSize: '0.9em', display: 'flex', flexDirection: 'column', gap: '0.3em' }}>
         {xp > 0 && <div>経験値 +{xp}</div>}
         {phase.levelUps?.player && (
           <div style={{ color: 'var(--color-accent)', fontWeight: 700 }}>
@@ -390,7 +398,7 @@ export function TrialArena({
         )}
         {phase.levelUps?.job && (
           <div style={{ color: 'var(--color-accent)', fontWeight: 700 }}>
-            {jobDisplayName(phase.levelUps.job.archetype as Archetype, 'default')}のジョブレベルが {phase.levelUps.job.to} に あがった!
+            {jobDisplayName(phase.levelUps.job.archetype, 'default')}のジョブレベルが {phase.levelUps.job.to} に あがった!
           </div>
         )}
         {drops.length > 0 && (

--- a/apps/web/src/lib/battle-log.test.ts
+++ b/apps/web/src/lib/battle-log.test.ts
@@ -241,18 +241,24 @@ describe('record lifecycle (start/finish/awardBattleXp)', () => {
     // またがない: 直後 (crossing+30) から +30 が境界を再度またぐとは限らないので Lv1 序盤で確認
     const flat = await awardBattleXp(mkAgent(0, 0), 'did:test', 1);
     expect(flat?.player).toBeUndefined();
-    // offset: jobXpOffset を足した位置で判定される (表示レベルとの一致)
-    let jobCrossing = -1;
-    for (let x = 0; x < 5000; x++) {
-      if (jobLevelFromXp(x) < jobLevelFromXp(x + 30)) { jobCrossing = x; break; }
+    // offset: jobXpOffset を足した位置で判定される (表示レベルとの一致)。
+    // 「offset なしなら境界をまたぐが、offset を足すとまたがない」xp を探すことで、
+    // 実装が offset を無視していたら fail する判別力を持たせる (レビュー指摘:
+    // 初版は offset 0 と同じ結果になる縮退ケースだった)
+    let discriminating = -1;
+    for (let off = 1; off < 5000; off++) {
+      const noOff = jobLevelFromXp(0) < jobLevelFromXp(30); // base 0 は +30 で必ずまたぐ (LV2 閾値 30)
+      const withOff = jobLevelFromXp(off) < jobLevelFromXp(off + 30);
+      if (noOff && !withOff) { discriminating = off; break; }
     }
-    expect(jobCrossing).toBeGreaterThanOrEqual(0);
-    const withOffset = await awardBattleXp(mkAgent(0, 0), 'did:test', 30, { jobXpOffset: jobCrossing });
-    expect(withOffset?.job).toEqual({
-      from: jobLevelFromXp(jobCrossing),
-      to: jobLevelFromXp(jobCrossing + 30),
-      archetype: 'sage',
-    });
+    expect(discriminating).toBeGreaterThan(0);
+    const noUp = await awardBattleXp(mkAgent(0, 0), 'did:test', 30, { jobXpOffset: discriminating });
+    expect(noUp?.job).toBeUndefined(); // offset 適用でまたがない
+    const withUp = await awardBattleXp(mkAgent(0, 0), 'did:test', 30);
+    expect(withUp?.job).toEqual({ from: 1, to: jobLevelFromXp(30), archetype: 'sage' }); // offset なしはまたぐ
+    // playerXpOffset も同様に判別力のあるケースで検証
+    const pNoUp = await awardBattleXp(mkAgent(crossing, 0), 'did:test', 30, { playerXpOffset: 5000 });
+    expect(pNoUp?.player?.from).not.toBe(playerLevelFromXp(crossing)); // offset が効いて基準が動く
   });
 
   test('awardBattleXp は analysis 未作成なら何も書かない', async () => {

--- a/apps/web/src/lib/battle-log.test.ts
+++ b/apps/web/src/lib/battle-log.test.ts
@@ -215,6 +215,46 @@ describe('record lifecycle (start/finish/awardBattleXp)', () => {
     expect(saved.playerLevel.streakDays).toBe(3);
   });
 
+  test('awardBattleXp はレベルアップを検出して返す (境界をまたぐ/またがない/offset)', async () => {
+    const { playerLevelFromXp, jobLevelFromXp } = await import('@aozoraquest/core');
+    // +30 でプレイヤーレベル境界をまたぐ xp を決定的に探す
+    let crossing = -1;
+    for (let x = 0; x < 5000; x++) {
+      if (playerLevelFromXp(x) < playerLevelFromXp(x + 30)) { crossing = x; break; }
+    }
+    expect(crossing).toBeGreaterThanOrEqual(0);
+    const mkAgent = (playerXp: number, jobXp: number) => ({
+      assertDid: 'did:test',
+      com: { atproto: { repo: {
+        getRecord: vi.fn(async () => ({ data: { value: {
+          $type: 'x.analysis', archetype: 'sage', analyzedAt: '2026-01-01T00:00:00.000Z',
+          playerLevel: { xp: playerXp, streakDays: 0 },
+          jobLevel: { archetype: 'sage', xp: jobXp, joinedAt: '2026-01-01T00:00:00.000Z' },
+        } } })),
+        putRecord: vi.fn(async () => ({ data: {} })),
+      } } },
+    }) as any;
+    const { awardBattleXp } = await import('./battle-log');
+    // またぐ: player は from→to、job は同じ xp なら jobLevelFromXp 基準で判定される
+    const ups = await awardBattleXp(mkAgent(crossing, 0), 'did:test', 30);
+    expect(ups?.player).toEqual({ from: playerLevelFromXp(crossing), to: playerLevelFromXp(crossing + 30) });
+    // またがない: 直後 (crossing+30) から +30 が境界を再度またぐとは限らないので Lv1 序盤で確認
+    const flat = await awardBattleXp(mkAgent(0, 0), 'did:test', 1);
+    expect(flat?.player).toBeUndefined();
+    // offset: jobXpOffset を足した位置で判定される (表示レベルとの一致)
+    let jobCrossing = -1;
+    for (let x = 0; x < 5000; x++) {
+      if (jobLevelFromXp(x) < jobLevelFromXp(x + 30)) { jobCrossing = x; break; }
+    }
+    expect(jobCrossing).toBeGreaterThanOrEqual(0);
+    const withOffset = await awardBattleXp(mkAgent(0, 0), 'did:test', 30, { jobXpOffset: jobCrossing });
+    expect(withOffset?.job).toEqual({
+      from: jobLevelFromXp(jobCrossing),
+      to: jobLevelFromXp(jobCrossing + 30),
+      archetype: 'sage',
+    });
+  });
+
   test('awardBattleXp は analysis 未作成なら何も書かない', async () => {
     const getRecordFn = vi.fn(async () => { throw new Error('not found'); });
     const putRecordFn = vi.fn();
@@ -223,7 +263,8 @@ describe('record lifecycle (start/finish/awardBattleXp)', () => {
       com: { atproto: { repo: { getRecord: getRecordFn, putRecord: putRecordFn } } },
     } as any;
     const { awardBattleXp } = await import('./battle-log');
-    await awardBattleXp(agent, 'did:test', 30);
+    const r = await awardBattleXp(agent, 'did:test', 30);
+    expect(r).toBeNull();
     expect(putRecordFn).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/battle-log.ts
+++ b/apps/web/src/lib/battle-log.ts
@@ -8,6 +8,7 @@
 
 import type { Agent } from '@atproto/api';
 import type { BattleOutcome, BattleRecordSummary } from '@aozoraquest/core';
+import { jobLevelFromXp, playerLevelFromXp } from '@aozoraquest/core';
 import { VIA, getRecord, putRecord } from './atproto';
 import { COL } from './collections';
 
@@ -80,11 +81,25 @@ export async function finishBattleRecord(
   });
 }
 
+/** awardBattleXp が検出したレベルアップ (演出 notifyLevelUp とリザルト文言用)。 */
+export interface BattleLevelUps {
+  player?: { from: number; to: number };
+  job?: { from: number; to: number; archetype: string };
+}
+
 /**
  * バトルの経験値を analysis レコードに加算する (post-processor と同じ流儀:
  * playerLevel.xp は常に、jobLevel.xp も現ジョブに積む)。失敗は warn して swallow。
+ * 戻り値でレベルアップの有無を返す (呼び出し側が演出を発火する)。
+ * offsets: 画面表示のレベルがレコード外 XP (クエスト報酬の questXp 等) を含む場合、
+ * 同じオフセットで判定しないと「表示 LV6 なのに 4→5 の演出」の食い違いが出る。
  */
-export async function awardBattleXp(agent: Agent, did: string, xp: number): Promise<void> {
+export async function awardBattleXp(
+  agent: Agent,
+  did: string,
+  xp: number,
+  offsets?: { jobXpOffset?: number; playerXpOffset?: number },
+): Promise<BattleLevelUps | null> {
   try {
     const analysis = await getRecord<{
       archetype: string;
@@ -93,7 +108,7 @@ export async function awardBattleXp(agent: Agent, did: string, xp: number): Prom
       jobLevel?: { archetype: string; xp: number; joinedAt: string };
       [k: string]: unknown;
     }>(agent, did, COL.analysis, 'self');
-    if (!analysis) return;
+    if (!analysis) return null;
     const playerLevel = analysis.playerLevel ?? { xp: 0, streakDays: 0 };
     const jobLevel = analysis.jobLevel ?? {
       archetype: analysis.archetype,
@@ -105,8 +120,19 @@ export async function awardBattleXp(agent: Agent, did: string, xp: number): Prom
       playerLevel: { ...playerLevel, xp: playerLevel.xp + xp },
       jobLevel: { ...jobLevel, xp: jobLevel.xp + xp },
     });
+    const jobOff = offsets?.jobXpOffset ?? 0;
+    const playerOff = offsets?.playerXpOffset ?? 0;
+    const ups: BattleLevelUps = {};
+    const pFrom = playerLevelFromXp(playerLevel.xp + playerOff);
+    const pTo = playerLevelFromXp(playerLevel.xp + xp + playerOff);
+    if (pTo > pFrom) ups.player = { from: pFrom, to: pTo };
+    const jFrom = jobLevelFromXp(jobLevel.xp + jobOff);
+    const jTo = jobLevelFromXp(jobLevel.xp + xp + jobOff);
+    if (jTo > jFrom) ups.job = { from: jFrom, to: jTo, archetype: jobLevel.archetype };
+    return ups;
   } catch (e) {
     console.warn('[battle] xp award failed', e);
+    return null;
   }
 }
 

--- a/apps/web/src/routes/spirit.tsx
+++ b/apps/web/src/routes/spirit.tsx
@@ -247,6 +247,14 @@ export function Spirit() {
                 playerName={userName}
                 rpgStats={diag.rpgStats ?? null}
                 jobXpOffset={questXp}
+                onXpAwarded={() => {
+                  // バトル XP 反映後に表示レベルを追従 (演出と select 画面の LV 食い違い防止)
+                  if (agent && did) {
+                    getRecord<DiagnosisResult>(agent, did, COL.analysis, 'self')
+                      .then((r) => { if (r) setDiag(r); })
+                      .catch(() => {});
+                  }
+                }}
                 points={points}
                 onPointsChanged={setPoints}
               />

--- a/apps/web/src/routes/spirit.tsx
+++ b/apps/web/src/routes/spirit.tsx
@@ -246,6 +246,7 @@ export function Spirit() {
                 playerLevel={playerLevelFromXp(diag.playerLevel?.xp ?? 0)}
                 playerName={userName}
                 rpgStats={diag.rpgStats ?? null}
+                jobXpOffset={questXp}
                 points={points}
                 onPointsChanged={setPoints}
               />

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
-import type { BattleState, Command, DiagnosisResult } from '@aozoraquest/core';
+import type { Archetype, BattleState, Command, DiagnosisResult } from '@aozoraquest/core';
 import {
   BATTLE_TUNING,
   ITEMS,
   MONSTERS_BY_ID,
+  jobDisplayName,
   encounterRateFor,
   isWalkable,
   jobLevelFromXp,
@@ -26,7 +27,8 @@ import { useSession } from '@/lib/session';
 import { getRecord } from '@/lib/atproto';
 import { COL } from '@/lib/collections';
 import { loadWorldState, saveWorldState } from '@/lib/world-state';
-import { awardBattleXp, finishBattleRecord, loadBattleStats, startBattleRecord } from '@/lib/battle-log';
+import { awardBattleXp, finishBattleRecord, loadBattleStats, startBattleRecord, type BattleLevelUps } from '@/lib/battle-log';
+import { notifyLevelUp } from '@/components/level-up-overlay';
 import { bumpPower, loadPointsState, type PointsState } from '@/lib/points';
 import { WORLD_PREVIEW_ENABLED } from '@/lib/world-preview';
 import { Avatar } from '@/components/avatar';
@@ -94,6 +96,8 @@ export function World() {
     drops: string[];
     xp: number;
     saveFailed: boolean;
+    /** XP 加算で確定したレベルアップ (非同期に届く) */
+    levelUps?: BattleLevelUps;
   } | null>(null);
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const mapRef = useRef<HTMLDivElement>(null);
@@ -318,7 +322,22 @@ export function World() {
           saveFailed = true;
         }
       }
-      if (xp > 0) void awardBattleXp(agent, did, xp);
+      if (xp > 0) {
+        void awardBattleXp(agent, did, xp).then((ups) => {
+          if (!ups) return;
+          if (ups.player) notifyLevelUp({ kind: 'player', from: ups.player.from, to: ups.player.to });
+          if (ups.job) {
+            notifyLevelUp({
+              kind: 'job',
+              from: ups.job.from,
+              to: ups.job.to,
+              jobName: jobDisplayName(ups.job.archetype as Archetype, 'default'),
+            });
+          }
+          // 同じ戦闘のリザルトが出ている間だけ文言も反映 (次の遭遇に紛れ込ませない)
+          setBattleResult((r) => (r && r.state.seed === next.seed ? { ...r, levelUps: ups } : r));
+        });
+      }
       // 手持ちを更新: 使った分を引き、ドロップ分を足す。
       // TODO(W3): 在庫の正は Worker (DO) に移す (フィールド使用分が記録されない併走は
       // プレビュー限定の割り切り)。
@@ -511,6 +530,16 @@ export function World() {
         )}
         <div style={{ margin: '0.6em 0', fontSize: '0.9em', display: 'flex', flexDirection: 'column', gap: '0.3em' }}>
           {xp > 0 && <div>経験値 +{xp}</div>}
+          {battleResult.levelUps?.player && (
+            <div style={{ color: 'var(--color-accent)', fontWeight: 700 }}>
+              レベルが {battleResult.levelUps.player.to} に あがった!
+            </div>
+          )}
+          {battleResult.levelUps?.job && (
+            <div style={{ color: 'var(--color-accent)', fontWeight: 700 }}>
+              {jobDisplayName(battleResult.levelUps.job.archetype as Archetype, 'default')}のジョブレベルが {battleResult.levelUps.job.to} に あがった!
+            </div>
+          )}
           {drops.length > 0 && (
             <div>素材を手に入れた: {drops.map((d) => ITEMS[d]?.name ?? d).join('、')}</div>
           )}

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
-import type { Archetype, BattleState, Command, DiagnosisResult } from '@aozoraquest/core';
+import type { BattleState, Command, DiagnosisResult } from '@aozoraquest/core';
 import {
   BATTLE_TUNING,
   ITEMS,
@@ -325,15 +325,21 @@ export function World() {
       if (xp > 0) {
         void awardBattleXp(agent, did, xp).then((ups) => {
           if (!ups) return;
-          if (ups.player) notifyLevelUp({ kind: 'player', from: ups.player.from, to: ups.player.to });
+          // 表示レベル (HP/MP バー分母・次戦の戦闘値) を追従させる。演出だけ出して
+          // maxHp が増えないと「LEVEL UP! なのに強くなってない」に見える (レビュー指摘)
+          void getRecord<DiagnosisResult>(agent, did, COL.analysis, 'self')
+            .then((d) => { if (d) setDiag(d); })
+            .catch(() => {});
+          // 発火順は投稿フロー (compose-modal) と同じ job → player
           if (ups.job) {
             notifyLevelUp({
               kind: 'job',
               from: ups.job.from,
               to: ups.job.to,
-              jobName: jobDisplayName(ups.job.archetype as Archetype, 'default'),
+              jobName: jobDisplayName(ups.job.archetype, 'default'),
             });
           }
+          if (ups.player) notifyLevelUp({ kind: 'player', from: ups.player.from, to: ups.player.to });
           // 同じ戦闘のリザルトが出ている間だけ文言も反映 (次の遭遇に紛れ込ませない)
           setBattleResult((r) => (r && r.state.seed === next.seed ? { ...r, levelUps: ups } : r));
         });
@@ -528,7 +534,7 @@ export function World() {
             {state.lastEvents.map((e, i) => <div key={i}>{e.text}</div>)}
           </div>
         )}
-        <div style={{ margin: '0.6em 0', fontSize: '0.9em', display: 'flex', flexDirection: 'column', gap: '0.3em' }}>
+        <div aria-live="polite" style={{ margin: '0.6em 0', fontSize: '0.9em', display: 'flex', flexDirection: 'column', gap: '0.3em' }}>
           {xp > 0 && <div>経験値 +{xp}</div>}
           {battleResult.levelUps?.player && (
             <div style={{ color: 'var(--color-accent)', fontWeight: 700 }}>
@@ -537,7 +543,7 @@ export function World() {
           )}
           {battleResult.levelUps?.job && (
             <div style={{ color: 'var(--color-accent)', fontWeight: 700 }}>
-              {jobDisplayName(battleResult.levelUps.job.archetype as Archetype, 'default')}のジョブレベルが {battleResult.levelUps.job.to} に あがった!
+              {jobDisplayName(battleResult.levelUps.job.archetype, 'default')}のジョブレベルが {battleResult.levelUps.job.to} に あがった!
             </div>
           )}
           {drops.length > 0 && (


### PR DESCRIPTION
## 概要

オーナー指摘 (2026-07-17):「ジョブとユーザーのレベルが上がった時のテキストと演出がないです」

投稿フローには既に LV UP 全画面演出 (LevelUpOverlay) があったが、**バトル XP の経路 (試練 / ワールド) は検出も通知もしていなかった**。

- `awardBattleXp` がレベルアップ (player / job) を検出して返すように拡張。
- 試練 / ワールドの決着時に `notifyLevelUp` を発火 → 既存の全画面演出「LEVEL UP! LV n→m」(ジョブはジョブ名付き、同時なら job → player の順に再生)。
- リザルト画面にも **「レベルが N に あがった!」「◯◯のジョブレベルが N に あがった!」** のテキスト行を追加。
- **表示レベルの追従**: レベルアップ確定時に analysis を再取得し、select 画面・次戦の戦闘値・HP/MP バー分母を新レベルに更新 (演出と表示の矛盾防止)。
- **jobXpOffset**: 試練のジョブレベル表示はクエスト報酬 XP を含むため、同じオフセットで判定して食い違いを防止。

## テスト
- web 276 (レベルアップ検出: 境界またぎ / またがない / **offset の有無で結果が変わる判別ケース**) / typecheck / build 緑

## Review

3 並列レビュー実施。★★★ 0 件。

**★★ の処理 (b638500 相当のコミットで対応 or issue):**
- trial の後追い反映に seed 照合がなく再戦リザルトに前戦の文言が付着しうる → 修正 (world と同じ防御に統一)
- 演出後も表示レベルが古いまま (「LEVEL UP! なのに強くなってない」) → analysis 再取得で追従
- offset テストが縮退していて実装が offset を無視しても緑 → 判別力のあるケースに書き換え
- 表示用 XP (questXp 込み/なし) の画面間不統一 (me/spirit/world で別々) → **#289** に集約 (canonical な導出ヘルパへの統一。W4 の API 形状の申し送り含む)

**★ の処理:** LevelUpOverlay を zIndex 1100 に (再戦ワイプに飲まれない) / 発火順を投稿フローと統一 (job→player) / 不要キャスト除去 / aria-live 追加 → 対応済み。敗北 +5 XP でも境界をまたげば演出が出るのは「経験値による成長は勝敗と独立」の RPG 文法として許容 (判断記録)。ステータス上昇値の表示 (「ちからが 2 あがった!」) は #285 に追記。