### PR TITLE
feat(edge): M2.5 OAuth write 認証基盤 (confidential client + DPoP + cron refresher)

### DIFF
--- a/apps/edge/.gitignore
+++ b/apps/edge/.gitignore
@@ -1,0 +1,5 @@
+# OAuth private 鍵 (gen-oauth-keys.mjs が書き出す。絶対に commit しない)
+.oauth-keys/
+# ローカル secret
+.dev.vars
+.dev.vars.*

--- a/apps/edge/scripts/gen-oauth-keys.mjs
+++ b/apps/edge/scripts/gen-oauth-keys.mjs
@@ -1,0 +1,47 @@
+/**
+ * OAuth confidential client 用の P-256 鍵ペアを生成する (docs/21 §12)。
+ *
+ *   - client 署名鍵 (private_key_jwt 用): private → Worker Secret / public → client-metadata.json の jwks
+ *   - DPoP 鍵: private → Worker Secret (公開部分は DPoP proof ヘッダに毎回埋まるので別途公開不要)
+ *
+ * private JWK は **gitignore 下の `.oauth-keys/` に書き出し**、標準出力には公開部分と設定コマンドだけ
+ * 出す (秘密鍵をチャット/クリップボードに晒さないため)。実行: `node scripts/gen-oauth-keys.mjs`
+ */
+import { p256 } from '@noble/curves/p256';
+import { sha256 } from '@noble/hashes/sha256';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const b64u = (u8) => Buffer.from(u8).toString('base64url');
+
+function makeKey() {
+  const d = p256.utils.randomPrivateKey();
+  const pub = p256.getPublicKey(d, false); // 0x04 || x(32) || y(32)
+  const x = b64u(pub.slice(1, 33));
+  const y = b64u(pub.slice(33, 65));
+  // RFC 7638 thumbprint を kid にする。
+  const kid = b64u(sha256(new TextEncoder().encode(`{"crv":"P-256","kty":"EC","x":"${x}","y":"${y}"}`)));
+  const priv = { kty: 'EC', crv: 'P-256', x, y, d: b64u(d), kid };
+  const pubJwk = { kty: 'EC', crv: 'P-256', x, y, kid, use: 'sig', alg: 'ES256' };
+  return { priv, pubJwk };
+}
+
+const outDir = join(dirname(fileURLToPath(import.meta.url)), '..', '.oauth-keys');
+mkdirSync(outDir, { recursive: true });
+
+const client = makeKey();
+const dpop = makeKey();
+const clientPath = join(outDir, 'client-private.jwk.json');
+const dpopPath = join(outDir, 'dpop-private.jwk.json');
+writeFileSync(clientPath, JSON.stringify(client.priv));
+writeFileSync(dpopPath, JSON.stringify(dpop.priv));
+
+const acct = 'CLOUDFLARE_ACCOUNT_ID=b9cec3916d500760a7c7b9c31c720d80';
+console.log(`\n✅ private 鍵を書き出しました (gitignore 下・commit されません):\n  ${clientPath}\n  ${dpopPath}\n`);
+console.log('── client-metadata.json の jwks に載せる公開鍵 (client 署名鍵) ──');
+console.log(JSON.stringify(client.pubJwk));
+console.log('\n── Secret 設定コマンド (apps/edge から) ──');
+console.log(`  ${acct} pnpm exec wrangler secret put OAUTH_CLIENT_PRIVATE_JWK < ${clientPath}`);
+console.log(`  ${acct} pnpm exec wrangler secret put OAUTH_DPOP_PRIVATE_JWK < ${dpopPath}`);
+console.log('\n設定後は .oauth-keys/ を消して構いません (Secret に入れば復元は再生成でなく再 OAuth 不要)。\n');

--- a/apps/edge/scripts/gen-oauth-keys.mjs
+++ b/apps/edge/scripts/gen-oauth-keys.mjs
@@ -37,11 +37,12 @@ const dpopPath = join(outDir, 'dpop-private.jwk.json');
 writeFileSync(clientPath, JSON.stringify(client.priv));
 writeFileSync(dpopPath, JSON.stringify(dpop.priv));
 
-const acct = 'CLOUDFLARE_ACCOUNT_ID=b9cec3916d500760a7c7b9c31c720d80';
+// account ID はソースに直書きしない (プロジェクトルール §4)。env にあれば使い、無ければプレースホルダ。
+const acct = process.env.CLOUDFLARE_ACCOUNT_ID ? `CLOUDFLARE_ACCOUNT_ID=${process.env.CLOUDFLARE_ACCOUNT_ID} ` : 'CLOUDFLARE_ACCOUNT_ID=<account-id> ';
 console.log(`\n✅ private 鍵を書き出しました (gitignore 下・commit されません):\n  ${clientPath}\n  ${dpopPath}\n`);
 console.log('── client-metadata.json の jwks に載せる公開鍵 (client 署名鍵) ──');
 console.log(JSON.stringify(client.pubJwk));
 console.log('\n── Secret 設定コマンド (apps/edge から) ──');
-console.log(`  ${acct} pnpm exec wrangler secret put OAUTH_CLIENT_PRIVATE_JWK < ${clientPath}`);
-console.log(`  ${acct} pnpm exec wrangler secret put OAUTH_DPOP_PRIVATE_JWK < ${dpopPath}`);
+console.log(`  ${acct}pnpm exec wrangler secret put OAUTH_CLIENT_PRIVATE_JWK < ${clientPath}`);
+console.log(`  ${acct}pnpm exec wrangler secret put OAUTH_DPOP_PRIVATE_JWK < ${dpopPath}`);
 console.log('\n設定後は .oauth-keys/ を消して構いません (Secret に入れば復元は再生成でなく再 OAuth 不要)。\n');

--- a/apps/edge/src/dpop-fetch.ts
+++ b/apps/edge/src/dpop-fetch.ts
@@ -1,0 +1,68 @@
+/**
+ * DPoP バインド付き fetch — docs/21 §12。RFC 9449。
+ *
+ * AT Protocol OAuth のトークン取得・PDS アクセスは全て DPoP (sender-constrained) を要求する。
+ * サーバーは初回に `DPoP-Nonce` を発行し `use_dpop_nonce` エラーを返すので、**その nonce で 1 回だけ
+ * 作り直して再送**する必要がある。この handshake を本ヘルパーに閉じ込め、OAuth クライアントと
+ * PDS 書き込みの両方から使う。nonce は接続をまたいで再利用できるよう `onNonce` で外に出す。
+ */
+import { dpopProof, type EcJwk } from './oauth-jwt';
+
+export interface DpopFetchOptions {
+  /** DPoP 署名鍵 (P-256 秘密鍵 JWK)。 */
+  jwk: EcJwk;
+  /** 直近に受け取った DPoP-Nonce (あれば最初から付ける)。 */
+  nonce?: string;
+  /** access token (付けると Authorization: DPoP <token> と ath クレームが入る)。 */
+  accessToken?: string;
+  /** epoch 秒。テスト用に注入可 (省略時は現在時刻)。 */
+  now?: number;
+  /** サーバーが新しい DPoP-Nonce を返したら通知 (呼び出し側でキャッシュ更新)。 */
+  onNonce?: (nonce: string) => void;
+  /** fetch 実装 (テスト用)。 */
+  fetchImpl?: typeof fetch;
+}
+
+/** レスポンスが「nonce を付けて出し直せ (use_dpop_nonce)」を意味するか。body は clone して読む。 */
+async function isUseDpopNonce(res: Response): Promise<boolean> {
+  if (res.status !== 400 && res.status !== 401) return false;
+  const auth = res.headers.get('www-authenticate') ?? '';
+  if (auth.includes('use_dpop_nonce')) return true;
+  try {
+    const body = (await res.clone().json()) as { error?: string };
+    return body.error === 'use_dpop_nonce';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * DPoP proof を付けて fetch。`use_dpop_nonce` チャレンジには受け取った nonce で 1 回だけ再送する。
+ * DPoP-Nonce レスポンスヘッダは毎回 `onNonce` に通知し、次回以降に使えるようにする。
+ */
+export async function dpopFetch(url: string, init: RequestInit, opts: DpopFetchOptions): Promise<Response> {
+  const f = opts.fetchImpl ?? fetch;
+  const now = opts.now ?? Math.floor(Date.now() / 1000);
+  const method = (init.method ?? 'GET').toUpperCase();
+  let nonce = opts.nonce;
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const proof = dpopProof({ jwk: opts.jwk, method, url, now, nonce, accessToken: opts.accessToken });
+    const headers = new Headers(init.headers);
+    headers.set('DPoP', proof);
+    if (opts.accessToken) headers.set('Authorization', `DPoP ${opts.accessToken}`);
+
+    const res = await f(url, { ...init, headers });
+
+    const fresh = res.headers.get('DPoP-Nonce');
+    if (fresh && fresh !== nonce) {
+      nonce = fresh;
+      opts.onNonce?.(fresh);
+    }
+    // 初回で nonce 要求 & 新 nonce を得たなら、その nonce で 1 回だけ出し直す。
+    if (attempt === 0 && fresh && (await isUseDpopNonce(res))) continue;
+    return res;
+  }
+  // 到達しない (ループは必ず return する) が、型のため。
+  throw new Error('dpopFetch: unreachable');
+}

--- a/apps/edge/src/index.ts
+++ b/apps/edge/src/index.ts
@@ -3,11 +3,20 @@ import { handleRequest, type Env } from './router';
 // として bundle する。docs/21 §4.2)。
 import wasmModule from './vendor/secp256k1-verify/secp256k1_verify_bg.wasm';
 import { initSecp256k1 } from './secp256k1-wasm';
+import { runCronRefresh } from './oauth-cron';
 
 initSecp256k1(wasmModule);
 
 export default {
   async fetch(req: Request, env: Env): Promise<Response> {
     return handleRequest(req, env);
+  },
+
+  // OAuth トークンの唯一の refresh 実行者 (docs/21 §12)。Cron Trigger から定期起動。
+  async scheduled(_event: ScheduledController, env: Env): Promise<void> {
+    const r = await runCronRefresh(env, Math.floor(Date.now() / 1000));
+    if (r.status === 'error' || r.status === 'not-configured') {
+      console.error(`oauth cron refresh: ${r.status} ${r.detail ?? ''}`);
+    }
   },
 };

--- a/apps/edge/src/oauth-client.ts
+++ b/apps/edge/src/oauth-client.ts
@@ -92,29 +92,35 @@ export async function buildAuthorizeUrl(
   return { url, state, verifier: pkce.verifier };
 }
 
-function normalize(t: TokenResponse, authServer: AuthServerMetadata, now: number, fallbackDid?: string): ServerOAuthTokens {
-  const did = t.sub ?? fallbackDid;
-  if (!did) throw new Error('トークン応答に sub が無く DID を確定できない');
-  if (!t.refresh_token) throw new Error('refresh_token が無い(offline_access スコープ要確認)');
+function normalize(t: TokenResponse, authServer: AuthServerMetadata, now: number, pdsUrl: string, expectedDid: string, opts: { requireSub?: boolean } = {}): ServerOAuthTokens {
+  // bootstrap (code 交換) では sub 必須。sub 欠落を serverDid で埋めない (別アカウントの取り違え防止)。
+  if (opts.requireSub && !t.sub) throw new Error('トークン応答に sub が無い (bootstrap では必須)');
+  const did = t.sub ?? expectedDid;
+  // アカウント取り違え/セッション固定対策: 認可されたアカウントが期待するサーバーアカウント
+  // (kojira.io) と一致することを必須にする。別アカウントでログインされてもトークンを保存しない。
+  if (did !== expectedDid) throw new Error(`予期しないアカウント: ${did} ≠ ${expectedDid}`);
+  if (!t.refresh_token) throw new Error('refresh_token が無い(atproto スコープの refresh 発行を要確認)');
   return {
     did,
     accessToken: t.access_token,
     refreshToken: t.refresh_token,
     tokenType: t.token_type || 'DPoP',
     expiresAt: now + (t.expires_in ?? 3600),
+    pdsUrl,
     authServer: authServer.issuer,
     scope: t.scope,
     updatedAt: now,
   };
 }
 
-/** callback の authorization code を token に交換する。 */
+/** callback の authorization code を token に交換する。sub は expectedDid と厳密一致必須。 */
 export async function exchangeCode(
   cfg: ClientConfig,
   authServer: AuthServerMetadata,
   code: string,
   verifier: string,
-  fallbackDid?: string,
+  pdsUrl: string,
+  expectedDid: string,
 ): Promise<ServerOAuthTokens> {
   const form = new URLSearchParams({
     grant_type: 'authorization_code',
@@ -126,15 +132,16 @@ export async function exchangeCode(
     client_assertion: assertion(cfg, authServer),
   });
   const t = await postForm<TokenResponse>(authServer.token_endpoint, form, cfg);
-  return normalize(t, authServer, cfg.now, fallbackDid);
+  return normalize(t, authServer, cfg.now, pdsUrl, expectedDid, { requireSub: true });
 }
 
-/** refresh_token でトークンを更新する(cron が使う)。 */
+/** refresh_token でトークンを更新する(cron が使う)。アカウントは bootstrap 済なので sub は任意。 */
 export async function refreshTokens(
   cfg: ClientConfig,
   authServer: AuthServerMetadata,
   refreshToken: string,
-  fallbackDid?: string,
+  pdsUrl: string,
+  expectedDid: string,
 ): Promise<ServerOAuthTokens> {
   const form = new URLSearchParams({
     grant_type: 'refresh_token',
@@ -144,5 +151,5 @@ export async function refreshTokens(
     client_assertion: assertion(cfg, authServer),
   });
   const t = await postForm<TokenResponse>(authServer.token_endpoint, form, cfg);
-  return normalize(t, authServer, cfg.now, fallbackDid);
+  return normalize(t, authServer, cfg.now, pdsUrl, expectedDid);
 }

--- a/apps/edge/src/oauth-client.ts
+++ b/apps/edge/src/oauth-client.ts
@@ -1,0 +1,148 @@
+/**
+ * AT Protocol OAuth confidential client のフロー — docs/21 §12。
+ *
+ * PKCE + PAR(Pushed Authorization Request) で authorize URL を作り、callback の code を token に
+ * 交換し、refresh する。クライアント認証は private_key_jwt、リクエストは DPoP バインド(nonce
+ * handshake は dpopFetch が処理)。トークンエンドポイント/PAR は form-urlencoded。
+ */
+import { sha256 } from '@noble/hashes/sha256';
+import { base64urlnopad } from '@scure/base';
+import { clientAssertion, type EcJwk } from './oauth-jwt';
+import { dpopFetch } from './dpop-fetch';
+import type { AuthServerMetadata } from './oauth-metadata';
+import type { ServerOAuthTokens } from './oauth-store';
+
+const enc = new TextEncoder();
+const CLIENT_ASSERTION_TYPE = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
+
+/** PKCE の code_verifier / code_challenge(S256)。`rand` を渡すとテストで固定できる。 */
+export function generatePkce(rand?: Uint8Array): { verifier: string; challenge: string } {
+  const bytes = rand ?? crypto.getRandomValues(new Uint8Array(32));
+  const verifier = base64urlnopad.encode(bytes); // 43 文字、PKCE 許容文字のみ
+  const challenge = base64urlnopad.encode(sha256(enc.encode(verifier)));
+  return { verifier, challenge };
+}
+
+/** CSRF 用 state。 */
+export function generateState(rand?: Uint8Array): string {
+  return base64urlnopad.encode(rand ?? crypto.getRandomValues(new Uint8Array(16)));
+}
+
+/** トークンエンドポイント応答 (使う項目)。 */
+interface TokenResponse {
+  access_token: string;
+  token_type: string;
+  refresh_token?: string;
+  expires_in?: number;
+  scope?: string;
+  sub?: string;
+}
+
+interface ClientConfig {
+  clientId: string;
+  redirectUri: string;
+  scope: string;
+  clientJwk: EcJwk; // private_key_jwt 署名鍵
+  dpopJwk: EcJwk; // DPoP 鍵
+  now: number; // epoch 秒
+  fetchImpl?: typeof fetch;
+}
+
+function assertion(cfg: ClientConfig, authServer: AuthServerMetadata): string {
+  return clientAssertion({ jwk: cfg.clientJwk, clientId: cfg.clientId, audience: authServer.issuer, now: cfg.now });
+}
+
+async function postForm<T>(url: string, form: URLSearchParams, cfg: ClientConfig): Promise<T> {
+  const res = await dpopFetch(
+    url,
+    { method: 'POST', headers: { 'content-type': 'application/x-www-form-urlencoded' }, body: form.toString() },
+    { jwk: cfg.dpopJwk, now: cfg.now, fetchImpl: cfg.fetchImpl },
+  );
+  const body = (await res.json().catch(() => ({}))) as T & { error?: string; error_description?: string };
+  if (!res.ok) throw new Error(`OAuth ${res.status}: ${body.error ?? ''} ${body.error_description ?? ''}`.trim());
+  return body as T;
+}
+
+/**
+ * PAR を実行して authorize URL を組み立てる。返す `state`/`verifier` は callback まで(KV 等に)
+ * 保存し、callback で照合・交換に使う。`loginHint` はサーバーアカウントの handle/DID(ログイン先誘導)。
+ */
+export async function buildAuthorizeUrl(
+  cfg: ClientConfig,
+  authServer: AuthServerMetadata,
+  opts: { loginHint?: string; state?: string; pkce?: { verifier: string; challenge: string } } = {},
+): Promise<{ url: string; state: string; verifier: string }> {
+  const state = opts.state ?? generateState();
+  const pkce = opts.pkce ?? generatePkce();
+  const form = new URLSearchParams({
+    response_type: 'code',
+    client_id: cfg.clientId,
+    redirect_uri: cfg.redirectUri,
+    scope: cfg.scope,
+    state,
+    code_challenge: pkce.challenge,
+    code_challenge_method: 'S256',
+    client_assertion_type: CLIENT_ASSERTION_TYPE,
+    client_assertion: assertion(cfg, authServer),
+  });
+  if (opts.loginHint) form.set('login_hint', opts.loginHint);
+  const par = await postForm<{ request_uri: string }>(authServer.pushed_authorization_request_endpoint, form, cfg);
+  if (!par.request_uri) throw new Error('PAR 応答に request_uri が無い');
+  const url = `${authServer.authorization_endpoint}?client_id=${encodeURIComponent(cfg.clientId)}&request_uri=${encodeURIComponent(par.request_uri)}`;
+  return { url, state, verifier: pkce.verifier };
+}
+
+function normalize(t: TokenResponse, authServer: AuthServerMetadata, now: number, fallbackDid?: string): ServerOAuthTokens {
+  const did = t.sub ?? fallbackDid;
+  if (!did) throw new Error('トークン応答に sub が無く DID を確定できない');
+  if (!t.refresh_token) throw new Error('refresh_token が無い(offline_access スコープ要確認)');
+  return {
+    did,
+    accessToken: t.access_token,
+    refreshToken: t.refresh_token,
+    tokenType: t.token_type || 'DPoP',
+    expiresAt: now + (t.expires_in ?? 3600),
+    authServer: authServer.issuer,
+    scope: t.scope,
+    updatedAt: now,
+  };
+}
+
+/** callback の authorization code を token に交換する。 */
+export async function exchangeCode(
+  cfg: ClientConfig,
+  authServer: AuthServerMetadata,
+  code: string,
+  verifier: string,
+  fallbackDid?: string,
+): Promise<ServerOAuthTokens> {
+  const form = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code,
+    redirect_uri: cfg.redirectUri,
+    code_verifier: verifier,
+    client_id: cfg.clientId,
+    client_assertion_type: CLIENT_ASSERTION_TYPE,
+    client_assertion: assertion(cfg, authServer),
+  });
+  const t = await postForm<TokenResponse>(authServer.token_endpoint, form, cfg);
+  return normalize(t, authServer, cfg.now, fallbackDid);
+}
+
+/** refresh_token でトークンを更新する(cron が使う)。 */
+export async function refreshTokens(
+  cfg: ClientConfig,
+  authServer: AuthServerMetadata,
+  refreshToken: string,
+  fallbackDid?: string,
+): Promise<ServerOAuthTokens> {
+  const form = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken,
+    client_id: cfg.clientId,
+    client_assertion_type: CLIENT_ASSERTION_TYPE,
+    client_assertion: assertion(cfg, authServer),
+  });
+  const t = await postForm<TokenResponse>(authServer.token_endpoint, form, cfg);
+  return normalize(t, authServer, cfg.now, fallbackDid);
+}

