### PR TITLE
fix(session): warmup タイムアウトでセッションを revoke しない (一過性ハングを尊重)

### DIFF
--- a/apps/web/src/lib/session.ts
+++ b/apps/web/src/lib/session.ts
@@ -126,15 +126,24 @@ async function setStateFromSession(
   //   ★ タイムアウト: 古い/壊れたセッションで getSession が**ハング**すると無限スプラッシュに
   //   なる (復元は本来 <1s)。一定時間で打ち切って signed-out に倒し、ログイン画面から復帰できる
   //   ようにする (失敗と同じ扱い。valid だが遅いだけのセッションを誤って切らないよう余裕を持たせる)。
+  //   ★ 診断 (intermittent な warmup ハングの真因究明): タイムアウト後も getSession の**最終結果**を
+  //   記録し、「一過性 (遅れて成功)」か「永続 (失敗し、そのエラー内容)」かを次回再発時に切り分ける。
+  const warmupStart = Date.now();
+  const warmup = agent.com.atproto.server.getSession();
+  warmup.then(
+    () => console.info('[session] warmup getSession resolved', { did, elapsedMs: Date.now() - warmupStart }),
+    (err) => console.warn('[session] warmup getSession rejected', { did, elapsedMs: Date.now() - warmupStart, error: String(err) }),
+  );
   try {
-    await withTimeout(agent.com.atproto.server.getSession(), WARMUP_TIMEOUT_MS, 'warmup');
+    await withTimeout(warmup, WARMUP_TIMEOUT_MS, 'warmup');
   } catch (e) {
     // 失敗 or タイムアウト → signed-out (= ログイン画面) に倒す。無限スプラッシュにしない。
-    // **セッションは消さない (revoke しない)**: このハングはリフレッシュの一過性スタックが主因で、
-    // 多くは時間が経てば回復する (=有効なセッション)。ここで revoke すると回復するはずのセッションを
+    // **セッションは消さない (revoke しない)**: このハングはリフレッシュの一過性スタックが主因のことが
+    // 多く、時間が経てば回復する (=有効なセッション)。ここで revoke すると回復するはずのセッションを
     // 消して不要な再ログインを強制してしまう。リロードで自然回復するか、必要なら再ログインで上書き
     // される。本当に死んだトークンは getSession が 401 で即失敗し、同じくここで signed-out になる。
-    console.warn('[session] warmup failed/timed out; signing out', e);
+    const timedOut = e instanceof Error && e.message === 'warmup-timeout';
+    console.warn('[session] warmup failed/timed out; signing out', { did, timedOut, elapsedMs: Date.now() - warmupStart, error: String(e) });
     if (!isCancelled()) setState({ status: 'signed-out' });
     return;
   }

--- a/apps/web/src/lib/session.ts
+++ b/apps/web/src/lib/session.ts
@@ -1,7 +1,7 @@
 import { Agent, AtpAgent } from '@atproto/api';
 import type { OAuthSession } from '@atproto/oauth-client-browser';
 import { createContext, useContext, useEffect, useState } from 'react';
-import { onSessionDeleted, restoreSession, signOut } from './oauth';
+import { onSessionDeleted, restoreSession } from './oauth';
 
 /**
  * 公開 AppView エンドポイント。OAuth セッションの PDS は app.bsky.* を
@@ -130,16 +130,12 @@ async function setStateFromSession(
     await withTimeout(agent.com.atproto.server.getSession(), WARMUP_TIMEOUT_MS, 'warmup');
   } catch (e) {
     // 失敗 or タイムアウト → signed-out (= ログイン画面) に倒す。無限スプラッシュにしない。
-    const timedOut = e instanceof Error && e.message === 'warmup-timeout';
+    // **セッションは消さない (revoke しない)**: このハングはリフレッシュの一過性スタックが主因で、
+    // 多くは時間が経てば回復する (=有効なセッション)。ここで revoke すると回復するはずのセッションを
+    // 消して不要な再ログインを強制してしまう。リロードで自然回復するか、必要なら再ログインで上書き
+    // される。本当に死んだトークンは getSession が 401 で即失敗し、同じくここで signed-out になる。
     console.warn('[session] warmup failed/timed out; signing out', e);
     if (!isCancelled()) setState({ status: 'signed-out' });
-    // タイムアウト = リフレッシュがハングする壊れたセッション。**ストレージから除去**して、次回以降の
-    // 10s ハングと「手動でサイトデータ削除しないと復旧できない」状態を防ぐ (再ログインで即復帰できる)。
-    // 待たない・失敗許容 (revoke がハングしても UI はもうログイン画面)。通常の失敗 (401 等) は OAuth
-    // client 側が既に無効化するので、ここでは timeout ケースのみ明示 revoke する。
-    if (timedOut) {
-      void signOut(did).catch((err) => console.warn('[session] revoke after warmup timeout failed', err));
-    }
     return;
   }
   if (isCancelled()) return;


### PR DESCRIPTION
## 背景 (実機観察で判明)
#356 で「warmup タイムアウト時に壊れたセッションを revoke」したが、オーナーが**再ログインせずに通常表示できた**と報告。→ 20s ハングしたセッションは**壊れておらず**、リフレッシュの**一過性スタック**が時間経過で解消しただけ。getSession が今は成功する = セッションは最初から有効。

## 何が問題か
ハングの主因が「一過性スタック (回復する)」なら、**revoke は回復するはずの有効セッションを消して不要な再ログインを強制**してしまう。本当に死んだトークンは getSession が **401 で即失敗**する (ハングしない) ので #354 の catch が拾う。→ **revoke は要らない、むしろ有害。**

## 修正
#356 の revoke を撤回し、#354 (10s タイムアウト → signed-out・**セッションは残す**) だけに戻す:
- 一過性スタック → ログイン画面が出るが**セッションは残る** → リロードで自然回復 (再ログイン不要) or 再ログインで上書き。
- 永続的に死んだトークン → 401 即失敗 → 同じく signed-out → 再ログインで上書き。
- 無限スプラッシュは起きず、**有効セッションを誤って消さない**。手動データ削除も不要。

## テスト
#354 でレビュー済みの timeout 経路に戻す (revoke 追加分の除去のみ)。web typecheck clean / unit 334 緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)