### PR TITLE
feat(edge): M2 権威 state の基盤 (PDS クライアント + CAS 契約 + /api/me/state)

### DIFF
--- a/apps/edge/src/game-state.ts
+++ b/apps/edge/src/game-state.ts
@@ -84,9 +84,13 @@ export async function readModifyWrite(
       await putRecord(session, GAME_STATE_COLLECTION, rkey, next, swap);
       return next;
     } catch (e) {
-      if (e instanceof PdsError && e.xrpcError === 'InvalidSwap' && attempt < retries) continue; // 競合 → 再読込してやり直し
-      throw e;
+      if (e instanceof PdsError && e.xrpcError === 'InvalidSwap') {
+        if (attempt < retries) continue; // 競合 → 再読込して mutate をやり直し
+        // 最終試行も競合 = 枯渇。上位が「503 相当」に振り分けられるよう sentinel を付ける
+        throw new PdsError('CAS リトライ上限 (競合が解消しない)', 409, 'CasExhausted');
+      }
+      throw e; // 非 InvalidSwap は即 throw (リトライしない)
     }
   }
-  throw new PdsError('CAS リトライ上限 (競合が解消しない)');
+  throw new PdsError('unreachable'); // ループは必ず return/throw する
 }

--- a/apps/edge/src/game-state.ts
+++ b/apps/edge/src/game-state.ts
@@ -1,0 +1,92 @@
+/**
+ * ゲーム経済の権威 state (docs/21-server-authority §4.1/§6)。
+ *
+ * サーバーアカウントの repo に **ユーザー DID をキーにした 1 レコード/人**で持つ。ユーザーは
+ * この repo に書けない = 偽造不可。二重使用防止は putRecord の swapRecord (CAS) + 本モジュールの
+ * **read-modify-write 契約** (レビュー ★★★) で担保する: CID 不一致 (InvalidSwap) 時は必ず最新を
+ * 再読込 → 副作用を再評価 → 再 put、をループする (楽観ロック)。
+ */
+import { sha256 } from '@noble/hashes/sha256';
+import { bytesToHex } from '@noble/hashes/utils';
+import { getRecord, putRecord, PdsError, type PdsSession } from './pds';
+
+export const GAME_STATE_COLLECTION = 'app.aozoraquest.gameState';
+export const GAME_STATE_VERSION = 1;
+
+export interface GameState {
+  /** どのユーザーの state か (監査用。rkey は DID のハッシュなので値に DID を残す)。 */
+  did: string;
+  /** あおぞらパワー残高。 */
+  power: number;
+  /** 冒険 XP (プレイヤーレベル)。 */
+  playerXp: number;
+  /** ジョブ別 XP。 */
+  jobXp: Record<string, number>;
+  /** 素材インベントリ (item id → 個数)。 */
+  materials: Record<string, number>;
+  /** 装備中の gear id。 */
+  gear: string[];
+  /** 位置。 */
+  x: number;
+  y: number;
+  version: number;
+  updatedAt: string;
+}
+
+/** DID → rkey。DID には rkey 非対応文字 (`:` 等) が含まれるので、衝突と長さを避けるため
+ *  sha256 の hex 32 文字にする (先頭に `u`)。決定的。DID 本体は record.value に残す。 */
+export function rkeyForDid(did: string): string {
+  return 'u' + bytesToHex(sha256(new TextEncoder().encode(did))).slice(0, 32);
+}
+
+export function emptyState(did: string, now: string): GameState {
+  return { did, power: 0, playerXp: 0, jobXp: {}, materials: {}, gear: [], x: 0, y: 0, version: GAME_STATE_VERSION, updatedAt: now };
+}
+
+/** 権威 state を取得 (無ければ null)。呼び出し側で無→初期化 or 移行を判断。 */
+export async function readState(session: PdsSession, did: string): Promise<{ state: GameState; cid: string } | null> {
+  const rec = await getRecord<GameState>(session.pdsUrl, session.did, GAME_STATE_COLLECTION, rkeyForDid(did));
+  return rec ? { state: rec.value, cid: rec.cid } : null;
+}
+
+export interface RmwOptions {
+  /** 現在時刻 (ISO)。テストで固定可。 */
+  now: string;
+  /** CAS 競合時の最大リトライ回数。 */
+  retries?: number;
+  /** state が無いときの初期値 (移行値など)。省略時 emptyState。 */
+  init?: (did: string, now: string) => GameState;
+}
+
+/**
+ * read-modify-write (CAS)。`mutate` に**最新の** state を渡し、返した新 state を CAS で書く。
+ * InvalidSwap (別リクエストが割り込んで CID が変わった) の時は最新を読み直して mutate をやり直す。
+ * → 「古い意思決定のまま上書き」して二重報酬/二重消費が通るのを防ぐ (§4.1 の契約)。
+ * mutate は**副作用を持たず** (パワー予約・報酬計算等をこの中で決定的にやる)、毎回新しい state を
+ * 返す純関数であること (リトライで複数回呼ばれる)。
+ */
+export async function readModifyWrite(
+  session: PdsSession,
+  did: string,
+  mutate: (current: GameState) => GameState,
+  opts: RmwOptions,
+): Promise<GameState> {
+  const rkey = rkeyForDid(did);
+  const init = opts.init ?? emptyState;
+  const retries = opts.retries ?? 5;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    const existing = await readState(session, did);
+    const current = existing?.state ?? init(did, opts.now);
+    const next: GameState = { ...mutate(current), did, version: GAME_STATE_VERSION, updatedAt: opts.now };
+    // 既存があればその CID を期待 (CAS)、無ければ null (新規作成のみ) で二重作成も防ぐ。
+    const swap = existing ? existing.cid : null;
+    try {
+      await putRecord(session, GAME_STATE_COLLECTION, rkey, next, swap);
+      return next;
+    } catch (e) {
+      if (e instanceof PdsError && e.xrpcError === 'InvalidSwap' && attempt < retries) continue; // 競合 → 再読込してやり直し
+      throw e;
+    }
+  }
+  throw new PdsError('CAS リトライ上限 (競合が解消しない)');
+}