--- a/apps/edge/src/oauth-config.ts
+++ b/apps/edge/src/oauth-config.ts
@@ -1,0 +1,95 @@
+/**
+ * OAuth confidential client の設定を Worker env から組み立てる — docs/21 §12。
+ *
+ * 秘密鍵 (client 署名鍵 / DPoP 鍵) は Worker Secret に JWK(JSON) で入れる。client_id / redirect_uri は
+ * edge の公開 origin から導出。管理者判定 (ADMIN_DIDS) は /oauth/start のゲートに使う。
+ * サーバーアカウント (kojira.io) の DID は SERVER_DID (Variable)。**ソースに直書きしない**。
+ */
+import { publicJwk, type EcJwk } from './oauth-jwt';
+
+export interface OAuthEnv {
+  /** client 署名鍵 (private_key_jwt)。Secret。JWK JSON。 */
+  OAUTH_CLIENT_PRIVATE_JWK?: string;
+  /** DPoP 鍵。Secret。JWK JSON。 */
+  OAUTH_DPOP_PRIVATE_JWK?: string;
+  /** サーバーアカウント DID (権威データの持ち主 = kojira.io)。Variable。 */
+  SERVER_DID?: string;
+  /** 管理者 DID 許可リスト (カンマ区切り)。/oauth/start ゲート用。Variable。 */
+  ADMIN_DIDS?: string;
+  /** この Worker の DID (did:web:edge.aozoraquest.app 等)。origin 導出に使う。 */
+  WORKER_DID?: string;
+  /** 公開 origin の明示指定 (WORKER_DID から導出できない場合)。 */
+  PUBLIC_ORIGIN?: string;
+  /** OAuth scope。既定 'atproto transition:generic'。 */
+  OAUTH_SCOPE?: string;
+}
+
+export class OAuthConfigError extends Error {}
+
+/** edge の公開 origin (client_id / redirect_uri のベース)。 */
+export function publicOrigin(env: OAuthEnv): string {
+  if (env.PUBLIC_ORIGIN) return env.PUBLIC_ORIGIN.replace(/\/$/, '');
+  const wd = env.WORKER_DID;
+  if (wd?.startsWith('did:web:')) return `https://${wd.slice('did:web:'.length).split(':')[0]}`;
+  throw new OAuthConfigError('PUBLIC_ORIGIN も WORKER_DID(did:web) も無い');
+}
+
+function parseJwk(raw: string | undefined, name: string): EcJwk {
+  if (!raw) throw new OAuthConfigError(`${name} が未設定`);
+  let j: EcJwk;
+  try {
+    j = JSON.parse(raw) as EcJwk;
+  } catch {
+    throw new OAuthConfigError(`${name} が JSON として不正`);
+  }
+  if (j.kty !== 'EC' || j.crv !== 'P-256' || !j.d) throw new OAuthConfigError(`${name} は P-256 秘密鍵 JWK である必要がある`);
+  return j;
+}
+
+export interface OAuthConfig {
+  clientId: string;
+  redirectUri: string;
+  scope: string;
+  clientJwk: EcJwk;
+  dpopJwk: EcJwk;
+  serverDid: string;
+  publicOrigin: string;
+}
+
+/** env から設定を読む。秘密鍵の未設定/不正・SERVER_DID 欠落は OAuthConfigError (fail-closed)。 */
+export function loadOAuthConfig(env: OAuthEnv): OAuthConfig {
+  const origin = publicOrigin(env);
+  if (!env.SERVER_DID) throw new OAuthConfigError('SERVER_DID が未設定');
+  return {
+    clientId: `${origin}/client-metadata.json`,
+    redirectUri: `${origin}/oauth/callback`,
+    scope: env.OAUTH_SCOPE ?? 'atproto transition:generic',
+    clientJwk: parseJwk(env.OAUTH_CLIENT_PRIVATE_JWK, 'OAUTH_CLIENT_PRIVATE_JWK'),
+    dpopJwk: parseJwk(env.OAUTH_DPOP_PRIVATE_JWK, 'OAUTH_DPOP_PRIVATE_JWK'),
+    serverDid: env.SERVER_DID,
+    publicOrigin: origin,
+  };
+}
+
+/** 呼び出し元 DID が edge の管理者許可リストに含まれるか (/oauth/start ゲート)。 */
+export function isEdgeAdmin(env: OAuthEnv, did: string): boolean {
+  return (env.ADMIN_DIDS ?? '').split(',').map((s) => s.trim()).filter(Boolean).includes(did);
+}
+
+/** AT Proto confidential client のメタデータ (GET /client-metadata.json で返す)。 */
+export function buildClientMetadata(cfg: OAuthConfig): Record<string, unknown> {
+  return {
+    client_id: cfg.clientId,
+    client_name: 'aozoraquest',
+    client_uri: 'https://aozoraquest.app',
+    redirect_uris: [cfg.redirectUri],
+    grant_types: ['authorization_code', 'refresh_token'],
+    response_types: ['code'],
+    scope: cfg.scope,
+    token_endpoint_auth_method: 'private_key_jwt',
+    token_endpoint_auth_signing_alg: 'ES256',
+    dpop_bound_access_tokens: true,
+    application_type: 'web',
+    jwks: { keys: [{ ...publicJwk(cfg.clientJwk), kid: cfg.clientJwk.kid, use: 'sig', alg: 'ES256' }] },
+  };
+}

--- a/apps/edge/src/oauth-cron.ts
+++ b/apps/edge/src/oauth-cron.ts
@@ -1,0 +1,48 @@
+/**
+ * OAuth トークンの cron refresher — docs/21 §12。
+ *
+ * **唯一の refresh 実行者**。Cron Trigger から定期起動し、access token 失効前に refresh_token で
+ * 更新して KV に書き戻す。リクエスト処理 Worker は refresh しない (書き手を 1 つに直列化し、
+ * refresh token ローテーションのレース = ロックアウトを防ぐ)。
+ *
+ * refresh 失敗 (invalid_grant = refresh token 失効) はロックアウトで、管理画面から再 OAuth が要る。
+ * その場合もトークンは残し (診断用)、書き込み経路は fail-closed に倒す。
+ */
+import { loadOAuthConfig, OAuthConfigError, type OAuthEnv } from './oauth-config';
+import { discoverForDid } from './oauth-metadata';
+import { refreshTokens } from './oauth-client';
+import { readServerTokens, writeServerTokens } from './oauth-store';
+
+/** 期限の何秒前から refresh するか。Cron 間隔 (<10 分) より十分大きくして取りこぼしを防ぐ。 */
+export const REFRESH_AHEAD_SEC = 900;
+
+export interface CronEnv extends OAuthEnv {
+  OAUTH_TOKENS?: KVNamespace;
+}
+
+export type CronStatus = 'refreshed' | 'not-due' | 'not-bootstrapped' | 'no-kv' | 'not-configured' | 'error';
+
+/** cron 1 回分の refresh 処理。副作用は KV 書き込みのみ。結果を返す (ログ/監視用)。 */
+export async function runCronRefresh(env: CronEnv, now: number, fetchImpl?: typeof fetch): Promise<{ status: CronStatus; detail?: string }> {
+  if (!env.OAUTH_TOKENS) return { status: 'no-kv' };
+  const tokens = await readServerTokens(env.OAUTH_TOKENS);
+  if (!tokens) return { status: 'not-bootstrapped' };
+  if (now < tokens.expiresAt - REFRESH_AHEAD_SEC) return { status: 'not-due' };
+
+  let cfg;
+  try {
+    cfg = loadOAuthConfig(env);
+  } catch (e) {
+    if (e instanceof OAuthConfigError) return { status: 'not-configured', detail: e.message };
+    throw e;
+  }
+  try {
+    const { authServer } = await discoverForDid(cfg.serverDid, fetchImpl);
+    const next = await refreshTokens({ ...cfg, now, fetchImpl }, authServer, tokens.refreshToken, cfg.serverDid);
+    // PDS 用 DPoP-Nonce は保持 (認可サーバーの nonce とは別物)。
+    await writeServerTokens(env.OAUTH_TOKENS, { ...next, dpopNonce: tokens.dpopNonce });
+    return { status: 'refreshed' };
+  } catch (e) {
+    return { status: 'error', detail: e instanceof Error ? e.message : String(e) };
+  }
+}

--- a/apps/edge/src/oauth-cron.ts
+++ b/apps/edge/src/oauth-cron.ts
@@ -13,21 +13,32 @@ import { discoverForDid } from './oauth-metadata';
 import { refreshTokens } from './oauth-client';
 import { readServerTokens, writeServerTokens } from './oauth-store';
 
-/** 期限の何秒前から refresh するか。Cron 間隔 (<10 分) より十分大きくして取りこぼしを防ぐ。 */
+/** 期限の何秒前から refresh するか。Cron 間隔より大きくして「1 tick 失敗しても次 tick で再試行」の
+ *  余裕を残す。二重 refresh の抑止は refreshingUntil ソフトロックで別途行う。 */
 export const REFRESH_AHEAD_SEC = 900;
+/** refresh 進行中ソフトロックの保持時間 (秒)。この間は他 tick が refresh を控える。 */
+export const REFRESH_LOCK_SEC = 120;
 
 export interface CronEnv extends OAuthEnv {
   OAUTH_TOKENS?: KVNamespace;
 }
 
-export type CronStatus = 'refreshed' | 'not-due' | 'not-bootstrapped' | 'no-kv' | 'not-configured' | 'error';
+export type CronStatus = 'refreshed' | 'not-due' | 'refreshing' | 'not-bootstrapped' | 'no-kv' | 'not-configured' | 'error';
 
