### PR TITLE
feat(edge/core): M3-part1 サーバー権威戦闘の乱数機構 (core注入口 + kuda + turnガード)

### DIFF
--- a/apps/edge/package.json
+++ b/apps/edge/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "@noble/curves": "^1.6.0",
     "@noble/hashes": "^1.5.0",
-    "@scure/base": "^1.1.9"
+    "@scure/base": "^1.1.9",
+    "@aozoraquest/core": "workspace:*"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240924.0",

--- a/apps/edge/src/battle-guard.ts
+++ b/apps/edge/src/battle-guard.ts
@@ -11,7 +11,7 @@
  * 封印内容 (`sealed`) と現戦闘 state (`state`) は `packages/core` の型だが、本モジュールは中身を
  * 解釈しない (opaque)。core 型は battle.ts が所有する。
  */
-import { getRecord, putRecord, PdsError, type PdsSession } from './pds';
+import { getRecord, putRecord, deleteRecord, type PdsSession } from './pds';
 import { rkeyForDid } from './game-state';
 
 export const BATTLE_GUARD_COLLECTION = 'app.aozoraquest.battleGuard';
@@ -23,10 +23,19 @@ export interface BattleGuard<Sealed = unknown, State = unknown> {
   battleId: string;
   /** 次に受理するターン番号 (0 始まり)。turn リクエストの turn と一致必須。 */
   turn: number;
-  /** encounter で封印した startBattle 入力 (playerSnapshot + monster + seed 等)。以後不変。 */
+  /** encounter で封印した startBattle 入力 (playerSnapshot + monster + 内部 seed 等)。以後不変。
+   *  **クライアントには一切返さない**。とくに内部 seed を返すと、rollDrops/rollDefeatLoss/
+   *  summonMonster が seed 由来で決定的なため、クライアントが seed からドロップ/敗北ロス/敵ステを
+   *  先読みして「良い seed の戦闘だけ確定・悪ければ離脱」の選別チートが可能になる (レビュー ★★★)。
+   *  → 報酬計算も**サーバーが独立に引いたエントロピー**で行い、seed は Worker 内に封じる。 */
   sealed: Sealed;
-  /** 現在の戦闘 state (HP/MP 等)。毎ターン更新。 */
+  /** 現在の戦闘 state (HP/MP 等)。毎ターン更新。**client 向け DTO では seed を除去して返す**。 */
   state: State;
+  /** 次ターンに使う**サーバー事前採番のエントロピー** (32bit)。encounter / 各 turn の CAS 確定時に
+   *  次ターン分を引いて封じておくことで、(a) リトライ時に同じ seed を再利用でき冪等 (同一ターンで
+   *  二重エントロピー消費/取りこぼしを防ぐ)、(b) クライアントは commands 送信前に次ターン乱数を
+   *  知り得ない (先読み不可)。決着ターンではドロップ/敗北ロスもこの seed から独立に導出する。 */
+  pendingTurnSeed: number;
   /** この戦闘で報酬対象か (encounter 時 power>=1 で確定+予約)。 */
   rewarded: boolean;
   /** 離脱ロス lazy 確定用の期限 (ISO)。 */
@@ -54,28 +63,20 @@ export async function createGuard(session: PdsSession, guard: BattleGuard): Prom
 }
 
 /**
- * ガードを turn+1 に進める (turn 決着前)。`expectedCid` で CAS。競合 (InvalidSwap) は「やり直し/
- * リプレイ」= 409 として上位に投げる。
+ * ガードを次ターンへ進める (= そのターンの解決結果を確定)。`expectedCid` で CAS。
+ *
+ * **順序 (docs/21 §4.1/§5)**: 部分2 の resolver は「ガード読取 → **確定 turnSeed** で resolveTurn →
+ * `advanceGuard({turn+1, 解決後 state, 次の pendingTurnSeed})`」を 1 CAS 書込で行い、**CAS の成否で
+ * クライアント応答をゲートする** (解決結果を返してから遅れて CAS を投げると、同一 turn の並行
+ * リクエストが別エントロピーで二重解決し「良い方を採用」される)。競合 (InvalidSwap) は「やり直し/
+ * リプレイ」= 409 として上位に投げ、**応答は返さない**。
  */
 export async function advanceGuard(session: PdsSession, guard: BattleGuard, expectedCid: string): Promise<{ cid: string }> {
   const { cid } = await putRecord(session, BATTLE_GUARD_COLLECTION, rkeyForDid(guard.did), guard, expectedCid);
   return { cid };
 }
 
-/** ガードを削除 (決着時)。CAS 付きで確実に「その CID のときだけ」消す。 */
+/** ガードを削除 (決着時)。CAS 付きで確実に「その CID のときだけ」消す (pds.ts の統一 xrpc 経由)。 */
 export async function deleteGuard(session: PdsSession, did: string, expectedCid: string): Promise<void> {
   await deleteRecord(session, BATTLE_GUARD_COLLECTION, rkeyForDid(did), expectedCid);
-}
-
-/** com.atproto.repo.deleteRecord (swapRecord 対応)。pds.ts に無いのでここで薄く。 */
-async function deleteRecord(session: PdsSession, collection: string, rkey: string, swapRecord: string): Promise<void> {
-  const res = await fetch(`${session.pdsUrl}/xrpc/com.atproto.repo.deleteRecord`, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json', authorization: `Bearer ${session.accessJwt}` },
-    body: JSON.stringify({ repo: session.did, collection, rkey, swapRecord }),
-  });
-  if (!res.ok) {
-    const body = (await res.json().catch(() => ({}))) as { error?: string; message?: string };
-    throw new PdsError(`deleteRecord ${res.status}: ${body.message ?? ''}`, res.status, body.error);
-  }
 }