--- a/apps/edge/src/pds.ts
+++ b/apps/edge/src/pds.ts
@@ -1,0 +1,98 @@
+/**
+ * 最小の PDS クライアント (fetch ベースの XRPC。docs/21-server-authority §4.1)。
+ *
+ * edge Worker がゲーム経済の権威 state を **app サーバー用アカウントの PDS** に読み書きする
+ * ための薄いクライアント。バンドルを小さく保つため `@atproto/api` は使わず、XRPC を素の
+ * fetch で叩く (Workers ネイティブ)。認証はサーバーアカウントの app-password (Worker Secret)。
+ *
+ * 権威 state はサーバーアカウントの repo に **ユーザー DID をキーにした 1 レコード/人**で持つ
+ * ので、ユーザーは書けない = 偽造不可。二重使用防止は putRecord の `swapRecord` (期待 CID)
+ * による compare-and-swap で行う (§4.1 の read-modify-write 契約と併用)。
+ */
+
+export class PdsError extends Error {
+  constructor(
+    message: string,
+    readonly status?: number,
+    /** XRPC のエラー名 (例 InvalidSwap = CAS 競合)。 */
+    readonly xrpcError?: string,
+  ) {
+    super(message);
+  }
+}
+
+export interface PdsSession {
+  pdsUrl: string;
+  accessJwt: string;
+  refreshJwt: string;
+  did: string;
+}
+
+async function xrpc<T>(url: string, init: RequestInit): Promise<T> {
+  const res = await fetch(url, init);
+  const text = await res.text();
+  const body = text ? (JSON.parse(text) as Record<string, unknown>) : {};
+  if (!res.ok) {
+    throw new PdsError(`XRPC ${res.status}: ${(body.message as string) ?? url}`, res.status, body.error as string | undefined);
+  }
+  return body as T;
+}
+
+/** app-password でセッション作成 (サーバーアカウント用)。 */
+export async function createSession(pdsUrl: string, identifier: string, password: string): Promise<PdsSession> {
+  const data = await xrpc<{ accessJwt: string; refreshJwt: string; did: string }>(`${pdsUrl}/xrpc/com.atproto.server.createSession`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ identifier, password }),
+  });
+  return { pdsUrl, accessJwt: data.accessJwt, refreshJwt: data.refreshJwt, did: data.did };
+}
+
+/** refreshJwt でアクセストークンを更新。 */
+export async function refreshSession(session: PdsSession): Promise<PdsSession> {
+  const data = await xrpc<{ accessJwt: string; refreshJwt: string; did: string }>(`${session.pdsUrl}/xrpc/com.atproto.server.refreshSession`, {
+    method: 'POST',
+    headers: { authorization: `Bearer ${session.refreshJwt}` },
+  });
+  return { pdsUrl: session.pdsUrl, accessJwt: data.accessJwt, refreshJwt: data.refreshJwt, did: data.did };
+}
+
+export interface RecordResult<T = unknown> {
+  uri: string;
+  cid: string;
+  value: T;
+}
+
+/** レコード取得 (public read、認証不要)。存在しなければ null。 */
+export async function getRecord<T = unknown>(pdsUrl: string, repo: string, collection: string, rkey: string): Promise<RecordResult<T> | null> {
+  const q = new URLSearchParams({ repo, collection, rkey });
+  try {
+    return await xrpc<RecordResult<T>>(`${pdsUrl}/xrpc/com.atproto.repo.getRecord?${q}`, { method: 'GET' });
+  } catch (e) {
+    if (e instanceof PdsError && (e.status === 400 || e.xrpcError === 'RecordNotFound')) return null;
+    throw e;
+  }
+}
+
+/**
+ * レコード put (認証要)。`swapRecord` を渡すと compare-and-swap:
+ *   - 期待 CID (既存レコードの cid) を渡す → その CID のときだけ上書き (競合は InvalidSwap)。
+ *   - null を渡す → 「まだ存在しない」ときだけ作成 (既存があれば InvalidSwap)。
+ *   - undefined → 無条件 put (CAS しない)。
+ * CAS 競合は PdsError.xrpcError === 'InvalidSwap' で判別し、呼び出し側が read-modify-write で再試行する。
+ */
+export async function putRecord(
+  session: PdsSession,
+  collection: string,
+  rkey: string,
+  record: object,
+  swapRecord?: string | null,
+): Promise<{ uri: string; cid: string }> {
+  const body: Record<string, unknown> = { repo: session.did, collection, rkey, record };
+  if (swapRecord !== undefined) body.swapRecord = swapRecord;
+  return xrpc<{ uri: string; cid: string }>(`${session.pdsUrl}/xrpc/com.atproto.repo.putRecord`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', authorization: `Bearer ${session.accessJwt}` },
+    body: JSON.stringify(body),
+  });
+}

