### PR TITLE
fix(world): 世界画面のクラッシュ修正 (React #310 = フックのルール違反)

### DIFF
--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -984,27 +984,24 @@ export function World() {
   const danger = regionDanger(regionOf(ws.x, ws.y));
 
   // 自分タップで開く DQ 風コマンド。街にいるときだけ「なんでも屋」を足す。
-  // 参照を安定させる (メニューは開いている間だけマウントされるが、将来キーボード
-  // ナビ等を足すときに毎レンダー別関数だと地雷 — レビュー ★★)
+  // **フックは使わない** (この行は早期 return より後にあるので useMemo だと
+  // フック数が可変になり React error #310 でクラッシュする — 2026-07-18 事故)。
+  // 毎レンダー生成でも、メニューは開いている間だけマウントされるので実害は無い。
   const inTown = !!town;
   const statusReady = !!combat && !!archetype;
-  const menuCommands: WorldMenuCommand[] = useMemo(
-    () => [
-      // 並び順は「しらべる」(次 PR) を どうぐ の後に差し込む前提で固定 (筋肉記憶を裏切らない)
-      { key: 'items', label: 'どうぐ', onSelect: () => setItemsOpen(true) },
-      // しらべるは街の外だけ (街=安全地帯で地方素材は出ない)。コストをラベルに明記
-      ...(inTown ? [] : [{ key: 'search', label: `しらべる (パワー${SEARCH_TUNING.powerCost})`, onSelect: () => setSearchMsg(searchHere()) } as WorldMenuCommand]),
-      { key: 'gear', label: 'そうび', onSelect: () => setGearOpen(true) },
-      { key: 'map', label: 'ちず', onSelect: () => setMapOpen(true) },
-      { key: 'inventory', label: 'もちもの', onSelect: () => setInvOpen(true) },
-      // 使えないコマンドはグレーで残さず消す (なんでも屋と同じポリシー — レビュー ★★)
-      ...(statusReady ? [{ key: 'status', label: 'つよさ', onSelect: () => setStatusOpen(true) } as WorldMenuCommand] : []),
-      ...(inTown
-        ? [{ key: 'shop', label: 'なんでも屋', onSelect: () => { setLastShopAction(null); setMaterialsView({ ...materialsRef.current }); setShopOpen(true); } } as WorldMenuCommand]
-        : []),
-    ],
-    [inTown, statusReady, searchHere],
-  );
+  const menuCommands: WorldMenuCommand[] = [
+    { key: 'items', label: 'どうぐ', onSelect: () => setItemsOpen(true) },
+    // しらべるは街の外だけ (街=安全地帯で地方素材は出ない)。コストをラベルに明記
+    ...(inTown ? [] : [{ key: 'search', label: `しらべる (パワー${SEARCH_TUNING.powerCost})`, onSelect: () => setSearchMsg(searchHere()) } as WorldMenuCommand]),
+    { key: 'gear', label: 'そうび', onSelect: () => setGearOpen(true) },
+    { key: 'map', label: 'ちず', onSelect: () => setMapOpen(true) },
+    { key: 'inventory', label: 'もちもの', onSelect: () => setInvOpen(true) },
+    // 使えないコマンドはグレーで残さず消す (なんでも屋と同じポリシー — レビュー ★★)
+    ...(statusReady ? [{ key: 'status', label: 'つよさ', onSelect: () => setStatusOpen(true) } as WorldMenuCommand] : []),
+    ...(inTown
+      ? [{ key: 'shop', label: 'なんでも屋', onSelect: () => { setLastShopAction(null); setMaterialsView({ ...materialsRef.current }); setShopOpen(true); } } as WorldMenuCommand]
+      : []),
+  ];
 
   // ビューポートのタイル列 (プレイヤー中央固定)。平地は見た目バリアントを散らす。
   const tiles = [];


### PR DESCRIPTION
## 問題

あおぞらワールドが「Unexpected Application Error / Minified React error #310」で**全く表示できない** (オーナー報告・dev で発生)。

## 原因

PR #313 で入れた `menuCommands` の `useMemo` が**早期 return (`if (!ws) return` 等) より後**に置かれていた。`ws` が null の初回描画ではこのフックが呼ばれず、ロード完了後の再描画でフック数が増えて「Rendered more hooks than during the previous render」= React error #310 でクラッシュする。

## 修正

`menuCommands` を `useMemo` から通常の配列生成に戻す (フックを使わない)。メニューは開いている間だけマウントされるので毎レンダー生成でも実害なし。他に早期 return より後のフックが無いことも確認済み。

## CI がすり抜けた理由 (テストの穴)

- このリポジトリには **ESLint (react-hooks/rules-of-hooks) が未設定** (`"lint": "echo lint (tbd)"`)。このルールがあれば「フックが条件付きで呼ばれる」を作者時点で静的に検出できた
- **World をマウントする (loading→loaded 遷移する) テストが無い**。unit テストは全緑だがこの経路を通らない

→ `eslint-plugin-react-hooks` の導入を別 PR (安全網) で行う。

## テスト

typecheck / web 325 / build 全緑 (この 1 行の削除で #310 は解消)

## Review

(実装レビュー実施 — 明確な correctness 修正のホットフィックス)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBG5bkB1QfXWSQKxQehSwf