### PR TITLE
fix(css): ボタン内包リンクの下線 (変な横線) を消す

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -172,6 +172,12 @@ a:active {
   opacity: 0.7;
 }
 
+/* <button> を内包するリンクは、テキストリンク用の下線 (border-bottom) を出さない。
+   これが無いとボタン直下に dotted の横線が走って見える (精霊画面の「冒険する」等)。 */
+a:has(button) {
+  border-bottom: none;
+}
+
 button {
   font-family: inherit;
   font-size: 1em;


### PR DESCRIPTION
## 症状

精霊画面「🗺 あおぞらワールドを冒険する」ボタンの直下に **謎の横線** が出る (dev 実機 iPhone で確認)。

## 原因

グローバル CSS の `a { border-bottom: 1px dotted var(--color-accent); }` (テキストリンクの下線) が、`<Link><button>…</button></Link>` の形のリンクにも適用され、アンカーの点線下線がボタン直下に横線として表示されていた。精霊画面だけでなく workspace / search / card / world / me / quests / friends などボタン内包リンク全般で同症状。

## 修正

```css
a:has(button) { border-bottom: none; }
```

ボタンを内包するリンクだけ下線を無効化 (1 行、根本修正)。`:has` は iOS Safari 15.4+ でサポートされ本アプリのターゲット内。テキストのみのリンク (例「精霊の社へ」) の下線は従来どおり維持。

## 確認

- typecheck ✅ / web-ci ✅
- 見た目のみの変更 (ロジック非依存)。dev デプロイ後に実機で横線消失を確認予定。

## Review

CSS 高速パス (§1.5) だがセレクタ追加のため 1 観点 (実装+UX 副作用) レビューを実施。**★★★/★★: なし**。

- **詳細度**: `a:has(button)` は (0,0,2) で base `a` (0,0,1) に確実に勝つ。`a:hover`(border-bottom-color のみ) / `a:active`(opacity のみ) / light テーマとも非干渉 (確認済み)。
- **副作用**: `<Link>` を使う全ファイルを走査し、button 内包リンクは全て button が唯一の可視子 = テキスト下線を残したいケースは皆無。下線が消えて困る箇所なし。
- **:has 対応**: iOS Safari 15.4+ 対応。未対応環境でもフェイルセーフ (下線が残るだけで機能は無傷)。本 file 内で `:has` は既に 6 箇所使用済み。
- **★ (任意)**: `a:has(> button)` (直接子限定) にすると text+ネスト button の将来ケースに僅かに堅牢。ただし現状全ケースが直接子で挙動同一。**再発しやすい「ボタン直下の下線」バグを装飾 div 越しでも拾えるよう子孫マッチのまま維持**する判断。

🤖 Generated with [Claude Code](https://claude.com/claude-code)