--- a/apps/edge/src/pds.ts
+++ b/apps/edge/src/pds.ts
@@ -31,7 +31,16 @@ export interface PdsSession {
 async function xrpc<T>(url: string, init: RequestInit): Promise<T> {
   const res = await fetch(url, init);
   const text = await res.text();
-  const body = text ? (JSON.parse(text) as Record<string, unknown>) : {};
+  // 非 JSON 応答 (502 HTML / プロキシエラー等) の JSON.parse 例外を PdsError にラップして
+  // 上位が「PDS 由来」と識別できるようにする (素の SyntaxError を漏らさない)。
+  let body: Record<string, unknown> = {};
+  if (text) {
+    try {
+      body = JSON.parse(text) as Record<string, unknown>;
+    } catch {
+      throw new PdsError(`XRPC 非 JSON 応答 (${res.status})`, res.status);
+    }
+  }
   if (!res.ok) {
     throw new PdsError(`XRPC ${res.status}: ${(body.message as string) ?? url}`, res.status, body.error as string | undefined);
   }
@@ -69,7 +78,8 @@ export async function getRecord<T = unknown>(pdsUrl: string, repo: string, colle
   try {
     return await xrpc<RecordResult<T>>(`${pdsUrl}/xrpc/com.atproto.repo.getRecord?${q}`, { method: 'GET' });
   } catch (e) {
-    if (e instanceof PdsError && (e.status === 400 || e.xrpcError === 'RecordNotFound')) return null;
+    // 不在は RecordNotFound のみで null に。他の 400 (InvalidRequest 等) は握り潰さず throw。
+    if (e instanceof PdsError && e.xrpcError === 'RecordNotFound') return null;
     throw e;
   }
 }

--- a/apps/edge/src/router.ts
+++ b/apps/edge/src/router.ts
@@ -10,6 +10,8 @@
  *   /api/battle/* /api/xp/* /api/me/state (M2〜)。依頼クエスト集約 (docs/15) も。
  */
 import { verifyServiceAuth, ServiceAuthError } from './service-auth';
+import { getRecord } from './pds';
+import { GAME_STATE_COLLECTION, rkeyForDid, emptyState } from './game-state';
 
 export interface Env {
   ENVIRONMENT?: string;
@@ -17,10 +19,14 @@ export interface Env {
   ALLOWED_ORIGINS?: string;
   /** この Worker の DID (service auth JWT の aud)。既定 did:web:edge.aozoraquest.app */
   WORKER_DID?: string;
+  /** 権威 state を置く app サーバーアカウントの PDS URL と DID (public read 用、非 secret)。 */
+  SERVER_PDS_URL?: string;
+  SERVER_DID?: string;
 }
 
 /** service auth の lexicon method (lxm)。エンドポイントごとに別値。 */
 const LXM_WHOAMI = 'app.aozoraquest.whoami';
+const LXM_ME_STATE = 'app.aozoraquest.me.state';
 
 const AOZORA_ORIGINS = new Set([
   'https://aozoraquest.app',
@@ -74,6 +80,24 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
       const msg = e instanceof ServiceAuthError ? e.message : 'verify_failed';
       return cors(json({ error: 'unauthorized', reason: msg }, 401), allowedOrigin);
     }
+  }
+
+  // 権威 state (ゲーム経済) の読み取り。自分の DID の分だけ返す (JWT で本人確認)。
+  // 読みは public getRecord なので session 不要。書き込みは M3 の battle 系で行う。
+  if (req.method === 'GET' && url.pathname === '/api/me/state') {
+    const token = bearer(req);
+    if (!token) return cors(json({ error: 'missing_token' }, 401), allowedOrigin);
+    const audience = env.WORKER_DID ?? 'did:web:edge.aozoraquest.app';
+    let did: string;
+    try {
+      ({ iss: did } = await verifyServiceAuth(token, { audience, lxm: LXM_ME_STATE }));
+    } catch (e) {
+      return cors(json({ error: 'unauthorized', reason: e instanceof ServiceAuthError ? e.message : 'verify_failed' }, 401), allowedOrigin);
+    }
+    if (!env.SERVER_PDS_URL || !env.SERVER_DID) return cors(json({ error: 'server_not_configured' }, 503), allowedOrigin);
+    const rec = await getRecord(env.SERVER_PDS_URL, env.SERVER_DID, GAME_STATE_COLLECTION, rkeyForDid(did));
+    // 未作成なら初期値を返す (実 state 化は初回の書込み = M3 で。移行はそこでクランプ)
+    return cors(json({ state: rec?.value ?? emptyState(did, new Date().toISOString()), initialized: rec !== null }), allowedOrigin);
   }
 
   return cors(json({ error: 'not_found', path: url.pathname }, 404), allowedOrigin);

--- a/apps/edge/test/game-state.test.ts
+++ b/apps/edge/test/game-state.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { rkeyForDid, readModifyWrite, GAME_STATE_COLLECTION, type GameState } from '../src/game-state';
+import type { PdsSession } from '../src/pds';
+
+const session: PdsSession = { pdsUrl: 'https://pds.example', accessJwt: 'A', refreshJwt: 'R', did: 'did:plc:server' };
+const NOW = '2026-07-18T00:00:00.000Z';
+const DID = 'did:plc:alice';
+
+/** ステートフルな PDS モック (swapRecord CAS を本物どおり実装)。`interferer` を渡すと
+ *  最初の putRecord の直前に「別リクエストが割り込んで書いた」状況を作れる (CAS 競合テスト用)。 */
+function statefulPds(interferer?: (store: Map<string, { value: unknown; cid: string }>) => void) {
+  const store = new Map<string, { value: unknown; cid: string }>();
+  let counter = 0;
+  let putCalls = 0;
+  const json = (status: number, body: unknown) => new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+  const fn = (async (url: string, init: RequestInit = {}) => {
+    if (url.includes('com.atproto.repo.getRecord')) {
+      const rkey = new URL(url).searchParams.get('rkey')!;
+      const rec = store.get(rkey);
+      return rec ? json(200, { uri: `at://${rkey}`, cid: rec.cid, value: rec.value }) : json(400, { error: 'RecordNotFound' });
+    }
+    if (url.includes('com.atproto.repo.putRecord')) {
+      putCalls++;
+      if (putCalls === 1 && interferer) interferer(store); // 1 回目の put 直前に競合を注入
+      const b = JSON.parse(init.body as string) as { rkey: string; record: unknown; swapRecord?: string | null };
+      const cur = store.get(b.rkey);
+      if (b.swapRecord === null && cur) return json(400, { error: 'InvalidSwap' });
+      if (typeof b.swapRecord === 'string' && (!cur || cur.cid !== b.swapRecord)) return json(400, { error: 'InvalidSwap' });
+      const cid = `cid${++counter}`;
+      store.set(b.rkey, { value: b.record, cid });
+      return json(200, { uri: `at://${b.rkey}`, cid });
+    }
+    return json(404, { error: 'not_found' });
+  }) as unknown as typeof fetch;
+  return { fn, store, get putCalls() { return putCalls; } };
+}
+
+describe('game-state', () => {
+  const orig = globalThis.fetch;
+  afterEach(() => { globalThis.fetch = orig; });
+
+  it('rkeyForDid は決定的で rkey 有効文字のみ', () => {
+    const rk = rkeyForDid(DID);
+    expect(rk).toBe(rkeyForDid(DID));
+    expect(rk).toMatch(/^u[0-9a-f]{32}$/);
+    expect(rkeyForDid('did:web:example.com')).not.toBe(rk);
+  });
+
+  it('state 無しなら初期値から作成 (swap=null で新規作成のみ)', async () => {
+    const m = statefulPds();
+    globalThis.fetch = m.fn;
+    const s = await readModifyWrite(session, DID, (c) => ({ ...c, power: c.power + 3 }), { now: NOW });
+    expect(s.power).toBe(3);
+    expect(s.did).toBe(DID);
+    expect(m.store.get(rkeyForDid(DID))).toBeTruthy();
+  });
+
+  it('既存 state を読んで mutate し CAS で更新', async () => {
+    const m = statefulPds();
+    globalThis.fetch = m.fn;
+    await readModifyWrite(session, DID, (c) => ({ ...c, power: 10 }), { now: NOW });
+    const s2 = await readModifyWrite(session, DID, (c) => ({ ...c, power: c.power - 1 }), { now: NOW });
+    expect(s2.power).toBe(9);
+  });
+
+  it('CAS 競合時は最新を読み直して再評価する (二重使用を通さない = ★★★ 契約)', async () => {
+    // 事前に power:100 を作成
+    const m = statefulPds((store) => {
+      // 1 回目の put 直前に「別端末が power を 100→50 に消費して書いた」状況を注入
+      const rk = rkeyForDid(DID);
+      store.set(rk, { value: { did: DID, power: 50, playerXp: 0, jobXp: {}, materials: {}, gear: [], x: 0, y: 0, version: 1, updatedAt: NOW }, cid: 'cidX' });
+    });
+    globalThis.fetch = m.fn;
+    // 先に power:100 のレコードを作る (この時点では interferer は putCalls===1 で発火するので注意)
+    // → 別のモックで素直に作成する
+    const setup = statefulPds();
+    globalThis.fetch = setup.fn;
+    await readModifyWrite(session, DID, (c) => ({ ...c, power: 100 }), { now: NOW });
+    // 以後は競合注入つきモックに切替え、power を 30 消費する RMW を実行
+    // (注入により最初の read は power:100 だが put が競合 → 再読込で power:50 になり、そこから -30)
+    const store2 = setup.store;
+    let interfered = false;
+    const m2fetch = (async (url: string, init: RequestInit = {}) => {
+      const json = (s: number, b: unknown) => new Response(JSON.stringify(b), { status: s, headers: { 'content-type': 'application/json' } });
+      if (url.includes('getRecord')) {
+        const rk = new URL(url).searchParams.get('rkey')!;
+        const rec = store2.get(rk)!;
+        return json(200, { uri: 'x', cid: rec.cid, value: rec.value });
+      }
+      const b = JSON.parse(init.body as string) as { rkey: string; record: GameState; swapRecord?: string | null };
+      if (!interfered) {
+        interfered = true;
+        // 競合注入: 別端末が power を 100→50 に書いた (cid も変わる)
+        store2.set(b.rkey, { value: { ...(store2.get(b.rkey)!.value as GameState), power: 50 }, cid: 'cidConcurrent' });
+        return json(400, { error: 'InvalidSwap' });
+      }
+      const cur = store2.get(b.rkey)!;
+      if (b.swapRecord !== cur.cid) return json(400, { error: 'InvalidSwap' });
+      store2.set(b.rkey, { value: b.record, cid: 'cidFinal' });
+      return json(200, { uri: 'x', cid: 'cidFinal' });
+    }) as unknown as typeof fetch;
+    globalThis.fetch = m2fetch;
+    const result = await readModifyWrite(session, DID, (c) => ({ ...c, power: c.power - 30 }), { now: NOW });
+    // 100-30=70 でなく、競合後の 50-30=20 になっていること (= 古い値のまま上書きしていない)
+    expect(result.power).toBe(20);
+  });
+});

--- a/apps/edge/test/game-state.test.ts
+++ b/apps/edge/test/game-state.test.ts
@@ -104,4 +104,36 @@ describe('game-state', () => {
     // 100-30=70 でなく、競合後の 50-30=20 になっていること (= 古い値のまま上書きしていない)
     expect(result.power).toBe(20);
   });
+
+  const jsonRes = (s: number, b: unknown) => new Response(JSON.stringify(b), { status: s, headers: { 'content-type': 'application/json' } });
+  const existingRec = { did: DID, power: 5, playerXp: 0, jobXp: {}, materials: {}, gear: [], x: 0, y: 0, version: 1, updatedAt: NOW };
+
+  it('CAS 競合が解消しなければ CasExhausted で throw', async () => {
+    globalThis.fetch = (async (url: string) =>
+      url.includes('getRecord') ? jsonRes(200, { uri: 'x', cid: 'cidA', value: existingRec }) : jsonRes(400, { error: 'InvalidSwap' })) as unknown as typeof fetch;
+    await expect(readModifyWrite(session, DID, (c) => ({ ...c, power: c.power + 1 }), { now: NOW, retries: 2 })).rejects.toMatchObject({ xrpcError: 'CasExhausted' });
+  });
+
+  it('InvalidSwap 以外のエラー (トークン失効等) は即 throw しリトライしない', async () => {
+    let puts = 0;
+    globalThis.fetch = (async (url: string) => {
+      if (url.includes('getRecord')) return jsonRes(400, { error: 'RecordNotFound' });
+      puts++;
+      return jsonRes(401, { error: 'ExpiredToken' });
+    }) as unknown as typeof fetch;
+    await expect(readModifyWrite(session, DID, (c) => c, { now: NOW, retries: 5 })).rejects.toMatchObject({ xrpcError: 'ExpiredToken' });
+    expect(puts).toBe(1);
+  });
+
+  it('CAS 競合時に mutate が再実行される (契約の可視化)', async () => {
+    let puts = 0;
+    globalThis.fetch = (async (url: string) => {
+      if (url.includes('getRecord')) return jsonRes(200, { uri: 'x', cid: `c${puts}`, value: existingRec });
+      puts++;
+      return puts === 1 ? jsonRes(400, { error: 'InvalidSwap' }) : jsonRes(200, { uri: 'x', cid: 'cFinal' });
+    }) as unknown as typeof fetch;
+    let mutateCalls = 0;
+    await readModifyWrite(session, DID, (c) => { mutateCalls++; return { ...c, power: c.power + 1 }; }, { now: NOW });
+    expect(mutateCalls).toBe(2);
+  });
 });

--- a/apps/edge/test/pds.test.ts
+++ b/apps/edge/test/pds.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { createSession, getRecord, putRecord, PdsError, type PdsSession } from '../src/pds';
+
+/** fetch をモックして、送られたリクエストを記録しつつ用意した応答を返す。 */
+function mockFetch(handler: (url: string, init: RequestInit) => { status: number; body: unknown }) {
+  const calls: { url: string; init: RequestInit }[] = [];
+  const fn = (async (url: string, init: RequestInit = {}) => {
+    calls.push({ url, init });
+    const { status, body } = handler(url, init);
+    return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+  }) as unknown as typeof fetch;
+  return { fn, calls };
+}
+
+const PDS = 'https://pds.example';
+const session: PdsSession = { pdsUrl: PDS, accessJwt: 'ACCESS', refreshJwt: 'REFRESH', did: 'did:plc:server' };
+
+describe('PDS クライアント (fetch ベース XRPC)', () => {
+  it('createSession は identifier/password を POST し did/jwt を返す', async () => {
+    const { fn, calls } = mockFetch(() => ({ status: 200, body: { accessJwt: 'A', refreshJwt: 'R', did: 'did:plc:server' } }));
+    const orig = globalThis.fetch;
+    globalThis.fetch = fn;
+    try {
+      const s = await createSession(PDS, 'game.bsky.social', 'app-pass');
+      expect(s.did).toBe('did:plc:server');
+      expect(s.accessJwt).toBe('A');
+      expect(calls[0]!.url).toBe(`${PDS}/xrpc/com.atproto.server.createSession`);
+      expect(calls[0]!.init.method).toBe('POST');
+      expect(JSON.parse(calls[0]!.init.body as string)).toEqual({ identifier: 'game.bsky.social', password: 'app-pass' });
+    } finally {
+      globalThis.fetch = orig;
+    }
+  });
+
+  it('getRecord は value+cid を返し、RecordNotFound(400) は null', async () => {
+    const orig = globalThis.fetch;
+    // 存在するケース
+    let m = mockFetch(() => ({ status: 200, body: { uri: 'at://x', cid: 'CID1', value: { hp: 10 } } }));
+    globalThis.fetch = m.fn;
+    try {
+      const r = await getRecord<{ hp: number }>(PDS, 'did:plc:server', 'app.aozoraquest.gameState', 'user1');
+      expect(r?.value.hp).toBe(10);
+      expect(r?.cid).toBe('CID1');
+      expect(m.calls[0]!.url).toContain('com.atproto.repo.getRecord?');
+      expect(m.calls[0]!.url).toContain('rkey=user1');
+      // 存在しないケース
+      m = mockFetch(() => ({ status: 400, body: { error: 'RecordNotFound', message: 'nope' } }));
+      globalThis.fetch = m.fn;
+      expect(await getRecord(PDS, 'did:plc:server', 'c', 'missing')).toBeNull();
+    } finally {
+      globalThis.fetch = orig;
+    }
+  });
+
+  it('putRecord は repo=session.did + auth header + swapRecord(CAS) を送る', async () => {
+    const orig = globalThis.fetch;
+    const m = mockFetch(() => ({ status: 200, body: { uri: 'at://x', cid: 'CID2' } }));
+    globalThis.fetch = m.fn;
+    try {
+      const res = await putRecord(session, 'app.aozoraquest.gameState', 'user1', { hp: 5 }, 'OLDCID');
+      expect(res.cid).toBe('CID2');
+      const sent = JSON.parse(m.calls[0]!.init.body as string);
+      expect(sent).toEqual({ repo: 'did:plc:server', collection: 'app.aozoraquest.gameState', rkey: 'user1', record: { hp: 5 }, swapRecord: 'OLDCID' });
+      expect((m.calls[0]!.init.headers as Record<string, string>).authorization).toBe('Bearer ACCESS');
+    } finally {
+      globalThis.fetch = orig;
+    }
+  });
+
+  it('swapRecord=null は「新規作成のみ」を意味する (既存なら InvalidSwap)', async () => {
+    const orig = globalThis.fetch;
+    const m = mockFetch(() => ({ status: 200, body: { uri: 'x', cid: 'C' } }));
+    globalThis.fetch = m.fn;
+    try {
+      await putRecord(session, 'c', 'rk', { a: 1 }, null);
+      expect(JSON.parse(m.calls[0]!.init.body as string).swapRecord).toBeNull();
+    } finally {
+      globalThis.fetch = orig;
+    }
+  });
+
+  it('CAS 競合 (InvalidSwap) は PdsError.xrpcError で判別できる', async () => {
+    const orig = globalThis.fetch;
+    const m = mockFetch(() => ({ status: 400, body: { error: 'InvalidSwap', message: 'CID mismatch' } }));
+    globalThis.fetch = m.fn;
+    try {
+      await expect(putRecord(session, 'c', 'rk', { a: 1 }, 'STALE')).rejects.toMatchObject({ xrpcError: 'InvalidSwap' });
+    } finally {
+      globalThis.fetch = orig;
+    }
+  });
+});

--- a/apps/edge/test/router.test.ts
+++ b/apps/edge/test/router.test.ts
@@ -74,4 +74,10 @@ describe('edge router', () => {
     );
     expect(res.status).toBe(401);
   });
