### PR TITLE
feat(edge): M3 権威 state の OAuth (DPoP) 書き込み経路

### DIFF
--- a/apps/edge/src/game-state.ts
+++ b/apps/edge/src/game-state.ts
@@ -1,17 +1,27 @@
 /**
  * ゲーム経済の権威 state (docs/21-server-authority §4.1/§6)。
  *
- * サーバーアカウントの repo に **ユーザー DID をキーにした 1 レコード/人**で持つ。ユーザーは
- * この repo に書けない = 偽造不可。二重使用防止は putRecord の swapRecord (CAS) + 本モジュールの
- * **read-modify-write 契約** (レビュー ★★★) で担保する: CID 不一致 (InvalidSwap) 時は必ず最新を
- * 再読込 → 副作用を再評価 → 再 put、をループする (楽観ロック)。
+ * サーバーアカウント (kojira.io) の repo に **ユーザー DID をキーにした 1 レコード/人**で持つ。
+ * ユーザーはこの repo に書けない = 偽造不可。二重使用防止は swapRecord (CAS) + 本モジュールの
+ * **read-modify-write 契約** (レビュー ★★★) で担保: CID 不一致 (InvalidSwap) 時は最新を再読込 →
+ * 副作用を再評価 → 再 put、をループする (楽観ロック)。
+ *
+ * 読み取りは public getRecord (SERVER_PDS_URL/SERVER_DID、認証不要)。**書き込みは M2.5 の OAuth
+ * (DPoP) トークン経由** (server-pds)。ユーザー由来のリクエストは書き込みトークンを持てない。
  */
 import { sha256 } from '@noble/hashes/sha256';
 import { bytesToHex } from '@noble/hashes/utils';
-import { getRecord, putRecord, PdsError, type PdsSession } from './pds';
+import { getRecord, PdsError } from './pds';
+import { serverPutRecord, ServerWriteError, type ServerPdsEnv } from './server-pds';
 
 export const GAME_STATE_COLLECTION = 'app.aozoraquest.gameState';
 export const GAME_STATE_VERSION = 1;
