### PR TITLE
fix(session): warmup barrier にタイムアウト (古いセッションの無限スプラッシュを解消)

### DIFF
--- a/apps/web/src/lib/__tests__/session-timeout.test.ts
+++ b/apps/web/src/lib/__tests__/session-timeout.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { withTimeout } from '../session';
+
+describe('withTimeout (warmup ハング対策)', () => {
+  afterEach(() => vi.useRealTimers());
+
+  it('期限内に解決すれば値を返す', async () => {
+    await expect(withTimeout(Promise.resolve('ok'), 1000, 'warmup')).resolves.toBe('ok');
+  });
+
+  it('期限内に reject すればその理由を伝える (タイムアウトで上書きしない)', async () => {
+    await expect(withTimeout(Promise.reject(new Error('boom')), 1000, 'warmup')).rejects.toThrow('boom');
+  });
+
+  it('解決しない promise は ms 後に <label>-timeout で reject (無限ハングにしない)', async () => {
+    vi.useFakeTimers();
+    const hang = new Promise<string>(() => {}); // 永遠に解決しない (= 壊れたセッションの getSession)
+    const p = withTimeout(hang, 10_000, 'warmup');
+    const assertion = expect(p).rejects.toThrow('warmup-timeout');
+    await vi.advanceTimersByTimeAsync(10_000);
+    await assertion;
+  });
+
+  it('解決が勝てばタイマーは片付けられ、後からの発火で余計な reject を残さない', async () => {
+    vi.useFakeTimers();
+    const p = withTimeout(Promise.resolve('done'), 10_000, 'warmup');
+    await expect(p).resolves.toBe('done');
+    // タイマーが残っていないこと (finally の clearTimeout)。進めても何も起きない。
+    await vi.advanceTimersByTimeAsync(20_000);
+  });
+});

--- a/apps/web/src/lib/session.ts
+++ b/apps/web/src/lib/session.ts
@@ -10,6 +10,20 @@ import { onSessionDeleted, restoreSession } from './oauth';
  */
 const PUBLIC_APPVIEW = 'https://api.bsky.app';
 
+/** warmup (getSession) の上限。復元は本来 <1s なので、これを超えたら「ハングした古い/壊れた
+ *  セッション」とみなし signed-out へ倒す (遅いだけの valid セッションを誤って切らない余裕を持たせる)。 */
+const WARMUP_TIMEOUT_MS = 10_000;
+
+/** `promise` を `ms` でタイムアウトさせる。超えたら `Error('<label>-timeout')` で reject。
+ *  勝敗どちらでもタイマーを片付ける (保留タイマー/unhandled rejection を残さない)。 */
+export function withTimeout<T>(promise: Promise<T>, ms: number, label = 'op'): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label}-timeout`)), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
 export interface SessionState {
   status: 'loading' | 'signed-in' | 'signed-out';
   did?: string;
@@ -109,10 +123,14 @@ async function setStateFromSession(
   //   全部 fresh token を SessionStore から読むだけで race が原理的に発生
   //   しなくなる。失敗したら signed-out に倒し、下流の useEffect が
   //   agent を一切触らないようにする。
+  //   ★ タイムアウト: 古い/壊れたセッションで getSession が**ハング**すると無限スプラッシュに
+  //   なる (復元は本来 <1s)。一定時間で打ち切って signed-out に倒し、ログイン画面から復帰できる
+  //   ようにする (失敗と同じ扱い。valid だが遅いだけのセッションを誤って切らないよう余裕を持たせる)。
   try {
-    await agent.com.atproto.server.getSession();
+    await withTimeout(agent.com.atproto.server.getSession(), WARMUP_TIMEOUT_MS, 'warmup');
   } catch (e) {
-    console.warn('[session] warmup failed; signing out', e);
+    // 失敗 or タイムアウト → signed-out (= ログイン画面) に倒す。無限スプラッシュにしない。
+    console.warn('[session] warmup failed/timed out; signing out', e);
     if (!isCancelled()) setState({ status: 'signed-out' });
     return;
   }


### PR DESCRIPTION
## 背景 (実機で発覚)
オーナーが dev.aozoraquest.app をスマホで開くと **スプラッシュ「準備しています/セッション確認中」で 20秒以上ハング**しタイムラインが出ない。プライベートウィンドウ (新規ログイン) では正常 → **アプリは無傷、端末に残った古いセッションの復元が詰まっていた**。

## 原因 (私の変更ではないことを確認済み)
- `session.ts` の **warmup barrier** (#56b8ffd, **2026-04-30 から本番**) は agent 公開前に `getSession()` を直列実行するが**タイムアウトが無い**。
- 通常のセッション切れ: `getSession` が 401 で**失敗** → `catch` → `signed-out` → **ログイン画面** (期待挙動)。
- 今回: リフレッシュトークンが死んだ状態で**トークン更新がハング** → `getSession` が返らない → **無限スプラッシュ** (ログイン画面に戻れない)。
- アプリの client-metadata.json は静的 (public client・鍵なし・VITE_APP_URL から決定的生成)、本セッションは oauth/session/vite.config/VITE_APP_URL を未変更。→ **既存セッションを壊す変更はしていない** (だから新規ログインは正常)。

## 修正
`withTimeout` で warmup を **10s** で打ち切り、ハング時も失敗時と同じく **`signed-out` (= ログイン画面)** に倒す。ユーザーが期待する「切れたらログイン画面」を回復し、**どのユーザーもセッション劣化で無限スプラッシュに陥らない**ようにする。復元は本来 <1s なので valid セッションを誤って切らない余裕あり。

## テスト
`withTimeout` を fake timer で 4 ケース (期限内解決 / 期限内 reject 透過 / ハング→`warmup-timeout` / 解決後のタイマー片付け)。web typecheck clean・unit **334 件緑**。

## Review
(§1.5 レビュー後に追記。session.ts は過去に微妙な race バグ歴があるため慎重に)

🤖 Generated with [Claude Code](https://claude.com/claude-code)