### PR TITLE
feat(world): DQ 風セリフウィンドウ + オンボーディング + 戦闘ログのタイプライター表示

### DIFF
--- a/apps/web/src/components/battle-view.tsx
+++ b/apps/web/src/components/battle-view.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useMemo, useState } from 'react';
 import type { BattleState, Command, TurnEvent } from '@aozoraquest/core';
 import { BATTLE_TUNING, MONSTERS_BY_ID, SKILL_KIND_LABELS } from '@aozoraquest/core';
 import { MonsterSvg } from './monster-svg';
@@ -56,13 +57,16 @@ export function BattleView({
           lineHeight: 1.6,
         }}
       >
-        {state.turn === 0 ? (
-          <div>
-            {state.monster.name}があらわれた! {monsterDef?.intro}
-          </div>
-        ) : (
-          state.lastEvents.map((e: TurnEvent, i: number) => <div key={i}>{e.text}</div>)
-        )}
+        {/* DQ1 風に 1 文字ずつ表示 (オーナー指示 2026-07-18)。key=turn で毎ターン
+            打ち直す。コマンドはブロックしない (テンポ優先、せっかちは次の入力で OK) */}
+        <TypedLines
+          key={state.turn}
+          lines={
+            state.turn === 0
+              ? [`${state.monster.name}があらわれた! ${monsterDef?.intro ?? ''}`]
+              : state.lastEvents.map((e: TurnEvent) => e.text)
+          }
+        />
       </div>
 
       {/* 自分 HP + MP */}
