### PR TITLE
fix(world): 一時メッセージを操作ボタンの直下に移動

### DIFF
--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -721,7 +721,7 @@ export function World() {
           すぐ近くに出す。minHeight 常設で出現時のレイアウトシフトを防ぐ */}
       <p
         aria-live="polite"
-        style={{ textAlign: 'center', fontSize: '0.85em', minHeight: '1.4em', margin: '0.5em 0 0' }}
+        style={{ textAlign: 'center', fontSize: '0.85em', minHeight: '1.6em', margin: '0.5em 0 0' }}
       >
         {notice && <strong style={{ color: 'var(--color-fg)' }}>{notice}</strong>}
       </p>

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -635,10 +635,11 @@ export function World() {
           ({ws.x}, {ws.y})
         </span>
       </div>
+      {/* 場所情報 (街名 / 危険度)。一時メッセージ (notice) はここではなく
+          操作ボタンの直下に出す — アイテムボタンは画面下部にあるのに結果表示が
+          マップ上部だと視界に入らない (オーナー報告 2026-07-17、スクリーンショット付き) */}
       <p style={{ margin: '0.2em 0 0.4em', fontSize: '0.8em', color: 'var(--color-muted)' }}>
-        {notice ? (
-          <strong style={{ color: 'var(--color-fg)' }}>{notice}</strong>
-        ) : town ? (
+        {town ? (
           <strong style={{ color: 'var(--color-fg)' }}>🏘 {town.name}</strong>
         ) : (
           <>このあたり: {DANGER_LABELS[danger]}{here === 'forest' ? ' / 深い森…' : ''}</>
@@ -716,6 +717,14 @@ export function World() {
           そらのしずく ×{tonicStock} <span style={{ fontSize: '0.85em', color: 'var(--color-muted)' }}>MP回復</span>
         </button>
       </div>
+      {/* 一時メッセージ (やくそう使用 / 進めない / 街で回復 など)。操作した指の
+          すぐ近くに出す。minHeight 常設で出現時のレイアウトシフトを防ぐ */}
+      <p
+        aria-live="polite"
+        style={{ textAlign: 'center', fontSize: '0.85em', minHeight: '1.4em', margin: '0.5em 0 0' }}
+      >
+        {notice && <strong style={{ color: 'var(--color-fg)' }}>{notice}</strong>}
+      </p>
       <p style={{ textAlign: 'center', fontSize: '0.72em', color: 'var(--color-muted)', marginTop: '0.4em' }}>
         PC は矢印キーでも移動できます。街に入ると全回復。
         {diag


### PR DESCRIPTION
## 概要

オーナー報告 (2026-07-17、スクリーンショット付き):「アイテム使用ボタンはマップの下の方にあるのに薬草を使った表示がマップの上にあるのでテキスト表示が全く見えない」

- 上部の行は**場所情報 (街名 / 危険度) 専任**に変更 (従来は notice が場所情報を隠していた — これも改善)。
- 一時メッセージ (やくそう使用 / そらのしずく使用 / そっちには進めない / 街で回復 / 通信エラー系、全 8 種) は**どうぐボタンの直下**に表示 — 操作した指のすぐ近く。
- minHeight 常設 (1.6em = 継承 line-height と一致) で出現時のレイアウトシフトなし、`aria-live="polite"` 付き。

## Review

表示位置のみの変更 (状態・条件・文言は不変) のため §1.5 の軽量パス (1 観点レビュー) を適用。★★★ 0 / ★★ 0 / ★ 2 — minHeight 1.4em が継承 line-height 1.6 と不一致で微小シフトが残る点を**追加コミットで修正**。長文 notice の 2 行折り返しは下方の非インタラクティブ要素しか動かさないため現状維持 (記録)。notice 全 8 種の新位置妥当性・stale 経路なし・aria-live 実装は確認済み。

## テスト
typecheck / web 276 tests 緑