### PR TITLE
feat(world): 戦闘コマンドを DQ 風コマンド窓に + リザルトはタップで戻る

### DIFF
--- a/apps/web/src/components/battle-view.tsx
+++ b/apps/web/src/components/battle-view.tsx
@@ -213,29 +213,17 @@ export function BattleCommands({
   );
 }
 
-/** DQ 風コマンド窓の 1 行 (フラットな文字コマンド、左寄せ、タイト)。compact 専用。 */
+/** DQ 風コマンド窓の 1 行 (フラットな文字コマンド、左寄せ、タイト)。compact 専用。
+ *  見た目・押下フィードバック・disabled は `.dq-command` (styles.css) に集約
+ *  (インライン background だと button:active の押下色を詳細度で潰す — レビュー ★★★)。 */
 function DqCommand({ label, onClick, disabled, span2 = false }: { label: string; onClick: () => void; disabled: boolean; span2?: boolean }) {
   return (
     <button
       type="button"
+      className="dq-command"
       onClick={onClick}
       disabled={disabled}
-      style={{
-        gridColumn: span2 ? '1 / -1' : undefined,
-        background: 'transparent',
-        border: 'none',
-        color: '#fff',
-        textAlign: 'left',
-        padding: '0.3em 0.3em',
-        fontSize: '0.95em',
-        lineHeight: 1.2,
-        minHeight: '2.2em',
-        display: 'flex',
-        alignItems: 'center',
-        touchAction: 'manipulation',
-        opacity: disabled ? 0.38 : 1,
-        textShadow: '0 1px 2px rgba(0,0,0,0.9)',
-      }}
+      style={span2 ? { gridColumn: '1 / -1' } : undefined}
     >
       {label}
     </button>

--- a/apps/web/src/components/battle-view.tsx
+++ b/apps/web/src/components/battle-view.tsx
@@ -159,68 +159,86 @@ export function BattleCommands({
     onCommand(c);
     setItemMenu(false);
   };
+
+  const skillMp = BATTLE_TUNING.skillMpCost;
+  type Cmd = { key: string; label: string; sub?: string | undefined; onClick: () => void; disabled: boolean; span2?: boolean };
+  const cmds: Cmd[] = itemMenu
+    ? [
+        { key: 'herb', label: `やくそう ×${state.herbs}`, sub: `HP ${Math.round(BATTLE_TUNING.herbHealRatio * 100)}% 回復`, onClick: () => applyItem('herb'), disabled: busy || !canHerb },
+        { key: 'tonic', label: `そらのしずく ×${state.tonics}`, sub: `MP ${Math.round(BATTLE_TUNING.tonicMpRatio * 100)}% 回復`, onClick: () => applyItem('tonic'), disabled: busy || !canTonic },
+        { key: 'back', label: 'もどる', onClick: () => setItemMenu(false), disabled: busy, span2: true },
+      ]
+    : [
+        { key: 'attack', label: 'たたかう', sub: state.mpAttackGain > 0 ? `MP +${state.mpAttackGain}${state.mpTraitName ? ` (${state.mpTraitName})` : ''}` : undefined, onClick: () => onCommand('attack'), disabled: busy },
+        { key: 'skill', label: state.playerSkill.name, sub: `MP ${skillMp} / ${SKILL_KIND_LABELS[state.playerSkill.kind].split(' ')[0]}`, onClick: () => onCommand('skill'), disabled: busy || state.player.mp < skillMp },
+        { key: 'guard', label: 'ぼうぎょ', sub: state.mpGuardGain > 0 ? `回避↑ / MP +${state.mpGuardGain}` : '回避↑', onClick: () => onCommand('guard'), disabled: busy },
+        { key: 'item', label: 'どうぐ', sub: hasItems ? `やくそう${state.herbs} / しずく${state.tonics}` : 'なし', onClick: () => setItemMenu(true), disabled: busy || !hasItems },
+        { key: 'flee', label: 'にげる', sub: '失敗すると 1 ターン失う', onClick: () => onCommand('flee'), disabled: busy, span2: true },
+      ];
+
+  // compact (あおぞらワールド): DQ 風コマンド窓。枠付きウィンドウにフラットな文字
+  // コマンドを 2 列で詰める (立体ボタン + 2 段説明は背が高く狭苦しい — オーナー要望
+  // 2026-07-18「ドラクエの配置を真似して」)。効果説明は省き 1 行 1 コマンドに。
+  if (compact) {
+    return (
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '1fr 1fr',
+          columnGap: '0.6em',
+          border: '2px solid rgba(255,255,255,0.6)',
+          borderRadius: 4,
+          background: 'rgba(16,18,26,0.85)',
+          padding: '0.15em 0.5em',
+        }}
+      >
+        {cmds.map((c) => (
+          <DqCommand key={c.key} label={c.label} onClick={c.onClick} disabled={c.disabled} span2={c.span2 ?? false} />
+        ))}
+      </div>
+    );
+  }
+
+  // 非 compact (試練): 画面が広いので従来の説明付きボタン + 自分の HP/MP バー。
   return (
     <div>
-      {!compact && (
-        <>
-          <HpBar name={state.player.name} hp={state.player.hp} maxHp={state.player.maxHp} mine />
-          <MpBar mp={state.player.mp} maxMp={state.player.maxMp} />
-        </>
-      )}
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: compact ? '0.4em' : '0.5em', marginTop: compact ? 0 : '0.6em' }}>
-        {itemMenu ? (
-          <>
-            <CommandButton
-              label={`やくそう ×${state.herbs}`}
-              sub={`HP ${Math.round(BATTLE_TUNING.herbHealRatio * 100)}% 回復`}
-              onClick={() => applyItem('herb')}
-              disabled={busy || !canHerb}
-              compact={compact}
-            />
-            <CommandButton
-              label={`そらのしずく ×${state.tonics}`}
-              sub={`MP ${Math.round(BATTLE_TUNING.tonicMpRatio * 100)}% 回復`}
-              onClick={() => applyItem('tonic')}
-              disabled={busy || !canTonic}
-              compact={compact}
-            />
-            <CommandButton label="もどる" onClick={() => setItemMenu(false)} disabled={busy} span2 compact={compact} />
-          </>
-        ) : (
-          <>
-            <CommandButton
-              label="たたかう"
-              sub={state.mpAttackGain > 0 ? `MP +${state.mpAttackGain}${state.mpTraitName ? ` (${state.mpTraitName})` : ''}` : undefined}
-              onClick={() => onCommand('attack')}
-              disabled={busy}
-              compact={compact}
-            />
-            <CommandButton
-              label={state.playerSkill.name}
-              sub={`MP ${BATTLE_TUNING.skillMpCost} / ${SKILL_KIND_LABELS[state.playerSkill.kind].split(' ')[0]}`}
-              onClick={() => onCommand('skill')}
-              disabled={busy || state.player.mp < BATTLE_TUNING.skillMpCost}
-              compact={compact}
-            />
-            <CommandButton
-              label="ぼうぎょ"
-              sub={state.mpGuardGain > 0 ? `回避↑ / MP +${state.mpGuardGain}` : '回避↑'}
-              onClick={() => onCommand('guard')}
-              disabled={busy}
-              compact={compact}
-            />
-            <CommandButton
-              label="どうぐ"
-              sub={hasItems ? `やくそう${state.herbs} / しずく${state.tonics}` : 'なし'}
-              onClick={() => setItemMenu(true)}
-              disabled={busy || !hasItems}
-              compact={compact}
-            />
-            <CommandButton label="にげる" sub="失敗すると 1 ターン失う" onClick={() => onCommand('flee')} disabled={busy} span2 compact={compact} />
-          </>
-        )}
+      <HpBar name={state.player.name} hp={state.player.hp} maxHp={state.player.maxHp} mine />
+      <MpBar mp={state.player.mp} maxMp={state.player.maxMp} />
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.5em', marginTop: '0.6em' }}>
+        {cmds.map((c) => (
+          <CommandButton key={c.key} label={c.label} sub={c.sub} onClick={c.onClick} disabled={c.disabled} span2={c.span2 ?? false} />
+        ))}
       </div>
     </div>
