### PR TITLE
feat(trial): 試練を 1 日 10 回までに制限 (JST 暦日)

### DIFF
--- a/apps/web/src/components/trial-arena.tsx
+++ b/apps/web/src/components/trial-arena.tsx
@@ -35,7 +35,7 @@ import {
   type BattleLevelUps,
   type BattleStats,
 } from '@/lib/battle-log';
-import { TRIAL_DAILY_LIMIT, trialsRemaining } from '@/lib/trial-limit';
+import { TRIAL_DAILY_LIMIT, isTrialCapped, trialsRemaining } from '@/lib/trial-limit';
 import { formatGain, notifyLevelUp } from './level-up-overlay';
 import { loadCraftInventory } from '@/lib/crafting';
 import { loadGearRefs, resolveGear } from '@/lib/gear';
@@ -105,6 +105,9 @@ export function TrialArena({
   const [phase, setPhase] = useState<Phase>({ kind: 'select' });
   const [stats, setStats] = useState<BattleStats | null>(null);
   const [trialsToday, setTrialsToday] = useState<number | null>(null);
+  // begin の連打レース対策: state 反映は await 後で非同期なので、同期的に読める
+  // ref で「今日ぶんの確定 + 進行中」を数えてガードする (state は表示用)
+  const trialsTodayRef = useRef<number | null>(null);
   const [gearSel, setGearSel] = useState<GearSelection>({});
   const gearReadyRef = useRef(false);
   const gearSelRef = useRef(gearSel);
@@ -117,7 +120,12 @@ export function TrialArena({
 
   const refreshStats = useCallback(() => {
     loadBattleStats(agent, did).then(setStats).catch(() => {});
-    loadTrialsToday(agent, did, new Date().toISOString()).then(setTrialsToday).catch(() => {});
+    loadTrialsToday(agent, did, new Date().toISOString())
+      .then((n) => {
+        setTrialsToday(n);
+        trialsTodayRef.current = n;
+      })
+      .catch(() => {});
     // 装備 (gear/self の rkey 参照を所持個体で解決 — docs/20 W6c)
     Promise.all([loadCraftInventory(agent, did), loadGearRefs(agent, did)])
       .then(([inv, refs]) => {
@@ -147,11 +155,15 @@ export function TrialArena({
   const begin = useCallback(
     async (fixedTier?: 1 | 2 | 3) => {
       if (points.balance < BATTLE_TUNING.powerCost) return;
-      // 1 日の挑戦上限 (未取得 null のときは通す — 表示側でボタンを塞ぐ)
-      if (trialsToday !== null && trialsToday >= TRIAL_DAILY_LIMIT) {
+      // 1 日の挑戦上限。ref は同期的に読めるので連打しても超過しない
+      // (state 反映は await 後で遅れる — 複数 begin が同じ古い値を読む穴を塞ぐ)。
+      // 未取得 (null) のときは通す (表示側でボタンを塞ぐ)
+      if (isTrialCapped(trialsTodayRef.current)) {
         setErr(`今日の試練はここまで。また明日 (1 日 ${TRIAL_DAILY_LIMIT} 回まで)。`);
         return;
       }
+      // 挑戦を確定する前に ref を先押しで +1 (楽観)。失敗時はロールバックする
+      trialsTodayRef.current = (trialsTodayRef.current ?? 0) + 1;
       setErr(null);
       // 32bit seed (Math.random で十分。決定性はエンジン側の性質)
       const seed = Math.floor(Math.random() * 0xffffffff) >>> 0;
@@ -173,7 +185,8 @@ export function TrialArena({
       try {
         // 支払い + 仮レコード (棄権 = 敗北)。ここが失敗したらバトルを始めない。
         const rkey = await startBattleRecord(agent, { seed, tier, monsterId: state.monsterId, source: 'trial' });
-        setTrialsToday((n) => (n ?? 0) + 1);
+        // 表示 state を ref に合わせる (ref は begin 冒頭で先押し済み)
+        setTrialsToday(trialsTodayRef.current);
         void bumpPower(agent, did, { battles: 1 });
         onPointsChanged({ ...points, battles: points.battles + 1, balance: points.balance - BATTLE_TUNING.powerCost });
         // starting 中のときだけ battle へ (hold タイムアウトで select に戻した後に
@@ -183,6 +196,8 @@ export function TrialArena({
         setWipe((w) => (w === 'hold' ? 'reveal' : w));
       } catch (e) {
         console.warn('battle start failed', e);
+        // 先押しした ref を戻す (レコードが書かれなかったので消費しない)
+        trialsTodayRef.current = Math.max(0, (trialsTodayRef.current ?? 1) - 1);
         setErr('試練を始められなかった。通信を確認してもう一度どうぞ。');
         setPhase({ kind: 'select' });
         // select に向かって開き直す (CSS の都合で一瞬全面黒に跳んでから開く。許容)
@@ -350,10 +365,13 @@ export function TrialArena({
   //  レビュー ★★★ 指摘: 支払いが cover より速いのが最頻パス)
   const coveringBattle = phase.kind === 'battle' && wipe !== null && wipe !== 'reveal';
   if (phase.kind === 'select' || phase.kind === 'starting' || coveringBattle) {
-    const capped = trialsToday !== null && trialsToday >= TRIAL_DAILY_LIMIT;
+    const capped = isTrialCapped(trialsToday);
     const canPlay = points.balance >= BATTLE_TUNING.powerCost && !capped;
     const starting = phase.kind !== 'select';
     const remaining = trialsToday !== null ? trialsRemaining(trialsToday) : null;
+    // 残数の色: 3 回以上=通常、1-2 回=注意 (accent)、0=danger (レビュー ★★)
+    const remainingColor =
+      remaining === null || remaining > 2 ? 'var(--color-fg)' : remaining > 0 ? 'var(--color-accent)' : 'var(--color-danger)';
     return (
       <div>
         <SpiritBubble>
@@ -365,7 +383,7 @@ export function TrialArena({
           {remaining !== null && (
             <>
               {' / '}きょうの試練: のこり{' '}
-              <strong style={{ color: remaining > 0 ? 'var(--color-fg)' : 'var(--color-danger)' }}>{remaining}</strong> 回
+              <strong style={{ color: remainingColor }}>{remaining}</strong> 回
             </>
           )}
         </div>
@@ -389,11 +407,11 @@ export function TrialArena({
           </p>
         </div>
         <p style={{ fontSize: '0.75em', color: 'var(--color-muted)', marginTop: '0.5em' }}>
-          ※ 試練の途中でやめる (画面を閉じる) と敗北あつかいになるよ。
+          ※ 試練の途中でやめる (画面を閉じる) と敗北あつかい + きょうの のこり回数も 1 へるよ。
         </p>
         {capped ? (
           <p style={{ fontSize: '0.8em', color: 'var(--color-muted)', marginTop: '0.5em' }}>
-            今日の試練は {TRIAL_DAILY_LIMIT} 回まで。また明日ちょうせんできるよ (あおぞらワールドの冒険はいつでも OK)。
+            今日の試練は {TRIAL_DAILY_LIMIT} 回まで。よなかの 0 時 (日本時間) に また {TRIAL_DAILY_LIMIT} 回 もらえるよ (あおぞらワールドの冒険はいつでも OK)。
           </p>
         ) : points.balance < BATTLE_TUNING.powerCost ? (
           <p style={{ fontSize: '0.8em', color: 'var(--color-muted)', marginTop: '0.5em' }}>
@@ -497,7 +515,7 @@ export function TrialArena({
       <div style={{ display: 'flex', gap: '0.6em', justifyContent: 'center', flexWrap: 'wrap' }}>
         <button
           type="button"
-          disabled={points.balance < BATTLE_TUNING.powerCost}
+          disabled={points.balance < BATTLE_TUNING.powerCost || isTrialCapped(trialsToday)}
           onClick={() => void begin(tier)}
           style={{ padding: '0.7em 1.4em' }}
         >
@@ -507,6 +525,11 @@ export function TrialArena({
           試練の間に戻る
         </button>
       </div>
+      {isTrialCapped(trialsToday) && (
+        <p style={{ fontSize: '0.78em', color: 'var(--color-muted)', textAlign: 'center', marginTop: '0.5em' }}>
+          今日の試練は {TRIAL_DAILY_LIMIT} 回まで。よなかの 0 時 (日本時間) に また ちょうせんできるよ。
+        </p>
+      )}
       {wipeOverlay}
     </div>
   );

--- a/apps/web/src/components/trial-arena.tsx
+++ b/apps/web/src/components/trial-arena.tsx
@@ -31,9 +31,11 @@ import {
   finishBattleRecord,
   loadBattleStats,
   startBattleRecord,
+  loadTrialsToday,
   type BattleLevelUps,
   type BattleStats,
 } from '@/lib/battle-log';
+import { TRIAL_DAILY_LIMIT, trialsRemaining } from '@/lib/trial-limit';
 import { formatGain, notifyLevelUp } from './level-up-overlay';
 import { loadCraftInventory } from '@/lib/crafting';
 import { loadGearRefs, resolveGear } from '@/lib/gear';
@@ -102,6 +104,7 @@ export function TrialArena({
 }) {
   const [phase, setPhase] = useState<Phase>({ kind: 'select' });
   const [stats, setStats] = useState<BattleStats | null>(null);
+  const [trialsToday, setTrialsToday] = useState<number | null>(null);
   const [gearSel, setGearSel] = useState<GearSelection>({});
   const gearReadyRef = useRef(false);
   const gearSelRef = useRef(gearSel);
@@ -114,6 +117,7 @@ export function TrialArena({
 
   const refreshStats = useCallback(() => {
     loadBattleStats(agent, did).then(setStats).catch(() => {});
+    loadTrialsToday(agent, did, new Date().toISOString()).then(setTrialsToday).catch(() => {});
     // 装備 (gear/self の rkey 参照を所持個体で解決 — docs/20 W6c)
     Promise.all([loadCraftInventory(agent, did), loadGearRefs(agent, did)])
       .then(([inv, refs]) => {
@@ -143,6 +147,11 @@ export function TrialArena({
   const begin = useCallback(
     async (fixedTier?: 1 | 2 | 3) => {
       if (points.balance < BATTLE_TUNING.powerCost) return;
+      // 1 日の挑戦上限 (未取得 null のときは通す — 表示側でボタンを塞ぐ)
+      if (trialsToday !== null && trialsToday >= TRIAL_DAILY_LIMIT) {
+        setErr(`今日の試練はここまで。また明日 (1 日 ${TRIAL_DAILY_LIMIT} 回まで)。`);
+        return;
+      }
       setErr(null);
       // 32bit seed (Math.random で十分。決定性はエンジン側の性質)
       const seed = Math.floor(Math.random() * 0xffffffff) >>> 0;
@@ -163,7 +172,8 @@ export function TrialArena({
       });
       try {
         // 支払い + 仮レコード (棄権 = 敗北)。ここが失敗したらバトルを始めない。
-        const rkey = await startBattleRecord(agent, { seed, tier, monsterId: state.monsterId });
+        const rkey = await startBattleRecord(agent, { seed, tier, monsterId: state.monsterId, source: 'trial' });
+        setTrialsToday((n) => (n ?? 0) + 1);
         void bumpPower(agent, did, { battles: 1 });
         onPointsChanged({ ...points, battles: points.battles + 1, balance: points.balance - BATTLE_TUNING.powerCost });
         // starting 中のときだけ battle へ (hold タイムアウトで select に戻した後に
@@ -179,7 +189,7 @@ export function TrialArena({
         setWipe((w) => (w ? 'reveal' : w));
       }
     },
-    [agent, did, archetype, jobLevel, playerLevel, playerName, rpgStats, points, onPointsChanged, stats, ensureGear],
+    [agent, did, archetype, jobLevel, playerLevel, playerName, rpgStats, points, onPointsChanged, stats, ensureGear, trialsToday],
   );
 
   const act = useCallback(
@@ -340,8 +350,10 @@ export function TrialArena({
   //  レビュー ★★★ 指摘: 支払いが cover より速いのが最頻パス)
   const coveringBattle = phase.kind === 'battle' && wipe !== null && wipe !== 'reveal';
   if (phase.kind === 'select' || phase.kind === 'starting' || coveringBattle) {
-    const canPlay = points.balance >= BATTLE_TUNING.powerCost;
+    const capped = trialsToday !== null && trialsToday >= TRIAL_DAILY_LIMIT;
+    const canPlay = points.balance >= BATTLE_TUNING.powerCost && !capped;
     const starting = phase.kind !== 'select';
+    const remaining = trialsToday !== null ? trialsRemaining(trialsToday) : null;
     return (
       <div>
         <SpiritBubble>
@@ -350,6 +362,12 @@ export function TrialArena({
         <div style={{ margin: '0.8em 0 0.4em', fontSize: '0.85em', color: 'var(--color-muted)' }}>
           あおぞらパワー: <strong style={{ color: 'var(--color-fg)' }}>{points.balance}</strong>
           (投稿すると増える)
+          {remaining !== null && (
+            <>
+              {' / '}きょうの試練: のこり{' '}
+              <strong style={{ color: remaining > 0 ? 'var(--color-fg)' : 'var(--color-danger)' }}>{remaining}</strong> 回
+            </>
+          )}
         </div>
         <div style={{ marginTop: '0.6em', textAlign: 'center' }}>
           <button
@@ -373,11 +391,15 @@ export function TrialArena({
         <p style={{ fontSize: '0.75em', color: 'var(--color-muted)', marginTop: '0.5em' }}>
           ※ 試練の途中でやめる (画面を閉じる) と敗北あつかいになるよ。
         </p>
-        {!canPlay && (
+        {capped ? (
+          <p style={{ fontSize: '0.8em', color: 'var(--color-muted)', marginTop: '0.5em' }}>
+            今日の試練は {TRIAL_DAILY_LIMIT} 回まで。また明日ちょうせんできるよ (あおぞらワールドの冒険はいつでも OK)。
+          </p>
+        ) : points.balance < BATTLE_TUNING.powerCost ? (
           <p style={{ fontSize: '0.8em', color: 'var(--color-muted)', marginTop: '0.5em' }}>
             パワーが足りない。あおぞらくえすとから投稿すると 1 つ増えるよ。
           </p>
-        )}
+        ) : null}
         {err && <p style={{ color: 'var(--color-danger)', fontSize: '0.85em' }}>{err}</p>}
         {stats && stats.total > 0 && <RecordPanel stats={stats} />}
         {wipeOverlay}

--- a/apps/web/src/lib/battle-log.ts
+++ b/apps/web/src/lib/battle-log.ts
@@ -11,6 +11,7 @@ import type { BattleOutcome, BattleRecordSummary } from '@aozoraquest/core';
 import { jobLevelFromXp, playerLevelFromXp } from '@aozoraquest/core';
 import { VIA, getRecord, putRecord } from './atproto';
 import { COL } from './collections';
+import { countTrialsToday, jstDayKey } from './trial-limit';
 
 export interface BattleLogRecord {
   $type: string;
@@ -33,6 +34,9 @@ export interface BattleLogRecord {
   materialsLost?: string[];
   at: string;
   via: string;
+  /** 挑戦の出所。試練の 1 日上限カウント (trial-limit) の対象判定に使う。
+   *  旧レコードは欠落 = 試練扱い (本番の過去戦闘は全て試練)。 */
+  source?: 'trial' | 'world';
 }
 
 /**
@@ -42,7 +46,7 @@ export interface BattleLogRecord {
  */
 export async function startBattleRecord(
   agent: Agent,
-  input: Pick<BattleLogRecord, 'seed' | 'tier' | 'monsterId' | 'materialsLost'>,
+  input: Pick<BattleLogRecord, 'seed' | 'tier' | 'monsterId' | 'materialsLost' | 'source'>,
 ): Promise<string> {
   const did = agent.assertDid;
   const rkey = `b-${Date.now().toString(36)}-${Math.floor(Math.random() * 1e6).toString(36)}`;
@@ -138,6 +142,40 @@ export async function awardBattleXp(
     console.warn('[battle] xp award failed', e);
     return null;
   }
+}
+
+/**
+ * 今日 (JST) の試練の挑戦回数を数える (1 日上限の判定用)。listRecords は新しい順
+ * に返るので、今日の JST 開始より前のレコードに達したら早期に打ち切る。
+ */
+export async function loadTrialsToday(agent: Agent, did: string, nowIso: string): Promise<number> {
+  const records: { at?: string; source?: string }[] = [];
+  const todayKey = jstDayKey(nowIso);
+  let cursor: string | undefined;
+  outer: for (let page = 0; page < 5; page++) {
+    let res;
+    try {
+      res = await agent.com.atproto.repo.listRecords({
+        repo: did,
+        collection: COL.battle,
+        limit: 100,
+        ...(cursor !== undefined ? { cursor } : {}),
+      });
+    } catch {
+      break; // 未作成
+    }
+    for (const r of res.data.records) {
+      const v = r.value as Partial<BattleLogRecord>;
+      const at = typeof v.at === 'string' ? v.at : undefined;
+      // 今日より前に達したら以降は全て過去 (新しい順) なので打ち切る
+      if (at && jstDayKey(at) < todayKey) break outer;
+      records.push({ ...(at ? { at } : {}), ...(v.source ? { source: v.source } : {}) });
+    }
+    const next = res.data.cursor;
+    if (!next || next === cursor) break;
+    cursor = next;
+  }
+  return countTrialsToday(records, nowIso);
 }
 
 /** 戦闘レコード数を数える (パワー再スキャン用。cardDraw と同じ最大 500 件)。 */

--- a/apps/web/src/lib/battle-log.ts
+++ b/apps/web/src/lib/battle-log.ts
@@ -145,8 +145,12 @@ export async function awardBattleXp(
 }
 
 /**
- * 今日 (JST) の試練の挑戦回数を数える (1 日上限の判定用)。listRecords は新しい順
- * に返るので、今日の JST 開始より前のレコードに達したら早期に打ち切る。
+ * 今日 (JST) の試練の挑戦回数を数える (1 日上限の判定用)。listRecords は rkey 降順
+ * (= 新しい順) に返り、rkey は `b-${Date.now().toString(36)}-...` の時刻ベースなので
+ * `at` と単調一致する。ゆえに `at` が今日の JST 開始より前に達したら以降は全て過去と
+ * みなして打ち切れる (日付境界の finishBattleRecord による at 上書きで最大 1 分の
+ * ずれは生じうるが、count 側は at===today のみ数えるので過剰カウントにはならない)。
+ * 上限は 10 なので今日ぶんは実質 1 ページ目で境界に達する。
  */
 export async function loadTrialsToday(agent: Agent, did: string, nowIso: string): Promise<number> {
   const records: { at?: string; source?: string }[] = [];

--- a/apps/web/src/lib/trial-limit.test.ts
+++ b/apps/web/src/lib/trial-limit.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'vitest';
+import { countTrialsToday, jstDayKey, TRIAL_DAILY_LIMIT, trialsRemaining } from './trial-limit';
+
+describe('jstDayKey', () => {
+  test('JST 暦日に変換する (UTC+9)', () => {
+    // 2026-07-18 15:00 UTC = 2026-07-19 00:00 JST → 19 日
+    expect(jstDayKey('2026-07-18T15:00:00.000Z')).toBe('2026-07-19');
+    // 2026-07-18 14:59 UTC = 2026-07-18 23:59 JST → まだ 18 日
+    expect(jstDayKey('2026-07-18T14:59:00.000Z')).toBe('2026-07-18');
+  });
+  test('不正な時刻は空文字', () => {
+    expect(jstDayKey('not-a-date')).toBe('');
+  });
+});
+
+describe('countTrialsToday', () => {
+  const now = '2026-07-18T12:00:00.000Z'; // JST 2026-07-18 21:00
+
+  test('今日の試練だけ数える (別日・野外遭遇は除外)', () => {
+    const records = [
+      { at: '2026-07-18T11:00:00.000Z', source: 'trial' }, // 今日
+      { at: '2026-07-18T02:00:00.000Z', source: 'trial' }, // 今日 (JST 11:00)
+      { at: '2026-07-17T12:00:00.000Z', source: 'trial' }, // 昨日
+      { at: '2026-07-18T11:30:00.000Z', source: 'world' }, // 野外 = 除外
+    ];
+    expect(countTrialsToday(records, now)).toBe(2);
+  });
+
+  test('source 欠落は試練として数える (旧レコード互換)', () => {
+    const records = [{ at: '2026-07-18T11:00:00.000Z' }];
+    expect(countTrialsToday(records, now)).toBe(1);
+  });
+
+  test('JST 日付境界をまたぐ: 前日 15:00 UTC 以降は今日扱い', () => {
+    // now = JST 07-18 21:00。07-17 15:00 UTC = JST 07-18 00:00 = 今日の始まり
+    const records = [
+      { at: '2026-07-17T15:00:00.000Z', source: 'trial' }, // JST 07-18 00:00 = 今日
+      { at: '2026-07-17T14:59:00.000Z', source: 'trial' }, // JST 07-17 23:59 = 昨日
+    ];
+    expect(countTrialsToday(records, now)).toBe(1);
+  });
+});
+
+describe('trialsRemaining', () => {
+  test('上限からの残り。0 未満にしない', () => {
+    expect(trialsRemaining(0)).toBe(TRIAL_DAILY_LIMIT);
+    expect(trialsRemaining(TRIAL_DAILY_LIMIT)).toBe(0);
+    expect(trialsRemaining(TRIAL_DAILY_LIMIT + 3)).toBe(0);
+  });
+});

--- a/apps/web/src/lib/trial-limit.test.ts
+++ b/apps/web/src/lib/trial-limit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { countTrialsToday, jstDayKey, TRIAL_DAILY_LIMIT, trialsRemaining } from './trial-limit';
+import { countTrialsToday, isTrialCapped, jstDayKey, TRIAL_DAILY_LIMIT, trialsRemaining } from './trial-limit';
 
 describe('jstDayKey', () => {
   test('JST 暦日に変換する (UTC+9)', () => {
@@ -46,5 +46,15 @@ describe('trialsRemaining', () => {
     expect(trialsRemaining(0)).toBe(TRIAL_DAILY_LIMIT);
     expect(trialsRemaining(TRIAL_DAILY_LIMIT)).toBe(0);
     expect(trialsRemaining(TRIAL_DAILY_LIMIT + 3)).toBe(0);
+  });
+});
+
+describe('isTrialCapped', () => {
+  test('未取得 (null) は未達扱い / 上限で true', () => {
+    expect(isTrialCapped(null)).toBe(false);
+    expect(isTrialCapped(0)).toBe(false);
+    expect(isTrialCapped(TRIAL_DAILY_LIMIT - 1)).toBe(false);
+    expect(isTrialCapped(TRIAL_DAILY_LIMIT)).toBe(true);
+    expect(isTrialCapped(TRIAL_DAILY_LIMIT + 5)).toBe(true);
   });
 });

--- a/apps/web/src/lib/trial-limit.ts
+++ b/apps/web/src/lib/trial-limit.ts
@@ -1,0 +1,45 @@
+/**
+ * ブルスコンの試練の 1 日あたり挑戦回数の上限 (オーナー要望 2026-07-18)。
+ *
+ * 「1 日」は JST 暦日 (00:00 JST 区切り)。APP_VERSION 等と同じく本アプリの
+ * 時刻基準は JST に揃える。カウントは試練の戦闘レコード (source='trial') を
+ * その日ぶん数える — 途中離脱 (棄権) も仮レコードが残るので 1 回と数える
+ * (負けそうで閉じて数え直す、を無料にしない。パワー消費と同じ考え方)。
+ *
+ * 野外遭遇 (source='world') は上限の対象外。旧レコード (source 欠落) は
+ * 本番では全て試練なので試練として数える。
+ */
+
+export const TRIAL_DAILY_LIMIT = 10;
+
+/** ISO 時刻を JST 暦日キー (YYYY-MM-DD) に変換する。純関数。 */
+export function jstDayKey(iso: string): string {
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return '';
+  // JST = UTC+9 (DST なし)。9h ずらして UTC 日付部を取れば JST 暦日になる
+  const d = new Date(t + 9 * 60 * 60 * 1000);
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+/** レコード群のうち「今日 (JST) の試練」を数える。source 欠落 = 試練扱い。 */
+export function countTrialsToday(
+  records: readonly { at?: string; source?: string }[],
+  nowIso: string,
+): number {
+  const today = jstDayKey(nowIso);
+  if (!today) return 0;
+  let n = 0;
+  for (const r of records) {
+    if (r.source === 'world') continue; // 野外遭遇は対象外
+    if (typeof r.at === 'string' && jstDayKey(r.at) === today) n++;
+  }
+  return n;
+}
+
+/** 残り挑戦回数 (0 未満にはしない)。 */
+export function trialsRemaining(usedToday: number): number {
+  return Math.max(0, TRIAL_DAILY_LIMIT - usedToday);
+}

--- a/apps/web/src/lib/trial-limit.ts
+++ b/apps/web/src/lib/trial-limit.ts
@@ -43,3 +43,8 @@ export function countTrialsToday(
 export function trialsRemaining(usedToday: number): number {
   return Math.max(0, TRIAL_DAILY_LIMIT - usedToday);
 }
+
+/** 上限に達しているか (判定を 1 箇所に集約。null = 未取得は false)。 */
+export function isTrialCapped(usedToday: number | null): boolean {
+  return usedToday !== null && usedToday >= TRIAL_DAILY_LIMIT;
+}

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -411,7 +411,7 @@ export function World() {
         void (async () => {
           try {
             // 支払い + 仮レコード (途中離脱 = 棄権 = 敗北)。失敗したら遭遇なしに戻す。
-            const rkey = await startBattleRecord(agent, { seed, tier, monsterId: state.monsterId, materialsLost });
+            const rkey = await startBattleRecord(agent, { seed, tier, monsterId: state.monsterId, materialsLost, source: 'world' });
             void bumpPower(agent, did, { battles: 1 });
             setPoints((p) => (p ? { ...p, battles: p.battles + 1, balance: p.balance - BATTLE_TUNING.powerCost } : p));
             setBattle((b) => {

--- a/docs/18-brusukon-trial.md
+++ b/docs/18-brusukon-trial.md
@@ -14,6 +14,14 @@
   (`app.aozoraquest.power/self` に `battles` カウンタを追加。旧レコードは欠落 → 0 扱い)。
 - 勝利でパワーは**返さない** (インフレ防止)。報酬は XP / 戦績 / 称号 / 素材ドロップ。
 - 挑戦条件: ブルスコン召喚済み (従来の SUMMON_THRESHOLD ゲートを流用)。
+- **1 日の挑戦上限 = 10 回** (`TRIAL_DAILY_LIMIT`、JST 暦日区切り。オーナー要望
+  2026-07-18)。上限は試練 (`source='trial'`) のみで、あおぞらワールドの野外遭遇
+  (`source='world'`) は対象外。カウントは battle レコードをその日ぶん集計 (専用
+  カウンタは持たない)。途中離脱 (棄権) も仮レコードが残るので 1 回と数える。
+  実装は `apps/web/src/lib/trial-limit.ts`。**W3 (Worker/DO 権威化) 時に上限判定を
+  サーバへ移す**まで、複数端末同時挑戦の厳密な超過防止はできない (クライアント
+  自己申告のため数回超過し得る。パワー消費は正しく引かれるので無料無制限ではない)。
+  その際は `TRIAL_DAILY_LIMIT` を core tuning へ移す想定。
 
 ## バトルエンジン (packages/core/src/battle.ts)
 


### PR DESCRIPTION
## 背景

オーナー要望「試練に挑めるのは一日10回まで」。

## 実装

- 上限は **JST 暦日**区切り (00:00 JST リセット)。source ('trial'|'world') で試練のみ対象 (冒険は無制限)。旧レコード (source 欠落) は試練扱い
- **途中離脱 (棄権) も 1 回**。負けそうで閉じて数え直す、を無料にしない
- `lib/trial-limit.ts`: jstDayKey / countTrialsToday / trialsRemaining / isTrialCapped の純関数 + テスト
- `loadTrialsToday`: 新しい順に読み今日ぶんで打ち切り
- 試練画面: 「きょうの試練: のこり N 回」(3段階の警告色)、上限時はボタン封鎖 + 「よなかの 0 時にまた 10 回」案内、result 画面の再戦も封鎖、途中離脱で 1 回消費の注意書き
- **連打レース対策**: 同期的に読める ref で先押しガード (state 反映の遅延で超過する穴を塞ぐ)

## テスト

trial-limit 純関数テスト + web 317 / core 279 / typecheck / build 全緑

## Review

3 並列レビュー (設計 / 実装 / UX) 実施。★★★ 0。対応 commit: 5fa5130

- **★★ 連打で上限 +1 のレース (実装)** → trialsTodayRef で同期先押しガード + 失敗ロールバック
- **★★ result 画面「もういちど挑む」が capped 時に無反応 (実装)** → disabled + 上限文言
- **★★ 残り 1-2 回の警告色なし (UX)** → 3段階の色
- **★★ JST リセット時刻が不明 (UX)** → 「よなかの 0 時 (日本時間)」明記
- **★★ 途中離脱で 1 回消費が伝わらない (UX)** → 注意書き補強
- **★★ loadTrialsToday の rkey/at 順序依存 (設計・実装共通)** → 単調一致の前提をコメント化 (実害は境界±1分で過剰カウントなし)
- **★ 上限値の位置 / docs 記載 (設計)** → docs/18 に上限 10 + W3 権威化・複数端末超過の申し送り
- **★ isTrialCapped の DRY (設計)** → 純関数化
- **★ 対応不要と判断 (記録)**: 楽観更新と再取得の合流ちらつき (docs のクライアント会計ドリフト方針で許容)、複数端末同時挑戦の厳密超過防止 (W3 待ち、docs に申し送り済み)、残数 null 読込中のちらつき (通常キャッシュで軽微)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBG5bkB1QfXWSQKxQehSwf