### PR TITLE
feat(admin): dev で管理者があおぞらパワーを付与できるコントロール

### DIFF
--- a/apps/web/src/lib/runtime-config.test.ts
+++ b/apps/web/src/lib/runtime-config.test.ts
@@ -31,6 +31,14 @@ describe('isAdminDid', () => {
     vi.stubEnv('VITE_ADMIN_DIDS', '');
     expect(isAdminDid('did:plc:aaa')).toBe(false);
   });
+
+  test('前後空白・空要素は正規化して判定する', () => {
+    vi.stubEnv('VITE_ADMIN_DIDS', ' did:plc:aaa ,, did:plc:bbb ,');
+    expect(isAdminDid('did:plc:aaa')).toBe(true);
+    expect(isAdminDid('did:plc:bbb')).toBe(true);
+    // 完全一致なので前後空白付きの引数は一致しない (session の did は正規化済み前提)
+    expect(isAdminDid(' did:plc:aaa ')).toBe(false);
+  });
 });
 
 describe('isFlagEnabled', () => {

--- a/apps/web/src/lib/runtime-config.test.ts
+++ b/apps/web/src/lib/runtime-config.test.ts
@@ -1,10 +1,37 @@
-import { describe, expect, test } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import { DEFAULT_RUNTIME_CONFIG, type RuntimeConfig } from '@aozoraquest/types';
-import { isBanned, isFlagEnabled, isUnderMaintenance } from './runtime-config';
+import { isAdminDid, isBanned, isFlagEnabled, isUnderMaintenance } from './runtime-config';
 
 function cfg(overrides: Partial<RuntimeConfig> = {}): RuntimeConfig {
   return { ...DEFAULT_RUNTIME_CONFIG, ...overrides };
 }
+
+describe('isAdminDid', () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  test('許可リストに含まれる DID は true', () => {
+    vi.stubEnv('VITE_ADMIN_DIDS', 'did:plc:aaa, did:plc:bbb');
+    expect(isAdminDid('did:plc:bbb')).toBe(true);
+    expect(isAdminDid('did:plc:aaa')).toBe(true);
+  });
+
+  test('含まれない DID は false', () => {
+    vi.stubEnv('VITE_ADMIN_DIDS', 'did:plc:aaa');
+    expect(isAdminDid('did:plc:zzz')).toBe(false);
+  });
+
+  test('null / undefined / 空は false', () => {
+    vi.stubEnv('VITE_ADMIN_DIDS', 'did:plc:aaa');
+    expect(isAdminDid(null)).toBe(false);
+    expect(isAdminDid(undefined)).toBe(false);
+    expect(isAdminDid('')).toBe(false);
+  });
+
+  test('VITE_ADMIN_DIDS 未設定なら常に false', () => {
+    vi.stubEnv('VITE_ADMIN_DIDS', '');
+    expect(isAdminDid('did:plc:aaa')).toBe(false);
+  });
+});
 
 describe('isFlagEnabled', () => {
   test('未定義フラグは false', () => {

--- a/apps/web/src/lib/runtime-config.ts
+++ b/apps/web/src/lib/runtime-config.ts
@@ -17,22 +17,24 @@ import { ADMIN_COL } from './collections';
 
 const PLC_DIRECTORY = 'https://plc.directory';
 
-function getPrimaryAdminDid(): string | null {
-  const raw = import.meta.env.VITE_ADMIN_DIDS ?? '';
-  const first = raw.split(',').map((s) => s.trim()).find(Boolean);
-  return first ?? null;
+/** VITE_ADMIN_DIDS (カンマ区切り) を trim + 空要素除去して配列化。
+ *  パース仕様を 1 箇所に集約し getPrimaryAdminDid / isAdminDid の食い違いを防ぐ。 */
+function getAdminDids(): string[] {
+  return (import.meta.env.VITE_ADMIN_DIDS ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
 }
 
-/** ログイン中の DID が管理者許可リスト (VITE_ADMIN_DIDS, カンマ区切り) に含まれるか。
+function getPrimaryAdminDid(): string | null {
+  return getAdminDids()[0] ?? null;
+}
+
+/** ログイン中の DID が管理者許可リスト (VITE_ADMIN_DIDS) に含まれるか。
  *  管理者限定 UI (dev のパワー付与など) のゲートに使う。未設定/空なら常に false。 */
 export function isAdminDid(did: string | null | undefined): boolean {
   if (!did) return false;
-  const raw = import.meta.env.VITE_ADMIN_DIDS ?? '';
-  return raw
-    .split(',')
-    .map((s) => s.trim())
-    .filter(Boolean)
-    .includes(did);
+  return getAdminDids().includes(did);
 }
 
 /** DID を PDS エンドポイントに解決する (公開 read の宛先決定に使う唯一の実装)。

--- a/apps/web/src/lib/runtime-config.ts
+++ b/apps/web/src/lib/runtime-config.ts
@@ -23,6 +23,18 @@ function getPrimaryAdminDid(): string | null {
   return first ?? null;
 }
 
+/** ログイン中の DID が管理者許可リスト (VITE_ADMIN_DIDS, カンマ区切り) に含まれるか。
+ *  管理者限定 UI (dev のパワー付与など) のゲートに使う。未設定/空なら常に false。 */
+export function isAdminDid(did: string | null | undefined): boolean {
+  if (!did) return false;
+  const raw = import.meta.env.VITE_ADMIN_DIDS ?? '';
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .includes(did);
+}
+
 /** DID を PDS エンドポイントに解決する (公開 read の宛先決定に使う唯一の実装)。
  *  did:plc:* は plc.directory、did:web:* はドメイン直 .well-known/did.json。 */
 export async function resolveDidToPds(did: string): Promise<string> {

--- a/apps/web/src/routes/spirit.tsx
+++ b/apps/web/src/routes/spirit.tsx
@@ -23,6 +23,7 @@ import { useRuntimeConfig } from '@/components/config-provider';
 import { applyPromptTemplate } from '@/lib/prompt-template';
 import { bumpPower, loadPointsState, SUMMON_THRESHOLD, type PointsState } from '@/lib/points';
 import { WORLD_PREVIEW_ENABLED } from '@/lib/world-preview';
+import { isAdminDid } from '@/lib/runtime-config';
 
 /**
  * 精霊ブルスコンのページ (docs/18-brusukon-trial.md)。
@@ -51,6 +52,8 @@ export function Spirit() {
   const [questXp, setQuestXp] = useState(0);
   const [loaded, setLoaded] = useState(false);
   const [ritualOpen, setRitualOpen] = useState(false);
+  // 管理者用パワー付与の書込み中フラグ (dev 限定・多重押し防止)
+  const [grantingPower, setGrantingPower] = useState(false);
 
   const agent = session.agent ?? null;
   const did = session.did ?? null;
@@ -260,6 +263,50 @@ export function Spirit() {
               <p style={{ fontSize: '0.75em', color: 'var(--color-muted)', marginTop: '0.4em', maxWidth: 260, marginInline: 'auto' }}>
                 街をめぐり、戦い、そうびを整える旅へ。
               </p>
+            </section>
+          )}
+
+          {/* 管理者用: dev でパワーを付与してテストする。VITE_ADMIN_DIDS の DID かつ
+              プレビュー環境 (dev/local) のときだけ表示。本番では WORLD_PREVIEW_ENABLED=false
+              なので出ない (二重ゲート)。viaPosts を加算 = 残高がそのぶん増える。 */}
+          {WORLD_PREVIEW_ENABLED && agent && did && isAdminDid(did) && (
+            <section style={{ marginTop: '1em', textAlign: 'center' }}>
+              <div
+                style={{
+                  display: 'inline-flex',
+                  gap: '0.5em',
+                  alignItems: 'center',
+                  fontSize: '0.78em',
+                  border: '1px dashed var(--color-muted)',
+                  borderRadius: 6,
+                  padding: '0.45em 0.7em',
+                  color: 'var(--color-muted)',
+                }}
+              >
+                <span>管理者用 · あおぞらパワー {points.balance}</span>
+                {[100, 1000].map((n) => (
+                  <button
+                    key={n}
+                    type="button"
+                    disabled={grantingPower}
+                    onClick={async () => {
+                      setGrantingPower(true);
+                      try {
+                        await bumpPower(agent, did, { viaPosts: n });
+                        const next = await loadPointsState(agent, did);
+                        setPoints(next);
+                      } catch (e) {
+                        console.warn('admin power grant failed', e);
+                      } finally {
+                        setGrantingPower(false);
+                      }
+                    }}
+                    style={{ fontSize: '1em', padding: '0.2em 0.6em' }}
+                  >
+                    +{n}
+                  </button>
+                ))}
+              </div>
             </section>
           )}
 

--- a/apps/web/src/routes/spirit.tsx
+++ b/apps/web/src/routes/spirit.tsx
@@ -267,8 +267,10 @@ export function Spirit() {
           )}
 
           {/* 管理者用: dev でパワーを付与してテストする。VITE_ADMIN_DIDS の DID かつ
-              プレビュー環境 (dev/local) のときだけ表示。本番では WORLD_PREVIEW_ENABLED=false
-              なので出ない (二重ゲート)。viaPosts を加算 = 残高がそのぶん増える。 */}
+              プレビュー環境 (dev/local) のときだけ表示。本番遮断は WORLD_PREVIEW_ENABLED
+              (本番ビルドでは false → dead-code) が担い、isAdminDid は dev 内での権限分離。
+              加算は残高に純増する salePowerEarned に乗せる (viaPosts は召喚進捗ゲージ・
+              toSummon も動かす別セマンティクスなので、残高だけ盛る用途では使わない)。 */}
           {WORLD_PREVIEW_ENABLED && agent && did && isAdminDid(did) && (
             <section style={{ marginTop: '1em', textAlign: 'center' }}>
               <div
@@ -283,7 +285,7 @@ export function Spirit() {
                   color: 'var(--color-muted)',
                 }}
               >
-                <span>管理者用 · あおぞらパワー {points.balance}</span>
+                <span>{grantingPower ? '管理者用 · 付与中…' : `管理者用 · あおぞらパワー ${points.balance}`}</span>
                 {[100, 1000].map((n) => (
                   <button
                     key={n}
@@ -292,7 +294,7 @@ export function Spirit() {
                     onClick={async () => {
                       setGrantingPower(true);
                       try {
-                        await bumpPower(agent, did, { viaPosts: n });
+                        await bumpPower(agent, did, { salePowerEarned: n });
                         const next = await loadPointsState(agent, did);
                         setPoints(next);
                       } catch (e) {


### PR DESCRIPTION
## 目的

ワールド/試練のテスト中に残高 (あおぞらパワー) が足りないと、装備・しらべる・戦闘まで到達できず検証しづらい。dev のログインユーザーが管理者のときだけ、その場で残高を盛れるコントロールを追加する。

## 変更

- **`isAdminDid(did)` を runtime-config に追加**: `VITE_ADMIN_DIDS` (カンマ区切り) の membership 判定。パースは `getAdminDids()` に集約し `getPrimaryAdminDid` と共有 (DRY)。
- **精霊画面にコントロール**: ワールド入口ボタンの下に「管理者用 · あおぞらパワー N `+100` `+1000`」。押すと `bumpPower({ salePowerEarned: n })` で残高を n 純増させ、`loadPointsState` で再取得して即反映。書込み中はラベルを「付与中…」にして多重押し防止。
- **表示ゲート**: `WORLD_PREVIEW_ENABLED && isAdminDid(did)`。本番遮断は `WORLD_PREVIEW_ENABLED` (本番ビルドでは false → Vite の dead-code elimination でボタン自体がバンドルから消える) が担保。`isAdminDid` は dev 環境内での権限分離 (管理者以外には出さない)。
- **テスト**: `isAdminDid` のユニットテスト 5 ケース (membership / 非該当 / null・undefined・空 / 未設定 / 空白正規化)。

## ローカル確認

- typecheck ✅ / lint 0 errors ✅ / test pass (isAdminDid 5 追加) ✅ / build ✅

## Review

§1.5 の 3 並列レビュー (設計 / 実装 / UX) を実施。**★★★: なし**。

**★★ (PR 内で対応済み)**
- (設計) 残高を盛るのに `viaPosts` を加算すると召喚進捗ゲージ・`toSummon` まで動く意味論のズレ → 純増ソース `salePowerEarned` に変更 (`e424cfa`)。balance だけ増え、召喚判定/アプリ投稿数統計を汚さない。
- (設計) 「二重ゲート = 本番漏洩防止」という説明が不正確 → 本番遮断は `WORLD_PREVIEW_ENABLED` の build-time dead-code が主、`isAdminDid` は dev 内の権限分離、と description・コード comment を正確化 (`e424cfa`)。

**★ (PR 内で対応 / 判断記録)**
- (設計) `VITE_ADMIN_DIDS` パース重複 → `getAdminDids()` に集約 (`e424cfa`)。
- (UX) 書込み中フィードバック → 「付与中…」表示を追加 (`e424cfa`)。
- (test) 空白/空要素の正規化ケース追加 (`e424cfa`)。
- (impl/UX) `balance = max(0, …)` の clamp で過剰消費状態だと +N が balance 表示に満たない件 → `max(0,…)` の仕様通りの挙動。summoned 済み admin テスト口座では実害なく、見送り。
- (impl/設計) DID 完全一致比較の大文字小文字 → session の DID は AT Protocol 正規化済みのため実害なし。`getPrimaryAdminDid` と挙動一致。見送り。

セキュリティ: 書込み対象は自分の PDS の `power/self` のみ。クライアントゲートを破っても他人の残高には触れられず、balance は消費側で都度 `max(0, …)` 再計算されるためサーバー権威データを侵さない (3 レビュー一致で妥当と評価)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)