+  );
+}
+
+/** DQ 風コマンド窓の 1 行 (フラットな文字コマンド、左寄せ、タイト)。compact 専用。 */
+function DqCommand({ label, onClick, disabled, span2 = false }: { label: string; onClick: () => void; disabled: boolean; span2?: boolean }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      style={{
+        gridColumn: span2 ? '1 / -1' : undefined,
+        background: 'transparent',
+        border: 'none',
+        color: '#fff',
+        textAlign: 'left',
+        padding: '0.3em 0.3em',
+        fontSize: '0.95em',
+        lineHeight: 1.2,
+        minHeight: '2.2em',
+        display: 'flex',
+        alignItems: 'center',
+        touchAction: 'manipulation',
+        opacity: disabled ? 0.38 : 1,
+        textShadow: '0 1px 2px rgba(0,0,0,0.9)',
+      }}
+    >
+      {label}
+    </button>
   );
 }
 
@@ -256,7 +274,7 @@ export function MpBar({ mp, maxMp }: { mp: number; maxMp: number }) {
   );
 }
 
-export function CommandButton({ label, sub, onClick, disabled, compact = false, span2 = false }: { label: string; sub?: string | undefined; onClick: () => void; disabled: boolean; compact?: boolean; span2?: boolean }) {
+export function CommandButton({ label, sub, onClick, disabled, span2 = false }: { label: string; sub?: string | undefined; onClick: () => void; disabled: boolean; span2?: boolean }) {
   return (
     <button
       type="button"
@@ -264,14 +282,14 @@ export function CommandButton({ label, sub, onClick, disabled, compact = false, 
       disabled={disabled}
       style={{
         gridColumn: span2 ? '1 / -1' : undefined,
-        padding: compact ? '0.45em 0.2em' : '0.8em 0.2em',
-        fontSize: compact ? '0.85em' : '0.9em',
+        padding: '0.8em 0.2em',
+        fontSize: '0.9em',
         lineHeight: 1.25,
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
-        gap: compact ? 0 : '0.1em',
-        minHeight: compact ? '2.6em' : '3.6em',
+        gap: '0.1em',
+        minHeight: '3.6em',
         touchAction: 'manipulation',
       }}
     >

--- a/apps/web/src/components/world-battle-result.tsx
+++ b/apps/web/src/components/world-battle-result.tsx
@@ -28,7 +28,9 @@ export function BattleResultPanel({ result, onClose }: { result: WorldBattleResu
   const title =
     state.outcome === 'win' ? '勝利!' : state.outcome === 'lose' ? 'まけてしまった…' : state.outcome === 'fled' ? 'にげだした!' : 'ひきわけ';
   return (
-    // どこをタップしてもマップへ戻る (ボタンは置かない)
+    // どこをタップしてもマップへ戻る (ボタンは置かない)。将来パネル内に
+    // リンク等のインタラクティブ要素を足す場合は、その要素で e.stopPropagation()
+    // して誤って閉じないようにする (今は子に操作要素が無いので素通しで安全)。
     <div onClick={onClose} style={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0, color: '#fff', cursor: 'pointer' }}>
       {/* 上段: たおした敵 (勝利なら反転+半透明)。小さめにしてメッセージ枠を広く取る */}
       <div style={{ textAlign: 'center', flex: '0 0 auto' }}>

--- a/apps/web/src/components/world-battle-result.tsx
+++ b/apps/web/src/components/world-battle-result.tsx
@@ -4,9 +4,10 @@ import { MonsterSvg } from './monster-svg';
 import type { BattleLevelUps } from '@/lib/battle-log';
 
 /**
- * 野外戦闘のリザルト。DQ1 風に「暗転したマップ枠内」で完結させ、報酬 (経験値・
- * 素材・レベルアップ等) もメッセージ枠内に出す (オーナー要望 2026-07-18
- * 「経験値・素材の表示もすべてメッセージ枠内で出すべき」)。ページ遷移しない。
+ * 野外戦闘のリザルト。DQ1 風に「暗転したマップ枠内」で完結させ、勝敗も報酬 (経験値・
+ * 素材・レベルアップ等) もメッセージ枠内に出す。見出し・ボタンは置かず、どこかを
+ * タップしたら自然にマップへ戻るだけ (オーナー要望 2026-07-18「勝利の文字を枠外に
+ * 出すのをやめ、マップへ戻るボタンも不要、タップで戻るだけで十分」)。
  */
 export interface WorldBattleResult {
   state: BattleState;
@@ -27,29 +28,28 @@ export function BattleResultPanel({ result, onClose }: { result: WorldBattleResu
   const title =
     state.outcome === 'win' ? '勝利!' : state.outcome === 'lose' ? 'まけてしまった…' : state.outcome === 'fled' ? 'にげだした!' : 'ひきわけ';
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0, color: '#fff' }}>
-      {/* 上段: たおした敵 (勝利なら反転+半透明) + 見出し */}
+    // どこをタップしてもマップへ戻る (ボタンは置かない)
+    <div onClick={onClose} style={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0, color: '#fff', cursor: 'pointer' }}>
+      {/* 上段: たおした敵 (勝利なら反転+半透明)。小さめにしてメッセージ枠を広く取る */}
       <div style={{ textAlign: 'center', flex: '0 0 auto' }}>
         <div style={{ opacity: win ? 0.45 : 1, display: 'inline-block', transform: win ? 'rotate(180deg)' : 'none' }}>
-          <MonsterSvg species={MONSTERS_BY_ID[state.monsterId]?.species ?? 'slime'} size={72} />
+          <MonsterSvg species={MONSTERS_BY_ID[state.monsterId]?.species ?? 'slime'} size={60} />
         </div>
-        <h3 style={{ margin: '0.1em 0 0', color: '#fff', textShadow: TEXT_SHADOW }}>{title}</h3>
       </div>
 
-      {/* 中段: 決着ログ + 報酬をメッセージ枠内に。行数が多ければ枠内スクロール
-          (ページは伸ばさない = マップ枠に収める) */}
+      {/* 中段: 勝敗 + 決着ログ + 報酬をメッセージ枠内に。行数が多ければ枠内スクロール */}
       <div
         aria-live="polite"
         style={{
           flex: '1 1 auto',
           minHeight: 0,
           overflowY: 'auto',
-          margin: '0.4em 0',
+          margin: '0.4em 0 0.2em',
           padding: '0.5em 0.7em',
           border: '2px solid rgba(255,255,255,0.35)',
           borderRadius: 4,
           background: 'rgba(20,22,30,0.72)',
-          fontSize: '0.82em',
+          fontSize: '0.85em',
           lineHeight: 1.6,
           textAlign: 'left',
           display: 'flex',
@@ -58,6 +58,7 @@ export function BattleResultPanel({ result, onClose }: { result: WorldBattleResu
           textShadow: TEXT_SHADOW,
         }}
       >
+        <div style={{ fontWeight: 700 }}>{title}</div>
         {state.lastEvents.map((e, i) => (
           <div key={i}>{e.text}</div>
         ))}
@@ -93,10 +94,10 @@ export function BattleResultPanel({ result, onClose }: { result: WorldBattleResu
         )}
       </div>
 
-      {/* 下段: マップへ戻る */}
-      <button type="button" onClick={onClose} style={{ flex: '0 0 auto', padding: '0.7em 1.6em', width: '100%' }}>
-        マップへ戻る
-      </button>
+      {/* 下段: ボタンでなく小さなタップ促し (どこを押しても戻る) */}
+      <p style={{ flex: '0 0 auto', margin: 0, textAlign: 'center', fontSize: '0.68em', color: 'rgba(255,255,255,0.65)', textShadow: TEXT_SHADOW }}>
+        タップで マップへ もどる
+      </p>
     </div>
   );
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -214,6 +214,29 @@ button:disabled {
   opacity: 0.45;
   cursor: not-allowed;
 }
+/* 戦闘の DQ 風コマンド窓の行 (battle-view DqCommand)。透明ボタンなので、
+   インライン background を持たせると button:active の押下フィードバックを詳細度で
+   潰してしまう。ここで背景と active/hover を定義し「押した感」を確保する
+   (暗転オーバーレイ上なので active は半透明白。opacity は button:disabled が担う)。 */
+.dq-command {
+  background: transparent;
+  border: none;
+  color: #fff;
+  text-align: left;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.9);
+  padding: 0.3em;
+  font-size: 0.95em;
+  line-height: 1.2;
+  min-height: 2.4em;
+  display: flex;
+  align-items: center;
+  border-radius: 3px;
+  touch-action: manipulation;
+}
+.dq-command:hover:not(:disabled),
+.dq-command:active:not(:disabled) {
+  background: rgba(255, 255, 255, 0.16);
+}
 button.secondary {
   background: transparent;
   color: var(--color-fg);


### PR DESCRIPTION
## 目的 (オーナー実機フィードバック 2026-07-18)

- コマンドボタンが大きすぎて狭苦しい → **ドラクエの配置を真似る**。
- リザルトの「勝利」見出しを**メッセージ枠の外に出すのをやめる**。「マップへ戻る」ボタンも不要。**タップで自然にマップへ戻る**だけでよい。

## 変更

- **DQ 風コマンド窓** (`battle-view.tsx`, compact のみ)。枠付きウィンドウにフラットな文字コマンドを 2 列で詰め、効果説明の 2 段目を撤去して **1 行 1 コマンド**。立体ボタン+2段は非 compact=試練 のみ継続。コマンド定義を配列化し両レンダラで共有。未使用化した `CommandButton` の `compact` prop 削除。
- **リザルト簡素化** (`world-battle-result.tsx`)。枠外見出し (勝敗 h3) と「マップへ戻る」ボタンを撤去。勝敗はメッセージ枠先頭行へ、たおした敵は小さめ (60) に。**どこをタップしても onClose = マップへ戻る**。
- **押下フィードバック**は `.dq-command` クラス (`styles.css`) に集約。

## 確認

- typecheck ✅ / lint 0 errors ✅ / test 330 ✅ / build ✅ / web-ci ✅
- ⚠️ 実機での見た目・タップ感・長いリザルトのタップ挙動は dev で要確認。

## Review

実装 / UX の 2 観点レビュー実施。**★★★ 1 件 → 対応済み**。

**★★★ (PR 内で対応)**
- (UX) DqCommand のインライン `background:transparent` が `button:active` の押下色を詳細度で潰し、タップの視覚フィードバックが消えていた (DESIGN.md 違反、過去の footer 透け事故と同型) → 見た目・active/hover・disabled を `.dq-command` クラスに集約し、暗転上では半透明白で押下フィードバックを出す (`49586bd`)。

**★★ (PR 内で対応 / issue 化)**
- (UX) disabled opacity 0.38 が攻めすぎ → global `button:disabled` の 0.45 に統一 (`49586bd`)。
- (UX) MP 不足スキルの「押せない理由」が消えた → declutter 要望を優先しつつ #334 で対応検討 (小さな MP 表示 or DQ ▶カーソル)。
- (impl) リザルト全体 onClick のバブリング → 子に操作要素を足す時の `stopPropagation` 注記をコメントで残す (`49586bd`)。

**★ (対応 / issue 化)**
- (UX) タップ target 2.2em→2.4em に (`49586bd`)。
- (impl/UX) 長いリザルトでドラッグ→タップ誤クローズ → #335 で実機確認。
- (impl) cmds 配列化の等価性・`span2 ?? false`・試練非 compact 維持は問題なしと確認。

follow-up: #334, #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)