-/** cron 1 回分の refresh 処理。副作用は KV 書き込みのみ。結果を返す (ログ/監視用)。 */
+/**
+ * cron 1 回分の refresh 処理。副作用は KV 書き込みのみ。結果を返す (ログ/監視用)。
+ *
+ * **二重 refresh の抑止**: Cloudflare の cron は tick が重なりうる (遅い refresh が次 tick に追いつく) ため、
+ * refresh 前に `refreshingUntil` マーカーを書き、他 tick はそれを見て控える (ソフトロック)。KV に CAS が
+ * 無いので厳密ではない (同時 tick は稀に競合しうる) が、ロックアウトは再 OAuth で復旧できる。
+ */
 export async function runCronRefresh(env: CronEnv, now: number, fetchImpl?: typeof fetch): Promise<{ status: CronStatus; detail?: string }> {
   if (!env.OAUTH_TOKENS) return { status: 'no-kv' };
   const tokens = await readServerTokens(env.OAUTH_TOKENS);
   if (!tokens) return { status: 'not-bootstrapped' };
   if (now < tokens.expiresAt - REFRESH_AHEAD_SEC) return { status: 'not-due' };
+  // 別 tick が refresh 中ならスキップ (ローテーション競合 = ロックアウト回避)。
+  if (tokens.refreshingUntil && now < tokens.refreshingUntil) return { status: 'refreshing' };
 
   let cfg;
   try {
@@ -36,11 +47,12 @@ export async function runCronRefresh(env: CronEnv, now: number, fetchImpl?: type
     if (e instanceof OAuthConfigError) return { status: 'not-configured', detail: e.message };
     throw e;
   }
+  // 先にマーカーを立ててから refresh (他 tick に「進行中」を知らせる)。
+  await writeServerTokens(env.OAUTH_TOKENS, { ...tokens, refreshingUntil: now + REFRESH_LOCK_SEC });
   try {
-    const { authServer } = await discoverForDid(cfg.serverDid, fetchImpl);
-    const next = await refreshTokens({ ...cfg, now, fetchImpl }, authServer, tokens.refreshToken, cfg.serverDid);
-    // PDS 用 DPoP-Nonce は保持 (認可サーバーの nonce とは別物)。
-    await writeServerTokens(env.OAUTH_TOKENS, { ...next, dpopNonce: tokens.dpopNonce });
+    const { pdsUrl, authServer } = await discoverForDid(cfg.serverDid, fetchImpl);
+    const next = await refreshTokens({ ...cfg, now, fetchImpl }, authServer, tokens.refreshToken, pdsUrl, cfg.serverDid);
+    await writeServerTokens(env.OAUTH_TOKENS, next); // refreshingUntil は載せない = ロック解除
     return { status: 'refreshed' };
   } catch (e) {
     return { status: 'error', detail: e instanceof Error ? e.message : String(e) };

--- a/apps/edge/src/oauth-jwt.ts
+++ b/apps/edge/src/oauth-jwt.ts
@@ -1,0 +1,113 @@
+/**
+ * OAuth (AT Protocol) 用の ES256 JWT 署名ユーティリティ — docs/21 §12。
+ *
+ * サーバーアカウントの書き込み認証を OAuth confidential client + DPoP で行うため、以下を署名する:
+ *   - **DPoP proof** (`typ: dpop+jwt`): 全トークン/PDS リクエストに付ける sender-constrained 証明。
+ *   - **client assertion** (`private_key_jwt`): confidential client のクライアント認証。
+ *
+ * 署名は `@noble/curves` p256 (ES256)、base64url は `@scure/base` — service-auth.ts の検証側と同じ道具
+ * (重い OAuth ライブラリを足さない = supply-chain cooldown も避ける)。鍵は EC P-256 の JWK。
+ */
+import { p256 } from '@noble/curves/p256';
+import { sha256 } from '@noble/hashes/sha256';
+import { base64urlnopad } from '@scure/base';
+
+/** EC P-256 の JWK。`d` があれば秘密鍵 (署名可)、無ければ公開鍵。 */
+export interface EcJwk {
+  kty: 'EC';
+  crv: 'P-256';
+  x: string;
+  y: string;
+  d?: string;
+  kid?: string;
+}
+
+const enc = new TextEncoder();
+const b64uJson = (o: unknown): string => base64urlnopad.encode(enc.encode(JSON.stringify(o)));
+const b64uStr = (s: string): string => base64urlnopad.encode(enc.encode(s));
+
+/** JWK から公開部分だけ取り出す (d と kid を除く。DPoP ヘッダの jwk 用)。 */
+export function publicJwk(jwk: EcJwk): EcJwk {
+  return { kty: 'EC', crv: 'P-256', x: jwk.x, y: jwk.y };
+}
+
+/** RFC 7638 JWK thumbprint (EC は crv,kty,x,y を辞書順で正規化 → sha256 → base64url)。 */
+export function jwkThumbprint(jwk: EcJwk): string {
+  const canon = `{"crv":"P-256","kty":"EC","x":"${jwk.x}","y":"${jwk.y}"}`;
+  return base64urlnopad.encode(sha256(enc.encode(canon)));
+}
+
+/** ES256 で JWT を署名する。`header`/`payload` は任意オブジェクト。 */
+export function signEs256(header: Record<string, unknown>, payload: Record<string, unknown>, jwk: EcJwk): string {
+  if (!jwk.d) throw new Error('signEs256: 秘密鍵 (d) が無い JWK では署名できない');
+  const signingInput = `${b64uJson(header)}.${b64uJson(payload)}`;
+  const d = base64urlnopad.decode(jwk.d);
+  // 検証側 (service-auth) と対称: sha256(signingInput) を prehash として渡し、low-S を強制。
+  const sig = p256.sign(sha256(enc.encode(signingInput)), d, { lowS: true });
+  return `${signingInput}.${base64urlnopad.encode(sig.toCompactRawBytes())}`;
+}
+
+/** access token の DPoP `ath` クレーム (base64url(sha256(token)))。 */
+export function accessTokenHash(accessToken: string): string {
+  return base64urlnopad.encode(sha256(enc.encode(accessToken)));
+}
+
+/** ランダムな jti (16 バイト CSPRNG → base64url)。 */
+export function randomJti(): string {
+  const b = new Uint8Array(16);
+  crypto.getRandomValues(b);
+  return base64urlnopad.encode(b);
+}
+
+/**
+ * DPoP proof JWT を作る (RFC 9449)。`htm`=HTTP メソッド, `htu`=URL (クエリ/フラグメント除去)。
+ * サーバーから `DPoP-Nonce` を要求されたら `nonce` を入れて作り直す。access token に紐づける
+ * リクエストでは `accessToken` を渡すと `ath` が入る。
+ */
+export function dpopProof(opts: {
+  jwk: EcJwk;
+  method: string;
+  url: string;
+  now: number; // epoch 秒
+  nonce?: string;
+  accessToken?: string;
+  jti?: string;
+}): string {
+  const u = new URL(opts.url);
+  const htu = `${u.origin}${u.pathname}`; // クエリ/フラグメントは htu から除く (RFC 9449)
+  const header = { typ: 'dpop+jwt', alg: 'ES256', jwk: publicJwk(opts.jwk) };
+  const payload: Record<string, unknown> = {
+    jti: opts.jti ?? randomJti(),
+    htm: opts.method.toUpperCase(),
+    htu,
+    iat: opts.now,
+  };
+  if (opts.nonce) payload.nonce = opts.nonce;
+  if (opts.accessToken) payload.ath = accessTokenHash(opts.accessToken);
+  return signEs256(header, payload, opts.jwk);
+}
+
+/**
+ * client assertion (`private_key_jwt`, RFC 7523)。confidential client のトークンリクエストで
+ * `client_assertion` として送る。`audience` は認可サーバーの issuer。
+ */
+export function clientAssertion(opts: {
+  jwk: EcJwk;
+  clientId: string;
+  audience: string;
+  now: number; // epoch 秒
+  ttlSec?: number;
+  jti?: string;
+}): string {
+  const header: Record<string, unknown> = { alg: 'ES256', typ: 'JWT' };
+  if (opts.jwk.kid) header.kid = opts.jwk.kid;
+  const payload = {
+    iss: opts.clientId,
+    sub: opts.clientId,
+    aud: opts.audience,
+    jti: opts.jti ?? randomJti(),
+    iat: opts.now,
+    exp: opts.now + (opts.ttlSec ?? 60),
+  };
+  return signEs256(header, payload, opts.jwk);
+}

--- a/apps/edge/src/oauth-metadata.ts
+++ b/apps/edge/src/oauth-metadata.ts
@@ -1,0 +1,76 @@
+/**
+ * AT Protocol OAuth のメタデータ discovery — docs/21 §12。
+ *
+ * サーバーアカウント (DID) から認可サーバーを解決する:
+ *   DID → DID document の #atproto_pds → PDS の `/.well-known/oauth-protected-resource`
+ *   → `authorization_servers[0]` → `/.well-known/oauth-authorization-server` (メタデータ)。
+ *
+ * DID 解決は service-auth の `resolveDidDocument` を再利用 (did:plc / did:web、SSRF 対策込み)。
+ */
+import { resolveDidDocument, ServiceAuthError } from './service-auth';
+
+/** service 配列込みの DID document (service-auth 側は verificationMethod だけの狭い型)。 */
+interface DidDocWithService {
+  id: string;
+  service?: { id: string; type: string; serviceEndpoint: string }[];
+}
+
+/** 認可サーバーメタデータ (RFC 8414 + AT Proto プロファイル)。使う項目だけ。 */
+export interface AuthServerMetadata {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  /** AT Proto は PAR 必須。 */
+  pushed_authorization_request_endpoint: string;
+  /** DPoP 対応アルゴリズム (ES256 が含まれること)。 */
+  dpop_signing_alg_values_supported?: string[];
+  scopes_supported?: string[];
+  token_endpoint_auth_methods_supported?: string[];
+}
+
+/** DID document から PDS エンドポイント (#atproto_pds) を取り出す。 */
+export function pdsEndpointFromDoc(doc: DidDocWithService, did: string): string {
+  const svc = doc.service?.find((s) => s.id === '#atproto_pds' || s.id === `${did}#atproto_pds` || s.type === 'AtprotoPersonalDataServer');
+  const ep = svc?.serviceEndpoint;
+  if (!ep || !/^https:\/\//.test(ep)) throw new ServiceAuthError(`#atproto_pds エンドポイントが見つからない: ${did}`);
+  return ep.replace(/\/$/, '');
+}
+
+async function fetchJson<T>(url: string, f: typeof fetch): Promise<T> {
+  const res = await f(url);
+  if (!res.ok) throw new ServiceAuthError(`メタデータ取得失敗 ${res.status}: ${url}`);
+  return (await res.json()) as T;
+}
+
+/**
+ * PDS URL から認可サーバーメタデータを解決・検証する。
+ * - protected-resource の authorization_servers[0] を採用。
+ * - メタデータの issuer が **その認可サーバー URL と一致**することを確認 (mix-up 対策)。
+ * - PAR エンドポイント必須 (AT Proto)。ES256 の DPoP 対応を確認。
+ */
+export async function discoverAuthServer(pdsUrl: string, fetchImpl: typeof fetch = fetch): Promise<AuthServerMetadata> {
+  const pr = await fetchJson<{ authorization_servers?: string[] }>(`${pdsUrl}/.well-known/oauth-protected-resource`, fetchImpl);
+  const as0 = pr.authorization_servers?.[0];
+  if (!as0 || !/^https:\/\//.test(as0)) throw new ServiceAuthError('protected-resource に authorization_servers が無い');
+  const issuerBase = as0.replace(/\/$/, '');
+
+  const meta = await fetchJson<AuthServerMetadata>(`${issuerBase}/.well-known/oauth-authorization-server`, fetchImpl);
+  // mix-up 攻撃対策: issuer は要求した認可サーバーと一致必須 (RFC 8414 §3.3 / 9207)。
+  if (meta.issuer?.replace(/\/$/, '') !== issuerBase) {
+    throw new ServiceAuthError(`issuer 不一致: メタデータ ${meta.issuer} ≠ ${issuerBase}`);
+  }
+  if (!meta.pushed_authorization_request_endpoint) throw new ServiceAuthError('PAR エンドポイントが無い (AT Proto は PAR 必須)');
+  if (!meta.authorization_endpoint || !meta.token_endpoint) throw new ServiceAuthError('authorization/token エンドポイントが無い');
+  if (meta.dpop_signing_alg_values_supported && !meta.dpop_signing_alg_values_supported.includes('ES256')) {
+    throw new ServiceAuthError('認可サーバーが DPoP ES256 に非対応');
+  }
+  return meta;
+}
+
+/** DID から認可サーバーメタデータまで一括解決 (DID → PDS → 認可サーバー)。 */
+export async function discoverForDid(did: string, fetchImpl: typeof fetch = fetch): Promise<{ pdsUrl: string; authServer: AuthServerMetadata }> {
+  const doc = (await resolveDidDocument(did, fetchImpl)) as DidDocWithService;
+  const pdsUrl = pdsEndpointFromDoc(doc, did);
+  const authServer = await discoverAuthServer(pdsUrl, fetchImpl);
+  return { pdsUrl, authServer };
+}

--- a/apps/edge/src/oauth-routes.ts
+++ b/apps/edge/src/oauth-routes.ts
@@ -1,0 +1,97 @@
+/**
+ * OAuth write 認証のルートハンドラ — docs/21 §12。router.ts から呼ぶ。
+ *
+ *   GET  /client-metadata.json  confidential client メタデータ (公開)
+ *   POST /api/oauth/start       管理者 (service auth JWT + ADMIN_DIDS) が OAuth を開始 → authorizeUrl
+ *   GET  /oauth/callback        認可サーバーからの code を token に交換し KV に格納 (state で CSRF 検証)
+ *
+ * 初回 bootstrap 用。以後の refresh は cron。依存 (verify/fetch/now/kv) は注入可能にしテストする。
+ */
+import { verifyServiceAuth, resolveDidDocument, type DidDocument } from './service-auth';
+import { loadOAuthConfig, buildClientMetadata, isEdgeAdmin, OAuthConfigError, type OAuthEnv } from './oauth-config';
+import { discoverForDid } from './oauth-metadata';
+import { buildAuthorizeUrl, exchangeCode } from './oauth-client';
+import { putPendingAuth, takePendingAuth, writeServerTokens } from './oauth-store';
+
+export const LXM_OAUTH_START = 'app.aozoraquest.oauth.start';
+
+/** router.ts の Env のうち OAuth ルートが使う部分 + KV。 */
+export interface OAuthRoutesEnv extends OAuthEnv {
+  OAUTH_TOKENS?: KVNamespace;
+}
+
+interface Deps {
+  now: number;
+  fetchImpl?: typeof fetch;
+  /** service auth 検証 (テストで差し替え)。 */
+  verify?: (token: string, opts: { audience?: string; lxm?: string; now: number; resolveDid?: (d: string) => Promise<DidDocument> }) => Promise<{ iss: string }>;
+}
+
+const json = (body: unknown, status = 200) => new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json; charset=utf-8' } });
+const html = (body: string, status = 200) => new Response(`<!doctype html><meta charset=utf-8><meta name=viewport content="width=device-width,initial-scale=1">${body}`, { status, headers: { 'content-type': 'text/html; charset=utf-8' } });
+const bearer = (req: Request) => req.headers.get('authorization')?.replace(/^Bearer\s+/i, '') ?? '';
+
+/** GET /client-metadata.json */
+export function handleClientMetadata(env: OAuthRoutesEnv): Response {
+  try {
+    return json(buildClientMetadata(loadOAuthConfig(env)));
+  } catch (e) {
+    if (e instanceof OAuthConfigError) return json({ error: 'oauth_not_configured', message: e.message }, 503);
+    throw e;
+  }
+}
+
+/** POST /api/oauth/start — 管理者のみ。authorizeUrl を返す。 */
+export async function handleOAuthStart(req: Request, env: OAuthRoutesEnv, deps: Deps): Promise<Response> {
+  if (!env.OAUTH_TOKENS) return json({ error: 'oauth_not_configured', message: 'KV 未 binding' }, 503);
+  let cfg;
+  try {
+    cfg = loadOAuthConfig(env);
+  } catch (e) {
+    if (e instanceof OAuthConfigError) return json({ error: 'oauth_not_configured', message: e.message }, 503);
+    throw e;
+  }
+  // 管理者ゲート: service auth JWT (aud=この Worker, lxm=oauth.start) → iss が ADMIN_DIDS に含まれること。
+  const audience = env.WORKER_DID;
+  if (!audience) return json({ error: 'oauth_not_configured', message: 'WORKER_DID 未設定' }, 503);
+  const token = bearer(req);
+  if (!token) return json({ error: 'missing_token' }, 401);
+  const verify = deps.verify ?? verifyServiceAuth;
+  let iss: string;
+  try {
+    ({ iss } = await verify(token, { audience, lxm: LXM_OAUTH_START, now: deps.now, resolveDid: (d) => resolveDidDocument(d, deps.fetchImpl) }));
+  } catch {
+    return json({ error: 'invalid_token' }, 401);
+  }
+  if (!isEdgeAdmin(env, iss)) return json({ error: 'forbidden' }, 403);
+
+  const { authServer } = await discoverForDid(cfg.serverDid, deps.fetchImpl);
+  const { url, state, verifier } = await buildAuthorizeUrl({ ...cfg, now: deps.now, fetchImpl: deps.fetchImpl }, authServer, { loginHint: cfg.serverDid });
+  await putPendingAuth(env.OAUTH_TOKENS, state, { verifier, authServer, createdAt: deps.now });
+  return json({ authorizeUrl: url });
+}
+
+/** GET /oauth/callback — 認可サーバーからのリダイレクト。code→token 交換し KV 格納。 */
+export async function handleOAuthCallback(req: Request, env: OAuthRoutesEnv, deps: Deps): Promise<Response> {
+  const url = new URL(req.url);
+  const err = url.searchParams.get('error');
+  if (err) return html(`<h1>連携に失敗しました</h1><p>${err}: ${url.searchParams.get('error_description') ?? ''}</p>`, 400);
+  const code = url.searchParams.get('code');
+  const state = url.searchParams.get('state');
+  if (!code || !state) return html('<h1>不正なコールバック</h1><p>code / state がありません</p>', 400);
+  if (!env.OAUTH_TOKENS) return html('<h1>設定エラー</h1><p>KV 未 binding</p>', 503);
+
+  const pending = await takePendingAuth(env.OAUTH_TOKENS, state);
+  if (!pending) return html('<h1>セッション切れ</h1><p>state が無効か期限切れです。もう一度お試しください</p>', 400);
+
+  let cfg;
+  try {
+    cfg = loadOAuthConfig(env);
+  } catch (e) {
+    if (e instanceof OAuthConfigError) return html('<h1>設定エラー</h1>', 503);
+    throw e;
+  }
+  const tokens = await exchangeCode({ ...cfg, now: deps.now, fetchImpl: deps.fetchImpl }, pending.authServer, code, pending.verifier, cfg.serverDid);
+  await writeServerTokens(env.OAUTH_TOKENS, tokens);
+  return html(`<h1>連携できました ✅</h1><p>サーバーアカウント (${tokens.did}) の書き込み認証を保存しました。このタブは閉じて構いません。</p>`);
+}

--- a/apps/edge/src/oauth-routes.ts
+++ b/apps/edge/src/oauth-routes.ts
@@ -65,9 +65,9 @@ export async function handleOAuthStart(req: Request, env: OAuthRoutesEnv, deps: 
   }
   if (!isEdgeAdmin(env, iss)) return json({ error: 'forbidden' }, 403);
 
-  const { authServer } = await discoverForDid(cfg.serverDid, deps.fetchImpl);
+  const { pdsUrl, authServer } = await discoverForDid(cfg.serverDid, deps.fetchImpl);
   const { url, state, verifier } = await buildAuthorizeUrl({ ...cfg, now: deps.now, fetchImpl: deps.fetchImpl }, authServer, { loginHint: cfg.serverDid });
-  await putPendingAuth(env.OAUTH_TOKENS, state, { verifier, authServer, createdAt: deps.now });
+  await putPendingAuth(env.OAUTH_TOKENS, state, { verifier, authServer, pdsUrl, createdAt: deps.now });
   return json({ authorizeUrl: url });
 }
 
@@ -91,7 +91,7 @@ export async function handleOAuthCallback(req: Request, env: OAuthRoutesEnv, dep
     if (e instanceof OAuthConfigError) return html('<h1>設定エラー</h1>', 503);
     throw e;
   }
-  const tokens = await exchangeCode({ ...cfg, now: deps.now, fetchImpl: deps.fetchImpl }, pending.authServer, code, pending.verifier, cfg.serverDid);
+  const tokens = await exchangeCode({ ...cfg, now: deps.now, fetchImpl: deps.fetchImpl }, pending.authServer, code, pending.verifier, pending.pdsUrl, cfg.serverDid);
   await writeServerTokens(env.OAUTH_TOKENS, tokens);
   return html(`<h1>連携できました ✅</h1><p>サーバーアカウント (${tokens.did}) の書き込み認証を保存しました。このタブは閉じて構いません。</p>`);
 }

--- a/apps/edge/src/oauth-store.ts
+++ b/apps/edge/src/oauth-store.ts
@@ -16,17 +16,23 @@ export interface ServerOAuthTokens {
   tokenType: string;
   /** access token 失効時刻 (epoch 秒)。cron はこれより前に refresh する。 */
   expiresAt: number;
-  /** 直近の DPoP-Nonce (あれば次リクエストで再利用)。 */
-  dpopNonce?: string;
+  /** 書き込み先 PDS URL (DID→#atproto_pds を discovery した結果)。M3 の書込がここに putRecord する。
+   *  レコードに持たせておくことで書込ごとの DID doc 再解決を避ける (レビュー ★★)。 */
+  pdsUrl: string;
   /** 認可サーバー issuer (refresh / token エンドポイント解決に使う)。 */
   authServer: string;
   scope?: string;
+  /** refresh 進行中マーカー (epoch 秒。cron の二重 refresh = ローテーション競合を抑えるソフトロック)。 */
+  refreshingUntil?: number;
   /** 最終更新 (epoch 秒、監査用)。 */
   updatedAt: number;
 }
 
 /** KV のキー (単一サーバーアカウント運用なので固定キー)。 */
 export const SERVER_OAUTH_KEY = 'server-oauth';
+/** PDS 用 DPoP-Nonce のキー。トークンレコードとは**別キー**にし、リクエスト Worker が nonce を
+ *  更新してもトークン本体 (cron が書く) を巻き込まない (レビュー ★★: 第二の書き手クロバー回避)。 */
+export const PDS_NONCE_KEY = 'oauth-pds-nonce';
 
 /** トークンを読む (無ければ null = 未 bootstrap)。 */
 export async function readServerTokens(kv: KVNamespace): Promise<ServerOAuthTokens | null> {
@@ -45,15 +51,16 @@ export async function writeServerTokens(kv: KVNamespace, tokens: ServerOAuthToke
 }
 
 /**
- * DPoP-Nonce だけを更新 (read-modify-write)。リクエスト Worker が新 nonce を受けたときに使う。
- * トークン本体が無ければ何もしない (書き手競合を避けるため nonce のみ触る)。
+ * PDS 用 DPoP-Nonce を読む (無ければ null)。**トークンレコードとは別キー**なので、リクエスト
+ * Worker がこれを更新しても cron が書くトークン本体を巻き込まない (レビュー ★★)。
  */
-export async function updateServerNonce(kv: KVNamespace, nonce: string, now: number): Promise<void> {
-  const t = await readServerTokens(kv);
-  if (!t || t.dpopNonce === nonce) return;
-  t.dpopNonce = nonce;
-  t.updatedAt = now;
-  await writeServerTokens(kv, t);
+export async function readPdsNonce(kv: KVNamespace): Promise<string | null> {
+  return kv.get(PDS_NONCE_KEY);
+}
+
+/** PDS 用 DPoP-Nonce を保存 (リクエスト Worker が新 nonce を受けたとき)。単一フィールドの上書きのみ。 */
+export async function writePdsNonce(kv: KVNamespace, nonce: string): Promise<void> {
+  await kv.put(PDS_NONCE_KEY, nonce);
 }
 
 /** トークンを消す (ロックアウト検知時・再 OAuth 前のクリーンアップ)。 */
@@ -67,6 +74,8 @@ export interface PendingAuth {
   verifier: string;
   /** 交換に使う認可サーバー (authorize 時に discovery したものを固定)。 */
   authServer: import('./oauth-metadata').AuthServerMetadata;
+  /** 書き込み先 PDS URL (authorize 時に discovery。callback でトークンレコードに載せる)。 */
+  pdsUrl: string;
   createdAt: number;
 }
 

--- a/apps/edge/src/oauth-store.ts
+++ b/apps/edge/src/oauth-store.ts
@@ -1,0 +1,62 @@
+/**
+ * サーバーアカウントの OAuth トークンストア (Cloudflare KV) — docs/21 §12。
+ *
+ * cron refresher が**唯一の書き手**、リクエスト処理 Worker が読み手。KV は結果整合だが、access token は
+ * refresh 後も期限まで有効なので少し古い読みでも可 (単回ローテーションが効くのは refresh token = cron のみ)。
+ * DPoP-Nonce は接続をまたいで再利用するためここに保持する。
+ */
+
+/** KV に保存する OAuth セッション。1 サーバーアカウント = 1 レコード。 */
+export interface ServerOAuthTokens {
+  /** サーバーアカウント DID (トークンの sub)。 */
+  did: string;
+  accessToken: string;
+  refreshToken: string;
+  /** 通常 "DPoP"。 */
+  tokenType: string;
+  /** access token 失効時刻 (epoch 秒)。cron はこれより前に refresh する。 */
+  expiresAt: number;
+  /** 直近の DPoP-Nonce (あれば次リクエストで再利用)。 */
+  dpopNonce?: string;
+  /** 認可サーバー issuer (refresh / token エンドポイント解決に使う)。 */
+  authServer: string;
+  scope?: string;
+  /** 最終更新 (epoch 秒、監査用)。 */
+  updatedAt: number;
+}
+
+/** KV のキー (単一サーバーアカウント運用なので固定キー)。 */
+export const SERVER_OAUTH_KEY = 'server-oauth';
+
+/** トークンを読む (無ければ null = 未 bootstrap)。 */
+export async function readServerTokens(kv: KVNamespace): Promise<ServerOAuthTokens | null> {
+  const raw = await kv.get(SERVER_OAUTH_KEY);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as ServerOAuthTokens;
+  } catch {
+    return null; // 壊れたレコードは未 bootstrap 扱い (fail-closed 側)
+  }
+}
+
+/** トークンを保存 (cron の refresh 後・初回 bootstrap 時)。 */
+export async function writeServerTokens(kv: KVNamespace, tokens: ServerOAuthTokens): Promise<void> {
+  await kv.put(SERVER_OAUTH_KEY, JSON.stringify(tokens));
+}
+
+/**
+ * DPoP-Nonce だけを更新 (read-modify-write)。リクエスト Worker が新 nonce を受けたときに使う。
+ * トークン本体が無ければ何もしない (書き手競合を避けるため nonce のみ触る)。
+ */
+export async function updateServerNonce(kv: KVNamespace, nonce: string, now: number): Promise<void> {
+  const t = await readServerTokens(kv);
+  if (!t || t.dpopNonce === nonce) return;
+  t.dpopNonce = nonce;
+  t.updatedAt = now;
+  await writeServerTokens(kv, t);
+}
+
+/** トークンを消す (ロックアウト検知時・再 OAuth 前のクリーンアップ)。 */
+export async function clearServerTokens(kv: KVNamespace): Promise<void> {
+  await kv.delete(SERVER_OAUTH_KEY);
+}

--- a/apps/edge/src/oauth-store.ts
+++ b/apps/edge/src/oauth-store.ts
@@ -60,3 +60,34 @@ export async function updateServerNonce(kv: KVNamespace, nonce: string, now: num
 export async function clearServerTokens(kv: KVNamespace): Promise<void> {
   await kv.delete(SERVER_OAUTH_KEY);
 }
+
+/** authorize→callback 間で保持する PKCE/state (CSRF)。TTL 付きで短命に持つ。 */
+export interface PendingAuth {
+  /** PKCE code_verifier。 */
+  verifier: string;
+  /** 交換に使う認可サーバー (authorize 時に discovery したものを固定)。 */
+  authServer: import('./oauth-metadata').AuthServerMetadata;
+  createdAt: number;
+}
+
+const PENDING_PREFIX = 'oauth-pending:';
+/** pending の既定 TTL (秒)。authorize→callback は数分で終わる。 */
+export const PENDING_TTL_SEC = 600;
+
+/** pending を保存 (state をキーに、TTL 付き)。 */
+export async function putPendingAuth(kv: KVNamespace, state: string, data: PendingAuth, ttlSec = PENDING_TTL_SEC): Promise<void> {
+  await kv.put(PENDING_PREFIX + state, JSON.stringify(data), { expirationTtl: ttlSec });
+}
+
+/** pending を取り出して削除 (使い捨て = リプレイ防止)。無効/期限切れは null。 */
+export async function takePendingAuth(kv: KVNamespace, state: string): Promise<PendingAuth | null> {
+  const key = PENDING_PREFIX + state;
+  const raw = await kv.get(key);
+  if (!raw) return null;
+  await kv.delete(key);
+  try {
+    return JSON.parse(raw) as PendingAuth;
+  } catch {
+    return null;
+  }
+}

--- a/apps/edge/src/router.ts
+++ b/apps/edge/src/router.ts
@@ -12,17 +12,18 @@
 import { verifyServiceAuth, ServiceAuthError } from './service-auth';
 import { getRecord } from './pds';
 import { GAME_STATE_COLLECTION, rkeyForDid, emptyState } from './game-state';
+import { handleClientMetadata, handleOAuthStart, handleOAuthCallback, type OAuthRoutesEnv } from './oauth-routes';
 
-export interface Env {
+/** WORKER_DID / SERVER_DID / OAUTH_* / ADMIN_DIDS / OAUTH_TOKENS は OAuthRoutesEnv から継承。 */
+export interface Env extends OAuthRoutesEnv {
   ENVIRONMENT?: string;
   /** カンマ区切り。空 or 未設定なら CORS 全許可 (dev 用)。production では必ず設定する */
   ALLOWED_ORIGINS?: string;
-  /** この Worker の DID (service auth JWT の aud)。既定 did:web:edge.aozoraquest.app */
-  WORKER_DID?: string;
-  /** 権威 state を置く app サーバーアカウントの PDS URL と DID (public read 用、非 secret)。 */
+  /** 権威 state を置く app サーバーアカウントの PDS URL (public read 用、非 secret)。SERVER_DID は継承。 */
   SERVER_PDS_URL?: string;
-  SERVER_DID?: string;
 }
+
+const nowSec = (): number => Math.floor(Date.now() / 1000);
 
 /** service auth の lexicon method (lxm)。エンドポイントごとに別値。 */
 const LXM_WHOAMI = 'app.aozoraquest.whoami';
@@ -98,6 +99,20 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
     const rec = await getRecord(env.SERVER_PDS_URL, env.SERVER_DID, GAME_STATE_COLLECTION, rkeyForDid(did));
     // 未作成なら初期値を返す (実 state 化は初回の書込み = M3 で。移行はそこでクランプ)
     return cors(json({ state: rec?.value ?? emptyState(did, new Date().toISOString()), initialized: rec !== null }), allowedOrigin);
+  }
+
+  // ── OAuth write 認証 (docs/21 §12) ──
+  // confidential client メタデータ (公開)。
+  if (req.method === 'GET' && url.pathname === '/client-metadata.json') {
+    return cors(handleClientMetadata(env), allowedOrigin);
+  }
+  // 管理者が OAuth 連携を開始 (service auth JWT + ADMIN_DIDS)。authorizeUrl を返す。
+  if (req.method === 'POST' && url.pathname === '/api/oauth/start') {
+    return cors(await handleOAuthStart(req, env, { now: nowSec() }), allowedOrigin);
+  }
+  // 認可サーバーからのリダイレクト先。ブラウザ遷移なので HTML を直接返す (CORS 不要)。
+  if (req.method === 'GET' && url.pathname === '/oauth/callback') {
+    return handleOAuthCallback(req, env, { now: nowSec() });
   }
 
   return cors(json({ error: 'not_found', path: url.pathname }, 404), allowedOrigin);

--- a/apps/edge/src/service-auth.ts
+++ b/apps/edge/src/service-auth.ts
@@ -47,7 +47,7 @@ export function decodeMultikey(multibase: string): SigningKey {
   throw new ServiceAuthError(`未対応の multicodec prefix: ${bytes[0]?.toString(16)} ${bytes[1]?.toString(16)}`);
 }
 
-interface DidDocument {
+export interface DidDocument {
   id: string;
   verificationMethod?: { id: string; type: string; controller?: string; publicKeyMultibase?: string }[];
 }

--- a/apps/edge/test/dpop-fetch.test.ts
+++ b/apps/edge/test/dpop-fetch.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { p256 } from '@noble/curves/p256';
+import { base64urlnopad } from '@scure/base';
+import { dpopFetch } from '../src/dpop-fetch';
+import type { EcJwk } from '../src/oauth-jwt';
+
+function makeJwk(): EcJwk {
+  const d = new Uint8Array(32).fill(9);
+  const pub = p256.getPublicKey(d, false);
+  return { kty: 'EC', crv: 'P-256', x: base64urlnopad.encode(pub.slice(1, 33)), y: base64urlnopad.encode(pub.slice(33, 65)), d: base64urlnopad.encode(d) };
+}
+const jwk = makeJwk();
+const NOW = 1000;
+const withNonce = (b: unknown, nonce: string, status = 400) => new Response(JSON.stringify(b), { status, headers: { 'content-type': 'application/json', 'DPoP-Nonce': nonce } });
+
+describe('dpop-fetch', () => {
+  it('DPoP ヘッダを付ける / accessToken 時は Authorization: DPoP も付ける', async () => {
+    let seen: Headers | undefined;
+    const f = (async (_u: string, init: RequestInit) => { seen = new Headers(init.headers); return new Response('{}', { status: 200 }); }) as unknown as typeof fetch;
+    await dpopFetch('https://pds.example/x', { method: 'POST' }, { jwk, accessToken: 'AT', now: NOW, fetchImpl: f });
+    expect(seen?.get('DPoP')).toBeTruthy();
+    expect(seen?.get('Authorization')).toBe('DPoP AT');
+  });
+
+  it('use_dpop_nonce (JSON body) チャレンジで nonce を付けて 1 回だけ再送し成功する', async () => {
+    let calls = 0;
+    const nonces: string[] = [];
+    const f = (async (_u: string, init: RequestInit) => {
+      calls++;
+      nonces.push(new Headers(init.headers).get('DPoP') ? 'proof' : '');
+      if (calls === 1) return withNonce({ error: 'use_dpop_nonce' }, 'NONCE-1', 400);
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }) as unknown as typeof fetch;
+    let captured = '';
+    const res = await dpopFetch('https://as.example/token', { method: 'POST' }, { jwk, now: NOW, fetchImpl: f, onNonce: (n) => { captured = n; } });
+    expect(res.status).toBe(200);
+    expect(calls).toBe(2); // 初回チャレンジ + nonce 付き再送
+    expect(captured).toBe('NONCE-1');
+  });
+
+  it('use_dpop_nonce (WWW-Authenticate ヘッダ) でも再送する', async () => {
+    let calls = 0;
+    const f = (async () => {
+      calls++;
+      if (calls === 1) return new Response('', { status: 401, headers: { 'www-authenticate': 'DPoP error="use_dpop_nonce"', 'DPoP-Nonce': 'N2' } });
+      return new Response('ok', { status: 200 });
+    }) as unknown as typeof fetch;
+    const res = await dpopFetch('https://pds.example/xrpc/x', { method: 'POST' }, { jwk, now: NOW, fetchImpl: f });
+    expect(res.status).toBe(200);
+    expect(calls).toBe(2);
+  });
+
+  it('再送は 1 回まで (nonce を出し続けても無限ループしない)', async () => {
+    let calls = 0;
+    const f = (async () => { calls++; return withNonce({ error: 'use_dpop_nonce' }, `N${calls}`, 400); }) as unknown as typeof fetch;
+    const res = await dpopFetch('https://as.example/token', { method: 'POST' }, { jwk, now: NOW, fetchImpl: f });
+    expect(calls).toBe(2); // 初回 + 再送 1 回で打ち止め
+    expect(res.status).toBe(400); // 最後のレスポンスをそのまま返す
+  });
+
+  it('nonce 要求でない 400/401 は再送せずそのまま返す (body は消費しない)', async () => {
+    let calls = 0;
+    const f = (async () => { calls++; return new Response(JSON.stringify({ error: 'invalid_grant' }), { status: 400, headers: { 'content-type': 'application/json' } }); }) as unknown as typeof fetch;
+    const res = await dpopFetch('https://as.example/token', { method: 'POST' }, { jwk, now: NOW, fetchImpl: f });
+    expect(calls).toBe(1);
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe('invalid_grant'); // body 未消費で読める
+  });
+
+  it('成功レスポンスの DPoP-Nonce も onNonce で通知する (次回用に更新)', async () => {
+    const f = (async () => new Response('{}', { status: 200, headers: { 'DPoP-Nonce': 'FRESH' } })) as unknown as typeof fetch;
+    let n = '';
+    await dpopFetch('https://pds.example/x', { method: 'GET' }, { jwk, now: NOW, fetchImpl: f, onNonce: (x) => { n = x; } });
+    expect(n).toBe('FRESH');
+  });
+});

--- a/apps/edge/test/oauth-client.test.ts
+++ b/apps/edge/test/oauth-client.test.ts
@@ -54,8 +54,8 @@ describe('oauth-client', () => {
   it('exchangeCode は token を正規化 (sub→did, expiresAt=now+expires_in)', async () => {
     let body = '';
     const f = (async (_u: string, init: RequestInit) => { body = init.body as string; return json({ access_token: 'AT', token_type: 'DPoP', refresh_token: 'RT', expires_in: 3600, sub: 'did:plc:kojira', scope: 'atproto' }); }) as unknown as typeof fetch;
-    const t = await exchangeCode({ ...cfg(), fetchImpl: f }, AS, 'CODE', 'VER');
-    expect(t).toMatchObject({ did: 'did:plc:kojira', accessToken: 'AT', refreshToken: 'RT', tokenType: 'DPoP', expiresAt: NOW + 3600, authServer: AS.issuer });
+    const t = await exchangeCode({ ...cfg(), fetchImpl: f }, AS, 'CODE', 'VER', 'https://pds.example', 'did:plc:kojira');
+    expect(t).toMatchObject({ did: 'did:plc:kojira', accessToken: 'AT', refreshToken: 'RT', tokenType: 'DPoP', expiresAt: NOW + 3600, authServer: AS.issuer, pdsUrl: 'https://pds.example' });
     const form = new URLSearchParams(body);
     expect(form.get('grant_type')).toBe('authorization_code');
     expect(form.get('code')).toBe('CODE');
@@ -65,7 +65,7 @@ describe('oauth-client', () => {
   it('refreshTokens は grant_type=refresh_token で更新する', async () => {
     let body = '';
     const f = (async (_u: string, init: RequestInit) => { body = init.body as string; return json({ access_token: 'AT2', token_type: 'DPoP', refresh_token: 'RT2', expires_in: 100, sub: 'did:plc:kojira' }); }) as unknown as typeof fetch;
-    const t = await refreshTokens({ ...cfg(), fetchImpl: f }, AS, 'OLD_RT');
+    const t = await refreshTokens({ ...cfg(), fetchImpl: f }, AS, 'OLD_RT', 'https://pds.example', 'did:plc:kojira');
     expect(t.accessToken).toBe('AT2');
     expect(t.refreshToken).toBe('RT2');
     expect(new URLSearchParams(body).get('refresh_token')).toBe('OLD_RT');
@@ -73,7 +73,20 @@ describe('oauth-client', () => {
 
   it('refresh_token が無い応答はエラー', async () => {
     const f = (async () => json({ access_token: 'AT', token_type: 'DPoP', sub: 'did:plc:x' })) as unknown as typeof fetch;
-    await expect(exchangeCode({ ...cfg(), fetchImpl: f }, AS, 'C', 'V')).rejects.toThrow(/refresh_token/);
+    await expect(exchangeCode({ ...cfg(), fetchImpl: f }, AS, 'C', 'V', 'https://pds.example', 'did:plc:x')).rejects.toThrow(/refresh_token/);
+  });
+
+  it('sub が期待アカウントと違えば拒否 (アカウント取り違え/セッション固定対策)', async () => {
+    const f = (async () => json({ access_token: 'AT', token_type: 'DPoP', refresh_token: 'RT', expires_in: 60, sub: 'did:plc:attacker' })) as unknown as typeof fetch;
+    await expect(exchangeCode({ ...cfg(), fetchImpl: f }, AS, 'C', 'V', 'https://pds.example', 'did:plc:kojira')).rejects.toThrow(/予期しないアカウント/);
+    // 一致すれば通る
+    const ok = (async () => json({ access_token: 'AT', token_type: 'DPoP', refresh_token: 'RT', expires_in: 60, sub: 'did:plc:kojira' })) as unknown as typeof fetch;
+    await expect(exchangeCode({ ...cfg(), fetchImpl: ok }, AS, 'C', 'V', 'https://pds.example', 'did:plc:kojira')).resolves.toMatchObject({ did: 'did:plc:kojira' });
+  });
+
+  it('bootstrap (exchangeCode) は sub 欠落を serverDid で埋めず拒否する', async () => {
+    const f = (async () => json({ access_token: 'AT', token_type: 'DPoP', refresh_token: 'RT', expires_in: 60 })) as unknown as typeof fetch; // sub なし
+    await expect(exchangeCode({ ...cfg(), fetchImpl: f }, AS, 'C', 'V', 'https://pds.example', 'did:plc:kojira')).rejects.toThrow(/sub/);
   });
 
   it('use_dpop_nonce チャレンジは nonce を付けて再送し成功する', async () => {
@@ -83,13 +96,13 @@ describe('oauth-client', () => {
       if (calls === 1) return json({ error: 'use_dpop_nonce' }, 400, { 'DPoP-Nonce': 'N1' });
       return json({ access_token: 'AT', token_type: 'DPoP', refresh_token: 'RT', expires_in: 60, sub: 'did:plc:x' });
     }) as unknown as typeof fetch;
-    const t = await exchangeCode({ ...cfg(), fetchImpl: f }, AS, 'C', 'V');
+    const t = await exchangeCode({ ...cfg(), fetchImpl: f }, AS, 'C', 'V', 'https://pds.example', 'did:plc:x');
     expect(calls).toBe(2);
     expect(t.accessToken).toBe('AT');
   });
 
   it('OAuth エラー応答 (invalid_grant 等) は throw', async () => {
     const f = (async () => json({ error: 'invalid_grant', error_description: 'bad code' }, 400)) as unknown as typeof fetch;
-    await expect(exchangeCode({ ...cfg(), fetchImpl: f }, AS, 'C', 'V')).rejects.toThrow(/invalid_grant/);
+    await expect(exchangeCode({ ...cfg(), fetchImpl: f }, AS, 'C', 'V', 'https://pds.example', 'did:plc:x')).rejects.toThrow(/invalid_grant/);
   });
 });

--- a/apps/edge/test/oauth-client.test.ts
+++ b/apps/edge/test/oauth-client.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { p256 } from '@noble/curves/p256';
+import { sha256 } from '@noble/hashes/sha256';
+import { base64urlnopad } from '@scure/base';
+import { generatePkce, generateState, buildAuthorizeUrl, exchangeCode, refreshTokens } from '../src/oauth-client';
+import type { EcJwk } from '../src/oauth-jwt';
+import type { AuthServerMetadata } from '../src/oauth-metadata';
+
+function makeJwk(fill: number): EcJwk {
+  const d = new Uint8Array(32).fill(fill);
+  const pub = p256.getPublicKey(d, false);
+  return { kty: 'EC', crv: 'P-256', x: base64urlnopad.encode(pub.slice(1, 33)), y: base64urlnopad.encode(pub.slice(33, 65)), d: base64urlnopad.encode(d) };
+}
+const AS: AuthServerMetadata = {
+  issuer: 'https://bsky.social',
+  authorization_endpoint: 'https://bsky.social/oauth/authorize',
+  token_endpoint: 'https://bsky.social/oauth/token',
+  pushed_authorization_request_endpoint: 'https://bsky.social/oauth/par',
+};
+const NOW = 1000;
+const cfg = () => ({ clientId: 'https://edge.example/client-metadata.json', redirectUri: 'https://edge.example/oauth/callback', scope: 'atproto transition:generic', clientJwk: makeJwk(3), dpopJwk: makeJwk(5), now: NOW });
+const json = (b: unknown, status = 200, headers: Record<string, string> = {}) => new Response(JSON.stringify(b), { status, headers: { 'content-type': 'application/json', ...headers } });
+
+describe('oauth-client', () => {
+  it('generatePkce は 43 文字 verifier と S256 challenge (決定的)', () => {
+    const rand = new Uint8Array(32).fill(1);
+    const p = generatePkce(rand);
+    expect(p.verifier).toHaveLength(43);
+    expect(p.verifier).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(p.challenge).toBe(base64urlnopad.encode(sha256(new TextEncoder().encode(p.verifier))));
+    expect(generatePkce(rand).verifier).toBe(p.verifier); // 決定的
+  });
+
+  it('generateState は base64url', () => {
+    expect(generateState(new Uint8Array(16).fill(2))).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it('buildAuthorizeUrl は PAR して authorize URL を返し、正しい form を送る', async () => {
+    let body = '';
+    const f = (async (_u: string, init: RequestInit) => { body = init.body as string; return json({ request_uri: 'urn:req:abc' }); }) as unknown as typeof fetch;
+    const r = await buildAuthorizeUrl({ ...cfg(), fetchImpl: f }, AS, { loginHint: 'kojira.io', state: 'ST', pkce: { verifier: 'VER', challenge: 'CHAL' } });
+    expect(r.url).toBe(`https://bsky.social/oauth/authorize?client_id=${encodeURIComponent(cfg().clientId)}&request_uri=urn%3Areq%3Aabc`);
+    expect(r.state).toBe('ST');
+    expect(r.verifier).toBe('VER');
+    const form = new URLSearchParams(body);
+    expect(form.get('response_type')).toBe('code');
+    expect(form.get('code_challenge')).toBe('CHAL');
+    expect(form.get('code_challenge_method')).toBe('S256');
+    expect(form.get('login_hint')).toBe('kojira.io');
+    expect(form.get('client_assertion_type')).toBe('urn:ietf:params:oauth:client-assertion-type:jwt-bearer');
+    expect(form.get('client_assertion')).toBeTruthy();
+  });
+
+  it('exchangeCode は token を正規化 (sub→did, expiresAt=now+expires_in)', async () => {
+    let body = '';
+    const f = (async (_u: string, init: RequestInit) => { body = init.body as string; return json({ access_token: 'AT', token_type: 'DPoP', refresh_token: 'RT', expires_in: 3600, sub: 'did:plc:kojira', scope: 'atproto' }); }) as unknown as typeof fetch;
+    const t = await exchangeCode({ ...cfg(), fetchImpl: f }, AS, 'CODE', 'VER');
+    expect(t).toMatchObject({ did: 'did:plc:kojira', accessToken: 'AT', refreshToken: 'RT', tokenType: 'DPoP', expiresAt: NOW + 3600, authServer: AS.issuer });
+    const form = new URLSearchParams(body);
+    expect(form.get('grant_type')).toBe('authorization_code');
+    expect(form.get('code')).toBe('CODE');
+    expect(form.get('code_verifier')).toBe('VER');
+  });
+
+  it('refreshTokens は grant_type=refresh_token で更新する', async () => {
+    let body = '';
+    const f = (async (_u: string, init: RequestInit) => { body = init.body as string; return json({ access_token: 'AT2', token_type: 'DPoP', refresh_token: 'RT2', expires_in: 100, sub: 'did:plc:kojira' }); }) as unknown as typeof fetch;
+    const t = await refreshTokens({ ...cfg(), fetchImpl: f }, AS, 'OLD_RT');
+    expect(t.accessToken).toBe('AT2');
+    expect(t.refreshToken).toBe('RT2');
+    expect(new URLSearchParams(body).get('refresh_token')).toBe('OLD_RT');
+  });
+
+  it('refresh_token が無い応答はエラー', async () => {
+    const f = (async () => json({ access_token: 'AT', token_type: 'DPoP', sub: 'did:plc:x' })) as unknown as typeof fetch;
+    await expect(exchangeCode({ ...cfg(), fetchImpl: f }, AS, 'C', 'V')).rejects.toThrow(/refresh_token/);
+  });
+
+  it('use_dpop_nonce チャレンジは nonce を付けて再送し成功する', async () => {
+    let calls = 0;
+    const f = (async (_u: string) => {
+      calls++;
+      if (calls === 1) return json({ error: 'use_dpop_nonce' }, 400, { 'DPoP-Nonce': 'N1' });
+      return json({ access_token: 'AT', token_type: 'DPoP', refresh_token: 'RT', expires_in: 60, sub: 'did:plc:x' });
+    }) as unknown as typeof fetch;
+    const t = await exchangeCode({ ...cfg(), fetchImpl: f }, AS, 'C', 'V');
+    expect(calls).toBe(2);
+    expect(t.accessToken).toBe('AT');
+  });
+
+  it('OAuth エラー応答 (invalid_grant 等) は throw', async () => {
+    const f = (async () => json({ error: 'invalid_grant', error_description: 'bad code' }, 400)) as unknown as typeof fetch;
+    await expect(exchangeCode({ ...cfg(), fetchImpl: f }, AS, 'C', 'V')).rejects.toThrow(/invalid_grant/);
+  });
+});

--- a/apps/edge/test/oauth-config.test.ts
+++ b/apps/edge/test/oauth-config.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { p256 } from '@noble/curves/p256';
+import { base64urlnopad } from '@scure/base';
+import { loadOAuthConfig, publicOrigin, isEdgeAdmin, buildClientMetadata, OAuthConfigError, type OAuthEnv } from '../src/oauth-config';
+
+function jwkJson(fill: number): string {
+  const d = new Uint8Array(32).fill(fill);
+  const pub = p256.getPublicKey(d, false);
+  return JSON.stringify({ kty: 'EC', crv: 'P-256', x: base64urlnopad.encode(pub.slice(1, 33)), y: base64urlnopad.encode(pub.slice(33, 65)), d: base64urlnopad.encode(d), kid: `k${fill}` });
+}
+const baseEnv = (): OAuthEnv => ({
+  OAUTH_CLIENT_PRIVATE_JWK: jwkJson(3),
+  OAUTH_DPOP_PRIVATE_JWK: jwkJson(5),
+  SERVER_DID: 'did:plc:kojira',
+  WORKER_DID: 'did:web:edge.aozoraquest.app',
+  ADMIN_DIDS: 'did:plc:admin1, did:plc:admin2',
+});
+
+describe('oauth-config', () => {
+  it('publicOrigin は WORKER_DID(did:web) から導出 / PUBLIC_ORIGIN 優先', () => {
+    expect(publicOrigin({ WORKER_DID: 'did:web:edge.aozoraquest.app' })).toBe('https://edge.aozoraquest.app');
+    expect(publicOrigin({ PUBLIC_ORIGIN: 'https://x.example/', WORKER_DID: 'did:web:y' })).toBe('https://x.example');
+    expect(() => publicOrigin({})).toThrow(OAuthConfigError);
+  });
+
+  it('loadOAuthConfig は client_id/redirect を導出し鍵を読む', () => {
+    const c = loadOAuthConfig(baseEnv());
+    expect(c.clientId).toBe('https://edge.aozoraquest.app/client-metadata.json');
+    expect(c.redirectUri).toBe('https://edge.aozoraquest.app/oauth/callback');
+    expect(c.scope).toBe('atproto transition:generic');
+    expect(c.serverDid).toBe('did:plc:kojira');
+    expect(c.clientJwk.d).toBeTruthy();
+  });
+
+  it('SERVER_DID / 鍵の欠落・不正は OAuthConfigError (fail-closed)', () => {
+    expect(() => loadOAuthConfig({ ...baseEnv(), SERVER_DID: undefined })).toThrow(OAuthConfigError);
+    expect(() => loadOAuthConfig({ ...baseEnv(), OAUTH_CLIENT_PRIVATE_JWK: undefined })).toThrow(OAuthConfigError);
+    expect(() => loadOAuthConfig({ ...baseEnv(), OAUTH_DPOP_PRIVATE_JWK: '{bad json' })).toThrow(OAuthConfigError);
+    expect(() => loadOAuthConfig({ ...baseEnv(), OAUTH_CLIENT_PRIVATE_JWK: JSON.stringify({ kty: 'EC', crv: 'P-256', x: 'a', y: 'b' }) })).toThrow(/秘密鍵/);
+  });
+
+  it('isEdgeAdmin は ADMIN_DIDS 許可リストで判定', () => {
+    const env = baseEnv();
+    expect(isEdgeAdmin(env, 'did:plc:admin1')).toBe(true);
+    expect(isEdgeAdmin(env, 'did:plc:admin2')).toBe(true);
+    expect(isEdgeAdmin(env, 'did:plc:other')).toBe(false);
+    expect(isEdgeAdmin({}, 'did:plc:admin1')).toBe(false);
+  });
+
+  it('buildClientMetadata は confidential client (private_key_jwt + 公開 jwks)', () => {
+    const m = buildClientMetadata(loadOAuthConfig(baseEnv()));
+    expect(m.client_id).toBe('https://edge.aozoraquest.app/client-metadata.json');
+    expect(m.redirect_uris).toEqual(['https://edge.aozoraquest.app/oauth/callback']);
+    expect(m.token_endpoint_auth_method).toBe('private_key_jwt');
+    expect(m.dpop_bound_access_tokens).toBe(true);
+    const keys = (m.jwks as { keys: Record<string, unknown>[] }).keys;
+    expect(keys[0]!.d).toBeUndefined(); // 公開鍵のみ (秘密鍵を晒さない)
+    expect(keys[0]!.kid).toBe('k3');
+    expect(keys[0]!.use).toBe('sig');
+  });
+});

--- a/apps/edge/test/oauth-cron.test.ts
+++ b/apps/edge/test/oauth-cron.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { p256 } from '@noble/curves/p256';
+import { base64urlnopad } from '@scure/base';
+import { runCronRefresh, REFRESH_AHEAD_SEC, type CronEnv } from '../src/oauth-cron';
+import { writeServerTokens, readServerTokens, type ServerOAuthTokens } from '../src/oauth-store';
+
+function jwkJson(fill: number): string {
+  const d = new Uint8Array(32).fill(fill);
+  const pub = p256.getPublicKey(d, false);
+  return JSON.stringify({ kty: 'EC', crv: 'P-256', x: base64urlnopad.encode(pub.slice(1, 33)), y: base64urlnopad.encode(pub.slice(33, 65)), d: base64urlnopad.encode(d), kid: `k${fill}` });
+}
+function mockKv() {
+  const m = new Map<string, string>();
+  return { get: async (k: string) => m.get(k) ?? null, put: async (k: string, v: string) => { m.set(k, v); }, delete: async (k: string) => { m.delete(k); } } as unknown as KVNamespace;
+}
+const AS = 'https://bsky.social';
+const env = (kv?: KVNamespace): CronEnv => ({ OAUTH_CLIENT_PRIVATE_JWK: jwkJson(3), OAUTH_DPOP_PRIVATE_JWK: jwkJson(5), SERVER_DID: 'did:plc:kojira', WORKER_DID: 'did:web:edge.aozoraquest.app', OAUTH_TOKENS: kv });
+const json = (b: unknown, s = 200) => new Response(JSON.stringify(b), { status: s, headers: { 'content-type': 'application/json' } });
+const NOW = 100000;
+const tokens = (over: Partial<ServerOAuthTokens> = {}): ServerOAuthTokens => ({ did: 'did:plc:kojira', accessToken: 'AT', refreshToken: 'RT', tokenType: 'DPoP', expiresAt: NOW + 3600, authServer: AS, updatedAt: NOW, ...over });
+
+const refreshFetch = (tokenResp: () => Response) => (async (url: string) => {
+  if (url.includes('plc.directory')) return json({ id: 'did:plc:kojira', service: [{ id: '#atproto_pds', type: 'AtprotoPersonalDataServer', serviceEndpoint: 'https://pds.example' }] });
+  if (url.includes('oauth-protected-resource')) return json({ authorization_servers: [AS] });
+  if (url.includes('oauth-authorization-server')) return json({ issuer: AS, authorization_endpoint: `${AS}/a`, token_endpoint: `${AS}/oauth/token`, pushed_authorization_request_endpoint: `${AS}/par` });
+  if (url.includes('/oauth/token')) return tokenResp();
+  return json({ error: 'nf' }, 404);
+}) as unknown as typeof fetch;
+
+describe('oauth-cron', () => {
+  it('KV 無し / 未 bootstrap は skip', async () => {
+    expect((await runCronRefresh(env(), NOW)).status).toBe('no-kv');
+    expect((await runCronRefresh(env(mockKv()), NOW)).status).toBe('not-bootstrapped');
+  });
+
+  it('期限に余裕があれば not-due (無駄な refresh をしない)', async () => {
+    const kv = mockKv();
+    await writeServerTokens(kv, tokens({ expiresAt: NOW + REFRESH_AHEAD_SEC + 100 }));
+    expect((await runCronRefresh(env(kv), NOW)).status).toBe('not-due');
+  });
+
+  it('期限が近ければ refresh して KV を更新 (dpopNonce は保持)', async () => {
+    const kv = mockKv();
+    await writeServerTokens(kv, tokens({ expiresAt: NOW + 60, dpopNonce: 'PDS-NONCE' }));
+    const f = refreshFetch(() => json({ access_token: 'AT2', token_type: 'DPoP', refresh_token: 'RT2', expires_in: 3600, sub: 'did:plc:kojira' }));
+    const r = await runCronRefresh(env(kv), NOW, f);
+    expect(r.status).toBe('refreshed');
+    const saved = await readServerTokens(kv);
+    expect(saved).toMatchObject({ accessToken: 'AT2', refreshToken: 'RT2', dpopNonce: 'PDS-NONCE' });
+    expect(saved!.expiresAt).toBe(NOW + 3600);
+  });
+
+  it('refresh 失敗 (invalid_grant) は error を返しトークンは残す (診断用)', async () => {
+    const kv = mockKv();
+    await writeServerTokens(kv, tokens({ expiresAt: NOW + 60 }));
+    const f = refreshFetch(() => json({ error: 'invalid_grant' }, 400));
+    const r = await runCronRefresh(env(kv), NOW, f);
+    expect(r.status).toBe('error');
+    expect((await readServerTokens(kv))?.refreshToken).toBe('RT'); // 消さない
+  });
+
+  it('設定不備 (鍵欠落) は not-configured', async () => {
+    const kv = mockKv();
+    await writeServerTokens(kv, tokens({ expiresAt: NOW + 60 }));
+    const r = await runCronRefresh({ ...env(kv), OAUTH_CLIENT_PRIVATE_JWK: undefined }, NOW);
+    expect(r.status).toBe('not-configured');
+  });
+});

--- a/apps/edge/test/oauth-cron.test.ts
+++ b/apps/edge/test/oauth-cron.test.ts
@@ -17,7 +17,7 @@ const AS = 'https://bsky.social';
 const env = (kv?: KVNamespace): CronEnv => ({ OAUTH_CLIENT_PRIVATE_JWK: jwkJson(3), OAUTH_DPOP_PRIVATE_JWK: jwkJson(5), SERVER_DID: 'did:plc:kojira', WORKER_DID: 'did:web:edge.aozoraquest.app', OAUTH_TOKENS: kv });
 const json = (b: unknown, s = 200) => new Response(JSON.stringify(b), { status: s, headers: { 'content-type': 'application/json' } });
 const NOW = 100000;
-const tokens = (over: Partial<ServerOAuthTokens> = {}): ServerOAuthTokens => ({ did: 'did:plc:kojira', accessToken: 'AT', refreshToken: 'RT', tokenType: 'DPoP', expiresAt: NOW + 3600, authServer: AS, updatedAt: NOW, ...over });
+const tokens = (over: Partial<ServerOAuthTokens> = {}): ServerOAuthTokens => ({ did: 'did:plc:kojira', accessToken: 'AT', refreshToken: 'RT', tokenType: 'DPoP', expiresAt: NOW + 3600, pdsUrl: 'https://pds.example', authServer: AS, updatedAt: NOW, ...over });
 
 const refreshFetch = (tokenResp: () => Response) => (async (url: string) => {
   if (url.includes('plc.directory')) return json({ id: 'did:plc:kojira', service: [{ id: '#atproto_pds', type: 'AtprotoPersonalDataServer', serviceEndpoint: 'https://pds.example' }] });
@@ -39,15 +39,22 @@ describe('oauth-cron', () => {
     expect((await runCronRefresh(env(kv), NOW)).status).toBe('not-due');
   });
 
-  it('期限が近ければ refresh して KV を更新 (dpopNonce は保持)', async () => {
+  it('期限が近ければ refresh して KV を更新 (refreshingUntil は解除)', async () => {
     const kv = mockKv();
-    await writeServerTokens(kv, tokens({ expiresAt: NOW + 60, dpopNonce: 'PDS-NONCE' }));
+    await writeServerTokens(kv, tokens({ expiresAt: NOW + 60 }));
     const f = refreshFetch(() => json({ access_token: 'AT2', token_type: 'DPoP', refresh_token: 'RT2', expires_in: 3600, sub: 'did:plc:kojira' }));
     const r = await runCronRefresh(env(kv), NOW, f);
     expect(r.status).toBe('refreshed');
     const saved = await readServerTokens(kv);
-    expect(saved).toMatchObject({ accessToken: 'AT2', refreshToken: 'RT2', dpopNonce: 'PDS-NONCE' });
+    expect(saved).toMatchObject({ accessToken: 'AT2', refreshToken: 'RT2', pdsUrl: 'https://pds.example' });
     expect(saved!.expiresAt).toBe(NOW + 3600);
+    expect(saved!.refreshingUntil).toBeUndefined(); // ロック解除
+  });
+
+  it('別 tick が refresh 中 (refreshingUntil) ならスキップ (二重 refresh 回避)', async () => {
+    const kv = mockKv();
+    await writeServerTokens(kv, tokens({ expiresAt: NOW + 60, refreshingUntil: NOW + 100 }));
+    expect((await runCronRefresh(env(kv), NOW)).status).toBe('refreshing');
   });
 
   it('refresh 失敗 (invalid_grant) は error を返しトークンは残す (診断用)', async () => {

--- a/apps/edge/test/oauth-jwt.test.ts
+++ b/apps/edge/test/oauth-jwt.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { p256 } from '@noble/curves/p256';
+import { sha256 } from '@noble/hashes/sha256';
+import { base64urlnopad } from '@scure/base';
+import { signEs256, publicJwk, jwkThumbprint, dpopProof, clientAssertion, accessTokenHash, type EcJwk } from '../src/oauth-jwt';
+
+/** テスト用の固定 P-256 JWK を作る (決定的な秘密鍵から x/y/d を導出)。 */
+function makeJwk(): EcJwk {
+  const d = new Uint8Array(32).fill(7); // 決定的な秘密スカラ (0 でも 32byte でもない有効値)
+  const pub = p256.getPublicKey(d, false); // 0x04 || x(32) || y(32)
+  return {
+    kty: 'EC', crv: 'P-256',
+    x: base64urlnopad.encode(pub.slice(1, 33)),
+    y: base64urlnopad.encode(pub.slice(33, 65)),
+    d: base64urlnopad.encode(d),
+  };
+}
+const jwk = makeJwk();
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+/** JWT を検証: 署名が公開鍵で通り、header/payload を返す。 */
+function verifyJwt(jwt: string, j: EcJwk): { header: Record<string, unknown>; payload: Record<string, unknown>; valid: boolean } {
+  const [h, p, s] = jwt.split('.');
+  const pub = new Uint8Array([4, ...base64urlnopad.decode(j.x), ...base64urlnopad.decode(j.y)]);
+  const valid = p256.verify(base64urlnopad.decode(s), sha256(enc.encode(`${h}.${p}`)), pub, { lowS: true });
+  return {
+    header: JSON.parse(dec.decode(base64urlnopad.decode(h))),
+    payload: JSON.parse(dec.decode(base64urlnopad.decode(p))),
+    valid,
+  };
+}
+
+describe('oauth-jwt (ES256 署名)', () => {
+  it('signEs256 は p256 で検証可能な low-S 署名を作る', () => {
+    const jwt = signEs256({ alg: 'ES256', typ: 'JWT' }, { hello: 'world', n: 1 }, jwk);
+    const v = verifyJwt(jwt, jwk);
+    expect(v.valid).toBe(true);
+    expect(v.header).toMatchObject({ alg: 'ES256', typ: 'JWT' });
+    expect(v.payload).toMatchObject({ hello: 'world', n: 1 });
+  });
+
+  it('改竄した payload は検証に失敗する', () => {
+    const jwt = signEs256({ alg: 'ES256' }, { amount: 1 }, jwk);
+    const [h, , s] = jwt.split('.');
+    const tampered = `${h}.${base64urlnopad.encode(enc.encode(JSON.stringify({ amount: 999 })))}.${s}`;
+    expect(verifyJwt(tampered, jwk).valid).toBe(false);
+  });
+
+  it('d の無い JWK では署名できない', () => {
+    expect(() => signEs256({}, {}, publicJwk(jwk))).toThrow();
+  });
+
+  it('publicJwk は d/kid を落とす', () => {
+    const pub = publicJwk({ ...jwk, kid: 'k1' });
+    expect(pub.d).toBeUndefined();
+    expect(pub.kid).toBeUndefined();
+    expect(pub).toMatchObject({ kty: 'EC', crv: 'P-256', x: jwk.x, y: jwk.y });
+  });
+
+  it('jwkThumbprint は決定的で公開鍵のみに依存 (d を含めても同じ)', () => {
+    const t1 = jwkThumbprint(jwk);
+    const t2 = jwkThumbprint(publicJwk(jwk));
+    expect(t1).toBe(t2);
+    expect(t1).toMatch(/^[A-Za-z0-9_-]{43}$/); // base64url(sha256) = 43 文字
+  });
+
+  it('dpopProof は typ=dpop+jwt・jwk 公開鍵・htm/htu を持ち、htu はクエリを除く', () => {
+    const jwt = dpopProof({ jwk, method: 'post', url: 'https://pds.example/xrpc/com.atproto.repo.putRecord?foo=1#frag', now: 1000 });
+    const v = verifyJwt(jwt, jwk);
+    expect(v.valid).toBe(true);
+    expect(v.header).toMatchObject({ typ: 'dpop+jwt', alg: 'ES256' });
+    expect((v.header.jwk as EcJwk).d).toBeUndefined(); // 公開鍵のみ
+    expect(v.payload).toMatchObject({ htm: 'POST', htu: 'https://pds.example/xrpc/com.atproto.repo.putRecord', iat: 1000 });
+    expect(typeof v.payload.jti).toBe('string');
+    expect(v.payload.nonce).toBeUndefined();
+  });
+
+  it('dpopProof は nonce と accessToken(ath) を入れられる', () => {
+    const at = 'access-token-xyz';
+    const jwt = dpopProof({ jwk, method: 'GET', url: 'https://pds.example/x', now: 5, nonce: 'N1', accessToken: at });
+    const v = verifyJwt(jwt, jwk);
+    expect(v.payload.nonce).toBe('N1');
+    expect(v.payload.ath).toBe(accessTokenHash(at));
+  });
+
+  it('clientAssertion は iss=sub=clientId・aud・exp>iat の private_key_jwt', () => {
+    const jwt = clientAssertion({ jwk, clientId: 'https://edge.example/client-metadata.json', audience: 'https://bsky.social', now: 100, ttlSec: 60 });
+    const v = verifyJwt(jwt, jwk);
+    expect(v.valid).toBe(true);
+    expect(v.payload).toMatchObject({
+      iss: 'https://edge.example/client-metadata.json',
+      sub: 'https://edge.example/client-metadata.json',
+      aud: 'https://bsky.social',
+      iat: 100, exp: 160,
+    });
+  });
+});

--- a/apps/edge/test/oauth-metadata.test.ts
+++ b/apps/edge/test/oauth-metadata.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { pdsEndpointFromDoc, discoverAuthServer, discoverForDid, type AuthServerMetadata } from '../src/oauth-metadata';
+
+const DID = 'did:plc:server';
+const PDS = 'https://pds.example';
+const AS = 'https://bsky.social';
+
+const goodMeta: AuthServerMetadata = {
+  issuer: AS,
+  authorization_endpoint: `${AS}/oauth/authorize`,
+  token_endpoint: `${AS}/oauth/token`,
+  pushed_authorization_request_endpoint: `${AS}/oauth/par`,
+  dpop_signing_alg_values_supported: ['ES256', 'RS256'],
+};
+
+const json = (b: unknown, status = 200) => new Response(JSON.stringify(b), { status, headers: { 'content-type': 'application/json' } });
+
+/** URL に応じて用意した応答を返す fetch モック。 */
+function mock(routes: Record<string, () => Response>) {
+  return (async (url: string) => {
+    for (const [frag, fn] of Object.entries(routes)) if (url.includes(frag)) return fn();
+    return json({ error: 'not_found' }, 404);
+  }) as unknown as typeof fetch;
+}
+
+describe('oauth-metadata', () => {
+  it('pdsEndpointFromDoc は #atproto_pds を取り出す (id / 完全 id / type いずれでも)', () => {
+    expect(pdsEndpointFromDoc({ id: DID, service: [{ id: '#atproto_pds', type: 'AtprotoPersonalDataServer', serviceEndpoint: 'https://pds.a/' }] }, DID)).toBe('https://pds.a');
+    expect(pdsEndpointFromDoc({ id: DID, service: [{ id: `${DID}#atproto_pds`, type: 'X', serviceEndpoint: 'https://pds.b' }] }, DID)).toBe('https://pds.b');
+    expect(pdsEndpointFromDoc({ id: DID, service: [{ id: '#other', type: 'AtprotoPersonalDataServer', serviceEndpoint: 'https://pds.c' }] }, DID)).toBe('https://pds.c');
+  });
+
+  it('pdsEndpointFromDoc は無い / http (非https) を弾く', () => {
+    expect(() => pdsEndpointFromDoc({ id: DID, service: [] }, DID)).toThrow();
+    expect(() => pdsEndpointFromDoc({ id: DID, service: [{ id: '#atproto_pds', type: 'X', serviceEndpoint: 'http://insecure' }] }, DID)).toThrow();
+  });
+
+  it('discoverAuthServer は protected-resource → メタデータを解決する', async () => {
+    const f = mock({
+      'oauth-protected-resource': () => json({ authorization_servers: [AS] }),
+      'oauth-authorization-server': () => json(goodMeta),
+    });
+    const meta = await discoverAuthServer(PDS, f);
+    expect(meta.issuer).toBe(AS);
+    expect(meta.pushed_authorization_request_endpoint).toBe(`${AS}/oauth/par`);
+  });
+
+  it('issuer 不一致 (mix-up) は弾く', async () => {
+    const f = mock({
+      'oauth-protected-resource': () => json({ authorization_servers: [AS] }),
+      'oauth-authorization-server': () => json({ ...goodMeta, issuer: 'https://evil.example' }),
+    });
+    await expect(discoverAuthServer(PDS, f)).rejects.toThrow(/issuer/);
+  });
+
+  it('PAR エンドポイントが無ければ弾く (AT Proto 必須)', async () => {
+    const { pushed_authorization_request_endpoint, ...noPar } = goodMeta;
+    const f = mock({
+      'oauth-protected-resource': () => json({ authorization_servers: [AS] }),
+      'oauth-authorization-server': () => json(noPar),
+    });
+    await expect(discoverAuthServer(PDS, f)).rejects.toThrow(/PAR/);
+  });
+
+  it('DPoP ES256 非対応は弾く', async () => {
+    const f = mock({
+      'oauth-protected-resource': () => json({ authorization_servers: [AS] }),
+      'oauth-authorization-server': () => json({ ...goodMeta, dpop_signing_alg_values_supported: ['RS256'] }),
+    });
+    await expect(discoverAuthServer(PDS, f)).rejects.toThrow(/DPoP/);
+  });
+
+  it('authorization_servers が無ければ弾く', async () => {
+    const f = mock({ 'oauth-protected-resource': () => json({}) });
+    await expect(discoverAuthServer(PDS, f)).rejects.toThrow(/authorization_servers/);
+  });
+
+  it('discoverForDid は DID→PDS→認可サーバーまで一括解決', async () => {
+    const f = mock({
+      'plc.directory': () => json({ id: DID, service: [{ id: '#atproto_pds', type: 'AtprotoPersonalDataServer', serviceEndpoint: PDS }] }),
+      'oauth-protected-resource': () => json({ authorization_servers: [AS] }),
+      'oauth-authorization-server': () => json(goodMeta),
+    });
+    const r = await discoverForDid(DID, f);
+    expect(r.pdsUrl).toBe(PDS);
+    expect(r.authServer.token_endpoint).toBe(`${AS}/oauth/token`);
+  });
+});

--- a/apps/edge/test/oauth-routes.test.ts
+++ b/apps/edge/test/oauth-routes.test.ts
@@ -72,7 +72,7 @@ describe('oauth-routes', () => {
 
   it('callback: 正しい state で code を token に交換し KV に保存する', async () => {
     const kv = mockKv();
-    await putPendingAuth(kv, 'ST', { verifier: 'VER', authServer: meta, createdAt: NOW });
+    await putPendingAuth(kv, 'ST', { verifier: 'VER', authServer: meta, pdsUrl: 'https://pds.example', createdAt: NOW });
     const f = discoveryFetch({ '/oauth/token': () => json({ access_token: 'AT', token_type: 'DPoP', refresh_token: 'RT', expires_in: 3600, sub: 'did:plc:kojira' }) });
     const res = await handleOAuthCallback(new Request('https://x/oauth/callback?code=CODE&state=ST'), env(kv), { now: NOW, fetchImpl: f });
     expect(res.status).toBe(200);

--- a/apps/edge/test/oauth-routes.test.ts
+++ b/apps/edge/test/oauth-routes.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { p256 } from '@noble/curves/p256';
+import { base64urlnopad } from '@scure/base';
+import { handleClientMetadata, handleOAuthStart, handleOAuthCallback, type OAuthRoutesEnv } from '../src/oauth-routes';
+import { putPendingAuth, readServerTokens } from '../src/oauth-store';
+import type { AuthServerMetadata } from '../src/oauth-metadata';
+
+function jwkJson(fill: number): string {
+  const d = new Uint8Array(32).fill(fill);
+  const pub = p256.getPublicKey(d, false);
+  return JSON.stringify({ kty: 'EC', crv: 'P-256', x: base64urlnopad.encode(pub.slice(1, 33)), y: base64urlnopad.encode(pub.slice(33, 65)), d: base64urlnopad.encode(d), kid: `k${fill}` });
+}
+function mockKv() {
+  const m = new Map<string, string>();
+  return { get: async (k: string) => m.get(k) ?? null, put: async (k: string, v: string) => { m.set(k, v); }, delete: async (k: string) => { m.delete(k); } } as unknown as KVNamespace;
+}
+const AS = 'https://bsky.social';
+const meta: AuthServerMetadata = { issuer: AS, authorization_endpoint: `${AS}/oauth/authorize`, token_endpoint: `${AS}/oauth/token`, pushed_authorization_request_endpoint: `${AS}/oauth/par` };
+const json = (b: unknown, s = 200) => new Response(JSON.stringify(b), { status: s, headers: { 'content-type': 'application/json' } });
+const env = (kv?: KVNamespace): OAuthRoutesEnv => ({ OAUTH_CLIENT_PRIVATE_JWK: jwkJson(3), OAUTH_DPOP_PRIVATE_JWK: jwkJson(5), SERVER_DID: 'did:plc:kojira', WORKER_DID: 'did:web:edge.aozoraquest.app', ADMIN_DIDS: 'did:plc:admin1', OAUTH_TOKENS: kv });
+
+const discoveryFetch = (extra: Record<string, () => Response> = {}) => (async (url: string) => {
+  if (url.includes('plc.directory')) return json({ id: 'did:plc:kojira', service: [{ id: '#atproto_pds', type: 'AtprotoPersonalDataServer', serviceEndpoint: 'https://pds.example' }] });
+  if (url.includes('oauth-protected-resource')) return json({ authorization_servers: [AS] });
+  if (url.includes('oauth-authorization-server')) return json(meta);
+  for (const [frag, fn] of Object.entries(extra)) if (url.includes(frag)) return fn();
+  return json({ error: 'nf' }, 404);
+}) as unknown as typeof fetch;
+
+const okVerify = async () => ({ iss: 'did:plc:admin1' });
+const NOW = 1000;
+
+describe('oauth-routes', () => {
+  it('client-metadata: 設定ありで confidential client を返す / 未設定は 503', () => {
+    expect(handleClientMetadata(env()).status).toBe(200);
+    expect(handleClientMetadata({ ...env(), OAUTH_CLIENT_PRIVATE_JWK: undefined }).status).toBe(503);
+  });
+
+  it('start: KV 未 binding は 503 / トークン無しは 401', async () => {
+    expect((await handleOAuthStart(new Request('https://x/api/oauth/start', { method: 'POST' }), env(), { now: NOW })).status).toBe(503);
+    const r = await handleOAuthStart(new Request('https://x/api/oauth/start', { method: 'POST' }), env(mockKv()), { now: NOW });
+    expect(r.status).toBe(401);
+  });
+
+  it('start: 検証失敗は 401 / 非管理者は 403', async () => {
+    const req = new Request('https://x/api/oauth/start', { method: 'POST', headers: { authorization: 'Bearer t' } });
+    const bad = await handleOAuthStart(req, env(mockKv()), { now: NOW, verify: async () => { throw new Error('bad'); } });
+    expect(bad.status).toBe(401);
+    const nonAdmin = await handleOAuthStart(req, env(mockKv()), { now: NOW, verify: async () => ({ iss: 'did:plc:someone' }) });
+    expect(nonAdmin.status).toBe(403);
+  });
+
+  it('start: 管理者は PAR して authorizeUrl を返し pending を保存する', async () => {
+    const kv = mockKv();
+    const req = new Request('https://x/api/oauth/start', { method: 'POST', headers: { authorization: 'Bearer t' } });
+    const res = await handleOAuthStart(req, env(kv), { now: NOW, verify: okVerify, fetchImpl: discoveryFetch({ '/oauth/par': () => json({ request_uri: 'urn:req:1' }) }) });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { authorizeUrl: string };
+    expect(body.authorizeUrl).toContain(`${AS}/oauth/authorize`);
+    expect(body.authorizeUrl).toContain('request_uri=urn%3Areq%3A1');
+  });
+
+  it('callback: error パラメータは失敗ページ / code|state 欠落は 400', async () => {
+    expect((await handleOAuthCallback(new Request('https://x/oauth/callback?error=access_denied'), env(mockKv()), { now: NOW })).status).toBe(400);
+    expect((await handleOAuthCallback(new Request('https://x/oauth/callback?code=c'), env(mockKv()), { now: NOW })).status).toBe(400);
+  });
+
+  it('callback: 未知 state は 400 (CSRF/期限切れ)', async () => {
+    const res = await handleOAuthCallback(new Request('https://x/oauth/callback?code=c&state=unknown'), env(mockKv()), { now: NOW });
+    expect(res.status).toBe(400);
+  });
+
+  it('callback: 正しい state で code を token に交換し KV に保存する', async () => {
+    const kv = mockKv();
+    await putPendingAuth(kv, 'ST', { verifier: 'VER', authServer: meta, createdAt: NOW });
+    const f = discoveryFetch({ '/oauth/token': () => json({ access_token: 'AT', token_type: 'DPoP', refresh_token: 'RT', expires_in: 3600, sub: 'did:plc:kojira' }) });
+    const res = await handleOAuthCallback(new Request('https://x/oauth/callback?code=CODE&state=ST'), env(kv), { now: NOW, fetchImpl: f });
+    expect(res.status).toBe(200);
+    const saved = await readServerTokens(kv);
+    expect(saved).toMatchObject({ did: 'did:plc:kojira', accessToken: 'AT', refreshToken: 'RT' });
+  });
+});

--- a/apps/edge/test/oauth-store.test.ts
+++ b/apps/edge/test/oauth-store.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { readServerTokens, writeServerTokens, updateServerNonce, clearServerTokens, SERVER_OAUTH_KEY, type ServerOAuthTokens } from '../src/oauth-store';
+
+/** 最小の in-memory KVNamespace モック (get/put/delete のみ)。 */
+function mockKv() {
+  const m = new Map<string, string>();
+  const kv = {
+    get: async (k: string) => m.get(k) ?? null,
+    put: async (k: string, v: string) => { m.set(k, v); },
+    delete: async (k: string) => { m.delete(k); },
+  } as unknown as KVNamespace;
+  return { kv, m };
+}
+
+const tokens = (over: Partial<ServerOAuthTokens> = {}): ServerOAuthTokens => ({
+  did: 'did:plc:server', accessToken: 'AT', refreshToken: 'RT', tokenType: 'DPoP',
+  expiresAt: 2000, authServer: 'https://bsky.social', updatedAt: 1000, ...over,
+});
+
+describe('oauth-store', () => {
+  it('未 bootstrap は null / 保存後は読める', async () => {
+    const { kv } = mockKv();
+    expect(await readServerTokens(kv)).toBeNull();
+    await writeServerTokens(kv, tokens());
+    const t = await readServerTokens(kv);
+    expect(t).toMatchObject({ did: 'did:plc:server', accessToken: 'AT', tokenType: 'DPoP' });
+  });
+
+  it('壊れた JSON は null (fail-closed 側)', async () => {
+    const { kv, m } = mockKv();
+    m.set(SERVER_OAUTH_KEY, '{not json');
+    expect(await readServerTokens(kv)).toBeNull();
+  });
+
+  it('updateServerNonce は nonce だけ更新し他フィールドは保つ', async () => {
+    const { kv } = mockKv();
+    await writeServerTokens(kv, tokens({ dpopNonce: 'OLD' }));
+    await updateServerNonce(kv, 'NEW', 1500);
+    const t = await readServerTokens(kv);
+    expect(t?.dpopNonce).toBe('NEW');
+    expect(t?.accessToken).toBe('AT'); // 本体は不変
+    expect(t?.updatedAt).toBe(1500);
+  });
+
+  it('updateServerNonce は同一 nonce や未 bootstrap では書かない', async () => {
+    const { kv, m } = mockKv();
+    // 未 bootstrap: 何もしない
+    await updateServerNonce(kv, 'X', 1);
+    expect(m.has(SERVER_OAUTH_KEY)).toBe(false);
+    // 同一 nonce: 無駄書きしない (updatedAt が動かないことで確認)
+    await writeServerTokens(kv, tokens({ dpopNonce: 'SAME', updatedAt: 1000 }));
+    await updateServerNonce(kv, 'SAME', 9999);
+    expect((await readServerTokens(kv))?.updatedAt).toBe(1000);
+  });
+
+  it('clearServerTokens で消える (再 OAuth 前クリーンアップ)', async () => {
+    const { kv } = mockKv();
+    await writeServerTokens(kv, tokens());
+    await clearServerTokens(kv);
+    expect(await readServerTokens(kv)).toBeNull();
+  });
+});

--- a/apps/edge/test/oauth-store.test.ts
+++ b/apps/edge/test/oauth-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { readServerTokens, writeServerTokens, updateServerNonce, clearServerTokens, putPendingAuth, takePendingAuth, SERVER_OAUTH_KEY, type ServerOAuthTokens } from '../src/oauth-store';
+import { readServerTokens, writeServerTokens, readPdsNonce, writePdsNonce, clearServerTokens, putPendingAuth, takePendingAuth, SERVER_OAUTH_KEY, type ServerOAuthTokens } from '../src/oauth-store';
 import type { AuthServerMetadata } from '../src/oauth-metadata';
 
 /** 最小の in-memory KVNamespace モック (get/put/delete のみ)。 */
@@ -15,7 +15,7 @@ function mockKv() {
 
 const tokens = (over: Partial<ServerOAuthTokens> = {}): ServerOAuthTokens => ({
   did: 'did:plc:server', accessToken: 'AT', refreshToken: 'RT', tokenType: 'DPoP',
-  expiresAt: 2000, authServer: 'https://bsky.social', updatedAt: 1000, ...over,
+  expiresAt: 2000, pdsUrl: 'https://pds.example', authServer: 'https://bsky.social', updatedAt: 1000, ...over,
 });
 
 describe('oauth-store', () => {
@@ -33,25 +33,14 @@ describe('oauth-store', () => {
     expect(await readServerTokens(kv)).toBeNull();
   });
 
-  it('updateServerNonce は nonce だけ更新し他フィールドは保つ', async () => {
+  it('PDS nonce は別キーで読み書きし、トークンレコードを巻き込まない (★★)', async () => {
     const { kv } = mockKv();
-    await writeServerTokens(kv, tokens({ dpopNonce: 'OLD' }));
-    await updateServerNonce(kv, 'NEW', 1500);
-    const t = await readServerTokens(kv);
-    expect(t?.dpopNonce).toBe('NEW');
-    expect(t?.accessToken).toBe('AT'); // 本体は不変
-    expect(t?.updatedAt).toBe(1500);
-  });
-
-  it('updateServerNonce は同一 nonce や未 bootstrap では書かない', async () => {
-    const { kv, m } = mockKv();
-    // 未 bootstrap: 何もしない
-    await updateServerNonce(kv, 'X', 1);
-    expect(m.has(SERVER_OAUTH_KEY)).toBe(false);
-    // 同一 nonce: 無駄書きしない (updatedAt が動かないことで確認)
-    await writeServerTokens(kv, tokens({ dpopNonce: 'SAME', updatedAt: 1000 }));
-    await updateServerNonce(kv, 'SAME', 9999);
-    expect((await readServerTokens(kv))?.updatedAt).toBe(1000);
+    await writeServerTokens(kv, tokens());
+    expect(await readPdsNonce(kv)).toBeNull();
+    await writePdsNonce(kv, 'NONCE-1');
+    expect(await readPdsNonce(kv)).toBe('NONCE-1');
+    // トークン本体は無傷 (別キーなので cron の書き込みとぶつからない)
+    expect((await readServerTokens(kv))?.accessToken).toBe('AT');
   });
 
   it('clearServerTokens で消える (再 OAuth 前クリーンアップ)', async () => {
@@ -65,7 +54,7 @@ describe('oauth-store', () => {
 
   it('pending は state キーで保存し、take で取り出して削除 (使い捨て=リプレイ防止)', async () => {
     const { kv } = mockKv();
-    await putPendingAuth(kv, 'STATE1', { verifier: 'VER', authServer, createdAt: 1000 });
+    await putPendingAuth(kv, 'STATE1', { verifier: 'VER', authServer, pdsUrl: 'https://pds.example', createdAt: 1000 });
     const p = await takePendingAuth(kv, 'STATE1');
     expect(p?.verifier).toBe('VER');
     expect(p?.authServer.issuer).toBe('https://bsky.social');

--- a/apps/edge/test/oauth-store.test.ts
+++ b/apps/edge/test/oauth-store.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { readServerTokens, writeServerTokens, updateServerNonce, clearServerTokens, SERVER_OAUTH_KEY, type ServerOAuthTokens } from '../src/oauth-store';
+import { readServerTokens, writeServerTokens, updateServerNonce, clearServerTokens, putPendingAuth, takePendingAuth, SERVER_OAUTH_KEY, type ServerOAuthTokens } from '../src/oauth-store';
+import type { AuthServerMetadata } from '../src/oauth-metadata';
 
 /** 最小の in-memory KVNamespace モック (get/put/delete のみ)。 */
 function mockKv() {
@@ -58,5 +59,22 @@ describe('oauth-store', () => {
     await writeServerTokens(kv, tokens());
     await clearServerTokens(kv);
     expect(await readServerTokens(kv)).toBeNull();
+  });
+
+  const authServer: AuthServerMetadata = { issuer: 'https://bsky.social', authorization_endpoint: 'a', token_endpoint: 't', pushed_authorization_request_endpoint: 'p' };
+
+  it('pending は state キーで保存し、take で取り出して削除 (使い捨て=リプレイ防止)', async () => {
+    const { kv } = mockKv();
+    await putPendingAuth(kv, 'STATE1', { verifier: 'VER', authServer, createdAt: 1000 });
+    const p = await takePendingAuth(kv, 'STATE1');
+    expect(p?.verifier).toBe('VER');
+    expect(p?.authServer.issuer).toBe('https://bsky.social');
+    // 2 回目は消えている (リプレイ不可)
+    expect(await takePendingAuth(kv, 'STATE1')).toBeNull();
+  });
+
+  it('未知の state は null', async () => {
+    const { kv } = mockKv();
+    expect(await takePendingAuth(kv, 'nope')).toBeNull();
   });
 });

--- a/apps/edge/test/router.test.ts
+++ b/apps/edge/test/router.test.ts
@@ -80,4 +80,21 @@ describe('edge router', () => {
     expect(res.status).toBe(401);
     expect(((await res.json()) as { error: string }).error).toBe('missing_token');
   });
+
+  it('GET /client-metadata.json は OAuth 未設定なら 503', async () => {
+    const res = await handleRequest(new Request('https://x/client-metadata.json'), env);
+    expect(res.status).toBe(503);
+    expect(((await res.json()) as { error: string }).error).toBe('oauth_not_configured');
+  });
+
+  it('POST /api/oauth/start は OAuth 未設定 (KV 無し) なら 503', async () => {
+    const res = await handleRequest(new Request('https://x/api/oauth/start', { method: 'POST' }), env);
+    expect(res.status).toBe(503);
+  });
+
+  it('GET /oauth/callback は code 欠落なら 400 (HTML)', async () => {
+    const res = await handleRequest(new Request('https://x/oauth/callback'), env);
+    expect(res.status).toBe(400);
+    expect(res.headers.get('content-type')).toContain('text/html');
+  });
 });

--- a/apps/edge/wrangler.toml
+++ b/apps/edge/wrangler.toml
@@ -18,3 +18,8 @@ compatibility_flags = ["nodejs_compat"]
 binding = "OAUTH_TOKENS"
 id = "fa7215e005474e6cac81745c463333ba"
 preview_id = "c1f3e394d104413192a0dac7303b6443"
+
+# OAuth トークンの唯一の refresh 実行者 (docs/21 §12)。10 分ごとに起動し、access token 失効前に
+# refresh_token で更新する (REFRESH_AHEAD_SEC=900 = 15 分前から。cron 間隔 < ahead で取りこぼし防止)。
+[triggers]
+crons = ["*/10 * * * *"]

--- a/apps/edge/wrangler.toml
+++ b/apps/edge/wrangler.toml
@@ -10,3 +10,11 @@ name = "aozoraquest-edge"
 main = "src/index.ts"
 compatibility_date = "2026-04-24"
 compatibility_flags = ["nodejs_compat"]
+
+# OAuth write 認証 (docs/21 §12) のトークンストア。cron refresher が書き、リクエスト Worker が読む。
+# 実行時に書き換えられる保管場所が要るので Secret/env でなく KV (Durable Object は Paid 要で不採用)。
+# Kojiran@gmail.com アカウントに作成 (wrangler kv namespace create OAUTH_TOKENS)。
+[[kv_namespaces]]
+binding = "OAUTH_TOKENS"
+id = "fa7215e005474e6cac81745c463333ba"
+preview_id = "c1f3e394d104413192a0dac7303b6443"

--- a/docs/21-server-authority.md
+++ b/docs/21-server-authority.md
@@ -162,8 +162,12 @@ commands 送信前に client が次乱数を知り得ないようにする。レ
   アカウント認証情報 (Secret) で putRecord。`app.aozoraquest.gameState` レコード (per DID)。
   `GET /api/me/state` (JWT 必須・自分のみ)。初回はクランプ移行。compare-and-swap 実装。**課金不要
   (DO 無し)。**
+- **M2.5 — OAuth write 認証基盤 (§12)**: app-password が legacy 廃止トレンドのため、書き込み認証を
+  AT Proto OAuth (confidential client) + DPoP + cron refresher で組む。client-metadata + KV トークン
+  ストア + アプリ内設定の管理者リンクからの初回 OAuth。M3 の書き込みはこれを消費。
 - **M3 — 戦闘の権威化**: §5 の毎ターンプロトコル (encounter/turn) + kuda 物理乱数 + core への乱数
   注入口。playerSnapshot 封印、パワー/素材/gear/戦闘 XP を権威 state に。§7 パワーモデル。
+  part1 (乱数機構) ✅ #347 / part2 (resolver、M2.5 の write 認証を消費)。
 - **M4 — 投稿 XP の権威化**: `/api/xp/post` + 冪等化 + レート制限。「アプリ経由」要件緩和。
 - **M5 — リリース判断**、**M6+ — 対人 (トレード #327/ランキング)**。
 
@@ -191,3 +195,54 @@ kuda は `pool_remaining` を監視し、枯渇/障害時は fail-closed か CSP
 - **本設計 (Worker + サーバーアカウント PDS 権威 + サーバー乱数(既定CSPRNG/任意kuda) + 毎ターン + snapshot 封印)**: DO 不要・
   課金不要・ATP ネイティブ。`packages/core` 決定性と既存 edge Worker と kuda を活かす。AT Proto の
   "PDS が正本" のまま、**正本の repo をユーザーから app サーバーアカウントへ移す**のが要点。
+
+## 12. OAuth write 認証基盤 (M2.5、app-password を使わない)
+
+**背景 (方針変更)**: 当初は権威 state への書き込みをサーバーアカウントの **app-password** (Worker
+Secret) + `createSession` で行う設計だった (§4.1)。しかし **app-password は Bluesky が OAuth へ移行する
+流れで legacy 扱い → 将来廃止の可能性**があるため、書き込み認証を **AT Protocol OAuth (confidential
+client) + DPoP** で組み直す。これを M3-part2 (resolver) の前段 **M2.5** として先に作る。
+
+### 12.1 なぜ cron refresher か
+OAuth の refresh token は **単回使用でローテーション**する。stateless な Worker は複数 isolate で
+並行するので、複数箇所が同時に refresh すると token が壊れてロックアウトする。→ **refresh するのは
+Cron Trigger Worker 1 つだけ**に限定 (書き手を直列化)。リクエスト処理 Worker は現在の access token を
+**読むだけ**で refresh しない。Cron Trigger は無料プランで使え、DO/Paid 不要の方針を維持する。
+
+### 12.2 構成要素
+- **client-metadata.json**: edge に公開する confidential client メタデータ (`client_id` = その URL)。
+  M1 の `did:web:edge.aozoraquest.app` + well-known 配信インフラを流用。トークン寿命を延ばすため
+  **`private_key_jwt`** でクライアント認証する。
+- **クライアント鍵 (ES256 JWK)**: `private_key_jwt` 署名用。安定なので Worker Secret。公開鍵は
+  client-metadata の `jwks` に載せる。署名は `@noble/curves` (M1 と同じ道具、重い依存を足さない)。
+- **DPoP 鍵 (P-256)**: 全トークン/PDS リクエストは DPoP バインド (sender-constrained)。毎リクエストで
+  DPoP proof JWT を生成。安定鍵なので Worker Secret。
+- **トークンストア (Cloudflare KV)**: `{accessToken, refreshToken, expiresAt, dpopNonce}` を 1 箇所に。
+  cron が唯一の書き手、リクエスト Worker は読み手。KV は結果整合だが、access token は refresh 後も
+  期限まで有効なので少し古くても可 (refresh token の単回性が効くのは cron のみ)。
+- **Cron refresher Worker**: access token 失効前に refresh → 新トークンを KV へ。**refresh 成功後の
+  KV 保存失敗 = 旧 refresh token 消費済みでロックアウト**が唯一の弱点 → 保存を確認してから確定、
+  失敗は監査ログ + 管理画面で再 OAuth 導線。
+- **管理画面 (アプリ内設定)**: 初回だけ owner が authorize (code+PKCE) → callback で初期 refresh token
+  を KV に格納。**別アプリ (apps/admin) ではなく、メインアプリの設定画面内に「管理者 DID でログイン
+  している時だけ」表示する管理者リンク**から入る (owner 要望)。ロックアウト時も同じ導線で再 OAuth。
+
+### 12.3 リクエスト時の書き込み経路
+encounter/turn 等の書き込み Worker: KV から access token + DPoP 鍵を読む → PDS へ DPoP 認証付き
+putRecord/deleteRecord。token 失効 (401) は **fail-closed (503)** に倒し、次の cron 補充を待つ
+(request Worker は refresh しない = 直列化維持)。cron 間隔 << token 寿命にしてダウンタイムを避ける。
+`server-session.ts` (app-password 版) はこの OAuth トークン読取に置き換える (`withServerAuth` の
+「失効時リトライを1箇所に閉じ込める」構造は流用)。
+
+### 12.4 owner セットアップ (app-password の "Secret 1個" より増える)
+1. Cloudflare KV namespace 作成 + wrangler binding。
+2. クライアント鍵・DPoP 鍵を Secret 設定 (鍵生成はこちらでスクリプト用意)。
+3. アプリ内設定 → 管理者リンク → 1 回 OAuth ログイン (初期 refresh token を格納)。
+`SERVER_HANDLE` は廃止 (createSession の identifier は不要、OAuth は DID/handle 解決で処理)。
+
+### 12.5 実装順 (mock で単体テスト、owner セットアップ後に dev 疎通)
+1. DPoP / private_key_jwt の JWT 生成・検証ユーティリティ (@noble、単体テスト)。
+2. client-metadata.json 配信 + OAuth authorize/callback ルート (PKCE)。
+3. KV トークンストア抽象 + cron refresher。
+4. 書き込み経路を OAuth トークン読取へ (server-session 置換)。
+5. アプリ内設定の管理者リンク (管理者 DID 限定表示) → OAuth 開始導線。

--- a/docs/21-server-authority.md
+++ b/docs/21-server-authority.md
@@ -217,12 +217,15 @@ Cron Trigger Worker 1 つだけ**に限定 (書き手を直列化)。リクエ�
   client-metadata の `jwks` に載せる。署名は `@noble/curves` (M1 と同じ道具、重い依存を足さない)。
 - **DPoP 鍵 (P-256)**: 全トークン/PDS リクエストは DPoP バインド (sender-constrained)。毎リクエストで
   DPoP proof JWT を生成。安定鍵なので Worker Secret。
-- **トークンストア (Cloudflare KV)**: `{accessToken, refreshToken, expiresAt, dpopNonce}` を 1 箇所に。
-  cron が唯一の書き手、リクエスト Worker は読み手。KV は結果整合だが、access token は refresh 後も
-  期限まで有効なので少し古くても可 (refresh token の単回性が効くのは cron のみ)。
+- **トークンストア (Cloudflare KV)**: `{accessToken, refreshToken, expiresAt, pdsUrl, authServer}` を
+  1 レコードに。**PDS 用 DPoP-Nonce は別キー** (トークン本体は cron が書き手、nonce はリクエスト
+  Worker が更新するので、同一レコードにすると RMW でトークンを巻き込むため分離。レビュー ★★)。
+  `pdsUrl` を持たせて M3 書込が DID doc を毎回再解決せずに済むようにする。KV は結果整合だが、access
+  token は refresh 後も期限まで有効なので少し古くても可 (refresh token の単回性が効くのは cron のみ)。
 - **Cron refresher Worker**: access token 失効前に refresh → 新トークンを KV へ。**refresh 成功後の
-  KV 保存失敗 = 旧 refresh token 消費済みでロックアウト**が唯一の弱点 → 保存を確認してから確定、
-  失敗は監査ログ + 管理画面で再 OAuth 導線。
+  KV 保存失敗 = 旧 refresh token 消費済みでロックアウト**が弱点 → 失敗は監査ログ + 管理画面で再 OAuth。
+  cron の tick は重なりうる (KV に CAS が無い) ので、refresh 前に `refreshingUntil` ソフトロックを立てて
+  他 tick を控えさせる (厳密でないが二重 refresh を大幅に抑える。レビュー ★★)。
 - **管理画面 (アプリ内設定)**: 初回だけ owner が authorize (code+PKCE) → callback で初期 refresh token
   を KV に格納。**別アプリ (apps/admin) ではなく、メインアプリの設定画面内に「管理者 DID でログイン
   している時だけ」表示する管理者リンク**から入る (owner 要望)。ロックアウト時も同じ導線で再 OAuth。
@@ -235,10 +238,14 @@ putRecord/deleteRecord。token 失効 (401) は **fail-closed (503)** に倒し�
 「失効時リトライを1箇所に閉じ込める」構造は流用)。
 
 ### 12.4 owner セットアップ (app-password の "Secret 1個" より増える)
-1. Cloudflare KV namespace 作成 + wrangler binding。
-2. クライアント鍵・DPoP 鍵を Secret 設定 (鍵生成はこちらでスクリプト用意)。
-3. アプリ内設定 → 管理者リンク → 1 回 OAuth ログイン (初期 refresh token を格納)。
-`SERVER_HANDLE` は廃止 (createSession の identifier は不要、OAuth は DID/handle 解決で処理)。
+1. Cloudflare KV namespace 作成 + wrangler binding。**(済: アシスタントが作成・binding)**
+2. クライアント鍵・DPoP 鍵を Secret 設定 (鍵生成スクリプト `scripts/gen-oauth-keys.mjs`)。SERVER_DID
+   (=kojira.io の DID)・ADMIN_DIDS を Variable 設定。
+3. **edge Worker を初回デプロイ** — 認可サーバーが authorize/PAR 時に `client_id`
+   (=`/client-metadata.json` の URL) を fetch するので、**OAuth ログインより前に edge が serve
+   している必要がある** (deploy → Secret 投入 → OAuth の順)。
+4. アプリ内設定 → 管理者リンク → 1 回 OAuth ログイン (初期 refresh token を格納)。
+`SERVER_HANDLE` は廃止 (OAuth は DID/handle 解決で処理)。サーバーアカウントは **kojira.io** (§9-1 確定)。
 
 ### 12.5 実装順 (mock で単体テスト、owner セットアップ後に dev 疎通)
 1. DPoP / private_key_jwt の JWT 生成・検証ユーティリティ (@noble、単体テスト)。


### PR DESCRIPTION
## 目的
権威 state 書き込みの認証を **AT Protocol OAuth (confidential client) + DPoP** で組む基盤 (docs/21 §12)。当初 app-password 案だったが **legacy 廃止トレンドのためオーナー判断で OAuth に変更**。M3 resolver の書き込みがこの基盤を消費する。**サーバーアカウント = kojira.io**(ソース非直書き、Variable 経由)。

## なぜ cron refresher か
OAuth の refresh token は単回ローテーション。stateless Worker で複数 isolate が同時 refresh するとロックアウトする → **refresh は Cron Trigger Worker 1 つに直列化**、リクエスト Worker は KV から読むだけ。Cron Trigger は無料なので **DO/Paid 不要**を維持。

## モジュール (全て `@noble` のみ、重い OAuth ライブラリ不使用 = Workers 互換 + supply-chain cooldown 回避)
| モジュール | 役割 |
|---|---|
| `oauth-jwt.ts` | ES256 署名 / DPoP proof (RFC 9449) / client assertion (private_key_jwt) / JWK thumbprint |
| `dpop-fetch.ts` | DPoP バインド fetch + `use_dpop_nonce` handshake (1 回再送) |
| `oauth-metadata.ts` | 認可サーバー discovery (DID→PDS→protected-resource→AS)、issuer/PAR/DPoP 検証 |
| `oauth-client.ts` | PKCE + PAR で authorize URL / code 交換 / refresh |
| `oauth-store.ts` | KV トークンストア + pending(PKCE/state, 使い捨て) |
| `oauth-config.ts` | env から設定/鍵ロード (fail-closed) + client-metadata + admin 判定 |
| `oauth-routes.ts` | `/client-metadata.json`・`/api/oauth/start`(管理者ゲート)・`/oauth/callback` |
| `oauth-cron.ts` | 唯一の refresh 実行者 (scheduled handler、失効前更新) |

## インフラ (アシスタントが設定済み — オーナー操作不要)
- KV namespace 作成 + `wrangler.toml` binding (Kojiran@gmail.com アカウント)
- cron trigger `*/10 * * * *`
- 鍵生成スクリプト `scripts/gen-oauth-keys.mjs` (private は gitignore、公開鍵と secret 投入コマンドだけ出力)

## テスト
edge **112 件緑**。dry-run build 64 KiB gzip (Free plan 内)。各モジュール mock で単体テスト、ルートは verify/fetch/now を注入。

## デプロイ時に必要 (今は不要)
- edge Worker 初回デプロイ (未デプロイ)。クライアント鍵・DPoP 鍵を Secret 投入 (アシスタントが wrangler で実行可)。SERVER_DID / ADMIN_DIDS を Variable 設定。
- **人手が要るのは 1 回だけ: 設定画面の管理者リンクから kojira.io で OAuth ログイン (スマホ可)**。

## Review
(§1.5 3並列レビュー後に追記)

## 次
- apps/web 設定画面の管理者 DID 限定リンク → `/api/oauth/start` 呼び出し (別 PR、UX レビュー付き)
- M3 resolver がこの OAuth トークンで PDS 書き込み (write-path helper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)