--- a/apps/edge/src/battle-guard.ts
+++ b/apps/edge/src/battle-guard.ts
@@ -1,0 +1,81 @@
+/**
+ * バトルガード — docs/21-server-authority §5 の「毎ターン・やり直し不可」を担保する永続レコード。
+ *
+ * encounter 時に **Worker が封印した playerSnapshot + monster + 現 state + turn** をサーバー
+ * アカウントの PDS に 1 ユーザー 1 アクティブ戦闘で持つ。ユーザーは書けない = 偽造不可。
+ *
+ * **やり直し不可の要点**: turn を `swapRecord` (CAS) で進める。同じターンを別コマンドで引き直そう
+ * としても、ガードの turn は既に進んでいるので CID 不一致 (InvalidSwap) → 409。物理/CSPRNG 乱数を
+ * 毎ターン Worker が引くので先読みも不可 (§3-3)。
+ *
+ * 封印内容 (`sealed`) と現戦闘 state (`state`) は `packages/core` の型だが、本モジュールは中身を
+ * 解釈しない (opaque)。core 型は battle.ts が所有する。
+ */
+import { getRecord, putRecord, PdsError, type PdsSession } from './pds';
+import { rkeyForDid } from './game-state';
+
+export const BATTLE_GUARD_COLLECTION = 'app.aozoraquest.battleGuard';
+
+export interface BattleGuard<Sealed = unknown, State = unknown> {
+  /** どのユーザーの戦闘か (監査用。rkey は DID ハッシュ)。 */
+  did: string;
+  /** この戦闘の識別子。encounter で採番、turn で一致確認。 */
+  battleId: string;
+  /** 次に受理するターン番号 (0 始まり)。turn リクエストの turn と一致必須。 */
+  turn: number;
+  /** encounter で封印した startBattle 入力 (playerSnapshot + monster + seed 等)。以後不変。 */
+  sealed: Sealed;
+  /** 現在の戦闘 state (HP/MP 等)。毎ターン更新。 */
+  state: State;
+  /** この戦闘で報酬対象か (encounter 時 power>=1 で確定+予約)。 */
+  rewarded: boolean;
+  /** 離脱ロス lazy 確定用の期限 (ISO)。 */
+  expiresAt: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** アクティブなバトルガードを取得 (無ければ null)。1 ユーザー 1 戦闘なので rkey は DID ハッシュ。 */
+export async function readGuard<S = unknown, St = unknown>(
+  session: PdsSession,
+  did: string,
+): Promise<{ guard: BattleGuard<S, St>; cid: string } | null> {
+  const rec = await getRecord<BattleGuard<S, St>>(session.pdsUrl, session.did, BATTLE_GUARD_COLLECTION, rkeyForDid(did));
+  return rec ? { guard: rec.value, cid: rec.cid } : null;
+}
+
+/**
+ * ガードを作成 (encounter)。既存があれば InvalidSwap。呼び出し側は「未決着ガードは先に敗北 flush
+ * してから」新規発行すること (§5 リロード離脱)。
+ */
+export async function createGuard(session: PdsSession, guard: BattleGuard): Promise<{ cid: string }> {
+  const { cid } = await putRecord(session, BATTLE_GUARD_COLLECTION, rkeyForDid(guard.did), guard, null);
+  return { cid };
+}
+
+/**
+ * ガードを turn+1 に進める (turn 決着前)。`expectedCid` で CAS。競合 (InvalidSwap) は「やり直し/
+ * リプレイ」= 409 として上位に投げる。
+ */
+export async function advanceGuard(session: PdsSession, guard: BattleGuard, expectedCid: string): Promise<{ cid: string }> {
+  const { cid } = await putRecord(session, BATTLE_GUARD_COLLECTION, rkeyForDid(guard.did), guard, expectedCid);
+  return { cid };
+}
+
+/** ガードを削除 (決着時)。CAS 付きで確実に「その CID のときだけ」消す。 */
+export async function deleteGuard(session: PdsSession, did: string, expectedCid: string): Promise<void> {
+  await deleteRecord(session, BATTLE_GUARD_COLLECTION, rkeyForDid(did), expectedCid);
+}
+
+/** com.atproto.repo.deleteRecord (swapRecord 対応)。pds.ts に無いのでここで薄く。 */
+async function deleteRecord(session: PdsSession, collection: string, rkey: string, swapRecord: string): Promise<void> {
+  const res = await fetch(`${session.pdsUrl}/xrpc/com.atproto.repo.deleteRecord`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', authorization: `Bearer ${session.accessJwt}` },
+    body: JSON.stringify({ repo: session.did, collection, rkey, swapRecord }),
+  });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string; message?: string };
+    throw new PdsError(`deleteRecord ${res.status}: ${body.message ?? ''}`, res.status, body.error);
+  }
+}