+
+/** 権威 state の読み書きに必要な env (読み取り config + OAuth 書き込み)。 */
+export interface GameStateEnv extends ServerPdsEnv {
+  /** 読み取り用 (public getRecord)。SERVER_DID は ServerPdsEnv(OAuthEnv) から。 */
+  SERVER_PDS_URL?: string;
+}
 
 export interface GameState {
   /** どのユーザーの state か (監査用。rkey は DID のハッシュなので値に DID を残す)。 */
@@ -43,53 +53,54 @@ export function emptyState(did: string, now: string): GameState {
   return { did, power: 0, playerXp: 0, jobXp: {}, materials: {}, gear: [], x: 0, y: 0, version: GAME_STATE_VERSION, updatedAt: now };
 }
 
-/** 権威 state を取得 (無ければ null)。呼び出し側で無→初期化 or 移行を判断。 */
-export async function readState(session: PdsSession, did: string): Promise<{ state: GameState; cid: string } | null> {
-  const rec = await getRecord<GameState>(session.pdsUrl, session.did, GAME_STATE_COLLECTION, rkeyForDid(did));
+/** 権威 state を取得 (無ければ null)。読みは public getRecord (認証不要)。 */
+export async function readState(env: GameStateEnv, targetDid: string): Promise<{ state: GameState; cid: string } | null> {
+  if (!env.SERVER_PDS_URL || !env.SERVER_DID) throw new ServerWriteError('SERVER_PDS_URL/SERVER_DID 未設定', 'not-configured');
+  const rec = await getRecord<GameState>(env.SERVER_PDS_URL, env.SERVER_DID, GAME_STATE_COLLECTION, rkeyForDid(targetDid));
   return rec ? { state: rec.value, cid: rec.cid } : null;
 }
 
 export interface RmwOptions {
-  /** 現在時刻 (ISO)。テストで固定可。 */
-  now: string;
+  /** 現在時刻 (epoch 秒)。updatedAt(ISO) と DPoP/token 期限判定に使う。テストで固定可。 */
+  now: number;
   /** CAS 競合時の最大リトライ回数。 */
   retries?: number;
   /** state が無いときの初期値 (移行値など)。省略時 emptyState。 */
-  init?: (did: string, now: string) => GameState;
+  init?: (did: string, nowIso: string) => GameState;
 }
 
 /**
- * read-modify-write (CAS)。`mutate` に**最新の** state を渡し、返した新 state を CAS で書く。
+ * read-modify-write (CAS)。`mutate` に**最新の** state を渡し、返した新 state を OAuth (DPoP) で書く。
  * InvalidSwap (別リクエストが割り込んで CID が変わった) の時は最新を読み直して mutate をやり直す。
  * → 「古い意思決定のまま上書き」して二重報酬/二重消費が通るのを防ぐ (§4.1 の契約)。
- * mutate は**副作用を持たず** (パワー予約・報酬計算等をこの中で決定的にやる)、毎回新しい state を
- * 返す純関数であること (リトライで複数回呼ばれる)。
+ * mutate は**副作用を持たず**、毎回新しい state を返す純関数であること (リトライで複数回呼ばれる)。
+ * 書き込みトークンが無い/失効は server-pds が ServerWriteError で fail-closed に倒す。
  */
 export async function readModifyWrite(
-  session: PdsSession,
-  did: string,
+  env: GameStateEnv,
+  targetDid: string,
   mutate: (current: GameState) => GameState,
   opts: RmwOptions,
 ): Promise<GameState> {
-  const rkey = rkeyForDid(did);
+  const rkey = rkeyForDid(targetDid);
   const init = opts.init ?? emptyState;
   const retries = opts.retries ?? 5;
+  const nowIso = new Date(opts.now * 1000).toISOString();
   for (let attempt = 0; attempt <= retries; attempt++) {
-    const existing = await readState(session, did);
-    const current = existing?.state ?? init(did, opts.now);
-    const next: GameState = { ...mutate(current), did, version: GAME_STATE_VERSION, updatedAt: opts.now };
+    const existing = await readState(env, targetDid);
+    const current = existing?.state ?? init(targetDid, nowIso);
+    const next: GameState = { ...mutate(current), did: targetDid, version: GAME_STATE_VERSION, updatedAt: nowIso };
     // 既存があればその CID を期待 (CAS)、無ければ null (新規作成のみ) で二重作成も防ぐ。
     const swap = existing ? existing.cid : null;
     try {
-      await putRecord(session, GAME_STATE_COLLECTION, rkey, next, swap);
+      await serverPutRecord(env, opts.now, GAME_STATE_COLLECTION, rkey, next, swap);
       return next;
     } catch (e) {
       if (e instanceof PdsError && e.xrpcError === 'InvalidSwap') {
         if (attempt < retries) continue; // 競合 → 再読込して mutate をやり直し
-        // 最終試行も競合 = 枯渇。上位が「503 相当」に振り分けられるよう sentinel を付ける
         throw new PdsError('CAS リトライ上限 (競合が解消しない)', 409, 'CasExhausted');
       }
-      throw e; // 非 InvalidSwap は即 throw (リトライしない)
+      throw e; // 非 InvalidSwap (ServerWriteError 含む) は即 throw
     }
   }
   throw new PdsError('unreachable'); // ループは必ず return/throw する

--- a/apps/edge/src/game-state.ts
+++ b/apps/edge/src/game-state.ts
@@ -12,16 +12,14 @@
 import { sha256 } from '@noble/hashes/sha256';
 import { bytesToHex } from '@noble/hashes/utils';
 import { getRecord, PdsError } from './pds';
+import { readServerTokens } from './oauth-store';
 import { serverPutRecord, ServerWriteError, type ServerPdsEnv } from './server-pds';
 
 export const GAME_STATE_COLLECTION = 'app.aozoraquest.gameState';
 export const GAME_STATE_VERSION = 1;
 
-/** 権威 state の読み書きに必要な env (読み取り config + OAuth 書き込み)。 */
-export interface GameStateEnv extends ServerPdsEnv {
-  /** 読み取り用 (public getRecord)。SERVER_DID は ServerPdsEnv(OAuthEnv) から。 */
-  SERVER_PDS_URL?: string;
-}
+/** 権威 state の読み書きに必要な env (OAuth トークン KV)。読み書きとも repo はトークン由来で一致。 */
+export type GameStateEnv = ServerPdsEnv;
 
 export interface GameState {
   /** どのユーザーの state か (監査用。rkey は DID のハッシュなので値に DID を残す)。 */
@@ -53,10 +51,16 @@ export function emptyState(did: string, now: string): GameState {
   return { did, power: 0, playerXp: 0, jobXp: {}, materials: {}, gear: [], x: 0, y: 0, version: GAME_STATE_VERSION, updatedAt: now };
 }
 
-/** 権威 state を取得 (無ければ null)。読みは public getRecord (認証不要)。 */
+/**
+ * 権威 state を取得 (無ければ null)。読みは public getRecord (認証不要) だが、**書き込みと同じ
+ * トークン由来の pdsUrl/did を repo に使う**ことで、config と書込先の食い違い (別 repo を読んで CAS が
+ * 常に外れる/誤 repo へ書く) を構造的に防ぐ (レビュー ★★)。
+ */
 export async function readState(env: GameStateEnv, targetDid: string): Promise<{ state: GameState; cid: string } | null> {
-  if (!env.SERVER_PDS_URL || !env.SERVER_DID) throw new ServerWriteError('SERVER_PDS_URL/SERVER_DID 未設定', 'not-configured');
-  const rec = await getRecord<GameState>(env.SERVER_PDS_URL, env.SERVER_DID, GAME_STATE_COLLECTION, rkeyForDid(targetDid));
+  if (!env.OAUTH_TOKENS) throw new ServerWriteError('KV 未 binding', 'no-kv');
+  const tokens = await readServerTokens(env.OAUTH_TOKENS);
+  if (!tokens) throw new ServerWriteError('サーバートークン未 bootstrap (管理画面で OAuth 連携が必要)', 'not-bootstrapped');
+  const rec = await getRecord<GameState>(tokens.pdsUrl, tokens.did, GAME_STATE_COLLECTION, rkeyForDid(targetDid));
   return rec ? { state: rec.value, cid: rec.cid } : null;
 }
 

--- a/apps/edge/src/server-pds.ts
+++ b/apps/edge/src/server-pds.ts
@@ -42,10 +42,11 @@ async function authedXrpc<T>(env: ServerPdsEnv, now: number, nsid: string, body:
 
   const nonce = (await readPdsNonce(kv)) ?? undefined;
   let latest = nonce;
-  // repo は常にサーバーアカウント (kojira.io) の DID。呼び出し側は指定不要。
+  // repo は常にサーバーアカウント (kojira.io) の DID。**body の後に置き**、呼び出し側が誤って
+  // repo を含めても上書きできないようにする (認証境界の固定。レビュー ★)。
   const res = await dpopFetch(
     `${tokens.pdsUrl}/xrpc/${nsid}`,
-    { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ repo: tokens.did, ...body }) },
+    { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ ...body, repo: tokens.did }) },
     { jwk: cfg.dpopJwk, accessToken: tokens.accessToken, now, nonce, onNonce: (n) => { latest = n; } },
   );
   if (latest && latest !== nonce) await writePdsNonce(kv, latest); // 次回のため保存 (別キー)

--- a/apps/edge/src/server-pds.ts
+++ b/apps/edge/src/server-pds.ts
@@ -1,0 +1,89 @@
+/**
+ * サーバーアカウント PDS への **OAuth (DPoP) 認証付き書き込み** — docs/21 §12.3 / M3。
+ *
+ * M2.5 で取得・保管した OAuth トークン (KV) を使い、サーバーアカウント (kojira.io) の PDS に
+ * putRecord / deleteRecord する。書き込みは DPoP バインド (sender-constrained) で、access token +
+ * DPoP 鍵 (Worker Secret) + PDS 用 DPoP-Nonce (別 KV キー) を使う。
+ *
+ * **request Worker は refresh しない** (直列化維持 = §12.3)。token 失効/未 bootstrap は fail-closed で
+ * ServerWriteError を投げ、上位は 503 に倒す (次の cron 補充を待つ)。読み取りは public getRecord
+ * (pds.ts) で足りるので本モジュールは書き込み専用。
+ */
+import { dpopFetch } from './dpop-fetch';
+import { readServerTokens, readPdsNonce, writePdsNonce } from './oauth-store';
+import { loadOAuthConfig, OAuthConfigError, type OAuthEnv } from './oauth-config';
+import { PdsError } from './pds';
+
+export interface ServerPdsEnv extends OAuthEnv {
+  OAUTH_TOKENS?: KVNamespace;
+}
+
+/** 書き込み不能 (fail-closed) の理由。上位は 503 に振り分ける。 */
+export class ServerWriteError extends Error {
+  constructor(message: string, readonly reason: 'no-kv' | 'not-bootstrapped' | 'token-expired' | 'not-configured') {
+    super(message);
+  }
+}
+
+/** サーバー PDS への認証付き XRPC (POST/JSON)。DPoP + access token を付け、nonce を KV に反映。 */
+async function authedXrpc<T>(env: ServerPdsEnv, now: number, nsid: string, body: object): Promise<T> {
+  if (!env.OAUTH_TOKENS) throw new ServerWriteError('KV 未 binding', 'no-kv');
+  const kv = env.OAUTH_TOKENS;
+  const tokens = await readServerTokens(kv);
+  if (!tokens) throw new ServerWriteError('サーバートークン未 bootstrap (管理画面で OAuth 連携が必要)', 'not-bootstrapped');
+  if (now >= tokens.expiresAt) throw new ServerWriteError('access token 失効 (cron 補充待ち)', 'token-expired');
+  let cfg;
+  try {
+    cfg = loadOAuthConfig(env);
+  } catch (e) {
+    if (e instanceof OAuthConfigError) throw new ServerWriteError(e.message, 'not-configured');
+    throw e;
+  }
+
+  const nonce = (await readPdsNonce(kv)) ?? undefined;
+  let latest = nonce;
+  // repo は常にサーバーアカウント (kojira.io) の DID。呼び出し側は指定不要。
+  const res = await dpopFetch(
+    `${tokens.pdsUrl}/xrpc/${nsid}`,
+    { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ repo: tokens.did, ...body }) },
+    { jwk: cfg.dpopJwk, accessToken: tokens.accessToken, now, nonce, onNonce: (n) => { latest = n; } },
+  );
+  if (latest && latest !== nonce) await writePdsNonce(kv, latest); // 次回のため保存 (別キー)
+
+  const text = await res.text();
+  let json: Record<string, unknown> = {};
+  if (text) {
+    try {
+      json = JSON.parse(text) as Record<string, unknown>;
+    } catch {
+      throw new PdsError(`XRPC 非 JSON 応答 (${res.status})`, res.status);
+    }
+  }
+  if (!res.ok) throw new PdsError(`XRPC ${res.status}: ${(json.message as string) ?? nsid}`, res.status, json.error as string | undefined);
+  return json as T;
+}
+
+/**
+ * サーバー repo に putRecord (認証付き)。`swapRecord` で CAS:
+ *   期待 CID → その CID のときだけ上書き / null → 未存在のときだけ作成 / undefined → 無条件。
+ * CAS 競合は PdsError.xrpcError === 'InvalidSwap'。
+ */
+export async function serverPutRecord(
+  env: ServerPdsEnv,
+  now: number,
+  collection: string,
+  rkey: string,
+  record: object,
+  swapRecord?: string | null,
+): Promise<{ uri: string; cid: string }> {
+  const body: Record<string, unknown> = { collection, rkey, record };
+  if (swapRecord !== undefined) body.swapRecord = swapRecord;
+  return authedXrpc<{ uri: string; cid: string }>(env, now, 'com.atproto.repo.putRecord', body);
+}
+
+/** サーバー repo の deleteRecord (認証付き、swapRecord CAS 対応)。 */
+export async function serverDeleteRecord(env: ServerPdsEnv, now: number, collection: string, rkey: string, swapRecord?: string): Promise<void> {
+  const body: Record<string, unknown> = { collection, rkey };
+  if (swapRecord !== undefined) body.swapRecord = swapRecord;
+  await authedXrpc(env, now, 'com.atproto.repo.deleteRecord', body);
+}

