### PR TITLE
fix(session): warmup タイムアウト時に壊れたセッションを revoke (手動データ削除を不要に)

### DIFF
--- a/apps/web/src/lib/session.ts
+++ b/apps/web/src/lib/session.ts
@@ -1,7 +1,7 @@
 import { Agent, AtpAgent } from '@atproto/api';
 import type { OAuthSession } from '@atproto/oauth-client-browser';
 import { createContext, useContext, useEffect, useState } from 'react';
-import { onSessionDeleted, restoreSession } from './oauth';
+import { onSessionDeleted, restoreSession, signOut } from './oauth';
 
 /**
  * 公開 AppView エンドポイント。OAuth セッションの PDS は app.bsky.* を
@@ -130,8 +130,16 @@ async function setStateFromSession(
     await withTimeout(agent.com.atproto.server.getSession(), WARMUP_TIMEOUT_MS, 'warmup');
   } catch (e) {
     // 失敗 or タイムアウト → signed-out (= ログイン画面) に倒す。無限スプラッシュにしない。
+    const timedOut = e instanceof Error && e.message === 'warmup-timeout';
     console.warn('[session] warmup failed/timed out; signing out', e);
     if (!isCancelled()) setState({ status: 'signed-out' });
+    // タイムアウト = リフレッシュがハングする壊れたセッション。**ストレージから除去**して、次回以降の
+    // 10s ハングと「手動でサイトデータ削除しないと復旧できない」状態を防ぐ (再ログインで即復帰できる)。
+    // 待たない・失敗許容 (revoke がハングしても UI はもうログイン画面)。通常の失敗 (401 等) は OAuth
+    // client 側が既に無効化するので、ここでは timeout ケースのみ明示 revoke する。
+    if (timedOut) {
+      void signOut(did).catch((err) => console.warn('[session] revoke after warmup timeout failed', err));
+    }
     return;
   }
   if (isCancelled()) return;


### PR DESCRIPTION
## 背景
オーナー指摘: 「データ削除しないと復旧できないのは困る」。#354 (warmup タイムアウト) だけだと、ハングする**壊れたセッションがストレージに残る**ため、次回以降も 10s ハング → 実質「手動でサイトデータ削除」しないと快適に戻れない。

## 修正
warmup が**タイムアウト**した場合 (= リフレッシュがハングする壊れたセッション) のみ、`signOut(did)` (`client.revoke`) でストレージから除去する。
→ 「10s → ログイン画面 → 壊れたセッション自動消去 → 再ログインで即復帰」。**手動データ削除が完全に不要**に。

- 待たない・失敗許容 (`void signOut(did).catch(...)`) — revoke がハングしても UI はもうログイン画面。
- **timeout ケースのみ** revoke (通常の失敗 401 等は OAuth client 側が既に無効化 + 一過性の可能性があるので温存)。
- revoke → onSessionDeleted broadcast は既存ガード (`curr.status !== 'signed-in'` → no-op) で安全。

## テスト
web typecheck clean / unit **334 緑**。setStateFromSession の統合テストは #355 で追跡 (Agent モックが非自明)。

## Review
(§1.5 レビュー後に追記。#354 の延長)

🤖 Generated with [Claude Code](https://claude.com/claude-code)