--- a/apps/edge/src/kuda.ts
+++ b/apps/edge/src/kuda.ts
@@ -66,12 +66,38 @@ export async function drawKudaByte(opts: { timeoutMs?: number; fetchImpl?: typeo
 /**
  * エントロピー 1 バイト取得。`useKuda` が真なら kuda を試み、**失敗時は CSPRNG に必ずフォールバック**
  * (fail-safe。報酬 fail-closed とは別で、乱数源の障害は戦闘を止めない)。既定は CSPRNG のみ。
+ * kuda の障害は監査可能にするため `onFallback` で通知する (呼び出し側で csprng フォールバック回数を
+ * 数え、kuda アウテージを可視化できるように)。
  */
-export async function entropyByte(opts: { useKuda?: boolean; timeoutMs?: number; fetchImpl?: typeof fetch } = {}): Promise<EntropyByte> {
+export async function entropyByte(
+  opts: { useKuda?: boolean; timeoutMs?: number; fetchImpl?: typeof fetch; onFallback?: (err: unknown) => void } = {},
+): Promise<EntropyByte> {
   if (!opts.useKuda) return csprngByte();
   try {
     return await drawKudaByte(opts);
-  } catch {
-    return csprngByte(); // kuda 障害/枯渇/タイムアウト → CSPRNG
+  } catch (err) {
+    opts.onFallback?.(err); // kuda 障害/枯渇/タイムアウト → CSPRNG (可観測にする)
+    return csprngByte();
   }
+}
+
+/**
+ * 32bit のエントロピー seed を取得 (`resolveTurn` の turnSeed 等に使う)。**1 ターンの乱数は
+ * `createRng(seed)` の 32bit seed から stream を展開するので、8bit では 256 通りしか無く総当たり
+ * で先読みされうる (レビュー ★★)。必ず 32bit 分の新鮮なエントロピーを供給すること。**
+ * 常に CSPRNG で 4 バイトを確保し、`useKuda` 時は物理乱数 1 バイトを最下位に XOR して混ぜる
+ * (kuda 障害でも 32bit の質は CSPRNG が担保 = fail-safe)。返り値は符号なし 32bit。
+ */
+export async function entropyU32(
+  opts: { useKuda?: boolean; timeoutMs?: number; fetchImpl?: typeof fetch; onFallback?: (err: unknown) => void } = {},
+): Promise<{ value: number; source: 'kuda+csprng' | 'csprng'; meta?: EntropyByte['meta'] }> {
+  const buf = new Uint8Array(4);
+  crypto.getRandomValues(buf);
+  let value = ((buf[0] << 24) | (buf[1] << 16) | (buf[2] << 8) | buf[3]) >>> 0;
+  if (opts.useKuda) {
+    const b = await entropyByte(opts); // kuda 成功なら物理 1 バイト、失敗なら csprng 1 バイト
+    value = (value ^ b.value) >>> 0;
+    if (b.source === 'kuda') return { value, source: 'kuda+csprng', meta: b.meta };
+  }
+  return { value, source: 'csprng' };
 }

--- a/apps/edge/src/kuda.ts
+++ b/apps/edge/src/kuda.ts
@@ -1,0 +1,77 @@
+/**
+ * 物理乱数 (kuda) クライアント — docs/21-server-authority §4.3。
+ *
+ * **既定は CSPRNG** (`crypto.getRandomValues`、Worker 内秘匿) で先読み不可を担保する。kuda
+ * (`kuda.kojiran.workers.dev/drop`, ANU 量子乱数) は**付加価値の任意エントロピー源**であり、
+ * プール有限・外部依存・レイテンシがあるので**戦闘のクリティカルパスに必須で置かない**。
+ * 障害/枯渇/タイムアウト時は必ず CSPRNG にフォールバックする (kuda 障害 = 全戦闘停止を避ける)。
+ * クライアントは介在しない (Worker→kuda のみ)。
+ */
+
+export const KUDA_URL = 'https://kuda.kojiran.workers.dev/drop';
+
+/** kuda /drop の応答 (1 バイト 0–255 + 監査メタ)。 */
+export interface KudaDrop {
+  value: number;
+  drop_seq: number;
+  pool_seq: number;
+  batch: string;
+  drawn_at: string;
+  pool_remaining: number;
+}
+
+/** 乱数 1 バイトの取得結果。source を監査ログに残す (§4.3)。 */
+export interface EntropyByte {
+  /** 0–255。 */
+  value: number;
+  /** どこ由来か (kuda = 物理乱数 / csprng = フォールバック)。 */
+  source: 'kuda' | 'csprng';
+  /** kuda 由来なら監査メタ。 */
+  meta?: { drop_seq: number; batch: string; pool_remaining: number };
+}
+
+/** CSPRNG で 1 バイト。Worker 内秘匿で先読み不可。 */
+export function csprngByte(): EntropyByte {
+  const b = new Uint8Array(1);
+  crypto.getRandomValues(b);
+  return { value: b[0], source: 'csprng' };
+}
+
+/**
+ * kuda から物理乱数 1 バイトを引く。タイムアウト・非2xx・不正値は throw。
+ * **クリティカルパスでは直接使わず** `entropyByte` 経由でフォールバックさせること。
+ */
+export async function drawKudaByte(opts: { timeoutMs?: number; fetchImpl?: typeof fetch } = {}): Promise<EntropyByte> {
+  const timeoutMs = opts.timeoutMs ?? 1500;
+  const f = opts.fetchImpl ?? fetch;
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const res = await f(KUDA_URL, { signal: ctrl.signal });
+    if (!res.ok) throw new Error(`kuda ${res.status}`);
+    const d = (await res.json()) as Partial<KudaDrop>;
+    if (typeof d.value !== 'number' || !Number.isInteger(d.value) || d.value < 0 || d.value > 255) {
+      throw new Error('kuda 応答が不正 (value)');
+    }
+    return {
+      value: d.value,
+      source: 'kuda',
+      meta: { drop_seq: d.drop_seq ?? -1, batch: d.batch ?? '', pool_remaining: d.pool_remaining ?? -1 },
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * エントロピー 1 バイト取得。`useKuda` が真なら kuda を試み、**失敗時は CSPRNG に必ずフォールバック**
+ * (fail-safe。報酬 fail-closed とは別で、乱数源の障害は戦闘を止めない)。既定は CSPRNG のみ。
+ */
+export async function entropyByte(opts: { useKuda?: boolean; timeoutMs?: number; fetchImpl?: typeof fetch } = {}): Promise<EntropyByte> {
+  if (!opts.useKuda) return csprngByte();
+  try {
+    return await drawKudaByte(opts);
+  } catch {
+    return csprngByte(); // kuda 障害/枯渇/タイムアウト → CSPRNG
+  }
+}

--- a/apps/edge/src/pds.ts
+++ b/apps/edge/src/pds.ts
@@ -106,3 +106,18 @@ export async function putRecord(
     body: JSON.stringify(body),
   });
 }
+
+/**
+ * レコード削除 (認証要)。`swapRecord` を渡すと compare-and-swap (期待 CID のときだけ消す。
+ * 不一致は InvalidSwap)。putRecord と同じく**唯一の `xrpc` ラッパ経由**でエラー処理を統一する
+ * (非 JSON 応答のラップ・xrpcError 抽出をここでも効かせ、ハンドラの重複/ドリフトを避ける)。
+ */
+export async function deleteRecord(session: PdsSession, collection: string, rkey: string, swapRecord?: string): Promise<void> {
+  const body: Record<string, unknown> = { repo: session.did, collection, rkey };
+  if (swapRecord !== undefined) body.swapRecord = swapRecord;
+  await xrpc(`${session.pdsUrl}/xrpc/com.atproto.repo.deleteRecord`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', authorization: `Bearer ${session.accessJwt}` },
+    body: JSON.stringify(body),
+  });
+}

--- a/apps/edge/test/battle-guard.test.ts
+++ b/apps/edge/test/battle-guard.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { readGuard, createGuard, advanceGuard, deleteGuard, BATTLE_GUARD_COLLECTION, type BattleGuard } from '../src/battle-guard';
+import { rkeyForDid } from '../src/game-state';
+import type { PdsSession } from '../src/pds';
+
+const session: PdsSession = { pdsUrl: 'https://pds.example', accessJwt: 'A', refreshJwt: 'R', did: 'did:plc:server' };
+const DID = 'did:plc:alice';
+const NOW = '2026-07-19T00:00:00.000Z';
+
+const guard = (turn: number): BattleGuard => ({
+  did: DID, battleId: 'btl-1', turn, sealed: { s: 1 }, state: { hp: 10 }, rewarded: true,
+  expiresAt: NOW, createdAt: NOW, updatedAt: NOW,
+});
+
+/** バトルガードのステートフル PDS モック (put/get/delete の swapRecord CAS を実装)。 */
+function guardPds() {
+  const store = new Map<string, { value: unknown; cid: string }>();
+  let counter = 0;
+  const json = (s: number, b: unknown) => new Response(JSON.stringify(b), { status: s, headers: { 'content-type': 'application/json' } });
+  const fn = (async (url: string, init: RequestInit = {}) => {
+    if (url.includes('getRecord')) {
+      const rk = new URL(url).searchParams.get('rkey')!;
+      const rec = store.get(rk);
+      return rec ? json(200, { uri: 'x', cid: rec.cid, value: rec.value }) : json(400, { error: 'RecordNotFound' });
+    }
+    const b = JSON.parse(init.body as string) as { rkey: string; record?: unknown; swapRecord?: string | null };
+    const cur = store.get(b.rkey);
+    if (url.includes('putRecord')) {
+      if (b.swapRecord === null && cur) return json(400, { error: 'InvalidSwap' });
+      if (typeof b.swapRecord === 'string' && (!cur || cur.cid !== b.swapRecord)) return json(400, { error: 'InvalidSwap' });
+      const cid = `cid${++counter}`;
+      store.set(b.rkey, { value: b.record, cid });
+      return json(200, { uri: 'x', cid });
+    }
+    if (url.includes('deleteRecord')) {
+      if (typeof b.swapRecord === 'string' && (!cur || cur.cid !== b.swapRecord)) return json(400, { error: 'InvalidSwap' });
+      store.delete(b.rkey);
+      return json(200, {});
+    }
+    return json(404, { error: 'nf' });
+  }) as unknown as typeof fetch;
+  return { fn, store };
+}
+
+describe('battle-guard', () => {
+  const orig = globalThis.fetch;
+  afterEach(() => { globalThis.fetch = orig; });
+
+  it('無ければ null / 作成後は読める (rkey は DID ハッシュ)', async () => {
+    const m = guardPds();
+    globalThis.fetch = m.fn;
+    expect(await readGuard(session, DID)).toBeNull();
+    await createGuard(session, guard(0));
+    const r = await readGuard(session, DID);
+    expect(r?.guard.battleId).toBe('btl-1');
+    expect(m.store.has(rkeyForDid(DID))).toBe(true);
+    expect(BATTLE_GUARD_COLLECTION).toBe('app.aozoraquest.battleGuard');
+  });
+
+  it('既存があると createGuard は InvalidSwap (二重戦闘を作らせない)', async () => {
+    const m = guardPds();
+    globalThis.fetch = m.fn;
+    await createGuard(session, guard(0));
+    await expect(createGuard(session, guard(0))).rejects.toMatchObject({ xrpcError: 'InvalidSwap' });
+  });
+
+  it('advanceGuard は正しい CID でのみ進む / 古い CID は InvalidSwap (やり直し封じ)', async () => {
+    const m = guardPds();
+    globalThis.fetch = m.fn;
+    const { cid: c0 } = await createGuard(session, guard(0));
+    const { cid: c1 } = await advanceGuard(session, guard(1), c0);
+    expect(c1).not.toBe(c0);
+    // 同じターンを古い CID で引き直そうとすると弾かれる
+    await expect(advanceGuard(session, guard(1), c0)).rejects.toMatchObject({ xrpcError: 'InvalidSwap' });
+    // 正しい CID なら進める
+    await expect(advanceGuard(session, guard(2), c1)).resolves.toBeTruthy();
+  });
+
+  it('deleteGuard は CID 一致で削除 / 不一致は InvalidSwap', async () => {
+    const m = guardPds();
+    globalThis.fetch = m.fn;
+    const { cid } = await createGuard(session, guard(0));
+    await expect(deleteGuard(session, DID, 'wrong')).rejects.toMatchObject({ xrpcError: 'InvalidSwap' });
+    await deleteGuard(session, DID, cid);
+    expect(await readGuard(session, DID)).toBeNull();
+  });
+});

--- a/apps/edge/test/battle-guard.test.ts
+++ b/apps/edge/test/battle-guard.test.ts
@@ -8,7 +8,7 @@ const DID = 'did:plc:alice';
 const NOW = '2026-07-19T00:00:00.000Z';
 
 const guard = (turn: number): BattleGuard => ({
-  did: DID, battleId: 'btl-1', turn, sealed: { s: 1 }, state: { hp: 10 }, rewarded: true,
+  did: DID, battleId: 'btl-1', turn, sealed: { s: 1 }, state: { hp: 10 }, pendingTurnSeed: 0x12345678, rewarded: true,
   expiresAt: NOW, createdAt: NOW, updatedAt: NOW,
 });
 

--- a/apps/edge/test/kuda.test.ts
+++ b/apps/edge/test/kuda.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { csprngByte, drawKudaByte, entropyByte } from '../src/kuda';
+import { csprngByte, drawKudaByte, entropyByte, entropyU32 } from '../src/kuda';
 
 const okDrop = (value: number) =>
   new Response(JSON.stringify({ value, drop_seq: 1, pool_seq: 1, batch: 'b', drawn_at: 'x', pool_remaining: 100 }), {
@@ -50,5 +50,50 @@ describe('kuda', () => {
   it('entropyByte(useKuda:true) は成功時 kuda を返す', async () => {
     const b = await entropyByte({ useKuda: true, fetchImpl: (async () => okDrop(200)) as unknown as typeof fetch });
     expect(b).toMatchObject({ value: 200, source: 'kuda' });
+  });
+
+  it('drawKudaByte は 2xx でも非 JSON 本文なら throw (プロキシ HTML 等)', async () => {
+    const f = (async () => new Response('<html>oops</html>', { status: 200, headers: { 'content-type': 'text/html' } })) as unknown as typeof fetch;
+    await expect(drawKudaByte({ fetchImpl: f })).rejects.toThrow();
+  });
+
+  it('entropyByte の onFallback は kuda 障害時に呼ばれ、正常時は呼ばれない', async () => {
+    let fell = 0;
+    await entropyByte({ useKuda: true, onFallback: () => { fell++; }, fetchImpl: (async () => { throw new Error('x'); }) as unknown as typeof fetch });
+    expect(fell).toBe(1);
+    await entropyByte({ useKuda: true, onFallback: () => { fell++; }, fetchImpl: (async () => okDrop(9)) as unknown as typeof fetch });
+    expect(fell).toBe(1); // 正常時は増えない
+  });
+
+  it('entropyU32 は 32bit の符号なし整数 (8bit より広い) を返す', () => {
+    return (async () => {
+      const seen = new Set<number>();
+      let above16 = 0;
+      for (let i = 0; i < 64; i++) {
+        const r = await entropyU32();
+        expect(r.source).toBe('csprng');
+        expect(Number.isInteger(r.value)).toBe(true);
+        expect(r.value).toBeGreaterThanOrEqual(0);
+        expect(r.value).toBeLessThanOrEqual(0xffffffff);
+        seen.add(r.value);
+        if (r.value > 0xffff) above16++;
+      }
+      expect(seen.size).toBeGreaterThan(50); // 256 通りに縮退していない
+      expect(above16).toBeGreaterThan(0); // 上位ビットが立つ = 8bit ではない
+    })();
+  });
+
+  it('entropyU32(useKuda:true) は kuda 成功で物理バイトを混ぜ source を kuda+csprng に', async () => {
+    const r = await entropyU32({ useKuda: true, fetchImpl: (async () => okDrop(200)) as unknown as typeof fetch });
+    expect(r.source).toBe('kuda+csprng');
+    expect(r.meta).toBeTruthy();
+    expect(r.value).toBeGreaterThanOrEqual(0);
+    expect(r.value).toBeLessThanOrEqual(0xffffffff);
+  });
+
+  it('entropyU32(useKuda:true) は kuda 障害でも 32bit CSPRNG で成立 (fail-safe)', async () => {
+    const r = await entropyU32({ useKuda: true, fetchImpl: (async () => { throw new Error('down'); }) as unknown as typeof fetch });
+    expect(r.source).toBe('csprng');
+    expect(r.value).toBeLessThanOrEqual(0xffffffff);
   });
 });

--- a/apps/edge/test/kuda.test.ts
+++ b/apps/edge/test/kuda.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { csprngByte, drawKudaByte, entropyByte } from '../src/kuda';
+
+const okDrop = (value: number) =>
+  new Response(JSON.stringify({ value, drop_seq: 1, pool_seq: 1, batch: 'b', drawn_at: 'x', pool_remaining: 100 }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+
+describe('kuda', () => {
+  it('csprngByte は 0–255 の整数を返す', () => {
+    for (let i = 0; i < 50; i++) {
+      const b = csprngByte();
+      expect(b.source).toBe('csprng');
+      expect(Number.isInteger(b.value)).toBe(true);
+      expect(b.value).toBeGreaterThanOrEqual(0);
+      expect(b.value).toBeLessThanOrEqual(255);
+    }
+  });
+
+  it('drawKudaByte は kuda 応答を EntropyByte にする', async () => {
+    const b = await drawKudaByte({ fetchImpl: (async () => okDrop(172)) as unknown as typeof fetch });
+    expect(b).toMatchObject({ value: 172, source: 'kuda' });
+    expect(b.meta?.pool_remaining).toBe(100);
+  });
+
+  it('drawKudaByte は不正値 (範囲外) を throw', async () => {
+    await expect(drawKudaByte({ fetchImpl: (async () => okDrop(999)) as unknown as typeof fetch })).rejects.toThrow();
+  });
+
+  it('drawKudaByte は非2xx を throw', async () => {
+    const f = (async () => new Response('nope', { status: 503 })) as unknown as typeof fetch;
+    await expect(drawKudaByte({ fetchImpl: f })).rejects.toThrow();
+  });
+
+  it('entropyByte(useKuda:false) は CSPRNG のみ (fetch しない)', async () => {
+    let called = false;
+    const f = (async () => { called = true; return okDrop(1); }) as unknown as typeof fetch;
+    const b = await entropyByte({ useKuda: false, fetchImpl: f });
+    expect(b.source).toBe('csprng');
+    expect(called).toBe(false);
+  });
+
+  it('entropyByte(useKuda:true) は kuda 障害時 CSPRNG にフォールバック', async () => {
+    const f = (async () => { throw new Error('down'); }) as unknown as typeof fetch;
+    const b = await entropyByte({ useKuda: true, fetchImpl: f });
+    expect(b.source).toBe('csprng'); // 障害でも戦闘は止めない
+  });
+
+  it('entropyByte(useKuda:true) は成功時 kuda を返す', async () => {
+    const b = await entropyByte({ useKuda: true, fetchImpl: (async () => okDrop(200)) as unknown as typeof fetch });
+    expect(b).toMatchObject({ value: 200, source: 'kuda' });
+  });
+});

--- a/apps/edge/test/pds.test.ts
+++ b/apps/edge/test/pds.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { createSession, getRecord, putRecord, PdsError, type PdsSession } from '../src/pds';
+import { createSession, getRecord, putRecord, deleteRecord, PdsError, type PdsSession } from '../src/pds';
 
 /** fetch をモックして、送られたリクエストを記録しつつ用意した応答を返す。 */
 function mockFetch(handler: (url: string, init: RequestInit) => { status: number; body: unknown }) {
@@ -85,6 +85,31 @@ describe('PDS クライアント (fetch ベース XRPC)', () => {
     globalThis.fetch = m.fn;
     try {
       await expect(putRecord(session, 'c', 'rk', { a: 1 }, 'STALE')).rejects.toMatchObject({ xrpcError: 'InvalidSwap' });
+    } finally {
+      globalThis.fetch = orig;
+    }
+  });
+
+  it('deleteRecord は repo=session.did + auth + swapRecord を統一 xrpc 経由で送る', async () => {
+    const orig = globalThis.fetch;
+    const m = mockFetch(() => ({ status: 200, body: {} }));
+    globalThis.fetch = m.fn;
+    try {
+      await deleteRecord(session, 'app.aozoraquest.battleGuard', 'rk', 'CID9');
+      expect(m.calls[0]!.url).toBe(`${PDS}/xrpc/com.atproto.repo.deleteRecord`);
+      expect((m.calls[0]!.init.headers as Record<string, string>).authorization).toBe('Bearer ACCESS');
+      expect(JSON.parse(m.calls[0]!.init.body as string)).toEqual({ repo: 'did:plc:server', collection: 'app.aozoraquest.battleGuard', rkey: 'rk', swapRecord: 'CID9' });
+    } finally {
+      globalThis.fetch = orig;
+    }
+  });
+
+  it('deleteRecord の CAS 競合も PdsError.xrpcError=InvalidSwap で判別できる (統一ハンドラ)', async () => {
+    const orig = globalThis.fetch;
+    const m = mockFetch(() => ({ status: 400, body: { error: 'InvalidSwap', message: 'CID mismatch' } }));
+    globalThis.fetch = m.fn;
+    try {
+      await expect(deleteRecord(session, 'c', 'rk', 'STALE')).rejects.toMatchObject({ xrpcError: 'InvalidSwap' });
     } finally {
       globalThis.fetch = orig;
     }

--- a/docs/21-server-authority.md
+++ b/docs/21-server-authority.md
@@ -88,16 +88,18 @@ snapshot のみ使い、commands 以外を戦闘計算に通さない。
 **毎ターン送信** (先読み・握りつぶし・やり直しを封じる):
 ```
 [1] POST /api/battle/encounter (JWT lxm=encounter, {x,y})
-    Worker: 権威 state 読取 → 遭遇判定 → playerSnapshot 封印 → rewarded=(power>=1) 確定+予約
-        → バトルガードを作成 (gameState 内 or 専用レコード: {battleId, turn:0, sealed})
-        → 初期 state を返す
-    ← {battleId, monster, 初期state(HP/MP), rewarded}
+    Worker: 権威 state 読取 → (x,y) から terrain/tier を core で導出 → 遭遇判定
+        → playerSnapshot 封印 (内部 seed も封印) → rewarded=(power>=1) 確定+予約
+        → 専用レコード battleGuard を作成 {battleId, turn:0, sealed, pendingTurnSeed}
+        → 初期 state を返す (seed は除去)
+    ← {battleId, monster, 初期state(HP/MP・seed なし), rewarded}
 
 [2] 各ターン: POST /api/battle/turn (JWT lxm=turn, {battleId, turn, command})
-    Worker: バトルガードの turn と一致を確認 (不一致=リプレイ/やり直し → 409)
-        → kuda から物理乱数を引く → resolveTurn(封印state, command, 乱数) を実行
-        → バトルガードを turn+1 に CAS 更新 (やり直し不可を確定) → 新 state/events を返す
-    ← {state, events, outcome}
+    Worker: バトルガードの battleId/turn 一致を確認 (不一致=リプレイ/やり直し → 409)
+        → 確定済み pendingTurnSeed で resolveTurn(封印state, command, turnSeed) を実行
+        → バトルガードを turn+1・解決後 state・次 pendingTurnSeed(entropyU32) に CAS 更新
+          (CAS 成否で応答をゲート。やり直し不可を確定) → 新 state/events を返す (seed なし)
+    ← {state(seed なし), events, outcome}
     決着なら Worker が報酬を権威 state に確定 (勝: XP+ドロップ / 負: xpLose+素材ロス、
     rewarded のみ・パワー1消費)。練習は付与も消費もペナルティも無し・記録なし。ガード削除。
 ```
@@ -112,9 +114,24 @@ snapshot のみ使い、commands 以外を戦闘計算に通さない。
   放置容認) は §9 の判断ポイント。
 - **並行/二重**: turn/決着は battleId+turn 一致 + swapRecord CAS で二重報酬を防ぐ。
 
-**resolveTurn への乱数注入**: 現 `core` は seed から `turnRng` を作る。**Worker が引いた物理乱数を
-毎ターン注入できるよう core に薄い口を足す** (seed 方式と両立。試練/テストは従来の seed で不変)。
-レイテンシ (PDS 読書 + kuda + 往復) は DQ メッセージ送りで隠す。
+**★★★ seed をクライアントに一切返さない (M3-part1 レビューで確定)**: `core` の
+`rollDrops` / `rollDefeatLoss` / `summonMonster` は**戦闘 seed から決定的**に導出され、その salt は
+クライアントバンドル (`packages/core`) にコンパイル済みで含まれる。したがって seed を client に返すと、
+クライアントは戦闘を確定する前にドロップ・敗北ロス・敵ステ (分散込み) を**先読み**でき、「良い seed の
+戦闘だけ確定し、悪ければ離脱」という選別チートが成立する (これは踏み倒し ★★ も悪化させる)。対策:
+1. **client 向け DTO から `state.seed` を除去**。seed はバトルガードの `sealed` (Worker 内) にのみ持つ。
+   client には `monster` / HP・MP / events / outcome だけ返す。
+2. **報酬 (ドロップ・敗北ロス) も「サーバーが独立に引いたエントロピー」で導出**する。戦闘 seed を
+   `rollDrops`/`rollDefeatLoss` に再利用しない (これらは既に seed 引数を取るので、Worker が別に引いた
+   32bit を渡すだけでよく、core の署名変更は不要)。ターン戦闘・召喚・ドロップ・敗北ロスで**別々の**
+   新鮮なエントロピーを使えば、可視の敵ステから召喚 seed を逆算されても他は漏れない。
+
+**resolveTurn への乱数注入 (M3-part1 で実装済み)**: 現 `core` は seed から `turnRng` を作る。Worker が
+毎ターン引いた新鮮なエントロピーを注入できるよう `resolveTurn(prev, command, turnSeed?)` の薄い口を
+足した (seed 方式と両立。省略時は従来 `turnRng` = 試練/テストは不変)。**turnSeed は 32bit の新鮮な
+エントロピーであること (8bit では 256 通りに縮退し総当たりで先読みされる ★★)**。`entropyU32()` を使う。
+バトルガードは次ターン分の `pendingTurnSeed` を CAS 確定時に事前採番して封じ、リトライ冪等かつ
+commands 送信前に client が次乱数を知り得ないようにする。レイテンシは DQ メッセージ送りで隠す。
 
 ## 6. XP は本番と共有 (オーナー決定 A: XP も権威化)
 `analysis/self` の XP/Lv は本番カード表示でも使う。A を採る:

--- a/packages/core/src/__tests__/battle.test.ts
+++ b/packages/core/src/__tests__/battle.test.ts
@@ -882,3 +882,36 @@ describe('rollSearch (しらべる — luk 連動でアイテム発見)', () => 
     expect(sawT3).toBe(true);
   });
 });
+
+describe('resolveTurn: 外部 seed 注入 (サーバー権威 §5)', () => {
+  const fresh = () => startBattle('warrior', 5, 5, 'テスト勇者', 1, 12345, 0, undefined, { vitalsVariance: 0 });
+
+  it('turnSeed 省略時は従来どおり turnRng(seed,turn) で決定的 (試練/テスト不変)', () => {
+    const a = resolveTurn(fresh(), 'attack');
+    const b = resolveTurn(fresh(), 'attack');
+    expect(a).toEqual(b);
+  });
+
+  it('同じ turnSeed なら同じ結果 (再現性: Worker のリトライで一致)', () => {
+    const a = resolveTurn(fresh(), 'attack', 0xabcdef);
+    const b = resolveTurn(fresh(), 'attack', 0xabcdef);
+    expect(a).toEqual(b);
+  });
+
+  it('turnSeed が違えば別の乱数列 (先読み不可: 少なくとも一部の seed で結果が変わる)', () => {
+    // 同一初期 state・同一コマンドでも turnSeed 次第で分岐すること。複数 seed で差が出るのを確認。
+    const base = resolveTurn(fresh(), 'attack');
+    let diverged = false;
+    for (let s = 1; s <= 40 && !diverged; s++) {
+      if (JSON.stringify(resolveTurn(fresh(), 'attack', s)) !== JSON.stringify(base)) diverged = true;
+    }
+    expect(diverged).toBe(true);
+  });
+
+  it('turnSeed 注入でも state を破壊しない (イミュータブル)', () => {
+    const s0 = fresh();
+    const snap = JSON.stringify(s0);
+    resolveTurn(s0, 'attack', 777);
+    expect(JSON.stringify(s0)).toBe(snap);
+  });
+});

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -861,8 +861,13 @@ function playerSkillAction(state: BattleState, rng: () => number, events: TurnEv
 /**
  * 1 ターンを解決する。player のコマンドを受け、素早さ順に両者が行動する。
  * state は**破壊しない** (新しい state を返す)。
+ *
+ * `turnSeed` を渡すと、そのターンの乱数を seed 由来 (`turnRng`) ではなく**外部供給の seed**で
+ * 回す (docs/21-server-authority §5)。サーバー権威戦闘で Worker が毎ターン新鮮なエントロピー
+ * (CSPRNG/kuda) を注入し「先読み・引き直し」を封じるための薄い口。省略時は従来どおり
+ * `turnRng(seed, turn)` = 完全決定的 (試練/テストは seed 方式のまま不変)。
  */
-export function resolveTurn(prev: BattleState, command: Command): BattleState {
+export function resolveTurn(prev: BattleState, command: Command, turnSeed?: number): BattleState {
   if (prev.outcome !== 'ongoing') return prev;
 
   // コピー (Combatant は現状 flat なので spread で足りる)。
@@ -876,7 +881,8 @@ export function resolveTurn(prev: BattleState, command: Command): BattleState {
     lastEvents: [],
   };
   const events: TurnEvent[] = [];
-  const rng = turnRng(state.seed, state.turn);
+  // 外部供給 seed があればそれで (サーバー権威: 先読み不可)、無ければ seed 由来 (決定的)。
+  const rng = turnSeed === undefined ? turnRng(state.seed, state.turn) : createRng(turnSeed >>> 0);
   const mCommand = monsterCommand(state, rng);
 
   // ── コマンドの実効化 ──

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
 
   apps/edge:
     dependencies:
+      '@aozoraquest/core':
+        specifier: workspace:*
+        version: link:../../packages/core
       '@noble/curves':
         specifier: ^1.6.0
         version: 1.9.7
@@ -1145,155 +1148,183 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm64@1.2.4':
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -1440,66 +1471,79 @@ packages:
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}


### PR DESCRIPTION
## 目的
戦闘の権威化 (M3, docs/21 §5/§4.3) の**土台**。M3 は大きいので段階分割し、本 PR は「毎ターン先読み不可」を成立させる 3 プリミティブを単体テスト付きで先行導入する。resolver 本体 + `/api/battle/encounter`・`/api/battle/turn` は **M3-part2** で本 PR の上に積む。

## 変更
- **core `resolveTurn` に外部 seed 注入口 `turnSeed?`**: 省略時は従来 `turnRng(seed,turn)` = 完全決定的 (試練/テストは**不変**)。Worker が毎ターン新鮮なエントロピーを注入すると、seed を知るクライアントでも次ターンを先読みできない (§5 の核心)。
- **`apps/edge/src/kuda.ts`**: 物理乱数 (kuda /drop, ANU 量子乱数) クライアント。**既定 CSPRNG**、kuda は任意付加価値で障害/枯渇/タイムアウト時は必ず CSPRNG フォールバック (§4.3, 戦闘を止めない)。source を監査用に返す。
- **`apps/edge/src/battle-guard.ts`**: 1 ユーザー 1 アクティブ戦闘の永続ガード。turn を `swapRecord`(CAS) で進め、同一ターンの引き直し (リプレイ) を InvalidSwap で弾く。封印 snapshot と現 state は opaque。
- edge → @aozoraquest/core 依存追加。

## テスト
- core 306 件緑 (注入口 4 件追加: 省略=決定的 / 同 seed=同結果 / 別 seed=分岐 / 非破壊)。
- edge 48 件緑 (kuda 7 / battle-guard 4 追加)。

## Review
(§1.5 レビュー実施後に追記)

## 次 (M3-part2)
resolver (`battle.ts`): encounter で権威 GameState + (x,y)由来の tier/terrain から startBattle 入力を**サーバー封印** (C1) → 毎ターン Worker が entropy 注入で resolveTurn → 決着で XP/ドロップ/パワー/素材を権威 state に確定。playerSnapshot はクライアントから受けない。