@@ -164,5 +168,47 @@ export function CommandButton({ label, sub, onClick, disabled }: { label: string
       <span>{label}</span>
       {sub && <span style={{ fontSize: '0.68em', color: 'var(--color-muted)' }}>{sub}</span>}
     </button>
+  );
+}
+
+/** 戦闘ログの DQ1 風タイプライター表示。行を順に 1 文字ずつ出す。
+ *  reduced-motion では即時全文。セリフウィンドウ (dialogue-window) より速い
+ *  1 文字 22ms — 戦闘のテンポを削らない速度に留める。 */
+export function TypedLines({ lines }: { lines: readonly string[] }) {
+  const reduced = useMemo(
+    () => typeof matchMedia !== 'undefined' && matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+  const total = useMemo(() => lines.reduce((n, l) => n + l.length, 0), [lines]);
+  const [chars, setChars] = useState(reduced ? total : 0);
+  useEffect(() => {
+    setChars(reduced ? total : 0);
+    if (reduced) return;
+    const id = setInterval(() => {
+      setChars((c) => {
+        if (c >= total) {
+          clearInterval(id);
+          return c;
+        }
+        return c + 1;
+      });
+    }, 22);
+    return () => clearInterval(id);
+  }, [lines, total, reduced]);
+  let used = 0;
+  return (
+    <>
+      {lines.map((l, i) => {
+        const visible = Math.max(0, Math.min(l.length, chars - used));
+        used += l.length;
+        return (
+          <div key={i} aria-label={l}>
+            <span aria-hidden>{l.slice(0, visible)}</span>
+            {/* 高さを先に確保 (行が出るたびにコマンド段が下へずれるのを防ぐ) */}
+            {visible === 0 && <span aria-hidden>&nbsp;</span>}
+          </div>
+        );
+      })}
+    </>
   );
 }

--- a/apps/web/src/components/battle-view.tsx
+++ b/apps/web/src/components/battle-view.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { BattleState, Command, TurnEvent } from '@aozoraquest/core';
 import { BATTLE_TUNING, MONSTERS_BY_ID, SKILL_KIND_LABELS } from '@aozoraquest/core';
 import { MonsterSvg } from './monster-svg';
@@ -173,42 +173,69 @@ export function CommandButton({ label, sub, onClick, disabled }: { label: string
 
 /** 戦闘ログの DQ1 風タイプライター表示。行を順に 1 文字ずつ出す。
  *  reduced-motion では即時全文。セリフウィンドウ (dialogue-window) より速い
- *  1 文字 22ms — 戦闘のテンポを削らない速度に留める。 */
-export function TypedLines({ lines }: { lines: readonly string[] }) {
+ *  1 文字 22ms — 戦闘のテンポを削らない速度に留める。battle-view 専用。 */
+function TypedLines({ lines }: { lines: readonly string[] }) {
   const reduced = useMemo(
     () => typeof matchMedia !== 'undefined' && matchMedia('(prefers-reduced-motion: reduce)').matches,
     [],
   );
-  const total = useMemo(() => lines.reduce((n, l) => n + l.length, 0), [lines]);
+  // lines は毎レンダー新配列 (map で生成) なので、打ち直しの契機は内容文字列で
+  // 判定する — 親 (World) の notice 更新等の無関係な再レンダーで頭から
+  // タイプし直さない (レビュー指摘)
+  const joined = lines.join('\n');
+  // code point 単位 (絵文字がサロゲート半欠けで表示されない — レビュー指摘)
+  const cps = useMemo(() => lines.map((l) => Array.from(l)), [joined]); // eslint-disable-line react-hooks/exhaustive-deps
+  const total = cps.reduce((n, l) => n + l.length, 0);
   const [chars, setChars] = useState(reduced ? total : 0);
+  const doneCharsRef = useRef(reduced ? total : 0);
+  doneCharsRef.current = chars;
   useEffect(() => {
     setChars(reduced ? total : 0);
     if (reduced) return;
+    // updater 内で clearInterval しない (updater は純粋であるべき — レビュー指摘)。
+    // 打ち終わったら interval 自体を止める
     const id = setInterval(() => {
-      setChars((c) => {
-        if (c >= total) {
-          clearInterval(id);
-          return c;
-        }
-        return c + 1;
-      });
+      if (doneCharsRef.current >= total) {
+        clearInterval(id);
+        return;
+      }
+      setChars((c) => Math.min(total, c + 1));
     }, 22);
     return () => clearInterval(id);
-  }, [lines, total, reduced]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- lines は joined で代表する
+  }, [joined, total, reduced]);
   let used = 0;
   return (
-    <>
-      {lines.map((l, i) => {
-        const visible = Math.max(0, Math.min(l.length, chars - used));
-        used += l.length;
+    // タップで残りを即時全文 (セリフウィンドウと同じ「タップ = スキップ」作法。
+    // コマンドは非ブロックなので押し逃しの実害はないが、作法を統一する — レビュー指摘)
+    <div onClick={() => setChars(total)}>
+      {cps.map((cp, i) => {
+        const visible = Math.max(0, Math.min(cp.length, chars - used));
+        used += cp.length;
         return (
-          <div key={i} aria-label={l}>
-            <span aria-hidden>{l.slice(0, visible)}</span>
+          <div key={i}>
+            {/* SR には全文を渡し、タイプ途中表示は aria-hidden (汎用要素の
+                aria-label は多くの SR が無視する — レビュー指摘) */}
+            <span style={SR_ONLY}>{lines[i]}</span>
+            <span aria-hidden>{cp.slice(0, visible).join('')}</span>
             {/* 高さを先に確保 (行が出るたびにコマンド段が下へずれるのを防ぐ) */}
             {visible === 0 && <span aria-hidden>&nbsp;</span>}
           </div>
         );
       })}
-    </>
+    </div>
   );
 }
+
+/** visually-hidden (スクリーンリーダーにだけ全文を渡す) */
+const SR_ONLY: React.CSSProperties = {
+  position: 'absolute',
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: 'hidden',
+  clip: 'rect(0 0 0 0)',
+  whiteSpace: 'nowrap',
+  border: 0,
+};

--- a/apps/web/src/components/dialogue-window.tsx
+++ b/apps/web/src/components/dialogue-window.tsx
@@ -1,0 +1,123 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  advanceDialogue,
+  currentLine,
+  lineComplete,
+  startDialogue,
+  tickDialogue,
+  type DialogueLine,
+} from '@/lib/dialogue';
+
+/**
+ * DQ 風セリフウィンドウ (オーナー指示 2026-07-18)。
+ *
+ * 画面下部のウィンドウに話者名プレート + セリフを 1 文字ずつ表示する。
+ * どこをタップしても進む (タイプ中 → 全文表示、全文表示中 → 次の行)。
+ * オンボーディングで導入し、今後の NPC 会話 (ギルド・住人) はすべて
+ * このコンポーネントを使う。進行ロジックは lib/dialogue.ts (純関数・テスト済)。
+ *
+ * - reduced-motion では 1 文字送りをやめて行を即時全文表示する
+ * - 全文表示済みの行には ▼ を点滅させる (DQ の「送れます」記号)
+ */
+
+const CHAR_MS = 45;
+
+export function DialogueWindow({ lines, onDone }: { lines: readonly DialogueLine[]; onDone: () => void }) {
+  const [st, setSt] = useState(startDialogue);
+  const reduced = useMemo(
+    () => typeof matchMedia !== 'undefined' && matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+  const doneRef = useRef(false);
+
+  // タイプ進行。reduced-motion では行頭で即全文にする
+  useEffect(() => {
+    if (st.done) return;
+    if (reduced) {
+      if (!lineComplete(lines, st)) setSt((s) => ({ ...s, chars: currentLine(lines, s)?.text.length ?? 0 }));
+      return;
+    }
+    if (lineComplete(lines, st)) return;
+    const id = setInterval(() => setSt((s) => tickDialogue(lines, s)), CHAR_MS);
+    return () => clearInterval(id);
+  }, [lines, st, reduced]);
+
+  // done は effect 経由で一度だけ通知 (render 中の親 setState を避ける)
+  useEffect(() => {
+    if (st.done && !doneRef.current) {
+      doneRef.current = true;
+      onDone();
+    }
+  }, [st.done, onDone]);
+
+  const advance = useCallback(() => setSt((s) => advanceDialogue(lines, s)), [lines]);
+
+  const line = currentLine(lines, st);
+  if (!line || st.done) return null;
+  const complete = lineComplete(lines, st);
+
+  return (
+    // 全面オーバーレイ: どこをタップしても会話が進む (DQ の会話送り)。
+    // 背後の UI (スティック・ボタン) への誤タップもこれで防ぐ
+    <div
+      role="dialog"
+      aria-label={line.speaker ? `${line.speaker}のセリフ` : 'セリフ'}
+      onClick={advance}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          advance();
+        }
+      }}
+      tabIndex={0}
+      style={{ position: 'fixed', inset: 0, zIndex: 900, cursor: 'pointer', background: 'transparent' }}
+    >
+      <div
+        style={{
+          position: 'absolute',
+          left: '50%',
+          bottom: 'calc(env(safe-area-inset-bottom, 0px) + 68px)',
+          transform: 'translateX(-50%)',
+          width: 'min(94vw, 520px)',
+        }}
+      >
+        {line.speaker && (
+          <div
+            className="dq-window"
+            style={{
+              display: 'inline-block',
+              padding: '0.15em 0.8em',
+              marginBottom: -2,
+              marginLeft: 8,
+              fontSize: '0.8em',
+              fontWeight: 700,
+              position: 'relative',
+              zIndex: 1,
+            }}
+          >
+            {line.speaker}
+          </div>
+        )}
+        <div
+          className="dq-window"
+          style={{ padding: '0.7em 0.9em 0.8em', minHeight: '4.6em', fontSize: '0.92em', lineHeight: 1.7 }}
+        >
+          {/* 部分文字列の逐次読み上げは SR に不向きなので、全文を aria-label で渡す */}
+          <span aria-label={line.text}>
+            <span aria-hidden>{line.text.slice(0, st.chars)}</span>
+          </span>
+          {complete && (
+            <span aria-hidden className="aq-dialogue-next" style={{ float: 'right', marginTop: '0.6em' }}>
+              ▼
+            </span>
+          )}
+        </div>
+        <style>{`
+@keyframes aq-dialogue-blink { 0%, 55% { opacity: 1; } 56%, 100% { opacity: 0; } }
+.aq-dialogue-next { animation: aq-dialogue-blink 0.9s step-end infinite; }
+@media (prefers-reduced-motion: reduce) { .aq-dialogue-next { animation: none; } }
+`}</style>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/dialogue-window.tsx
+++ b/apps/web/src/components/dialogue-window.tsx
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   advanceDialogue,
+  charCount,
   currentLine,
   lineComplete,
   startDialogue,
   tickDialogue,
+  visibleText,
   type DialogueLine,
 } from '@/lib/dialogue';
 
@@ -22,25 +24,66 @@ import {
 
 const CHAR_MS = 45;
 
-export function DialogueWindow({ lines, onDone }: { lines: readonly DialogueLine[]; onDone: () => void }) {
+/** visually-hidden (スクリーンリーダーにだけ全文を渡す) */
+const SR_ONLY: React.CSSProperties = {
+  position: 'absolute',
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: 'hidden',
+  clip: 'rect(0 0 0 0)',
+  whiteSpace: 'nowrap',
+  border: 0,
+};
+
+export function DialogueWindow({
+  lines,
+  plateIcon,
+  onDone,
+}: {
+  lines: readonly DialogueLine[];
+  /** 話者名プレートに添えるアイコン (例: ブルスコンは SpiritIcon — 他画面の
+   *  吹き出しと同じ顔で認識できるように)。NPC ごとの出し分けは呼び出し側の責務 */
+  plateIcon?: React.ReactNode;
+  onDone: () => void;
+}) {
   const [st, setSt] = useState(startDialogue);
   const reduced = useMemo(
     () => typeof matchMedia !== 'undefined' && matchMedia('(prefers-reduced-motion: reduce)').matches,
     [],
   );
   const doneRef = useRef(false);
+  const overlayRef = useRef<HTMLDivElement>(null);
 
-  // タイプ進行。reduced-motion では行頭で即全文にする
+  // 空の lines でも必ず done になる (呼び出し側は表示中 move ガード等を掛けるため、
+  // ここで止まると不可視のまま永久ブロックになる — 動的生成セリフ時代への契約。レビュー指摘)
+  useEffect(() => {
+    if (lines.length === 0) setSt((s) => (s.done ? s : { ...s, done: true }));
+  }, [lines.length]);
+
+  // ★ キーボード操作: mount 時にオーバーレイへフォーカス (Enter/Space で送れるように)
+  useEffect(() => {
+    overlayRef.current?.focus();
+  }, []);
+
+  // タイプ進行。interval は行単位で張る (依存に st 全体を入れると 1 文字ごとに
+  // clear→再生成される setTimeout チェーンになる — レビュー指摘)。tickDialogue は
+  // 全文表示後 no-op なので、行が変わるまで回り続けても状態は進まない。
+  // reduced-motion では行頭で即全文にする
   useEffect(() => {
     if (st.done) return;
     if (reduced) {
-      if (!lineComplete(lines, st)) setSt((s) => ({ ...s, chars: currentLine(lines, s)?.text.length ?? 0 }));
+      setSt((s) => {
+        const line = currentLine(lines, s);
+        return line ? { ...s, chars: charCount(line.text) } : s;
+      });
       return;
     }
-    if (lineComplete(lines, st)) return;
     const id = setInterval(() => setSt((s) => tickDialogue(lines, s)), CHAR_MS);
     return () => clearInterval(id);
-  }, [lines, st, reduced]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- interval は行 (index) 単位
+  }, [lines, st.index, st.done, reduced]);
 
   // done は effect 経由で一度だけ通知 (render 中の親 setState を避ける)
   useEffect(() => {
@@ -60,7 +103,9 @@ export function DialogueWindow({ lines, onDone }: { lines: readonly DialogueLine
     // 全面オーバーレイ: どこをタップしても会話が進む (DQ の会話送り)。
     // 背後の UI (スティック・ボタン) への誤タップもこれで防ぐ
     <div
+      ref={overlayRef}
       role="dialog"
+      aria-modal="true"
       aria-label={line.speaker ? `${line.speaker}のセリフ` : 'セリフ'}
       onClick={advance}
       onKeyDown={(e) => {
@@ -76,7 +121,7 @@ export function DialogueWindow({ lines, onDone }: { lines: readonly DialogueLine
         style={{
           position: 'absolute',
           left: '50%',
-          bottom: 'calc(env(safe-area-inset-bottom, 0px) + 68px)',
+          bottom: 'calc(var(--footer-height, 4.5em) + 0.5em)', // footer 実測高 (app-shell が書き出す) に追従
           transform: 'translateX(-50%)',
           width: 'min(94vw, 520px)',
         }}
@@ -85,7 +130,9 @@ export function DialogueWindow({ lines, onDone }: { lines: readonly DialogueLine
           <div
             className="dq-window"
             style={{
-              display: 'inline-block',
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: '0.35em',
               padding: '0.15em 0.8em',
               marginBottom: -2,
               marginLeft: 8,
@@ -95,17 +142,19 @@ export function DialogueWindow({ lines, onDone }: { lines: readonly DialogueLine
               zIndex: 1,
             }}
           >
+            {plateIcon}
             {line.speaker}
           </div>
         )}
         <div
           className="dq-window"
-          style={{ padding: '0.7em 0.9em 0.8em', minHeight: '4.6em', fontSize: '0.92em', lineHeight: 1.7 }}
+          style={{ padding: '0.7em 0.9em 0.8em', minHeight: '5.8em', fontSize: '0.92em', lineHeight: 1.7 }}
         >
-          {/* 部分文字列の逐次読み上げは SR に不向きなので、全文を aria-label で渡す */}
-          <span aria-label={line.text}>
-            <span aria-hidden>{line.text.slice(0, st.chars)}</span>
-          </span>
+          {/* 部分文字列の逐次読み上げは SR に不向きなので、全文を visually-hidden で
+              先に置き、タイプ表示は aria-hidden にする (汎用要素の aria-label は
+              多くの SR が無視する — レビュー指摘) */}
+          <span style={SR_ONLY}>{line.text}</span>
+          <span aria-hidden>{visibleText(line.text, st.chars)}</span>
           {complete && (
             <span aria-hidden className="aq-dialogue-next" style={{ float: 'right', marginTop: '0.6em' }}>
               ▼

--- a/apps/web/src/components/spirit-bubble.tsx
+++ b/apps/web/src/components/spirit-bubble.tsx
@@ -17,6 +17,8 @@ interface SpiritBubbleProps {
 
 /**
  * 精霊の発言は必ずこの吹き出しで。アイコン (精霊キャラ) を左、右に本文。
+ * 例外: あおぞらワールドの会話は DQ 風セリフウィンドウ (dialogue-window) を使う
+ * (NPC 汎用の演出。話者プレートに SpiritIcon を添えて同一人物と分かるようにする)。
  * アイコンからの吹き出し矢尻は小さな三角で表現。
  */
 export function SpiritBubble({

--- a/apps/web/src/lib/dialogue.test.ts
+++ b/apps/web/src/lib/dialogue.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'vitest';
+import { advanceDialogue, currentLine, lineComplete, startDialogue, tickDialogue, type DialogueLine } from './dialogue';
+
+const LINES: DialogueLine[] = [
+  { speaker: 'ブルスコン', text: 'やあ!' },
+  { text: 'じの ぶん。' },
+];
+
+describe('dialogue 進行 (DQ 風セリフ送り)', () => {
+  test('tick で 1 文字ずつ進み、全文で止まる', () => {
+    let st = startDialogue();
+    st = tickDialogue(LINES, st);
+    expect(st.chars).toBe(1);
+    st = tickDialogue(LINES, st);
+    st = tickDialogue(LINES, st);
+    expect(st.chars).toBe(3);
+    expect(lineComplete(LINES, st)).toBe(true);
+    // 全文表示済みでは進まない (文字数がはみ出さない)
+    expect(tickDialogue(LINES, st)).toBe(st);
+  });
+
+  test('タイプ中のタップは全文表示 (スキップ)、全文表示中のタップは次の行へ', () => {
+    let st = startDialogue();
+    st = tickDialogue(LINES, st); // 1 文字目
+    st = advanceDialogue(LINES, st); // スキップ
+    expect(st.chars).toBe(LINES[0]!.text.length);
+    expect(st.index).toBe(0);
+    st = advanceDialogue(LINES, st); // 次の行
+    expect(st.index).toBe(1);
+    expect(st.chars).toBe(0);
+    expect(currentLine(LINES, st)!.speaker).toBeUndefined();
+  });
+
+  test('最後の行を送ると done になり、以降は不変', () => {
+    let st = { index: 1, chars: LINES[1]!.text.length, done: false };
+    st = advanceDialogue(LINES, st);
+    expect(st.done).toBe(true);
+    expect(advanceDialogue(LINES, st)).toBe(st);
+    expect(tickDialogue(LINES, st)).toBe(st);
+  });
+
+  test('空配列でも落ちない (advance で即 done)', () => {
+    const st = advanceDialogue([], startDialogue());
+    expect(st.done).toBe(true);
+  });
+});

--- a/apps/web/src/lib/dialogue.test.ts
+++ b/apps/web/src/lib/dialogue.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { advanceDialogue, currentLine, lineComplete, startDialogue, tickDialogue, type DialogueLine } from './dialogue';
+import { advanceDialogue, charCount, currentLine, lineComplete, startDialogue, tickDialogue, visibleText, type DialogueLine } from './dialogue';
 
 const LINES: DialogueLine[] = [
   { speaker: 'ブルスコン', text: 'やあ!' },
@@ -42,5 +42,17 @@ describe('dialogue 進行 (DQ 風セリフ送り)', () => {
   test('空配列でも落ちない (advance で即 done)', () => {
     const st = advanceDialogue([], startDialogue());
     expect(st.done).toBe(true);
+  });
+});
+
+describe('サロゲートペア (絵文字) の扱い', () => {
+  test('絵文字を 1 文字と数え、タイプ途中でも半欠けにならない', () => {
+    const text = '🗺 ちず';
+    expect(charCount(text)).toBe(4); // 🗺, 空白, ち, ず
+    expect(visibleText(text, 1)).toBe('🗺'); // lone surrogate にならない
+    const lines: DialogueLine[] = [{ text }];
+    let st = startDialogue();
+    for (let i = 0; i < 4; i++) st = tickDialogue(lines, st);
+    expect(lineComplete(lines, st)).toBe(true); // code unit (5) でなく code point (4) で完了
   });
 });

--- a/apps/web/src/lib/dialogue.ts
+++ b/apps/web/src/lib/dialogue.ts
@@ -30,6 +30,18 @@ export function startDialogue(): DialogueState {
   return { index: 0, chars: 0, done: false };
 }
 
+/** code point 単位の文字数 (サロゲートペア = 絵文字を 1 文字と数える)。
+ *  code unit (String.length) 基準だと 🗺 等が半欠けの壊れグリフで 1 tick
+ *  表示される (レビュー指摘)。chars はすべてこの単位。 */
+export function charCount(text: string): number {
+  return Array.from(text).length;
+}
+
+/** タイプ途中の表示文字列 (code point 単位で先頭 chars 文字) */
+export function visibleText(text: string, chars: number): string {
+  return Array.from(text).slice(0, chars).join('');
+}
+
 export function currentLine(lines: readonly DialogueLine[], st: DialogueState): DialogueLine | null {
   return lines[st.index] ?? null;
 }
@@ -37,7 +49,7 @@ export function currentLine(lines: readonly DialogueLine[], st: DialogueState): 
 /** 表示中の行が全文表示済みか */
 export function lineComplete(lines: readonly DialogueLine[], st: DialogueState): boolean {
   const line = lines[st.index];
-  return !!line && st.chars >= line.text.length;
+  return !!line && st.chars >= charCount(line.text);
 }
 
 /** 1 文字進める (interval から呼ぶ)。全文表示済み・done なら何もしない */
@@ -51,7 +63,7 @@ export function advanceDialogue(lines: readonly DialogueLine[], st: DialogueStat
   if (st.done) return st;
   const line = lines[st.index];
   if (!line) return { ...st, done: true };
-  if (st.chars < line.text.length) return { ...st, chars: line.text.length };
+  if (st.chars < charCount(line.text)) return { ...st, chars: charCount(line.text) };
   if (st.index + 1 >= lines.length) return { ...st, done: true };
   return { index: st.index + 1, chars: 0, done: false };
 }

--- a/apps/web/src/lib/dialogue.ts
+++ b/apps/web/src/lib/dialogue.ts
@@ -1,0 +1,57 @@
+/**
+ * DQ 風セリフウィンドウの進行ロジック (純関数)。
+ *
+ * 「話者名 + セリフを 1 文字ずつ表示」(オーナー指示 2026-07-18) の状態機械。
+ * コンポーネント (dialogue-window.tsx) は interval でこの tick を回し、
+ * タップで advance を呼ぶだけの薄いレンダラーにする — テスト環境が node
+ * (DOM なし) なので、進行の正しさはここで担保する。
+ *
+ * 進行の流れ (DQ の会話送りと同じ):
+ *   タイプ中にタップ → その行を全文表示 (せっかちスキップ)
+ *   全文表示中にタップ → 次の行へ (最後の行なら done)
+ */
+
+export interface DialogueLine {
+  /** 話者名 (名前プレートに出す)。省略時はプレートなし (地の文) */
+  speaker?: string;
+  text: string;
+}
+
+export interface DialogueState {
+  /** 表示中の行 index */
+  index: number;
+  /** 表示済み文字数 (0 〜 text.length) */
+  chars: number;
+  /** 全行を送り終えた */
+  done: boolean;
+}
+
+export function startDialogue(): DialogueState {
+  return { index: 0, chars: 0, done: false };
+}
+
+export function currentLine(lines: readonly DialogueLine[], st: DialogueState): DialogueLine | null {
+  return lines[st.index] ?? null;
+}
+
+/** 表示中の行が全文表示済みか */
+export function lineComplete(lines: readonly DialogueLine[], st: DialogueState): boolean {
+  const line = lines[st.index];
+  return !!line && st.chars >= line.text.length;
+}
+
+/** 1 文字進める (interval から呼ぶ)。全文表示済み・done なら何もしない */
+export function tickDialogue(lines: readonly DialogueLine[], st: DialogueState): DialogueState {
+  if (st.done || lineComplete(lines, st)) return st;
+  return { ...st, chars: st.chars + 1 };
+}
+
+/** タップ: タイプ中なら全文表示、全文表示済みなら次の行 (最後なら done) */
+export function advanceDialogue(lines: readonly DialogueLine[], st: DialogueState): DialogueState {
+  if (st.done) return st;
+  const line = lines[st.index];
+  if (!line) return { ...st, done: true };
+  if (st.chars < line.text.length) return { ...st, chars: line.text.length };
+  if (st.index + 1 >= lines.length) return { ...st, done: true };
+  return { index: st.index + 1, chars: 0, done: false };
+}

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -50,6 +50,7 @@ import { PLAINS_VARIANTS, TERRAIN_TILES } from '@/components/world-tiles';
 import { VirtualStick, type StickDir } from '@/components/virtual-stick';
 import { WorldMapModal } from '@/components/world-map-modal';
 import { DialogueWindow } from '@/components/dialogue-window';
+import { SpiritIcon } from '@/components/spirit-icon';
 import type { DialogueLine } from '@/lib/dialogue';
 
 /**
@@ -97,7 +98,7 @@ const ONBOARDING_LINES: readonly DialogueLine[] = [
   { speaker: 'ブルスコン', text: 'ようこそ あおぞらワールドへ! わたしは せいれいブルスコン。すこしだけ あんないするね。' },
   { speaker: 'ブルスコン', text: 'マップを おしたまま ゆびを うごかすと あるけるよ。' },
   { speaker: 'ブルスコン', text: 'そとには モンスターが いる。たたかいに まけると さいごに たちよった 街まで もどされちゃう。あぶなくなったら 街で やすもう。' },
-  { speaker: 'ブルスコン', text: '街に つくと「ちずのかけら」が 手に はいる。ちずは かけらを あつめた ちほうだけ ひろがっていくんだ。' },
+  { speaker: 'ブルスコン', text: '街に つくと「ちずのかけら」が 手に はいって、その街の まわりの ちずが ひろがっていくんだ。' },
   { speaker: 'ブルスコン', text: '🗺 ちずボタンで いつでも たしかめられる。それじゃ、よい たびを!' },
 ];
 
@@ -641,6 +642,7 @@ export function World() {
   // そらのはねを使う: 最後に立ち寄った街 (無ければはじまりの街) へ帰還。
   // フィールド専用 (戦闘中はにげるを使う)。消費の保存は TODO(W3) で DO に
   const useFeatherOnField = useCallback(() => {
+    if (onboardingRef.current) return;
     if (featherStock <= 0) return;
     const s = wsRef.current;
     // mapOpen / shopOpen も塞ぐ (モーダルの裏へ Tab で抜けて発動でき、店を開いた
@@ -1110,6 +1112,7 @@ export function World() {
       {onboarding && (
         <DialogueWindow
           lines={ONBOARDING_LINES}
+          plateIcon={<SpiritIcon size={20} />}
           onDone={() => {
             setOnboarding(false);
             onboardingRef.current = false;

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -49,6 +49,8 @@ import { MonsterSvg } from '@/components/monster-svg';
 import { PLAINS_VARIANTS, TERRAIN_TILES } from '@/components/world-tiles';
 import { VirtualStick, type StickDir } from '@/components/virtual-stick';
 import { WorldMapModal } from '@/components/world-map-modal';
+import { DialogueWindow } from '@/components/dialogue-window';
+import type { DialogueLine } from '@/lib/dialogue';
 
 /**
  * あおぞらワールド (docs/19-overworld.md) — 散歩 + 遭遇プレビュー。
@@ -86,6 +88,19 @@ interface Vitals {
   regions: number[];
 }
 
+/** 初回オンボーディングを見終えたかの localStorage キー (スティックのヒントと同じ方式) */
+const ONBOARDING_DONE_KEY = 'aq-world-onboarding-done';
+
+/** 初回オンボーディング (話者はブルスコン — 既存の案内役。オーナー指示 2026-07-18)。
+ *  操作 → 危険と回復 → ちずのかけら → ちずボタン、の順で旅の前提だけ伝える */
+const ONBOARDING_LINES: readonly DialogueLine[] = [
+  { speaker: 'ブルスコン', text: 'ようこそ あおぞらワールドへ! わたしは せいれいブルスコン。すこしだけ あんないするね。' },
+  { speaker: 'ブルスコン', text: 'マップを おしたまま ゆびを うごかすと あるけるよ。' },
+  { speaker: 'ブルスコン', text: 'そとには モンスターが いる。たたかいに まけると さいごに たちよった 街まで もどされちゃう。あぶなくなったら 街で やすもう。' },
+  { speaker: 'ブルスコン', text: '街に つくと「ちずのかけら」が 手に はいる。ちずは かけらを あつめた ちほうだけ ひろがっていくんだ。' },
+  { speaker: 'ブルスコン', text: '🗺 ちずボタンで いつでも たしかめられる。それじゃ、よい たびを!' },
+];
+
 export function World() {
   const session = useSession();
   const agent = session.agent ?? null;
@@ -94,6 +109,8 @@ export function World() {
   const [loadErr, setLoadErr] = useState(false);
   const [retryNonce, setRetryNonce] = useState(0);
   const [notice, setNotice] = useState<string | null>(null); // 進めない/回復などの一行メッセージ
+  const [onboarding, setOnboarding] = useState(false);
+  const onboardingRef = useRef(false);
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
   const [diag, setDiag] = useState<DiagnosisResult | null>(null);
   /** やくそう/そらのしずくの手持ち。戦闘内の使用と獲得は battle レコードに残る。
@@ -190,6 +207,12 @@ export function World() {
         const state = await loadWorldState(agent, did);
         if (cancelled) return;
         setWs({ x: state.x, y: state.y, hp: state.hp, mp: state.mp, lastTown: state.lastTown, regions: state.regions });
+        try {
+          if (typeof localStorage !== 'undefined' && localStorage.getItem(ONBOARDING_DONE_KEY) !== '1') {
+            setOnboarding(true);
+            onboardingRef.current = true;
+          }
+        } catch { /* private mode */ }
         if (state.relocated) {
           // 歩行不能地形からの退避 (橋の再配置など)。無言で数百タイル動くと混乱する
           const t = townAt(state.x, state.y);
@@ -284,7 +307,7 @@ export function World() {
       // cover 中も歩けてしまい、テレポート直後に戦闘が開く / featherDestRef が
       // 残留して次のエンカウントをハイジャックする (レビュー指摘)。
       // move() 冒頭で塞ぐことでキーボード・スティック・AT ボタン全経路を一括ガード
-      if (!s || battleRef.current || battleResultRef.current || mapOpenRef.current || shopOpenRef.current || gearOpenRef.current || wipeRef.current) return;
+      if (!s || battleRef.current || battleResultRef.current || mapOpenRef.current || shopOpenRef.current || gearOpenRef.current || wipeRef.current || onboardingRef.current) return;
       const { dx, dy } = DIRS[dir];
       const nx = wrap(s.x + dx);
       const ny = wrap(s.y + dy);
@@ -1084,6 +1107,16 @@ export function World() {
           : ''}
       </p>
       {mapOpen && <WorldMapModal x={ws.x} y={ws.y} regions={ws.regions} onClose={() => setMapOpen(false)} />}
+      {onboarding && (
+        <DialogueWindow
+          lines={ONBOARDING_LINES}
+          onDone={() => {
+            setOnboarding(false);
+            onboardingRef.current = false;
+            try { localStorage.setItem(ONBOARDING_DONE_KEY, '1'); } catch { /* private mode */ }
+          }}
+        />
+      )}
       {gearOpen && (
         <GearModal
           archetype={archetype}


### PR DESCRIPTION
## 背景

オーナー指示: 「オンボーディングで地図を集めると地図が埋まっていくことを説明すべき。ちゃんとオンボーディングのセリフ演出を画面に出そう。ドラクエ風セリフのウインドウに話者の名前とセリフを1文字ずつ表示。これから NPC が増えるとセリフは必須。なんなら戦闘画面のテキストもドラクエ1風に」。

## 実装

### セリフ基盤 (今後の NPC 会話の共通部品)

- `lib/dialogue.ts` — セリフ送りの状態機械 (純関数・テスト付き)。タイプ中にタップ = 全文表示、全文表示中にタップ = 次の行 (DQ の会話送り)。文字は code point 単位 (絵文字が半欠けしない)
- `components/dialogue-window.tsx` — 画面下部の DQ 風ウィンドウ。**話者名プレート (アイコン付き) + 1 文字ずつ表示 (45ms/字) + ▼ 点滅**。全面オーバーレイでどこをタップしても進む。Enter/Space でも送れる (mount 時 focus + aria-modal)。reduced-motion では即時全文

### 初回オンボーディング (話者: 精霊ブルスコン、全 5 行)

1. あいさつ / 2. 操作 / 3. 危険と回復 / 4. **「街に つくと『ちずのかけら』が 手に はいって、その街の まわりの ちずが ひろがっていくんだ」** / 5. 🗺 ちずボタン案内

localStorage で一度きり表示。表示中は移動・そらのはねをガード。

### 戦闘ログの DQ1 風表示

battle-view のログを 1 文字ずつ表示 (22ms/字、コマンド非ブロック = テンポ優先)。タップで残りを即時全文 (セリフと同じ作法)。

## テスト

dialogue 状態機械 (tick/スキップ/行送り/done/空配列/サロゲートペア) — core 279 / web 310 / typecheck / build 全緑

## Review

3 並列レビュー (設計 / 実装 / UX) 実施。★★★ 1 件。対応 commit: 3b6a977

- **★★★ TypedLines が同一ターン中の再レンダーで毎ターン打ち直される (実装)** → 打ち直し契機を内容文字列に変更
- **★★ 空 lines で不可視 + tick 無限ループ + onDone 未達 (設計・実装共通)** → 空なら即 done (動的 NPC セリフ時代への契約)
- **★★ キーボード/AT: フォーカス管理なし + そらのはねガード漏れ (設計・実装・UX 共通)** → mount 時 focus + aria-modal + useFeatherOnField に onboardingRef 追加
- **★★ サロゲートペアで絵文字が半欠け表示 (実装)** → 状態機械を code point 基準に + テスト追加
- **★★ SR 露出の後退 (汎用要素の aria-label は prohibited) (設計・実装・UX 共通)** → visually-hidden 全文 + aria-hidden タイプ表示
- **★★ ブルスコンは SpiritBubble 規約 (UX)** → 話者プレートに SpiritIcon、spirit-bubble docstring に例外明記
- **★ interval 構造 (1 文字ごと再生成 / updater 内 clearInterval)** → 行単位 interval / ref 判定に変更
- **★ footer 68px ハードコード** → `--footer-height` 追従。**★ かけら説明の「ちほう」が抽象的** → 「その街の まわりの ちずが ひろがる」。**★ 戦闘ログにスキップなし** → タップで即全文。**★ 行送りの上辺揺れ** → minHeight 5.8em
- **★ 対応不要と判断 (記録)**: スティックゴーストヒントとの二重説明 (補強と判断)、reduced-motion の動的追従、折返し行の高さ予約、選択肢分岐は W6e で拡張 (互換追加可能な設計)、zIndex 台帳化、既存プレイヤーへの一度きり表示 (かけら周知として有益)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBG5bkB1QfXWSQKxQehSwf