--- a/apps/edge/test/game-state.test.ts
+++ b/apps/edge/test/game-state.test.ts
@@ -1,13 +1,32 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { rkeyForDid, readModifyWrite, GAME_STATE_COLLECTION, type GameState } from '../src/game-state';
-import type { PdsSession } from '../src/pds';
+import { p256 } from '@noble/curves/p256';
+import { base64urlnopad } from '@scure/base';
+import { rkeyForDid, readModifyWrite, type GameState, type GameStateEnv } from '../src/game-state';
+import { writeServerTokens } from '../src/oauth-store';
 
-const session: PdsSession = { pdsUrl: 'https://pds.example', accessJwt: 'A', refreshJwt: 'R', did: 'did:plc:server' };
-const NOW = '2026-07-18T00:00:00.000Z';
-const DID = 'did:plc:alice';
+const DID = 'did:plc:alice'; // 対象ユーザー
+const SERVER_DID = 'did:plc:kojira'; // 権威 repo の持ち主 (kojira.io)
+const PDS = 'https://pds.example';
+const NOW = 1_700_000_000; // epoch 秒 (固定)
 
-/** ステートフルな PDS モック (swapRecord CAS を本物どおり実装)。`interferer` を渡すと
- *  最初の putRecord の直前に「別リクエストが割り込んで書いた」状況を作れる (CAS 競合テスト用)。 */
+function jwkJson(fill: number): string {
+  const d = new Uint8Array(32).fill(fill);
+  const pub = p256.getPublicKey(d, false);
+  return JSON.stringify({ kty: 'EC', crv: 'P-256', x: base64urlnopad.encode(pub.slice(1, 33)), y: base64urlnopad.encode(pub.slice(33, 65)), d: base64urlnopad.encode(d), kid: `k${fill}` });
+}
+function mockKv() {
+  const m = new Map<string, string>();
+  return { get: async (k: string) => m.get(k) ?? null, put: async (k: string, v: string) => { m.set(k, v); }, delete: async (k: string) => { m.delete(k); } } as unknown as KVNamespace;
+}
+/** bootstrap 済みトークンを持つ env。 */
+async function makeEnv(): Promise<GameStateEnv> {
+  const kv = mockKv();
+  await writeServerTokens(kv, { did: SERVER_DID, accessToken: 'AT', refreshToken: 'RT', tokenType: 'DPoP', expiresAt: NOW + 3600, pdsUrl: PDS, authServer: 'https://bsky.social', updatedAt: NOW });
+  return { SERVER_PDS_URL: PDS, SERVER_DID, OAUTH_CLIENT_PRIVATE_JWK: jwkJson(3), OAUTH_DPOP_PRIVATE_JWK: jwkJson(5), WORKER_DID: 'did:web:edge.aozoraquest.app', OAUTH_TOKENS: kv };
+}
+
+/** ステートフルな PDS モック: public getRecord + DPoP putRecord の swapRecord CAS を実装。
+ *  `interferer` を渡すと最初の putRecord 直前に「別リクエストが割り込んで書いた」状況を作れる。 */
 function statefulPds(interferer?: (store: Map<string, { value: unknown; cid: string }>) => void) {
   const store = new Map<string, { value: unknown; cid: string }>();
   let counter = 0;
@@ -21,7 +40,7 @@ function statefulPds(interferer?: (store: Map<string, { value: unknown; cid: str
     }
     if (url.includes('com.atproto.repo.putRecord')) {
       putCalls++;
-      if (putCalls === 1 && interferer) interferer(store); // 1 回目の put 直前に競合を注入
+      if (putCalls === 1 && interferer) interferer(store);
       const b = JSON.parse(init.body as string) as { rkey: string; record: unknown; swapRecord?: string | null };
       const cur = store.get(b.rkey);
       if (b.swapRecord === null && cur) return json(400, { error: 'InvalidSwap' });
@@ -32,10 +51,10 @@ function statefulPds(interferer?: (store: Map<string, { value: unknown; cid: str
     }
     return json(404, { error: 'not_found' });
   }) as unknown as typeof fetch;
-  return { fn, store, get putCalls() { return putCalls; } };
+  return { fn, store };
 }
 
-describe('game-state', () => {
+describe('game-state (OAuth 権威書き込み)', () => {
   const orig = globalThis.fetch;
   afterEach(() => { globalThis.fetch = orig; });
 
@@ -47,40 +66,34 @@ describe('game-state', () => {
   });
 
   it('state 無しなら初期値から作成 (swap=null で新規作成のみ)', async () => {
+    const env = await makeEnv();
     const m = statefulPds();
     globalThis.fetch = m.fn;
-    const s = await readModifyWrite(session, DID, (c) => ({ ...c, power: c.power + 3 }), { now: NOW });
+    const s = await readModifyWrite(env, DID, (c) => ({ ...c, power: c.power + 3 }), { now: NOW });
     expect(s.power).toBe(3);
     expect(s.did).toBe(DID);
     expect(m.store.get(rkeyForDid(DID))).toBeTruthy();
   });
 
   it('既存 state を読んで mutate し CAS で更新', async () => {
+    const env = await makeEnv();
     const m = statefulPds();
     globalThis.fetch = m.fn;
-    await readModifyWrite(session, DID, (c) => ({ ...c, power: 10 }), { now: NOW });
-    const s2 = await readModifyWrite(session, DID, (c) => ({ ...c, power: c.power - 1 }), { now: NOW });
+    await readModifyWrite(env, DID, (c) => ({ ...c, power: 10 }), { now: NOW });
+    const s2 = await readModifyWrite(env, DID, (c) => ({ ...c, power: c.power - 1 }), { now: NOW });
     expect(s2.power).toBe(9);
   });
 
   it('CAS 競合時は最新を読み直して再評価する (二重使用を通さない = ★★★ 契約)', async () => {
-    // 事前に power:100 を作成
-    const m = statefulPds((store) => {
-      // 1 回目の put 直前に「別端末が power を 100→50 に消費して書いた」状況を注入
-      const rk = rkeyForDid(DID);
-      store.set(rk, { value: { did: DID, power: 50, playerXp: 0, jobXp: {}, materials: {}, gear: [], x: 0, y: 0, version: 1, updatedAt: NOW }, cid: 'cidX' });
-    });
-    globalThis.fetch = m.fn;
-    // 先に power:100 のレコードを作る (この時点では interferer は putCalls===1 で発火するので注意)
-    // → 別のモックで素直に作成する
+    const env = await makeEnv();
+    // 先に power:100 を作る
     const setup = statefulPds();
     globalThis.fetch = setup.fn;
-    await readModifyWrite(session, DID, (c) => ({ ...c, power: 100 }), { now: NOW });
-    // 以後は競合注入つきモックに切替え、power を 30 消費する RMW を実行
-    // (注入により最初の read は power:100 だが put が競合 → 再読込で power:50 になり、そこから -30)
+    await readModifyWrite(env, DID, (c) => ({ ...c, power: 100 }), { now: NOW });
+    // 競合注入つきに切替え、power を 30 消費 (最初の read は 100 だが put が競合 → 再読込で 50 → -30)
     const store2 = setup.store;
     let interfered = false;
-    const m2fetch = (async (url: string, init: RequestInit = {}) => {
+    globalThis.fetch = (async (url: string, init: RequestInit = {}) => {
       const json = (s: number, b: unknown) => new Response(JSON.stringify(b), { status: s, headers: { 'content-type': 'application/json' } });
       if (url.includes('getRecord')) {
         const rk = new URL(url).searchParams.get('rkey')!;
@@ -90,7 +103,6 @@ describe('game-state', () => {
       const b = JSON.parse(init.body as string) as { rkey: string; record: GameState; swapRecord?: string | null };
       if (!interfered) {
         interfered = true;
-        // 競合注入: 別端末が power を 100→50 に書いた (cid も変わる)
         store2.set(b.rkey, { value: { ...(store2.get(b.rkey)!.value as GameState), power: 50 }, cid: 'cidConcurrent' });
         return json(400, { error: 'InvalidSwap' });
       }
@@ -99,33 +111,34 @@ describe('game-state', () => {
       store2.set(b.rkey, { value: b.record, cid: 'cidFinal' });
       return json(200, { uri: 'x', cid: 'cidFinal' });
     }) as unknown as typeof fetch;
-    globalThis.fetch = m2fetch;
-    const result = await readModifyWrite(session, DID, (c) => ({ ...c, power: c.power - 30 }), { now: NOW });
-    // 100-30=70 でなく、競合後の 50-30=20 になっていること (= 古い値のまま上書きしていない)
-    expect(result.power).toBe(20);
+    const result = await readModifyWrite(env, DID, (c) => ({ ...c, power: c.power - 30 }), { now: NOW });
+    expect(result.power).toBe(20); // 50-30=20 (古い 100 のまま上書きしていない)
   });
 
   const jsonRes = (s: number, b: unknown) => new Response(JSON.stringify(b), { status: s, headers: { 'content-type': 'application/json' } });
-  const existingRec = { did: DID, power: 5, playerXp: 0, jobXp: {}, materials: {}, gear: [], x: 0, y: 0, version: 1, updatedAt: NOW };
+  const existingRec = { did: DID, power: 5, playerXp: 0, jobXp: {}, materials: {}, gear: [], x: 0, y: 0, version: 1, updatedAt: '' };
 
   it('CAS 競合が解消しなければ CasExhausted で throw', async () => {
+    const env = await makeEnv();
     globalThis.fetch = (async (url: string) =>
       url.includes('getRecord') ? jsonRes(200, { uri: 'x', cid: 'cidA', value: existingRec }) : jsonRes(400, { error: 'InvalidSwap' })) as unknown as typeof fetch;
-    await expect(readModifyWrite(session, DID, (c) => ({ ...c, power: c.power + 1 }), { now: NOW, retries: 2 })).rejects.toMatchObject({ xrpcError: 'CasExhausted' });
+    await expect(readModifyWrite(env, DID, (c) => ({ ...c, power: c.power + 1 }), { now: NOW, retries: 2 })).rejects.toMatchObject({ xrpcError: 'CasExhausted' });
   });
 
   it('InvalidSwap 以外のエラー (トークン失効等) は即 throw しリトライしない', async () => {
+    const env = await makeEnv();
     let puts = 0;
     globalThis.fetch = (async (url: string) => {
       if (url.includes('getRecord')) return jsonRes(400, { error: 'RecordNotFound' });
       puts++;
       return jsonRes(401, { error: 'ExpiredToken' });
     }) as unknown as typeof fetch;
-    await expect(readModifyWrite(session, DID, (c) => c, { now: NOW, retries: 5 })).rejects.toMatchObject({ xrpcError: 'ExpiredToken' });
+    await expect(readModifyWrite(env, DID, (c) => c, { now: NOW, retries: 5 })).rejects.toMatchObject({ xrpcError: 'ExpiredToken' });
     expect(puts).toBe(1);
   });
 
   it('CAS 競合時に mutate が再実行される (契約の可視化)', async () => {
+    const env = await makeEnv();
     let puts = 0;
     globalThis.fetch = (async (url: string) => {
       if (url.includes('getRecord')) return jsonRes(200, { uri: 'x', cid: `c${puts}`, value: existingRec });
@@ -133,7 +146,14 @@ describe('game-state', () => {
       return puts === 1 ? jsonRes(400, { error: 'InvalidSwap' }) : jsonRes(200, { uri: 'x', cid: 'cFinal' });
     }) as unknown as typeof fetch;
     let mutateCalls = 0;
-    await readModifyWrite(session, DID, (c) => { mutateCalls++; return { ...c, power: c.power + 1 }; }, { now: NOW });
+    await readModifyWrite(env, DID, (c) => { mutateCalls++; return { ...c, power: c.power + 1 }; }, { now: NOW });
     expect(mutateCalls).toBe(2);
+  });
+
+  it('書き込みトークン未 bootstrap は fail-closed (ServerWriteError)', async () => {
+    const env = await makeEnv();
+    (env as { OAUTH_TOKENS?: KVNamespace }).OAUTH_TOKENS = mockKv(); // 空 = 未 bootstrap
+    globalThis.fetch = (async (url: string) => jsonRes(url.includes('getRecord') ? 400 : 200, url.includes('getRecord') ? { error: 'RecordNotFound' } : {})) as unknown as typeof fetch;
+    await expect(readModifyWrite(env, DID, (c) => c, { now: NOW })).rejects.toMatchObject({ reason: 'not-bootstrapped' });
   });
 });

--- a/apps/edge/test/game-state.test.ts
+++ b/apps/edge/test/game-state.test.ts
@@ -22,7 +22,7 @@ function mockKv() {
 async function makeEnv(): Promise<GameStateEnv> {
   const kv = mockKv();
   await writeServerTokens(kv, { did: SERVER_DID, accessToken: 'AT', refreshToken: 'RT', tokenType: 'DPoP', expiresAt: NOW + 3600, pdsUrl: PDS, authServer: 'https://bsky.social', updatedAt: NOW });
-  return { SERVER_PDS_URL: PDS, SERVER_DID, OAUTH_CLIENT_PRIVATE_JWK: jwkJson(3), OAUTH_DPOP_PRIVATE_JWK: jwkJson(5), WORKER_DID: 'did:web:edge.aozoraquest.app', OAUTH_TOKENS: kv };
+  return { SERVER_DID, OAUTH_CLIENT_PRIVATE_JWK: jwkJson(3), OAUTH_DPOP_PRIVATE_JWK: jwkJson(5), WORKER_DID: 'did:web:edge.aozoraquest.app', OAUTH_TOKENS: kv };
 }
 
 /** ステートフルな PDS モック: public getRecord + DPoP putRecord の swapRecord CAS を実装。
@@ -148,6 +148,18 @@ describe('game-state (OAuth 権威書き込み)', () => {
     let mutateCalls = 0;
     await readModifyWrite(env, DID, (c) => { mutateCalls++; return { ...c, power: c.power + 1 }; }, { now: NOW });
     expect(mutateCalls).toBe(2);
+  });
+
+  it('最初の InvalidSwap 後にトークン失効 (401) が来たら即 throw (mid-retry を握りつぶさない)', async () => {
+    const env = await makeEnv();
+    let puts = 0;
+    globalThis.fetch = (async (url: string) => {
+      if (url.includes('getRecord')) return jsonRes(200, { uri: 'x', cid: `c${puts}`, value: existingRec });
+      puts++;
+      return puts === 1 ? jsonRes(400, { error: 'InvalidSwap' }) : jsonRes(401, { error: 'ExpiredToken' });
+    }) as unknown as typeof fetch;
+    await expect(readModifyWrite(env, DID, (c) => ({ ...c, power: c.power + 1 }), { now: NOW })).rejects.toMatchObject({ xrpcError: 'ExpiredToken' });
+    expect(puts).toBe(2); // 1回目 InvalidSwap で再試行 → 2回目 401 で打ち止め (spin しない)
   });
 
   it('書き込みトークン未 bootstrap は fail-closed (ServerWriteError)', async () => {

--- a/apps/edge/test/server-pds.test.ts
+++ b/apps/edge/test/server-pds.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { p256 } from '@noble/curves/p256';
+import { base64urlnopad } from '@scure/base';
+import { serverPutRecord, serverDeleteRecord, ServerWriteError, type ServerPdsEnv } from '../src/server-pds';
+import { writeServerTokens, readPdsNonce, type ServerOAuthTokens } from '../src/oauth-store';
+
+function jwkJson(fill: number): string {
+  const d = new Uint8Array(32).fill(fill);
+  const pub = p256.getPublicKey(d, false);
+  return JSON.stringify({ kty: 'EC', crv: 'P-256', x: base64urlnopad.encode(pub.slice(1, 33)), y: base64urlnopad.encode(pub.slice(33, 65)), d: base64urlnopad.encode(d), kid: `k${fill}` });
+}
+function mockKv() {
+  const m = new Map<string, string>();
+  return { kv: { get: async (k: string) => m.get(k) ?? null, put: async (k: string, v: string) => { m.set(k, v); }, delete: async (k: string) => { m.delete(k); } } as unknown as KVNamespace, m };
+}
+const PDS = 'https://pds.example';
+const NOW = 100000;
+const tokens = (over: Partial<ServerOAuthTokens> = {}): ServerOAuthTokens => ({ did: 'did:plc:kojira', accessToken: 'ATOKEN', refreshToken: 'RT', tokenType: 'DPoP', expiresAt: NOW + 3600, pdsUrl: PDS, authServer: 'https://bsky.social', updatedAt: NOW, ...over });
+const env = (kv?: KVNamespace): ServerPdsEnv => ({ OAUTH_CLIENT_PRIVATE_JWK: jwkJson(3), OAUTH_DPOP_PRIVATE_JWK: jwkJson(5), SERVER_DID: 'did:plc:kojira', WORKER_DID: 'did:web:edge.aozoraquest.app', OAUTH_TOKENS: kv });
+const json = (b: unknown, s = 200, h: Record<string, string> = {}) => new Response(JSON.stringify(b), { status: s, headers: { 'content-type': 'application/json', ...h } });
+
+describe('server-pds (OAuth DPoP 書き込み)', () => {
+  const orig = globalThis.fetch;
+  afterEach(() => { globalThis.fetch = orig; });
+
+  it('serverPutRecord は repo=サーバーDID + DPoP + Authorization を付けて putRecord する', async () => {
+    const { kv } = mockKv();
+    await writeServerTokens(kv, tokens());
+    let seen: { url: string; headers: Headers; body: unknown } | undefined;
+    globalThis.fetch = (async (url: string, init: RequestInit) => { seen = { url, headers: new Headers(init.headers), body: JSON.parse(init.body as string) }; return json({ uri: 'at://x', cid: 'CID1' }); }) as unknown as typeof fetch;
+    const r = await serverPutRecord(env(kv), NOW, 'app.aozoraquest.gameState', 'u123', { power: 5 }, null);
+    expect(r).toMatchObject({ uri: 'at://x', cid: 'CID1' });
+    expect(seen!.url).toBe(`${PDS}/xrpc/com.atproto.repo.putRecord`);
+    expect(seen!.headers.get('DPoP')).toBeTruthy();
+    expect(seen!.headers.get('Authorization')).toBe('DPoP ATOKEN');
+    expect(seen!.body).toMatchObject({ repo: 'did:plc:kojira', collection: 'app.aozoraquest.gameState', rkey: 'u123', record: { power: 5 }, swapRecord: null });
+  });
+
+  it('未 bootstrap / KV 無し / 失効 / 設定不備は fail-closed (ServerWriteError)', async () => {
+    await expect(serverPutRecord(env(), NOW, 'c', 'r', {})).rejects.toMatchObject({ reason: 'no-kv' });
+    const { kv } = mockKv();
+    await expect(serverPutRecord(env(kv), NOW, 'c', 'r', {})).rejects.toMatchObject({ reason: 'not-bootstrapped' });
+    await writeServerTokens(kv, tokens({ expiresAt: NOW - 1 }));
+    await expect(serverPutRecord(env(kv), NOW, 'c', 'r', {})).rejects.toMatchObject({ reason: 'token-expired' });
+    const { kv: kv2 } = mockKv();
+    await writeServerTokens(kv2, tokens());
+    await expect(serverPutRecord({ ...env(kv2), OAUTH_DPOP_PRIVATE_JWK: undefined }, NOW, 'c', 'r', {})).rejects.toMatchObject({ reason: 'not-configured' });
+  });
+
+  it('CAS 競合 (InvalidSwap) は PdsError.xrpcError で判別できる', async () => {
+    const { kv } = mockKv();
+    await writeServerTokens(kv, tokens());
+    globalThis.fetch = (async () => json({ error: 'InvalidSwap', message: 'CID mismatch' }, 400)) as unknown as typeof fetch;
+    try {
+      await expect(serverPutRecord(env(kv), NOW, 'c', 'r', {}, 'STALE')).rejects.toMatchObject({ xrpcError: 'InvalidSwap' });
+    } finally { /* restored below */ }
+  });
+
+  it('use_dpop_nonce チャレンジで nonce を KV に保存し再送して成功する', async () => {
+    const { kv } = mockKv();
+    await writeServerTokens(kv, tokens());
+    let calls = 0;
+    globalThis.fetch = (async () => { calls++; return calls === 1 ? json({ error: 'use_dpop_nonce' }, 401, { 'DPoP-Nonce': 'PDSN1' }) : json({ uri: 'at://x', cid: 'CID2' }); }) as unknown as typeof fetch;
+    const r = await serverPutRecord(env(kv), NOW, 'c', 'r', {});
+    expect(calls).toBe(2);
+    expect(r.cid).toBe('CID2');
+    expect(await readPdsNonce(kv)).toBe('PDSN1'); // 次回のため保存
+  });
+
+  it('serverDeleteRecord は swapRecord CAS 付きで deleteRecord する', async () => {
+    const { kv } = mockKv();
+    await writeServerTokens(kv, tokens());
+    let body: unknown;
+    globalThis.fetch = (async (_u: string, init: RequestInit) => { body = JSON.parse(init.body as string); return json({}); }) as unknown as typeof fetch;
+    await serverDeleteRecord(env(kv), NOW, 'c', 'r', 'CID9');
+    expect(body).toMatchObject({ repo: 'did:plc:kojira', collection: 'c', rkey: 'r', swapRecord: 'CID9' });
+  });
+});


### PR DESCRIPTION
## 目的
M2.5 (#349) で取得・自動更新される OAuth トークンを使い、権威 state をサーバーアカウント (kojira.io) の PDS に **DPoP 認証付きで書き込む**経路 (docs/21 §12.3)。M3 resolver が報酬確定に使う。

## 変更
- **`server-pds.ts`**: OAuth (DPoP) 認証付き putRecord/deleteRecord。access token + DPoP 鍵 (Secret) + PDS 用 DPoP-Nonce (別 KV キー)。repo は常にサーバー DID を注入。**request Worker は refresh しない** (直列化維持)。未 bootstrap / token 失効 / KV 無し / 設定不備は fail-closed で ServerWriteError → 上位 503。
- **`game-state.ts`**: readModifyWrite を bearer (M2 の PdsSession) から OAuth 書き込み (server-pds) に付け替え。読みは public getRecord のまま。署名 `readModifyWrite(env, targetDid, mutate, {now: epoch秒})`。**CAS 契約 (InvalidSwap→再読込→再評価→CasExhausted) は不変**。

## テスト
edge **120 件緑**。server-pds 5 (認証ヘッダ / fail-closed 4 状態 / CAS / nonce handshake / delete)、game-state 8 (★★★ CAS 並行性を OAuth 経路で維持 + 未 bootstrap fail-closed)。

## Review
(§1.5 レビュー後に追記)

## 次 (M3 resolver 本体)
encounter/turn エンドポイント + GameState 戦闘プロフィール (archetype/baseStats/carry) + 決着で XP/ドロップ/パワー/素材を本経路で確定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)