### PR TITLE
feat(spirit): あおぞらワールドの入口を「冒険する」に変え試練より上へ

### DIFF
--- a/apps/web/src/routes/spirit.tsx
+++ b/apps/web/src/routes/spirit.tsx
@@ -236,7 +236,32 @@ export function Spirit() {
             ))}
           </section>
 
-          <section style={{ marginTop: '1em' }}>
+          {/* あおぞらワールド (docs/19) の入口。試練より上に置く (旅がメイン導線 —
+              オーナー要望 2026-07-18)。プレビュー段階 = dev 環境限定。 */}
+          {WORLD_PREVIEW_ENABLED && (
+            <section style={{ marginTop: '1.1em', textAlign: 'center' }}>
+              <Link to="/world">
+                <button
+                  type="button"
+                  style={{
+                    padding: '0.8em 1.8em',
+                    fontSize: '1.05em',
+                    background: 'var(--color-pill-bg)',
+                    color: 'var(--color-fg)',
+                    border: '3px solid var(--color-pill-border)',
+                    boxShadow: '0 0 16px rgba(159, 215, 255, 0.4)',
+                  }}
+                >
+                  🗺 あおぞらワールドを冒険する
+                </button>
+              </Link>
+              <p style={{ fontSize: '0.75em', color: 'var(--color-muted)', marginTop: '0.4em' }}>
+                街をめぐり、モンスターと戦い、そうびを整える旅へ。
+              </p>
+            </section>
+          )}
+
+          <section style={{ marginTop: '1.2em' }}>
             {agent && did && diag ? (
               <TrialArena
                 agent={agent}
@@ -267,17 +292,6 @@ export function Spirit() {
               </div>
             )}
           </section>
-
-          {/* あおぞらワールド (docs/19) の入口。散歩プレビュー段階 = dev 環境限定。 */}
-          {WORLD_PREVIEW_ENABLED && (
-            <section style={{ marginTop: '1.2em', textAlign: 'center' }}>
-              <Link to="/world">
-                <button type="button" style={{ padding: '0.6em 1.4em' }}>
-                  🗺 あおぞらワールドを歩く (プレビュー)
-                </button>
-              </Link>
-            </section>
-          )}
         </>
       )}
 

--- a/apps/web/src/routes/spirit.tsx
+++ b/apps/web/src/routes/spirit.tsx
@@ -239,8 +239,11 @@ export function Spirit() {
           {/* あおぞらワールド (docs/19) の入口。試練より上に置く (旅がメイン導線 —
               オーナー要望 2026-07-18)。プレビュー段階 = dev 環境限定。 */}
           {WORLD_PREVIEW_ENABLED && (
-            <section style={{ marginTop: '1.1em', textAlign: 'center' }}>
+            <section style={{ marginTop: '1.4em', textAlign: 'center' }}>
               <Link to="/world">
+                {/* 主導線として pill 枠 + 背景で目立たせる。発光グロー (boxShadow) は
+                    一度きりの「召喚の儀式」ボタン専用に温存し、最強調シグナルの
+                    希少性を保つ (レビュー ★★) */}
                 <button
                   type="button"
                   style={{
@@ -249,14 +252,13 @@ export function Spirit() {
                     background: 'var(--color-pill-bg)',
                     color: 'var(--color-fg)',
                     border: '3px solid var(--color-pill-border)',
-                    boxShadow: '0 0 16px rgba(159, 215, 255, 0.4)',
                   }}
                 >
                   🗺 あおぞらワールドを冒険する
                 </button>
               </Link>
-              <p style={{ fontSize: '0.75em', color: 'var(--color-muted)', marginTop: '0.4em' }}>
-                街をめぐり、モンスターと戦い、そうびを整える旅へ。
+              <p style={{ fontSize: '0.75em', color: 'var(--color-muted)', marginTop: '0.4em', maxWidth: 260, marginInline: 'auto' }}>
+                街をめぐり、戦い、そうびを整える旅へ。
               </p>
             </section>
           )}


### PR DESCRIPTION
## 背景

オーナー要望「あおぞらワールドを歩く(プレビュー)ではなくて冒険するに変えて欲しい。そして試練より上に表示して欲しい」。

## 実装

- ボタン文言「🗺 あおぞらワールドを歩く (プレビュー)」→「🗺 あおぞらワールドを冒険する」
- 配置を試練セクションの下から上 (召喚後の挨拶直下 = 旅がメイン導線) へ
- pill 枠 + 背景で目立たせ、一言を添える。dev 限定は据え置き

文言 + 配置 + CSS のみ。§1.5 高速パス。

## Review

UX 1 観点レビュー (高速パス)。★★★ 0。対応 commit あり。

- **★★ 発光 pill を召喚と冒険の 2 箇所で使うとシグナル希少性が薄まる** → 冒険ボタンは pill 枠 + 背景で主張しつつ boxShadow を外し、発光グローは一度きりの召喚専用に温存
- **★ 挨拶との間が薄い** → marginTop 1.4em に
- **★ 補足文がモバイルで pill より横広** → 短縮 + max-width 260 で pill 幅に寄せる
- **★ 対応不要 (良好と判断)**: 導線順序 (旅=上/試練=下)、文言のトーン、dev 限定の据え置き (本番漏れなし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBG5bkB1QfXWSQKxQehSwf