### PR TITLE
feat(web): M2.5-ui 設定画面の管理者用サーバーアカウント OAuth 連携リンク

### DIFF
--- a/apps/web/.env.production
+++ b/apps/web/.env.production
@@ -1,0 +1,4 @@
+# 本番/dev ビルドが読む公開設定 (非 secret)。secret や個人情報は Cloudflare build vars 側に置く。
+# サーバー権威化 edge Worker (docs/21 §12)。管理者の OAuth 連携導線が叩く公開エンドポイント。
+VITE_EDGE_URL=https://aozoraquest-edge.kojiran.workers.dev
+VITE_EDGE_DID=did:web:aozoraquest-edge.kojiran.workers.dev

--- a/apps/web/src/lib/server-oauth.ts
+++ b/apps/web/src/lib/server-oauth.ts
@@ -1,0 +1,33 @@
+/**
+ * サーバーアカウント (kojira.io) の OAuth 連携を管理者が開始する導線 — docs/21 §12。
+ *
+ * 管理者がログイン中に、自分の OAuth セッション (Agent) で **service auth JWT** (aud=edge Worker,
+ * lxm=oauth.start) を発行 → edge の `/api/oauth/start` に渡すと、edge が PAR して authorize URL を
+ * 返す。そこへリダイレクトし、サーバーアカウントで 1 回ログインすると edge がトークンを保管する。
+ */
+import type { Agent } from '@atproto/api';
+
+const EDGE_URL = (import.meta.env.VITE_EDGE_URL as string | undefined)?.trim();
+const EDGE_DID = (import.meta.env.VITE_EDGE_DID as string | undefined)?.trim();
+const LXM_OAUTH_START = 'app.aozoraquest.oauth.start';
+
+/** edge URL / DID が設定されていれば連携導線を出せる。 */
+export const serverOAuthConfigured = Boolean(EDGE_URL && EDGE_DID);
+
+/** サーバーアカウント OAuth 連携を開始し、認可 URL へ遷移する。失敗時は Error を throw。 */
+export async function startServerOAuth(agent: Agent): Promise<void> {
+  if (!EDGE_URL || !EDGE_DID) throw new Error('VITE_EDGE_URL / VITE_EDGE_DID が未設定です');
+  // 管理者本人の署名で service auth JWT を発行 (edge が aud/lxm と ADMIN_DIDS を検証)。
+  const { data } = await agent.com.atproto.server.getServiceAuth({ aud: EDGE_DID, lxm: LXM_OAUTH_START });
+  const res = await fetch(`${EDGE_URL}/api/oauth/start`, {
+    method: 'POST',
+    headers: { authorization: `Bearer ${data.token}` },
+  });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string; message?: string };
+    throw new Error(`連携開始に失敗しました (${res.status}): ${body.error ?? ''} ${body.message ?? ''}`.trim());
+  }
+  const { authorizeUrl } = (await res.json()) as { authorizeUrl: string };
+  if (!authorizeUrl) throw new Error('authorizeUrl が返りませんでした');
+  window.location.href = authorizeUrl; // 認可サーバーへ遷移
+}

