### PR TITLE
feat(battle): レベルアップ演出にステータス上昇量を表示

### DIFF
--- a/apps/web/src/components/compose-modal.tsx
+++ b/apps/web/src/components/compose-modal.tsx
@@ -7,7 +7,7 @@ import { TextField } from './text-field';
 import { processSelfPost } from '@/lib/post-processor';
 import { bumpPower } from '@/lib/points';
 import { LevelUpOverlay, notifyLevelUp } from './level-up-overlay';
-import { POST_MAX_LENGTH, jobDisplayName } from '@aozoraquest/core';
+import { POST_MAX_LENGTH, jobDisplayName, jobLevelFromXp, levelUpGains, playerLevelFromXp, statVectorToArray, type Archetype } from '@aozoraquest/core';
 
 export interface ComposeReplyTo {
   parent: { uri: string; cid: string };
@@ -395,12 +395,21 @@ function ComposeDialog({
         void (async () => {
           try {
             const result = await processSelfPost(agent, did, body, structure);
+            // ステータス上昇量 (バトルのレベルアップ演出と同じ表示。オーナー要望
+            // 2026-07-17)。区間は job → player の順で分けて二重計上しない
+            const arch = result.jobLevel?.archetype;
+            const base = result.updatedRpgStats ? statVectorToArray(result.updatedRpgStats) : undefined;
+            const jTo = result.jobLevel ? jobLevelFromXp(result.jobLevel.xp) : 1;
+            const jFrom = result.jobLeveledUp?.from ?? jTo;
+            const pTo = result.playerLevel ? playerLevelFromXp(result.playerLevel.xp) : 1;
+            const pFrom = result.playerLeveledUp?.from ?? pTo;
             if (result.jobLeveledUp && result.jobLevel) {
               notifyLevelUp({
                 kind: 'job',
                 from: result.jobLeveledUp.from,
                 to: result.jobLeveledUp.to,
                 jobName: jobDisplayName(result.jobLevel.archetype, 'default'),
+                ...(arch ? { gains: levelUpGains(arch as Archetype, { jobLevel: jFrom, playerLevel: pFrom }, { jobLevel: result.jobLeveledUp.to, playerLevel: pFrom }, base) } : {}),
               });
             }
             if (result.playerLeveledUp) {
@@ -408,6 +417,7 @@ function ComposeDialog({
                 kind: 'player',
                 from: result.playerLeveledUp.from,
                 to: result.playerLeveledUp.to,
+                ...(arch ? { gains: levelUpGains(arch as Archetype, { jobLevel: jTo, playerLevel: pFrom }, { jobLevel: jTo, playerLevel: result.playerLeveledUp.to }, base) } : {}),
               });
             }
           } catch (e) {

--- a/apps/web/src/components/compose-modal.tsx
+++ b/apps/web/src/components/compose-modal.tsx
@@ -7,7 +7,7 @@ import { TextField } from './text-field';
 import { processSelfPost } from '@/lib/post-processor';
 import { bumpPower } from '@/lib/points';
 import { LevelUpOverlay, notifyLevelUp } from './level-up-overlay';
-import { POST_MAX_LENGTH, jobDisplayName, jobLevelFromXp, levelUpGains, playerLevelFromXp, statVectorToArray, type Archetype } from '@aozoraquest/core';
+import { POST_MAX_LENGTH, jobDisplayName, jobLevelFromXp, levelUpGains, playerLevelFromXp, statVectorToArray } from '@aozoraquest/core';
 
 export interface ComposeReplyTo {
   parent: { uri: string; cid: string };
@@ -409,7 +409,7 @@ function ComposeDialog({
                 from: result.jobLeveledUp.from,
                 to: result.jobLeveledUp.to,
                 jobName: jobDisplayName(result.jobLevel.archetype, 'default'),
-                ...(arch ? { gains: levelUpGains(arch as Archetype, { jobLevel: jFrom, playerLevel: pFrom }, { jobLevel: result.jobLeveledUp.to, playerLevel: pFrom }, base) } : {}),
+                ...(arch ? { gains: levelUpGains(arch, { jobLevel: jFrom, playerLevel: pFrom }, { jobLevel: result.jobLeveledUp.to, playerLevel: pFrom }, base) } : {}),
               });
             }
             if (result.playerLeveledUp) {
@@ -417,7 +417,7 @@ function ComposeDialog({
                 kind: 'player',
                 from: result.playerLeveledUp.from,
                 to: result.playerLeveledUp.to,
-                ...(arch ? { gains: levelUpGains(arch as Archetype, { jobLevel: jTo, playerLevel: pFrom }, { jobLevel: jTo, playerLevel: result.playerLeveledUp.to }, base) } : {}),
+                ...(arch ? { gains: levelUpGains(arch, { jobLevel: jTo, playerLevel: pFrom }, { jobLevel: jTo, playerLevel: result.playerLeveledUp.to }, base) } : {}),
               });
             }
           } catch (e) {

--- a/apps/web/src/components/level-up-overlay.tsx
+++ b/apps/web/src/components/level-up-overlay.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { LEVEL_UP_OVERLAY_DURATION_MS, LEVEL_UP_POP_DURATION_MS } from '@aozoraquest/core';
+import { LEVEL_UP_OVERLAY_DURATION_MS, LEVEL_UP_POP_DURATION_MS, type StatGain } from '@aozoraquest/core';
 
 export interface LevelUpEvent {
   kind: 'job' | 'player';
@@ -7,6 +7,13 @@ export interface LevelUpEvent {
   to: number;
   /** ジョブレベルアップ時はジョブ表示名、プレイヤーは undefined */
   jobName?: string;
+  /** ステータス上昇量 (levelUpGains の出力。0.1 未満はヘルパ側で除外済み) */
+  gains?: StatGain[];
+}
+
+/** 上昇量の表示 (整数はそのまま、小数は 1 桁)。 */
+export function formatGain(delta: number): string {
+  return Number.isInteger(delta) ? String(delta) : delta.toFixed(1);
 }
 
 type Listener = (ev: LevelUpEvent) => void;
@@ -106,6 +113,30 @@ export function LevelUpOverlay() {
           <span style={{ color: 'var(--color-muted)', fontSize: '0.7em', margin: '0 0.1em' }}>→</span>
           <span style={{ color: 'var(--color-accent)' }}>{current.to}</span>
         </div>
+        {current.gains && current.gains.length > 0 && (
+          // ステータス上昇 (DQ の「ちからが あがった!」枠。2 列で 7 項目まで収める)
+          <div
+            style={{
+              marginTop: '0.5em',
+              display: 'grid',
+              gridTemplateColumns: 'auto auto',
+              columnGap: '1.2em',
+              rowGap: '0.15em',
+              fontSize: '0.85em',
+              textAlign: 'left',
+              justifyContent: 'center',
+            }}
+          >
+            {current.gains.map((g) => (
+              <div key={g.key} style={{ display: 'flex', justifyContent: 'space-between', gap: '0.6em' }}>
+                <span>{g.label}</span>
+                <span style={{ fontFamily: 'ui-monospace, monospace', color: 'var(--color-accent)' }}>
+                  +{formatGain(g.delta)}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
       </div>
       {/* 後光的な光る粒 */}
       <div

--- a/apps/web/src/components/level-up-overlay.tsx
+++ b/apps/web/src/components/level-up-overlay.tsx
@@ -16,6 +16,12 @@ export function formatGain(delta: number): string {
   return Number.isInteger(delta) ? String(delta) : delta.toFixed(1);
 }
 
+/** ステータス上昇行があるときの表示時間。7 行 + LV を 2.2 秒では読み切れない
+ *  (レビュー指摘。特に投稿経路はリザルト画面がなく読み逃すと消える)。 */
+function overlayDurationFor(ev: LevelUpEvent): number {
+  return LEVEL_UP_OVERLAY_DURATION_MS + (ev.gains && ev.gains.length > 0 ? 900 : 0);
+}
+
 type Listener = (ev: LevelUpEvent) => void;
 const listeners = new Set<Listener>();
 
@@ -45,7 +51,7 @@ export function LevelUpOverlay() {
       }
       playingRef.current = true;
       setCurrent(next);
-      window.setTimeout(playNext, LEVEL_UP_OVERLAY_DURATION_MS);
+      window.setTimeout(playNext, overlayDurationFor(next));
     };
     const listener: Listener = (ev) => {
       queueRef.current.push(ev);
@@ -83,7 +89,7 @@ export function LevelUpOverlay() {
           border: '3px solid var(--color-accent)',
           borderRadius: 6,
           textAlign: 'center',
-          animation: `lvup-pop ${LEVEL_UP_POP_DURATION_MS}ms cubic-bezier(0.2, 0.9, 0.4, 1.4) both, lvup-hold ${LEVEL_UP_OVERLAY_DURATION_MS}ms linear both`,
+          animation: `lvup-pop ${LEVEL_UP_POP_DURATION_MS}ms cubic-bezier(0.2, 0.9, 0.4, 1.4) both, lvup-hold ${overlayDurationFor(current)}ms linear both`,
           boxShadow: '0 0 24px rgba(159, 215, 255, 0.5)',
         }}
       >

--- a/apps/web/src/components/trial-arena.tsx
+++ b/apps/web/src/components/trial-arena.tsx
@@ -5,6 +5,8 @@ import {
   ITEMS,
   MONSTERS_BY_ID,
   jobDisplayName,
+  levelUpGains,
+  type StatGain,
   earnedTitles,
   pickTrialTier,
   resolveTurn,
@@ -31,7 +33,7 @@ import {
   type BattleLevelUps,
   type BattleStats,
 } from '@/lib/battle-log';
-import { notifyLevelUp } from './level-up-overlay';
+import { formatGain, notifyLevelUp } from './level-up-overlay';
 
 /**
  * ブルスコンの試練 — アリーナ UI (docs/18-brusukon-trial.md)。
@@ -56,6 +58,8 @@ type Phase =
       saveFailed: boolean;
       /** XP 加算で確定したレベルアップ (非同期に届くので optional) */
       levelUps?: BattleLevelUps;
+      /** レベルアップによるステータス上昇 (from 両軸 → to 両軸の合算、0.1 未満除外) */
+      statGains?: StatGain[];
     };
 
 const TIER_LABELS: Record<1 | 2 | 3, { name: string; hint: string }> = {
@@ -189,6 +193,13 @@ export function TrialArena({
           // 親に XP 反映を通知 (diag 再取得)。演出だけ出して表示レベルが古いままだと
           // 「LEVEL UP! と言われたのに次戦も LV5」の矛盾が見える (レビュー指摘)
           onXpAwarded?.();
+          // ステータス上昇量 (オーナー要望 2026-07-17: 何がいくつ上がったかを出す)。
+          // job → player の順に区間を分けて二重計上しない
+          const base = rpgStats ? statVectorToArray(rpgStats) : undefined;
+          const jFrom = ups.job?.from ?? jobLevel;
+          const jTo = ups.job?.to ?? jobLevel;
+          const pFrom = ups.player?.from ?? playerLevel;
+          const pTo = ups.player?.to ?? playerLevel;
           // 全画面演出 (LevelUpOverlay は app 全体に常時マウント済み)。
           // 発火順は投稿フロー (compose-modal) と同じ job → player
           if (ups.job) {
@@ -197,12 +208,21 @@ export function TrialArena({
               from: ups.job.from,
               to: ups.job.to,
               jobName: jobDisplayName(ups.job.archetype, 'default'),
+              gains: levelUpGains(archetype, { jobLevel: jFrom, playerLevel: pFrom }, { jobLevel: jTo, playerLevel: pFrom }, base),
             });
           }
-          if (ups.player) notifyLevelUp({ kind: 'player', from: ups.player.from, to: ups.player.to });
-          // リザルトの文言にも残す (演出は 2 秒で消えるため)。seed 照合で
-          // 再戦後の別リザルトに前戦の分を付けない (world 側と同じ防御)
-          setPhase((p) => (p.kind === 'result' && p.state.seed === next.seed ? { ...p, levelUps: ups } : p));
+          if (ups.player) {
+            notifyLevelUp({
+              kind: 'player',
+              from: ups.player.from,
+              to: ups.player.to,
+              gains: levelUpGains(archetype, { jobLevel: jTo, playerLevel: pFrom }, { jobLevel: jTo, playerLevel: pTo }, base),
+            });
+          }
+          // リザルトの文言にも残す (演出は 2 秒で消えるため)。文言は両軸まとめた合算。
+          // seed 照合で再戦後の別リザルトに前戦の分を付けない (world 側と同じ防御)
+          const statGains = levelUpGains(archetype, { jobLevel: jFrom, playerLevel: pFrom }, { jobLevel: jTo, playerLevel: pTo }, base);
+          setPhase((p) => (p.kind === 'result' && p.state.seed === next.seed ? { ...p, levelUps: ups, statGains } : p));
         });
       }
       // 称号の新規獲得判定 (確定前の stats と比較)。stats 未取得 (取得失敗) 時は
@@ -258,7 +278,7 @@ export function TrialArena({
       });
       refreshStats();
     },
-    [phase, agent, did, stats, refreshStats, jobXpOffset, onXpAwarded],
+    [phase, agent, did, stats, refreshStats, jobXpOffset, onXpAwarded, archetype, jobLevel, playerLevel, rpgStats],
   );
 
   // ワイプ進行: 覆い切った時点でバトル準備がまだなら hold でつなぐ
@@ -399,6 +419,11 @@ export function TrialArena({
         {phase.levelUps?.job && (
           <div style={{ color: 'var(--color-accent)', fontWeight: 700 }}>
             {jobDisplayName(phase.levelUps.job.archetype, 'default')}のジョブレベルが {phase.levelUps.job.to} に あがった!
+          </div>
+        )}
+        {phase.statGains && phase.statGains.length > 0 && (
+          <div style={{ fontSize: '0.85em', color: 'var(--color-muted)' }}>
+            {phase.statGains.map((g) => `${g.label} +${formatGain(g.delta)}`).join('、')}
           </div>
         )}
         {drops.length > 0 && (

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -6,6 +6,8 @@ import {
   ITEMS,
   MONSTERS_BY_ID,
   jobDisplayName,
+  levelUpGains,
+  type StatGain,
   encounterRateFor,
   isWalkable,
   jobLevelFromXp,
@@ -28,7 +30,7 @@ import { getRecord } from '@/lib/atproto';
 import { COL } from '@/lib/collections';
 import { loadWorldState, saveWorldState } from '@/lib/world-state';
 import { awardBattleXp, finishBattleRecord, loadBattleStats, startBattleRecord, type BattleLevelUps } from '@/lib/battle-log';
-import { notifyLevelUp } from '@/components/level-up-overlay';
+import { formatGain, notifyLevelUp } from '@/components/level-up-overlay';
 import { bumpPower, loadPointsState, type PointsState } from '@/lib/points';
 import { WORLD_PREVIEW_ENABLED } from '@/lib/world-preview';
 import { Avatar } from '@/components/avatar';
@@ -98,6 +100,8 @@ export function World() {
     saveFailed: boolean;
     /** XP 加算で確定したレベルアップ (非同期に届く) */
     levelUps?: BattleLevelUps;
+    /** レベルアップによるステータス上昇 (合算、0.1 未満除外) */
+    statGains?: StatGain[];
   } | null>(null);
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const mapRef = useRef<HTMLDivElement>(null);
@@ -186,6 +190,8 @@ export function World() {
   battleResultRef.current = battleResult;
   const pointsRef = useRef(points);
   pointsRef.current = points;
+  const diagRef = useRef(diag);
+  diagRef.current = diag;
   const wipeRef = useRef(wipe);
   wipeRef.current = wipe;
 
@@ -325,10 +331,20 @@ export function World() {
       if (xp > 0) {
         void awardBattleXp(agent, did, xp).then((ups) => {
           if (!ups) return;
+          // ステータス上昇量は再取得前の diag (レベルアップ前の基準) から計算する
+          const d = diagRef.current;
+          const base = d?.rpgStats ? statVectorToArray(d.rpgStats) : undefined;
+          const arch = d?.archetype;
+          const jNow = jobLevelFromXp(d?.jobLevel?.xp ?? 0);
+          const pNow = playerLevelFromXp(d?.playerLevel?.xp ?? 0);
+          const jFrom = ups.job?.from ?? jNow;
+          const jTo = ups.job?.to ?? jNow;
+          const pFrom = ups.player?.from ?? pNow;
+          const pTo = ups.player?.to ?? pNow;
           // 表示レベル (HP/MP バー分母・次戦の戦闘値) を追従させる。演出だけ出して
           // maxHp が増えないと「LEVEL UP! なのに強くなってない」に見える (レビュー指摘)
           void getRecord<DiagnosisResult>(agent, did, COL.analysis, 'self')
-            .then((d) => { if (d) setDiag(d); })
+            .then((nd) => { if (nd) setDiag(nd); })
             .catch(() => {});
           // 発火順は投稿フロー (compose-modal) と同じ job → player
           if (ups.job) {
@@ -337,11 +353,22 @@ export function World() {
               from: ups.job.from,
               to: ups.job.to,
               jobName: jobDisplayName(ups.job.archetype, 'default'),
+              ...(arch ? { gains: levelUpGains(arch, { jobLevel: jFrom, playerLevel: pFrom }, { jobLevel: jTo, playerLevel: pFrom }, base) } : {}),
             });
           }
-          if (ups.player) notifyLevelUp({ kind: 'player', from: ups.player.from, to: ups.player.to });
+          if (ups.player) {
+            notifyLevelUp({
+              kind: 'player',
+              from: ups.player.from,
+              to: ups.player.to,
+              ...(arch ? { gains: levelUpGains(arch, { jobLevel: jTo, playerLevel: pFrom }, { jobLevel: jTo, playerLevel: pTo }, base) } : {}),
+            });
+          }
           // 同じ戦闘のリザルトが出ている間だけ文言も反映 (次の遭遇に紛れ込ませない)
-          setBattleResult((r) => (r && r.state.seed === next.seed ? { ...r, levelUps: ups } : r));
+          const statGains = arch
+            ? levelUpGains(arch, { jobLevel: jFrom, playerLevel: pFrom }, { jobLevel: jTo, playerLevel: pTo }, base)
+            : [];
+          setBattleResult((r) => (r && r.state.seed === next.seed ? { ...r, levelUps: ups, statGains } : r));
         });
       }
       // 手持ちを更新: 使った分を引き、ドロップ分を足す。
@@ -544,6 +571,11 @@ export function World() {
           {battleResult.levelUps?.job && (
             <div style={{ color: 'var(--color-accent)', fontWeight: 700 }}>
               {jobDisplayName(battleResult.levelUps.job.archetype, 'default')}のジョブレベルが {battleResult.levelUps.job.to} に あがった!
+            </div>
+          )}
+          {battleResult.statGains && battleResult.statGains.length > 0 && (
+            <div style={{ fontSize: '0.85em', color: 'var(--color-muted)' }}>
+              {battleResult.statGains.map((g) => `${g.label} +${formatGain(g.delta)}`).join('、')}
             </div>
           )}
           {drops.length > 0 && (

--- a/packages/core/src/__tests__/battle.test.ts
+++ b/packages/core/src/__tests__/battle.test.ts
@@ -17,8 +17,11 @@ import {
   ITEMS,
   type BattleState,
   type Command,
+  levelUpGains,
+  playerStatsAt,
 } from '../battle.js';
 import { JOBS } from '../jobs.js';
+import type { Archetype, StatArray } from '../types.js';
 
 describe('createRng / turnRng', () => {
   it('同じ seed は同じ列を返す (決定的)', () => {
@@ -542,6 +545,43 @@ describe('序盤バランス (オーナー指摘 2026-07-17「序盤の敵が強
     expect(extreme.atk).toBeGreaterThanOrEqual(Math.floor((25 + 4) / 2));
     expect(extreme.atk).toBeLessThan(jobOnly.atk);
     expect(extreme.agi).toBeGreaterThan(jobOnly.agi); // 高い個人値は反映される
+  });
+
+  it('playerStatsAt は playerCombatant と丸めの点まで同期している', () => {
+    for (const [job, jobLv, plLv, base] of [
+      ['warrior', 1, 1, undefined],
+      ['bard', 5, 10, undefined],
+      ['sage', 8, 15, [4, 14, 5, 63, 14]],
+      ['ninja', 3, 7, [20, 20, 20, 20, 20]],
+    ] as Array<[Archetype, number, number, StatArray | undefined]>) {
+      const raw = playerStatsAt(job, jobLv, plLv, base);
+      const c = playerCombatant(job, jobLv, plLv, 'x', base);
+      expect(Math.round(raw.atk), `${job} atk`).toBe(c.atk);
+      expect(Math.round(raw.def), `${job} def`).toBe(c.def);
+      expect(Math.round(raw.agi), `${job} agi`).toBe(c.agi);
+      expect(Math.round(raw.int), `${job} int`).toBe(c.int);
+      expect(Math.round(raw.luk), `${job} luk`).toBe(c.luk);
+      expect(Math.round(raw.maxHp), `${job} maxHp`).toBe(c.maxHp);
+      expect(Math.round(raw.maxMp), `${job} maxMp`).toBe(c.maxMp);
+    }
+  });
+
+  it('levelUpGains: 上昇量を小数 1 桁で返し、0.1 未満と変化なしは出さない', () => {
+    // ジョブ Lv1→2: 全ステに jobLevelScale 4% が乗るので主要ステは上がる
+    const gains = levelUpGains('warrior', { jobLevel: 1, playerLevel: 1 }, { jobLevel: 2, playerLevel: 1 });
+    expect(gains.length).toBeGreaterThan(0);
+    const atk = gains.find((g) => g.key === 'atk');
+    expect(atk?.delta).toBeCloseTo(1.0, 5); // warrior atk25 × 0.04
+    for (const g of gains) {
+      expect(g.delta).toBeGreaterThanOrEqual(0.1);
+      expect(g.delta).toBe(Math.round(g.delta * 10) / 10);
+      expect(g.label.length).toBeGreaterThan(0);
+    }
+    // レベル変化なしは空 (全部 0 → フィルタで消える)
+    expect(levelUpGains('warrior', { jobLevel: 3, playerLevel: 5 }, { jobLevel: 3, playerLevel: 5 })).toEqual([]);
+    // 0.1 未満のみ落ちる: bard (atk7) の job Lv1→2 は atk +0.28 なので出る、
+    // 一方 agi の低い warrior (agi8) でも +0.32 — 全ステ 0.1 未満を作るのは
+    // 実カーブでは稀なので、フィルタ自体は変化なしケースで担保する
   });
 
   it('平坦レベル成長: 低ステータスほど相対的に伸びる (bard の atk が Lv で改善)', () => {

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -293,6 +293,98 @@ export function playerCombatant(
   return fromStats(displayName, grown, factor, playerLevel);
 }
 
+/** 丸め前の戦闘ステータス (レベルアップの上昇量表示用)。 */
+export interface CombatStatsRaw {
+  atk: number;
+  def: number;
+  agi: number;
+  int: number;
+  luk: number;
+  maxHp: number;
+  maxMp: number;
+}
+
+/**
+ * playerCombatant と同じ導出 (ブレンド + 平坦成長 + レベル係数) を **丸めずに** 返す。
+ * レベルアップの上昇量は 1 レベルあたり +0.2〜1.5 程度の小数なので、丸めた
+ * Combatant 同士の差分では 0 か 1 しか出ない。同期は「round(playerStatsAt) ==
+ * playerCombatant」のテストで固定する。
+ */
+export function playerStatsAt(
+  archetype: Archetype,
+  jobLevel: number,
+  playerLevel: number,
+  baseStats?: StatArray,
+): CombatStatsRaw {
+  const t = BATTLE_TUNING;
+  const job = JOBS_BY_ID[archetype].stats;
+  const w = t.baseStatsPersonalWeight;
+  const base: StatArray = baseStats
+    ? [
+        job[0] + (baseStats[0] - job[0]) * w,
+        job[1] + (baseStats[1] - job[1]) * w,
+        job[2] + (baseStats[2] - job[2]) * w,
+        job[3] + (baseStats[3] - job[3]) * w,
+        job[4] + (baseStats[4] - job[4]) * w,
+      ]
+    : job;
+  const factor = 1 + Math.max(0, jobLevel - 1) * t.jobLevelScale + Math.max(0, playerLevel - 1) * t.playerLevelScale;
+  const flat = t.flatLevelGain * Math.max(0, playerLevel - 1);
+  const g = (i: number) => (base[i]! + flat) * factor;
+  return {
+    atk: g(0),
+    def: g(1),
+    agi: g(2),
+    int: g(3),
+    luk: g(4),
+    maxHp: t.hpBase + (base[1]! + flat) * t.hpDefScale * factor + playerLevel * t.hpLevelScale,
+    maxMp: t.mpBase + (base[3]! + flat) * t.mpIntScale * factor,
+  };
+}
+
+/** レベルアップの上昇量表示で、これ未満の上昇は出さない (オーナー指定 2026-07-17)。 */
+export const STAT_GAIN_MIN_DISPLAY = 0.1;
+
+export interface StatGain {
+  key: keyof CombatStatsRaw;
+  /** 表示名 (DQ 風かな) */
+  label: string;
+  /** 上昇量 (小数 1 桁に丸め済み) */
+  delta: number;
+}
+
+const STAT_GAIN_LABELS: Array<[keyof CombatStatsRaw, string]> = [
+  ['maxHp', 'さいだいHP'],
+  ['maxMp', 'さいだいMP'],
+  ['atk', 'こうげき'],
+  ['def', 'まもり'],
+  ['agi', 'すばやさ'],
+  ['int', 'かしこさ'],
+  ['luk', 'うん'],
+];
+
+/**
+ * レベルアップ (from → to) によるステータス上昇量。0.1 未満の上昇は出さない。
+ * ジョブとプレイヤーが同時に上がった場合は呼び出し側が区間を分ける
+ * (job: (jF,pF)→(jT,pF) / player: (jT,pF)→(jT,pT)) と二重計上しない。
+ */
+export function levelUpGains(
+  archetype: Archetype,
+  from: { jobLevel: number; playerLevel: number },
+  to: { jobLevel: number; playerLevel: number },
+  baseStats?: StatArray,
+): StatGain[] {
+  const a = playerStatsAt(archetype, from.jobLevel, from.playerLevel, baseStats);
+  const b = playerStatsAt(archetype, to.jobLevel, to.playerLevel, baseStats);
+  const gains: StatGain[] = [];
+  for (const [key, label] of STAT_GAIN_LABELS) {
+    const raw = b[key] - a[key];
+    if (raw < STAT_GAIN_MIN_DISPLAY) continue;
+    gains.push({ key, label, delta: Math.round(raw * 10) / 10 });
+  }
+  return gains;
+}
+
 // StatVector → StatArray 変換は jobs.ts の statVectorToArray を使う (重複定義しない)。
 
 // ─── モンスター ─────────────────────────────────────────────


### PR DESCRIPTION
## 概要

オーナー要望 (2026-07-17):「レベルアップ時になんのパラメータがいくつ上がったかを出すべき。上昇値が 0.1 未満の場合は表示しないようにしてください」

- **core**: `playerStatsAt` (playerCombatant と同じ導出を**丸めずに**返す) + `levelUpGains` (from→to の上昇量、**0.1 未満は生値で除外**、小数 1 桁)。同期は round(playerStatsAt) == playerCombatant のテストで固定。
- **LevelUpOverlay**: LV n→m の下に「さいだいHP +2.3 / こうげき +1.0 / まもり +0.9 …」(かな表示、2 列グリッド)。**上昇行があるときは表示 3.1 秒** (通常 2.2 秒)。
- **3 経路すべて配線** (試練 / ワールド / 投稿)。同時レベルアップは区間を job → player に分けて二重計上しない。リザルト画面にも合算 1 行。

## テスト
core 249 / web 276 / typecheck / build 緑

## Review

2 並列レビュー (実装 / 設計+UX) 実施。★★★ 0 件。実装レビューは **16 職 × base 5 種 × Lv 網羅の約 2 万組合せスイープ**で、数式同期 (ミスマッチ 0)・区間分割の望遠鏡和 (誤差 0)・0.1 フィルタの生値判定・formatGain の浮動小数点安全性を実測確認。

**★★ の処理:**
- 2.2 秒で 7 行は読み切れない (特に投稿経路はリザルト画面がなく消えたら終わり) → **d9d6987 で対応** (上昇行あり時 +0.9 秒)
- 区間分割ロジックの 3 箇所コピペ (4 経路目で二重計上事故の種) → **#291** (splitLevelUpGains ヘルパ化 + property テスト)

**★ の処理:** compose の不要キャスト → d9d6987。playerCombatant の数式複製解消 / formatGain の core 移動 / 派生戦闘値の確認画面 → #291・#285。「overlay は生値 +0.9 だが整数表示は +0 のことがある」は小数表示仕様の帰結として許容 (判断記録: 丸め差分だと大半が +0/+1 で情報が死ぬ)。