### PR TITLE
chore: pnpm 10.34.5 + minimumReleaseAge (サプライチェーン cooldown)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,9 @@ jobs:
               - '.github/workflows/**'
 
       - name: Setup pnpm
+        # version は指定せず package.json の packageManager を単一の出所にする
+        # (明示 version と衝突すると ERR_PNPM_BAD_PM_VERSION になる)
         uses: pnpm/action-setup@v4
-        with:
-          version: 9.15.0
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/directory-refresh.yml
+++ b/.github/workflows/directory-refresh.yml
@@ -30,9 +30,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup pnpm
+        # version は指定せず package.json の packageManager を単一の出所にする
         uses: pnpm/action-setup@v4
-        with:
-          version: 9.15.0
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/docs/09-tech-stack.md
+++ b/docs/09-tech-stack.md
@@ -393,7 +393,7 @@ export async function loadRuntimeConfig() {
 {
   "name": "aozoraquest",
   "private": true,
-  "packageManager": "pnpm@9",
+  "packageManager": "pnpm@10.34.5",
   "scripts": {
     "dev": "turbo run dev --parallel",
     "build": "turbo run build",
@@ -612,7 +612,7 @@ MVP は日本語のみ。将来の i18n 対応のため:
 ## 開発環境の推奨
 
 - Node.js 22+
-- pnpm 9+
+- pnpm 10.16+ (サプライチェーン cooldown `minimumReleaseAge` を使う。packageManager で固定)
 - Chrome Canary (WebGPU のデバッグが最良)
 - Firefox (WebGPU 互換性確認)
 - VS Code + Biome / ESLint / Tailwind IntelliSense

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aozoraquest",
   "private": true,
-  "packageManager": "pnpm@9.15.0",
+  "packageManager": "pnpm@10.34.5",
   "scripts": {
     "dev": "turbo run dev --parallel",
     "build": "turbo run build",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,10 @@
 packages:
   - "apps/*"
   - "packages/*"
+
+# サプライチェーン対策: 公開から日が浅いバージョンは入れない (cooldown)。
+# 悪意ある npm パッケージは公開後 数日以内に検出・削除されることが多いので、
+# 一定期間 (7 日 = 10080 分) 寝かせてから解決する。security patch の取得は最大 7 日遅れる
+# トレードオフ。pnpm 10.16+ の機能。緊急で必要になったら該当パッケージだけ
+# minimumReleaseAgeExclude に足す。
+minimumReleaseAge: 10080

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,3 +8,10 @@ packages:
 # トレードオフ。pnpm 10.16+ の機能。緊急で必要になったら該当パッケージだけ
 # minimumReleaseAgeExclude に足す。
 minimumReleaseAge: 10080
+
+# pnpm 10 は依存の postinstall 等ビルドスクリプトを既定でブロックする (approve-builds で
+# 明示許可した依存のみ実行)。本 workspace は esbuild/onnxruntime-node/sharp/core-js/protobufjs/
+# playwright 等がブロックされるが、build/test/typecheck は全て通ることを検証済み (esbuild は
+# platform 別 optional dep で解決、playwright のブラウザは CI で別途 install)。よって
+# onlyBuiltDependencies は空のまま = postinstall を走らせない (攻撃面を減らす、サプライチェーン
+# 対策と一致)。特定依存の build script が必要になったらここに列挙する。


### PR DESCRIPTION
## 目的
サプライチェーン攻撃対策。公開から日が浅い (= 悪意ある版がまだ検出・削除されていない可能性がある) バージョンを入れない **cooldown** を導入。悪意ある npm パッケージは公開後 数日以内に検出されることが多いので、7 日 (10080 分) 寝かせてから解決する。

## 変更
- `packageManager` を **pnpm@9.15.0 → 10.34.5** (10 系最新。`minimumReleaseAge` は pnpm 10.16+ の機能)。lockfile 形式は 9.0 のままで **lockfile 差分なし**。
- `pnpm-workspace.yaml` に **`minimumReleaseAge: 10080`** (7 日)。

## 検証
- 隔離環境で cooldown の実効性を確認: 100 年設定にすると pnpm が install を拒否 (`ERR_PNPM_NO_MATCHING_VERSION`「最新版は若すぎる」) → **有効**。
- 7 日設定で `pnpm install --frozen-lockfile` 通過、lockfile 無変更。
- pnpm 10.34.5 で web typecheck / core 302 / edge 24 test 緑。
- CI (`pnpm/action-setup@v4`) は `packageManager` を読むので自動で 10.34.5 に追従。

## トレードオフ / 運用
- security patch の取得が最大 7 日遅れる。緊急時は該当パッケージだけ `minimumReleaseAgeExclude` に足す。

## Review
infra 変更 (依存解決に影響) のため 1 観点レビュー。

🤖 Generated with [Claude Code](https://claude.com/claude-code)