+
+  it('GET /api/me/state は JWT 無しなら 401', async () => {
+    const res = await handleRequest(new Request('https://x/api/me/state'), env);
+    expect(res.status).toBe(401);
+    expect(((await res.json()) as { error: string }).error).toBe('missing_token');
+  });
 });


### PR DESCRIPTION
## 目的
サーバー権威化 (docs/21) の **M2**: ゲーム経済の権威 state を app サーバーアカウントの PDS に置く基盤。ユーザーは書けない = 偽造不可。

## 変更
- **`pds.ts`**: fetch ベースの最小 XRPC クライアント (`@atproto/api` 不使用でバンドル維持)。createSession (app-password) / getRecord (public) / putRecord (**swapRecord = compare-and-swap**)。CAS 競合は `PdsError.xrpcError==='InvalidSwap'`。
- **`game-state.ts`**: 権威 state スキーマ (power/xp/materials/gear/位置)。`rkeyForDid` = DID の sha256 で衝突回避。**`readModifyWrite` (CAS リトライ)** = 前回レビュー ★★★ の「競合時は最新を読み直して副作用を再評価してから再 put」契約の実体。二重報酬/二重消費を通さない。
- **`GET /api/me/state`**: JWT で本人確認 → 自分の権威 state を返す (読みは public getRecord で session 不要)。

## 確認
- edge test 34 件 (CAS 競合注入で「100-30=70 でなく再読込後 50-30=**20**」= 古い値で上書きしないことを実証 / PDS リクエスト形状 / rkey 決定性 / 401)。typecheck / wrangler dry-run (gzip 59KB 維持)。

## 次 / owner 依存
- 書込み経路 (M3 battle) と移行 (ユーザー PDS→権威 state のクランプ取込)。
- **実デプロイは owner がサーバーアカウント (SERVER_PDS_URL/DID + app-password を Worker Secret) を用意する必要がある** (M1 の CF 認証と同様の owner ステップ)。

## Review
§1.5 (実装/セキュリティ + 設計整合) を実施し追記。

🤖 Generated with [Claude Code](https://claude.com/claude-code)