### PR TITLE
fix(edge/oauth): client_uri を client_id と同一オリジンに + PAR 失敗を catch

### DIFF
--- a/apps/edge/src/oauth-config.ts
+++ b/apps/edge/src/oauth-config.ts
@@ -81,7 +81,8 @@ export function buildClientMetadata(cfg: OAuthConfig): Record<string, unknown> {
   return {
     client_id: cfg.clientId,
     client_name: 'aozoraquest',
-    client_uri: 'https://aozoraquest.app',
+    // client_uri は client_id と**同一オリジン必須** (AT Proto OAuth)。edge のオリジンにする。
+    client_uri: cfg.publicOrigin,
     redirect_uris: [cfg.redirectUri],
     grant_types: ['authorization_code', 'refresh_token'],
     response_types: ['code'],

--- a/apps/edge/src/oauth-routes.ts
+++ b/apps/edge/src/oauth-routes.ts
@@ -65,10 +65,16 @@ export async function handleOAuthStart(req: Request, env: OAuthRoutesEnv, deps: 
   }
   if (!isEdgeAdmin(env, iss)) return json({ error: 'forbidden' }, 403);
 
-  const { pdsUrl, authServer } = await discoverForDid(cfg.serverDid, deps.fetchImpl);
-  const { url, state, verifier } = await buildAuthorizeUrl({ ...cfg, now: deps.now, fetchImpl: deps.fetchImpl }, authServer, { loginHint: cfg.serverDid });
-  await putPendingAuth(env.OAUTH_TOKENS, state, { verifier, authServer, pdsUrl, createdAt: deps.now });
-  return json({ authorizeUrl: url });
+  // discovery / PAR は失敗しうる (認可サーバーが client-metadata を弾く等)。**catch して JSON で返す**
+  // — 未処理例外だと 500 が CORS ヘッダ無しで返り、ブラウザ側が「Load failed」になり原因が見えない。
+  try {
+    const { pdsUrl, authServer } = await discoverForDid(cfg.serverDid, deps.fetchImpl);
+    const { url, state, verifier } = await buildAuthorizeUrl({ ...cfg, now: deps.now, fetchImpl: deps.fetchImpl }, authServer, { loginHint: cfg.serverDid });
+    await putPendingAuth(env.OAUTH_TOKENS, state, { verifier, authServer, pdsUrl, createdAt: deps.now });
+    return json({ authorizeUrl: url });
+  } catch (e) {
+    return json({ error: 'oauth_start_failed', message: e instanceof Error ? e.message : String(e) }, 502);
+  }
 }
 
 /** GET /oauth/callback — 認可サーバーからのリダイレクト。code→token 交換し KV 格納。 */


### PR DESCRIPTION
実機 bootstrap で判明した 2 バグの修正。**修正版を edge にデプロイし、OAuth bootstrap が本番で完全成功 (KV にトークン保存確認済み) = 動作実証済み。**

- client_uri を 'https://aozoraquest.app' ハードコードから `cfg.publicOrigin` (edge オリジン) に。AT Proto は client_uri が client_id と同一オリジン必須で、PAR が invalid_client_metadata 400 になっていた。
- handleOAuthStart が discovery/PAR 例外を catch せず未処理例外 → 500 が CORS 無しで返り「Load failed」。try/catch で JSON エラー (502) を返す。

edge 12 件緑。deploy 済み・bootstrap 成功で検証済みのため即マージ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)