--- a/apps/web/src/lib/server-oauth.ts
+++ b/apps/web/src/lib/server-oauth.ts
@@ -25,7 +25,8 @@ export async function startServerOAuth(agent: Agent): Promise<void> {
   });
   if (!res.ok) {
     const body = (await res.json().catch(() => ({}))) as { error?: string; message?: string };
-    throw new Error(`連携開始に失敗しました (${res.status}): ${body.error ?? ''} ${body.message ?? ''}`.trim());
+    const detail = [body.error, body.message].filter(Boolean).join(' ').trim();
+    throw new Error(`連携開始に失敗しました (${res.status})${detail ? `: ${detail}` : ''}`);
   }
   const { authorizeUrl } = (await res.json()) as { authorizeUrl: string };
   if (!authorizeUrl) throw new Error('authorizeUrl が返りませんでした');

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -631,7 +631,7 @@ function ServerOAuthAdmin({ agent }: { agent: Agent }) {
     <section style={{ marginTop: '2em' }}>
       <h3 style={{ fontSize: '0.95em' }}>管理者</h3>
       <p style={{ fontSize: '0.8em', color: 'var(--color-muted)', marginBottom: '0.5em' }}>
-        ゲームの権威データを書き込むサーバーアカウントの連携。初回のみ実行します。
+        ゲームの権威データを書き込むサーバーアカウントの連携。
       </p>
       <button onClick={onLink} disabled={busy}>
         {busy ? '連携中…' : 'サーバーアカウントと連携'}

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { AtpAgent } from '@atproto/api';
+import { AtpAgent, type Agent } from '@atproto/api';
 import type { Archetype, DiagnosisResult, StatVector } from '@aozoraquest/core';
 import { ARCHETYPES, JOBS_BY_ID, jobDisplayName, jobTagline, statArrayToVector } from '@aozoraquest/core';
 import { useSession } from '@/lib/session';
+import { isAdminDid } from '@/lib/runtime-config';
+import { startServerOAuth, serverOAuthConfigured } from '@/lib/server-oauth';
 import { signOut } from '@/lib/oauth';
 import { createTaggedPost, getRecord, putRecord } from '@/lib/atproto';
 import { COL } from '@/lib/collections';
@@ -335,6 +337,10 @@ export function Settings() {
         <PostQuestNotificationsToggle />
       </section>
 
+      {isAdminDid(session.did) && serverOAuthConfigured && session.agent && (
+        <ServerOAuthAdmin agent={session.agent} />
+      )}
+
       <section style={{ marginTop: '2em' }}>
         <h3 style={{ fontSize: '0.95em' }}>アカウント</h3>
         {session.status === 'signed-in' && (
@@ -604,5 +610,33 @@ function AnalyzePostsToggle() {
         URL とハッシュタグを取り除いた本文を ONNX 分類器で解析し、Fe / Ni などの心理機能スコア上位 3 を投稿下に表示します。ブラウザ内推論なので外部送信はありませんが、初回ロードでモデル (~30MB) がダウンロードされます。OFF にした場合も各投稿下の「🧠 気質を分析」ボタンから個別に解析できます。
       </p>
     </div>
+  );
+}
+
+/** 管理者専用: サーバーアカウント (権威 state の持ち主) の OAuth 連携を開始する。docs/21 §12。 */
+function ServerOAuthAdmin({ agent }: { agent: Agent }) {
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const onLink = async () => {
+    setBusy(true);
+    setErr(null);
+    try {
+      await startServerOAuth(agent); // 成功時は認可サーバーへ遷移する
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : '連携に失敗しました');
+      setBusy(false);
+    }
+  };
+  return (
+    <section style={{ marginTop: '2em' }}>
+      <h3 style={{ fontSize: '0.95em' }}>管理者</h3>
+      <p style={{ fontSize: '0.8em', color: 'var(--color-muted)', marginBottom: '0.5em' }}>
+        ゲームの権威データを書き込むサーバーアカウントの連携。初回のみ実行します。
+      </p>
+      <button onClick={onLink} disabled={busy}>
+        {busy ? '連携中…' : 'サーバーアカウントと連携'}
+      </button>
+      {err && <p style={{ fontSize: '0.8em', color: 'var(--color-danger, crimson)', marginTop: '0.4em' }}>{err}</p>}
+    </section>
   );
 }


### PR DESCRIPTION
## 目的
M2.5 (#349) で作った OAuth 認証基盤を **オーナーがスマホの設定画面から起動できる**導線 (docs/21 §12)。これで権威書き込みの bootstrap (kojira.io で 1 回 OAuth ログイン) が完結し、サーバー権威化を実機で確認できるようになる。

## 変更
- **`server-oauth.ts`**: `startServerOAuth(agent)` — 管理者本人の service auth JWT (aud=edge, lxm=oauth.start) を発行 → edge `/api/oauth/start` に渡す → 返ってきた authorizeUrl へ遷移。
- **`settings.tsx`**: `isAdminDid` かつ `serverOAuthConfigured` のときだけ「管理者」セクションに連携ボタン (loading/error 表示)。非管理者・未設定では一切出ない。
- **`.env.production`**: `VITE_EDGE_URL` / `VITE_EDGE_DID` (公開 URL / did:web、非 secret)。committed なので deploy が CF ダッシュボード操作なしで拾う。

## 前提 (設定済み)
edge Worker はデプロイ + OAuth 設定済み (#349、`https://aozoraquest-edge.kojiran.workers.dev/client-metadata.json` が本物のメタデータを返す)。マージ → dev デプロイ後、**設定画面 → 管理者 → 「サーバーアカウントと連携」→ kojira.io でログイン**で bootstrap 完了。

## テスト
web typecheck clean、unit 330 件緑。連携ボタンは admin 限定表示・成功時は認可サーバーへ遷移・失敗時はエラー表示。

## Review
(§1.5 レビュー後に追記)

🤖 Generated with [Claude Code](https://claude.com/claude-code)