### PR TITLE
fix(world): スティックの反応領域を外周 36px 素通しに (スクロール共存)

### DIFF
--- a/apps/web/src/components/virtual-stick.tsx
+++ b/apps/web/src/components/virtual-stick.tsx
@@ -24,6 +24,12 @@ const DEADZONE_PX = 14;
 const KNOB_RADIUS_PX = 44;
 /** 連続歩行の間隔 (十字キー時代の HOLD_REPEAT_INTERVAL と同じ体感)。 */
 const STEP_INTERVAL_MS = 170;
+/** マップの外周この幅 (px) はスティックが反応しない素通しゾーン。
+ *  端から始まるタッチはページスクロールに渡る (「スクロールしたいのに移動に
+ *  なってしまう」— オーナー実機フィードバック 2026-07-17)。
+ *  注: touch-action は要素単位の宣言なので、イベントを無視するだけでは
+ *  スクロールは復活しない — 反応領域そのものを inset で絞る必要がある。 */
+const EDGE_PASS_PX = 36;
 /** 即時歩行 (方向転換時) の最小間隔。ジッタ由来の軸反転バーストを抑える。 */
 const MIN_STEP_GAP_MS = Math.floor(STEP_INTERVAL_MS / 2);
 /** 軸を切り替えるのに必要な優位マージン (現在軸の 1.25 倍を要求)。
@@ -164,8 +170,10 @@ export function VirtualStick({ onMove }: { onMove: (dir: StickDir) => void }) {
       onContextMenu={(e) => e.preventDefault()}
       style={{
         position: 'absolute',
-        inset: 0,
-        // スクロール/ピンチに食われず pointermove を受け続ける
+        // 外周 EDGE_PASS_PX はスクロール用の素通しゾーン (touch-action none を
+        // 全面に張るとマップから始まるスクロールが全部移動になる)
+        inset: EDGE_PASS_PX,
+        // スクロール/ピンチに食われず pointermove を受け続ける (この領域内のみ)
         touchAction: 'none',
         userSelect: 'none',
         WebkitUserSelect: 'none',


### PR DESCRIPTION
## 概要

オーナー実機フィードバック (2026-07-17):「移動の感覚はかなりいい感じ!でもマップの端っこの方は判定なしにしないとスクロールしたいのに移動になってしまいそう」

- スティックの反応レイヤーを `inset: 36px` (親指の接地面相当) で内側に絞り、**マップ外周のストリップはブラウザのスクロールに素通し**。
- `touch-action` は要素単位の宣言なのでイベント無視では不十分 — 領域そのものを絞るのが正解。
- ドラッグ開始後は pointer capture で領域外へはみ出しても追従 (従来どおり)。初回ガイドの表示位置 (72%) は反応領域内。

## Review

反応領域の inset 1 箇所 + 定数追加のみ (ロジック・状態不変) のため §1.5 軽量パス適用: 実機での体感確認をオーナーが直接行う前提の微調整。typecheck / stick テスト 4 本緑。