### PR TITLE
feat(edge): M3 サーバー権威 戦闘 resolver (encounter/turn を毎回 Worker で処理・チート不可)

### DIFF
--- a/apps/edge/src/battle-guard.ts
+++ b/apps/edge/src/battle-guard.ts
@@ -2,16 +2,16 @@
  * バトルガード — docs/21-server-authority §5 の「毎ターン・やり直し不可」を担保する永続レコード。
  *
  * encounter 時に **Worker が封印した playerSnapshot + monster + 現 state + turn** をサーバー
- * アカウントの PDS に 1 ユーザー 1 アクティブ戦闘で持つ。ユーザーは書けない = 偽造不可。
+ * アカウント (kojira.io) の PDS に 1 ユーザー 1 アクティブ戦闘で持つ。ユーザーは書けない = 偽造不可。
+ * 書き込みは M2.5 の OAuth (DPoP) トークン経由 (server-pds)。読みは token 由来 pds の public getRecord。
  *
  * **やり直し不可の要点**: turn を `swapRecord` (CAS) で進める。同じターンを別コマンドで引き直そう
- * としても、ガードの turn は既に進んでいるので CID 不一致 (InvalidSwap) → 409。物理/CSPRNG 乱数を
- * 毎ターン Worker が引くので先読みも不可 (§3-3)。
- *
- * 封印内容 (`sealed`) と現戦闘 state (`state`) は `packages/core` の型だが、本モジュールは中身を
- * 解釈しない (opaque)。core 型は battle.ts が所有する。
+ * としても、ガードの turn は既に進んでいるので CID 不一致 (InvalidSwap) → 409。Worker が毎ターン新鮮な
+ * エントロピーを注入するので先読みも不可 (§3-3)。
  */
-import { getRecord, putRecord, deleteRecord, type PdsSession } from './pds';
+import { getRecord } from './pds';
+import { readServerTokens } from './oauth-store';
+import { serverPutRecord, serverDeleteRecord, ServerWriteError, type ServerPdsEnv } from './server-pds';
 import { rkeyForDid } from './game-state';
 
 export const BATTLE_GUARD_COLLECTION = 'app.aozoraquest.battleGuard';
@@ -23,18 +23,12 @@ export interface BattleGuard<Sealed = unknown, State = unknown> {
   battleId: string;
   /** 次に受理するターン番号 (0 始まり)。turn リクエストの turn と一致必須。 */
   turn: number;
-  /** encounter で封印した startBattle 入力 (playerSnapshot + monster + 内部 seed 等)。以後不変。
-   *  **クライアントには一切返さない**。とくに内部 seed を返すと、rollDrops/rollDefeatLoss/
-   *  summonMonster が seed 由来で決定的なため、クライアントが seed からドロップ/敗北ロス/敵ステを
-   *  先読みして「良い seed の戦闘だけ確定・悪ければ離脱」の選別チートが可能になる (レビュー ★★★)。
-   *  → 報酬計算も**サーバーが独立に引いたエントロピー**で行い、seed は Worker 内に封じる。 */
+  /** encounter で封印した startBattle 入力等。以後不変。**クライアントには一切返さない** (内部 seed を
+   *  返すと rollDrops/rollDefeatLoss/summonMonster が seed 由来で決定的なため先読み選別チートが可能)。 */
   sealed: Sealed;
   /** 現在の戦闘 state (HP/MP 等)。毎ターン更新。**client 向け DTO では seed を除去して返す**。 */
   state: State;
-  /** 次ターンに使う**サーバー事前採番のエントロピー** (32bit)。encounter / 各 turn の CAS 確定時に
-   *  次ターン分を引いて封じておくことで、(a) リトライ時に同じ seed を再利用でき冪等 (同一ターンで
-   *  二重エントロピー消費/取りこぼしを防ぐ)、(b) クライアントは commands 送信前に次ターン乱数を
-   *  知り得ない (先読み不可)。決着ターンではドロップ/敗北ロスもこの seed から独立に導出する。 */
+  /** 次ターンに使う**サーバー事前採番のエントロピー** (32bit)。リトライ冪等 + 先読み不可を担保。 */
   pendingTurnSeed: number;
   /** この戦闘で報酬対象か (encounter 時 power>=1 で確定+予約)。 */
   rewarded: boolean;
@@ -44,39 +38,41 @@ export interface BattleGuard<Sealed = unknown, State = unknown> {
   updatedAt: string;
 }
 
+/** 読み書き先 repo をトークン由来にするため、書込先 pds を token から得る。無ければ fail-closed。 */
+async function guardRepo(env: ServerPdsEnv): Promise<{ pdsUrl: string; did: string }> {
+  if (!env.OAUTH_TOKENS) throw new ServerWriteError('KV 未 binding', 'no-kv');
+  const t = await readServerTokens(env.OAUTH_TOKENS);
+  if (!t) throw new ServerWriteError('サーバートークン未 bootstrap', 'not-bootstrapped');
+  return { pdsUrl: t.pdsUrl, did: t.did };
+}
+
 /** アクティブなバトルガードを取得 (無ければ null)。1 ユーザー 1 戦闘なので rkey は DID ハッシュ。 */
 export async function readGuard<S = unknown, St = unknown>(
-  session: PdsSession,
-  did: string,
+  env: ServerPdsEnv,
+  targetDid: string,
 ): Promise<{ guard: BattleGuard<S, St>; cid: string } | null> {
-  const rec = await getRecord<BattleGuard<S, St>>(session.pdsUrl, session.did, BATTLE_GUARD_COLLECTION, rkeyForDid(did));
+  const repo = await guardRepo(env);
+  const rec = await getRecord<BattleGuard<S, St>>(repo.pdsUrl, repo.did, BATTLE_GUARD_COLLECTION, rkeyForDid(targetDid));
   return rec ? { guard: rec.value, cid: rec.cid } : null;
 }
 
-/**
- * ガードを作成 (encounter)。既存があれば InvalidSwap。呼び出し側は「未決着ガードは先に敗北 flush
- * してから」新規発行すること (§5 リロード離脱)。
- */
-export async function createGuard(session: PdsSession, guard: BattleGuard): Promise<{ cid: string }> {
-  const { cid } = await putRecord(session, BATTLE_GUARD_COLLECTION, rkeyForDid(guard.did), guard, null);
+/** ガードを作成 (encounter)。既存があれば InvalidSwap (二重戦闘を作らせない)。 */
+export async function createGuard(env: ServerPdsEnv, now: number, guard: BattleGuard): Promise<{ cid: string }> {
+  const { cid } = await serverPutRecord(env, now, BATTLE_GUARD_COLLECTION, rkeyForDid(guard.did), guard, null);
   return { cid };
 }
 
 /**
  * ガードを次ターンへ進める (= そのターンの解決結果を確定)。`expectedCid` で CAS。
- *
- * **順序 (docs/21 §4.1/§5)**: 部分2 の resolver は「ガード読取 → **確定 turnSeed** で resolveTurn →
- * `advanceGuard({turn+1, 解決後 state, 次の pendingTurnSeed})`」を 1 CAS 書込で行い、**CAS の成否で
- * クライアント応答をゲートする** (解決結果を返してから遅れて CAS を投げると、同一 turn の並行
- * リクエストが別エントロピーで二重解決し「良い方を採用」される)。競合 (InvalidSwap) は「やり直し/
- * リプレイ」= 409 として上位に投げ、**応答は返さない**。
+ * resolver は「読取 → 確定 turnSeed で resolveTurn → advance を 1 CAS 書込」で **CAS の成否で応答を
+ * ゲート**する (競合 = やり直し/リプレイ = 409、応答は返さない)。
  */
-export async function advanceGuard(session: PdsSession, guard: BattleGuard, expectedCid: string): Promise<{ cid: string }> {
-  const { cid } = await putRecord(session, BATTLE_GUARD_COLLECTION, rkeyForDid(guard.did), guard, expectedCid);
+export async function advanceGuard(env: ServerPdsEnv, now: number, guard: BattleGuard, expectedCid: string): Promise<{ cid: string }> {
+  const { cid } = await serverPutRecord(env, now, BATTLE_GUARD_COLLECTION, rkeyForDid(guard.did), guard, expectedCid);
   return { cid };
 }
 
-/** ガードを削除 (決着時)。CAS 付きで確実に「その CID のときだけ」消す (pds.ts の統一 xrpc 経由)。 */
-export async function deleteGuard(session: PdsSession, did: string, expectedCid: string): Promise<void> {
-  await deleteRecord(session, BATTLE_GUARD_COLLECTION, rkeyForDid(did), expectedCid);
+/** ガードを削除 (決着時)。CAS 付きで確実に「その CID のときだけ」消す。 */
+export async function deleteGuard(env: ServerPdsEnv, now: number, did: string, expectedCid: string): Promise<void> {
+  await serverDeleteRecord(env, now, BATTLE_GUARD_COLLECTION, rkeyForDid(did), expectedCid);
 }

--- a/apps/edge/src/battle-resolver.ts
+++ b/apps/edge/src/battle-resolver.ts
@@ -1,0 +1,174 @@
+/**
+ * サーバー権威の戦闘解決 — docs/21-server-authority §5 / M3-part2。
+ *
+ * **移動も攻撃も毎ターン Worker が処理する**のがアンチチートの核心:
+ *   - encounter: 権威 state + (x,y) 由来 tier + ユーザー診断 (archetype/baseStats) から startBattle 入力を
+ *     **サーバーが封印** (playerSnapshot はクライアントから受けない = §5 C1)。バトルガードを作成し、
+ *     turn1 用の pendingTurnSeed を事前採番。**内部 seed は client に返さない** (先読み防止 #348)。
+ *   - turn: バトルガードを読み、確定済み pendingTurnSeed で resolveTurn → 決着なら報酬を権威 state に
+ *     **fail-closed で確定** (readModifyWrite。トークン切れ等は throw = 報酬なし、クライアント権威への
+ *     フォールバックは存在しない §3-6)。未決着なら turn+1・新 pendingTurnSeed を **CAS で確定してから応答**
+ *     (同一ターンの並行二重解決/引き直しを弾く)。
+ */
+import {
+  startBattle, resolveTurn, statVectorToArray, jobLevelFromXp, playerLevelFromXp,
+  terrainAt, isWalkable, regionOf, regionDanger, tierForDanger, BATTLE_TUNING,
+  type BattleState, type Command, type Archetype, type StatVector,
+} from '@aozoraquest/core';
+import { entropyU32 } from './kuda';
+import { readGuard, createGuard, advanceGuard, deleteGuard, type BattleGuard } from './battle-guard';
+import { readState, readModifyWrite, emptyState, type GameStateEnv, type GameState } from './game-state';
+import { applyBattleOutcome, type AwardBreakdown, type BattleDecision } from './battle-reward';
+import { resolveDidDocument } from './service-auth';
+import { pdsEndpointFromDoc } from './oauth-metadata';
+import { getRecord, PdsError } from './pds';
+
+export const ANALYSIS_COLLECTION = 'app.aozoraquest.analysis';
+export const VALID_COMMANDS: readonly Command[] = ['attack', 'guard', 'skill', 'herb', 'tonic', 'flee'];
+
+/** 戦闘解決に必要な env (権威 state 読み書き + ユーザー診断 fetch)。 */
+export type ResolverEnv = GameStateEnv;
+
+/** ガードに封印する startBattle 由来のメタ (turn では state を使うが、報酬用に archetype を残す)。 */
+interface SealedMeta {
+  archetype: string;
+  tier: 1 | 2 | 3;
+}
+
+type Guard = BattleGuard<SealedMeta, BattleState>;
+
+/** 解決エラー。上位が HTTP status に振り分ける。 */
+export class ResolverError extends Error {
+  constructor(message: string, readonly status: number) {
+    super(message);
+  }
+}
+
+/** client 向けに BattleState から内部 seed を除去 (先読み防止 #348)。 */
+function stripState(s: BattleState) {
+  const { seed: _seed, ...rest } = s;
+  return rest;
+}
+
+/** ユーザーの PDS を DID から解決 (診断の public 読取用)。 */
+async function resolveUserPds(userDid: string, fetchImpl?: typeof fetch): Promise<string> {
+  const doc = (await resolveDidDocument(userDid, fetchImpl)) as { id: string; service?: { id: string; type: string; serviceEndpoint: string }[] };
+  return pdsEndpointFromDoc(doc, userDid);
+}
+
+/** ユーザーの診断 (archetype + baseStats) を PDS から読む。無ければ ResolverError(409)。 */
+async function readDiagnosis(userDid: string, fetchImpl?: typeof fetch): Promise<{ archetype: Archetype; baseStats: ReturnType<typeof statVectorToArray> }> {
+  const pds = await resolveUserPds(userDid, fetchImpl);
+  const rec = await getRecord<{ archetype: Archetype; rpgStats: StatVector }>(pds, userDid, ANALYSIS_COLLECTION, 'self');
+  if (!rec?.value?.archetype || !rec.value.rpgStats) throw new ResolverError('診断が未実施 (先に気質診断が必要)', 409);
+  return { archetype: rec.value.archetype, baseStats: statVectorToArray(rec.value.rpgStats) };
+}
+
+export interface EncounterResult {
+  battleId: string;
+  monsterId: string;
+  /** seed を除いた戦闘 state (HP/MP・monster・events 等)。 */
+  state: Omit<BattleState, 'seed'>;
+  rewarded: boolean;
+}
+
+/**
+ * encounter: (x,y) で遭遇を成立させ、サーバーが snapshot を封印してバトルを開始する。
+ * クライアントは監視 (どのモンスター・初期 HP/MP) しか受け取らない。1 ユーザー 1 戦闘。
+ */
+export async function handleEncounter(env: ResolverEnv, userDid: string, x: number, y: number, now: number, fetchImpl?: typeof fetch): Promise<EncounterResult> {
+  const terrain = terrainAt(x, y);
+  if (!isWalkable(terrain) || terrain === 'town') throw new ResolverError('その地形では遭遇しない', 400);
+
+  // 既存ガードがあれば二重戦闘不可 (createGuard の swap=null が弾くが、明示的に 409)。
+  if (await readGuard<SealedMeta, BattleState>(env, userDid)) throw new ResolverError('既に戦闘中', 409);
+
+  const existing = await readState(env, userDid);
+  const state = existing?.state ?? emptyState(userDid, new Date(now * 1000).toISOString());
+  const { archetype, baseStats } = await readDiagnosis(userDid, fetchImpl);
+
+  const tier = tierForDanger(regionDanger(regionOf(x, y)));
+  const seed = (await entropyU32()).value; // 召喚/敵ステ用 (client には返さない)
+  const jobLevel = jobLevelFromXp(state.jobXp[archetype] ?? 0);
+  const playerLevel = playerLevelFromXp(state.playerXp);
+
+  const battle = startBattle(archetype, jobLevel, playerLevel, userDid, tier, seed, state.herbs ?? 0, { hp: state.carryHp, mp: state.carryMp }, {
+    baseStats,
+    equipIds: state.gear,
+    tonics: state.tonics ?? 0,
+    vitalsVariance: BATTLE_TUNING.monsterVitalsVariance ?? 0.15,
+  });
+
+  const rewarded = state.power >= BATTLE_TUNING.powerCost;
+  const pendingTurnSeed = (await entropyU32()).value;
+  const battleId = 'b' + [...crypto.getRandomValues(new Uint8Array(12))].map((b) => b.toString(16).padStart(2, '0')).join('');
+  const nowIso = new Date(now * 1000).toISOString();
+  const guard: Guard = {
+    did: userDid, battleId, turn: 0, sealed: { archetype, tier }, state: battle, pendingTurnSeed, rewarded,
+    expiresAt: new Date((now + 3600) * 1000).toISOString(), createdAt: nowIso, updatedAt: nowIso,
+  };
+  await createGuard(env, now, guard); // 既存があれば InvalidSwap → 上位で 409
+
+  return { battleId, monsterId: battle.monsterId, state: stripState(battle), rewarded };
+}
+
+export interface TurnResult {
+  state: Omit<BattleState, 'seed'>;
+  events: BattleState['lastEvents'];
+  outcome: BattleState['outcome'];
+  awarded?: AwardBreakdown;
+}
+
+/**
+ * turn: 1 コマンドを**サーバーが**確定 pendingTurnSeed で解決する。
+ * 決着なら報酬を fail-closed で確定 + ガード削除。未決着なら CAS で turn を進めてから応答。
+ */
+export async function handleTurn(env: ResolverEnv, userDid: string, battleId: string, turn: number, command: Command, now: number): Promise<TurnResult> {
+  if (!VALID_COMMANDS.includes(command)) throw new ResolverError('不正なコマンド', 400);
+  const g = await readGuard<SealedMeta, BattleState>(env, userDid);
+  if (!g) throw new ResolverError('戦闘中でない', 409);
+  const { guard, cid } = g;
+  // battleId / turn 不一致 = リプレイ/やり直し → 409 (応答しない)。
+  if (guard.battleId !== battleId || guard.turn !== turn) throw new ResolverError('ターン不一致 (やり直し/リプレイ)', 409);
+
+  const next = resolveTurn(guard.state, command, guard.pendingTurnSeed);
+
+  if (next.outcome !== 'ongoing') {
+    // ── 決着: 報酬を権威 state に fail-closed で確定 ──
+    const decision = next.outcome as BattleDecision;
+    const rewardSeed = (await entropyU32()).value;
+    const lossSeed = (await entropyU32()).value;
+    let awarded: AwardBreakdown = {};
+    // readModifyWrite がトークン切れ等で throw したら報酬は付かず、ガードも消さない (リトライ可)。
+    // = クライアント権威へのフォールバックは存在しない。mutate は決定的なので awarded の取り込みは安全。
+    await readModifyWrite(env, userDid, (cur: GameState): GameState => {
+      const r = applyBattleOutcome(cur, {
+        outcome: decision, monsterId: next.monsterId, archetype: guard.sealed.archetype,
+        luk: next.player.luk, rewardSeed, lossSeed, rewarded: guard.rewarded,
+      });
+      awarded = r.awarded;
+      // 戦闘をまたぐ HP/MP・消費アイテムも権威 state に反映 (負けは全快で復帰)。
+      return {
+        ...r.next,
+        carryHp: decision === 'lose' ? undefined : next.player.hp,
+        carryMp: decision === 'lose' ? undefined : next.player.mp,
+        herbs: next.herbs,
+        tonics: next.tonics,
+      };
+    }, { now });
+    // 報酬確定後にガード削除 (ここで失敗しても報酬は確定済 = 二重報酬なし。次 encounter が flush)。
+    try { await deleteGuard(env, now, userDid, cid); } catch { /* CAS 不一致は無視 (別リクエストが消した) */ }
+    return { state: stripState(next), events: next.lastEvents, outcome: next.outcome, awarded };
+  }
+
+  // ── 未決着: turn+1・新 pendingTurnSeed を CAS で確定してから応答 (並行二重解決/引き直しを弾く) ──
+  const nextPending = (await entropyU32()).value;
+  const advanced: Guard = { ...guard, turn: turn + 1, state: next, pendingTurnSeed: nextPending, updatedAt: new Date(now * 1000).toISOString() };
+  try {
+    await advanceGuard(env, now, advanced, cid);
+  } catch (e) {
+    if (e instanceof PdsError && e.xrpcError === 'InvalidSwap') throw new ResolverError('ターン競合 (やり直し/リプレイ)', 409);
+    throw e;
+  }
+  return { state: stripState(next), events: next.lastEvents, outcome: next.outcome };
+}

--- a/apps/edge/src/battle-resolver.ts
+++ b/apps/edge/src/battle-resolver.ts
@@ -12,7 +12,7 @@
  */
 import {
   startBattle, resolveTurn, statVectorToArray, jobLevelFromXp, playerLevelFromXp,
-  terrainAt, isWalkable, regionOf, regionDanger, tierForDanger, BATTLE_TUNING,
+  terrainAt, isWalkable, regionOf, regionDanger, tierForDanger, encounterRateFor, BATTLE_TUNING,
   type BattleState, type Command, type Archetype, type StatVector,
 } from '@aozoraquest/core';
 import { entropyU32 } from './kuda';
@@ -64,7 +64,11 @@ async function readDiagnosis(userDid: string, fetchImpl?: typeof fetch): Promise
   return { archetype: rec.value.archetype, baseStats: statVectorToArray(rec.value.rpgStats) };
 }
 
-export interface EncounterResult {
+/** バトルガードの寿命 (秒)。各ターンで更新。切れたガードは move 時に flush = クラッシュしても
+ *  永久ロックアウトしない (docs/21 §5 lazy 敗北)。 */
+export const GUARD_TTL_SEC = 900;
+
+export interface EncounterInfo {
   battleId: string;
   monsterId: string;
   /** seed を除いた戦闘 state (HP/MP・monster・events 等)。 */
@@ -72,44 +76,69 @@ export interface EncounterResult {
   rewarded: boolean;
 }
 
-/**
- * encounter: (x,y) で遭遇を成立させ、サーバーが snapshot を封印してバトルを開始する。
- * クライアントは監視 (どのモンスター・初期 HP/MP) しか受け取らない。1 ユーザー 1 戦闘。
- */
-export async function handleEncounter(env: ResolverEnv, userDid: string, x: number, y: number, now: number, fetchImpl?: typeof fetch): Promise<EncounterResult> {
-  const terrain = terrainAt(x, y);
-  if (!isWalkable(terrain) || terrain === 'town') throw new ResolverError('その地形では遭遇しない', 400);
-
-  // 既存ガードがあれば二重戦闘不可 (createGuard の swap=null が弾くが、明示的に 409)。
-  if (await readGuard<SealedMeta, BattleState>(env, userDid)) throw new ResolverError('既に戦闘中', 409);
-
-  const existing = await readState(env, userDid);
-  const state = existing?.state ?? emptyState(userDid, new Date(now * 1000).toISOString());
+/** 遭遇を成立させ snapshot を封印してガードを作る。位置は**権威** (move が渡す) = tier を選べない。
+ *  move からのみ呼ばれる (client から直接遭遇を起こせない = 座標/遭遇を偽造不可)。export はテスト用。 */
+export async function sealEncounter(env: ResolverEnv, userDid: string, state: GameState, x: number, y: number, now: number, fetchImpl?: typeof fetch): Promise<EncounterInfo> {
   const { archetype, baseStats } = await readDiagnosis(userDid, fetchImpl);
-
   const tier = tierForDanger(regionDanger(regionOf(x, y)));
   const seed = (await entropyU32()).value; // 召喚/敵ステ用 (client には返さない)
   const jobLevel = jobLevelFromXp(state.jobXp[archetype] ?? 0);
   const playerLevel = playerLevelFromXp(state.playerXp);
-
   const battle = startBattle(archetype, jobLevel, playerLevel, userDid, tier, seed, state.herbs ?? 0, { hp: state.carryHp, mp: state.carryMp }, {
-    baseStats,
-    equipIds: state.gear,
-    tonics: state.tonics ?? 0,
-    vitalsVariance: BATTLE_TUNING.monsterVitalsVariance ?? 0.15,
+    baseStats, equipIds: state.gear, tonics: state.tonics ?? 0, vitalsVariance: BATTLE_TUNING.monsterVitalsVariance,
   });
-
   const rewarded = state.power >= BATTLE_TUNING.powerCost;
   const pendingTurnSeed = (await entropyU32()).value;
   const battleId = 'b' + [...crypto.getRandomValues(new Uint8Array(12))].map((b) => b.toString(16).padStart(2, '0')).join('');
   const nowIso = new Date(now * 1000).toISOString();
   const guard: Guard = {
     did: userDid, battleId, turn: 0, sealed: { archetype, tier }, state: battle, pendingTurnSeed, rewarded,
-    expiresAt: new Date((now + 3600) * 1000).toISOString(), createdAt: nowIso, updatedAt: nowIso,
+    expiresAt: new Date((now + GUARD_TTL_SEC) * 1000).toISOString(), createdAt: nowIso, updatedAt: nowIso,
   };
   await createGuard(env, now, guard); // 既存があれば InvalidSwap → 上位で 409
-
   return { battleId, monsterId: battle.monsterId, state: stripState(battle), rewarded };
+}
+
+export interface MoveResult {
+  x: number;
+  y: number;
+  terrain: string;
+  /** サーバーが遭遇を判定した場合のみ。 */
+  encounter?: EncounterInfo;
+}
+
+/**
+ * move: **位置を Worker が権威更新し、遭遇もサーバーが判定する**。クライアントは方向 (隣接1マス) しか
+ * 送れず、座標も遭遇有無も tier も偽造できない (§5 のアンチチート核: 移動を毎回 Worker で処理)。
+ */
+export async function handleMove(env: ResolverEnv, userDid: string, dx: number, dy: number, now: number, fetchImpl?: typeof fetch): Promise<MoveResult> {
+  if (![-1, 0, 1].includes(dx) || ![-1, 0, 1].includes(dy) || (dx === 0 && dy === 0)) throw new ResolverError('不正な移動 (隣接1マスのみ)', 400);
+
+  // 未決着ガード: 期限内なら移動不可 (戦闘中)、期限切れは flush して先へ (クラッシュ復帰・ロックアウト回避)。
+  const g = await readGuard<SealedMeta, BattleState>(env, userDid);
+  if (g) {
+    if (now * 1000 < Date.parse(g.guard.expiresAt)) throw new ResolverError('戦闘中は移動不可', 409);
+    await deleteGuard(env, now, userDid, g.cid); // 期限切れ = lazy flush (踏み倒し容認 §5)
+  }
+
+  // 権威位置を CAS 更新。移動先の歩行可否は mutate 内で検証 (CAS リトライで再検証される)。
+  const committed = { x: 0, y: 0 };
+  const moved = await readModifyWrite(env, userDid, (cur: GameState): GameState => {
+    const tx = cur.x + dx, ty = cur.y + dy;
+    if (!isWalkable(terrainAt(tx, ty))) throw new ResolverError('進めない地形', 400);
+    committed.x = tx; committed.y = ty;
+    return { ...cur, x: tx, y: ty };
+  }, { now });
+
+  const terrain = terrainAt(committed.x, committed.y);
+  if (terrain !== 'town') {
+    const roll = (await entropyU32()).value / 0x1_0000_0000; // [0,1)
+    if (roll < encounterRateFor(terrain)) {
+      const encounter = await sealEncounter(env, userDid, moved, committed.x, committed.y, now, fetchImpl);
+      return { x: committed.x, y: committed.y, terrain, encounter };
+    }
+  }
+  return { x: committed.x, y: committed.y, terrain };
 }
 
 export interface TurnResult {
@@ -134,13 +163,22 @@ export async function handleTurn(env: ResolverEnv, userDid: string, battleId: st
   const next = resolveTurn(guard.state, command, guard.pendingTurnSeed);
 
   if (next.outcome !== 'ongoing') {
-    // ── 決着: 報酬を権威 state に fail-closed で確定 ──
+    // ── 決着: **まずガードを CAS 削除して「この決着ターンは自分が消費」を確定** ──
+    // これで並行/リプレイの重複リクエストは InvalidSwap → 409 になり、報酬確定に到達できるのは
+    // ガードを消せた 1 リクエストだけ = **二重報酬を防ぐ** (applyBattleOutcome は加算なので必須。§4.1c 冪等)。
+    // token 切れで delete が失敗 → ServerWriteError が伝播し上位で 503 (報酬なし・guard 残る=リトライ可、
+    // fail-closed)。この順序 (消費確定 → 報酬) が §4.1 の「CAS で先に確定 → その後 resolve/確定」。
     const decision = next.outcome as BattleDecision;
+    try {
+      await deleteGuard(env, now, userDid, cid);
+    } catch (e) {
+      if (e instanceof PdsError && e.xrpcError === 'InvalidSwap') throw new ResolverError('決着競合 (二重確定防止)', 409);
+      throw e; // ServerWriteError(token 切れ) 等 → 上位で 503 (報酬なし)
+    }
+    // ここに来られるのはガードを消せた 1 リクエストだけ → 報酬を fail-closed で確定。
     const rewardSeed = (await entropyU32()).value;
     const lossSeed = (await entropyU32()).value;
     let awarded: AwardBreakdown = {};
-    // readModifyWrite がトークン切れ等で throw したら報酬は付かず、ガードも消さない (リトライ可)。
-    // = クライアント権威へのフォールバックは存在しない。mutate は決定的なので awarded の取り込みは安全。
     await readModifyWrite(env, userDid, (cur: GameState): GameState => {
       const r = applyBattleOutcome(cur, {
         outcome: decision, monsterId: next.monsterId, archetype: guard.sealed.archetype,
@@ -156,14 +194,14 @@ export async function handleTurn(env: ResolverEnv, userDid: string, battleId: st
         tonics: next.tonics,
       };
     }, { now });
-    // 報酬確定後にガード削除 (ここで失敗しても報酬は確定済 = 二重報酬なし。次 encounter が flush)。
-    try { await deleteGuard(env, now, userDid, cid); } catch { /* CAS 不一致は無視 (別リクエストが消した) */ }
     return { state: stripState(next), events: next.lastEvents, outcome: next.outcome, awarded };
   }
 
   // ── 未決着: turn+1・新 pendingTurnSeed を CAS で確定してから応答 (並行二重解決/引き直しを弾く) ──
+  // expiresAt も更新し、長い戦闘が move の flush 対象にならないようにする (ターンごとに寿命を延ばす)。
   const nextPending = (await entropyU32()).value;
-  const advanced: Guard = { ...guard, turn: turn + 1, state: next, pendingTurnSeed: nextPending, updatedAt: new Date(now * 1000).toISOString() };
+  const nowIso = new Date(now * 1000).toISOString();
+  const advanced: Guard = { ...guard, turn: turn + 1, state: next, pendingTurnSeed: nextPending, expiresAt: new Date((now + GUARD_TTL_SEC) * 1000).toISOString(), updatedAt: nowIso };
   try {
     await advanceGuard(env, now, advanced, cid);
   } catch (e) {

--- a/apps/edge/src/battle-reward.ts
+++ b/apps/edge/src/battle-reward.ts
@@ -1,0 +1,90 @@
+/**
+ * 戦闘決着の報酬を権威 state (GameState) に適用する純関数 — docs/21 §5/§7 / M3。
+ *
+ * **サーバーが報酬を計算する**のが要点。これを readModifyWrite の `mutate` として渡し、CAS で確定する。
+ * 純粋 (副作用なし・毎回同じ入力で同じ出力) なのでリトライで複数回呼ばれても安全。
+ *
+ * **fail-closed / パワーモデル (§7)**:
+ *   - `rewarded=false` (encounter 時にパワー残高 0) → 勝敗どちらも**何も付与しない・消費しない**。
+ *   - 勝ち (rewarded): +XP (player/job 両方) + ドロップ + パワー 1 消費。
+ *   - 負け (rewarded): 素材ロス + パワー 1 消費。
+ *   - 引き分け / 逃走: 決着ではない → 何も変えない。
+ *
+ * **seed 秘匿 (#348)**: ドロップ/敗北ロスの seed は**サーバーが独立に引いた rewardSeed/lossSeed** を使う
+ * (戦闘 seed は client に返さない・再利用しない)。呼び出し側が entropyU32 で引いて渡す。
+ */
+import { battleXpFor, rollDrops, rollDefeatLoss, BATTLE_TUNING } from '@aozoraquest/core';
+import type { GameState } from './game-state';
+
+export type BattleDecision = 'win' | 'lose' | 'draw' | 'fled';
+
+export interface BattleOutcomeInput {
+  outcome: BattleDecision;
+  /** 倒した/対峙したモンスター id (勝利 XP・ドロップ表の決定に使う)。 */
+  monsterId: string;
+  /** jobXp のキー (プレイヤーの archetype)。 */
+  archetype: string;
+  /** ドロップ/敗北ロスの luk ボーナス。 */
+  luk: number;
+  /** サーバーが独立に引いたドロップ用エントロピー (32bit)。 */
+  rewardSeed: number;
+  /** サーバーが独立に引いた敗北ロス用エントロピー (32bit)。 */
+  lossSeed: number;
+  /** encounter 時に power>=1 で確定した「報酬対象」フラグ。 */
+  rewarded: boolean;
+}
+
+/** 適用結果 (client 表示・監査用の内訳)。 */
+export interface AwardBreakdown {
+  xp?: number;
+  drops?: string[];
+  materialsLost?: string[];
+  powerSpent?: number;
+}
+
+const POWER_COST = BATTLE_TUNING.powerCost;
+
+function addItems(materials: Record<string, number>, items: string[], delta: 1 | -1): Record<string, number> {
+  const next = { ...materials };
+  for (const item of items) {
+    const v = (next[item] ?? 0) + delta;
+    if (v <= 0) delete next[item];
+    else next[item] = v;
+  }
+  return next;
+}
+
+/**
+ * 決着の報酬を state に適用し、新 state と内訳を返す。純粋。
+ * `applyBattleOutcome(current, input).next` を readModifyWrite の mutate 結果に使う。
+ */
+export function applyBattleOutcome(state: GameState, o: BattleOutcomeInput): { next: GameState; awarded: AwardBreakdown } {
+  // パワー無し = 練習相当。勝敗どちらも付与も消費もペナルティも無し (§7)。
+  if (!o.rewarded) return { next: state, awarded: {} };
+
+  if (o.outcome === 'win') {
+    const xp = battleXpFor(o.monsterId);
+    const drops = rollDrops(o.monsterId, o.luk, o.rewardSeed);
+    const next: GameState = {
+      ...state,
+      playerXp: state.playerXp + xp,
+      jobXp: { ...state.jobXp, [o.archetype]: (state.jobXp[o.archetype] ?? 0) + xp },
+      materials: addItems(state.materials, drops, 1),
+      power: Math.max(0, state.power - POWER_COST),
+    };
+    return { next, awarded: { xp, drops, powerSpent: POWER_COST } };
+  }
+
+  if (o.outcome === 'lose') {
+    const materialsLost = rollDefeatLoss(state.materials, o.luk, o.lossSeed);
+    const next: GameState = {
+      ...state,
+      materials: addItems(state.materials, materialsLost, -1),
+      power: Math.max(0, state.power - POWER_COST),
+    };
+    return { next, awarded: { materialsLost, powerSpent: POWER_COST } };
+  }
+
+  // draw / fled は決着扱いにしない (パワーも消費しない)。
+  return { next: state, awarded: {} };
+}

--- a/apps/edge/src/game-state.ts
+++ b/apps/edge/src/game-state.ts
@@ -37,6 +37,12 @@ export interface GameState {
   /** 位置。 */
   x: number;
   y: number;
+  /** 戦闘をまたいで持続する HP/MP (docs/19)。未設定は全快で開始。 */
+  carryHp?: number;
+  carryMp?: number;
+  /** 持ち込み消費アイテム (やくそう / そらのしずく)。 */
+  herbs?: number;
+  tonics?: number;
   version: number;
   updatedAt: string;
 }

--- a/apps/edge/src/router.ts
+++ b/apps/edge/src/router.ts
@@ -13,6 +13,9 @@ import { verifyServiceAuth, ServiceAuthError } from './service-auth';
 import { getRecord } from './pds';
 import { GAME_STATE_COLLECTION, rkeyForDid, emptyState } from './game-state';
 import { handleClientMetadata, handleOAuthStart, handleOAuthCallback, type OAuthRoutesEnv } from './oauth-routes';
+import { handleEncounter, handleTurn, ResolverError } from './battle-resolver';
+import { ServerWriteError } from './server-pds';
+import type { Command } from '@aozoraquest/core';
 
 /** WORKER_DID / SERVER_DID / OAUTH_* / ADMIN_DIDS / OAUTH_TOKENS は OAuthRoutesEnv から継承。 */
 export interface Env extends OAuthRoutesEnv {
@@ -28,6 +31,8 @@ const nowSec = (): number => Math.floor(Date.now() / 1000);
 /** service auth の lexicon method (lxm)。エンドポイントごとに別値。 */
 const LXM_WHOAMI = 'app.aozoraquest.whoami';
 const LXM_ME_STATE = 'app.aozoraquest.me.state';
+const LXM_BATTLE_ENCOUNTER = 'app.aozoraquest.battle.encounter';
+const LXM_BATTLE_TURN = 'app.aozoraquest.battle.turn';
 
 const AOZORA_ORIGINS = new Set([
   'https://aozoraquest.app',
@@ -101,6 +106,33 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
     return cors(json({ state: rec?.value ?? emptyState(did, new Date().toISOString()), initialized: rec !== null }), allowedOrigin);
   }
 
+  // ── サーバー権威 戦闘 (docs/21 §5) ── 移動遭遇/攻撃を毎回 Worker が処理 = チート不可 ──
+  if (req.method === 'POST' && (url.pathname === '/api/battle/encounter' || url.pathname === '/api/battle/turn')) {
+    const isTurn = url.pathname === '/api/battle/turn';
+    const token = bearer(req);
+    if (!token) return cors(json({ error: 'missing_token' }, 401), allowedOrigin);
+    const audience = env.WORKER_DID ?? 'did:web:edge.aozoraquest.app';
+    let did: string;
+    try {
+      ({ iss: did } = await verifyServiceAuth(token, { audience, lxm: isTurn ? LXM_BATTLE_TURN : LXM_BATTLE_ENCOUNTER }));
+    } catch (e) {
+      return cors(json({ error: 'unauthorized', reason: e instanceof ServiceAuthError ? e.message : 'verify_failed' }, 401), allowedOrigin);
+    }
+    const body = (await req.json().catch(() => ({}))) as { x?: number; y?: number; battleId?: string; turn?: number; command?: string };
+    try {
+      if (isTurn) {
+        if (typeof body.battleId !== 'string' || typeof body.turn !== 'number' || typeof body.command !== 'string') {
+          return cors(json({ error: 'bad_request' }, 400), allowedOrigin);
+        }
+        return cors(json(await handleTurn(env, did, body.battleId, body.turn, body.command as Command, nowSec())), allowedOrigin);
+      }
+      if (typeof body.x !== 'number' || typeof body.y !== 'number') return cors(json({ error: 'bad_request' }, 400), allowedOrigin);
+      return cors(json(await handleEncounter(env, did, body.x, body.y, nowSec())), allowedOrigin);
+    } catch (e) {
+      return cors(battleError(e), allowedOrigin);
+    }
+  }
+
   // ── OAuth write 認証 (docs/21 §12) ──
   // confidential client メタデータ (公開)。
   if (req.method === 'GET' && url.pathname === '/client-metadata.json') {
@@ -116,6 +148,14 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
   }
 
   return cors(json({ error: 'not_found', path: url.pathname }, 404), allowedOrigin);
+}
+
+/** 戦闘エラーを HTTP に振り分ける。**トークン切れ/未設定 (ServerWriteError) は 503 で fail-closed**
+ *  (報酬は付かない・クライアント権威へのフォールバックは無い §3-6)。ResolverError はその status。 */
+function battleError(e: unknown): Response {
+  if (e instanceof ResolverError) return json({ error: 'battle_error', message: e.message }, e.status);
+  if (e instanceof ServerWriteError) return json({ error: 'server_write_unavailable', reason: e.reason }, 503);
+  return json({ error: 'internal' }, 500);
 }
 
 /** Authorization: Bearer <jwt> を取り出す。 */

--- a/apps/edge/src/router.ts
+++ b/apps/edge/src/router.ts
@@ -10,10 +10,10 @@
  *   /api/battle/* /api/xp/* /api/me/state (M2〜)。依頼クエスト集約 (docs/15) も。
  */
 import { verifyServiceAuth, ServiceAuthError } from './service-auth';
-import { getRecord } from './pds';
+import { getRecord, PdsError } from './pds';
 import { GAME_STATE_COLLECTION, rkeyForDid, emptyState } from './game-state';
 import { handleClientMetadata, handleOAuthStart, handleOAuthCallback, type OAuthRoutesEnv } from './oauth-routes';
-import { handleEncounter, handleTurn, ResolverError } from './battle-resolver';
+import { handleMove, handleTurn, ResolverError } from './battle-resolver';
 import { ServerWriteError } from './server-pds';
 import type { Command } from '@aozoraquest/core';
 
@@ -31,7 +31,7 @@ const nowSec = (): number => Math.floor(Date.now() / 1000);
 /** service auth の lexicon method (lxm)。エンドポイントごとに別値。 */
 const LXM_WHOAMI = 'app.aozoraquest.whoami';
 const LXM_ME_STATE = 'app.aozoraquest.me.state';
-const LXM_BATTLE_ENCOUNTER = 'app.aozoraquest.battle.encounter';
+const LXM_WORLD_MOVE = 'app.aozoraquest.world.move';
 const LXM_BATTLE_TURN = 'app.aozoraquest.battle.turn';
 
 const AOZORA_ORIGINS = new Set([
@@ -106,19 +106,19 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
     return cors(json({ state: rec?.value ?? emptyState(did, new Date().toISOString()), initialized: rec !== null }), allowedOrigin);
   }
 
-  // ── サーバー権威 戦闘 (docs/21 §5) ── 移動遭遇/攻撃を毎回 Worker が処理 = チート不可 ──
-  if (req.method === 'POST' && (url.pathname === '/api/battle/encounter' || url.pathname === '/api/battle/turn')) {
+  // ── サーバー権威 ワールド/戦闘 (docs/21 §5) ── 移動も攻撃も毎回 Worker が処理 = チート不可 ──
+  if (req.method === 'POST' && (url.pathname === '/api/world/move' || url.pathname === '/api/battle/turn')) {
     const isTurn = url.pathname === '/api/battle/turn';
     const token = bearer(req);
     if (!token) return cors(json({ error: 'missing_token' }, 401), allowedOrigin);
     const audience = env.WORKER_DID ?? 'did:web:edge.aozoraquest.app';
     let did: string;
     try {
-      ({ iss: did } = await verifyServiceAuth(token, { audience, lxm: isTurn ? LXM_BATTLE_TURN : LXM_BATTLE_ENCOUNTER }));
+      ({ iss: did } = await verifyServiceAuth(token, { audience, lxm: isTurn ? LXM_BATTLE_TURN : LXM_WORLD_MOVE }));
     } catch (e) {
       return cors(json({ error: 'unauthorized', reason: e instanceof ServiceAuthError ? e.message : 'verify_failed' }, 401), allowedOrigin);
     }
-    const body = (await req.json().catch(() => ({}))) as { x?: number; y?: number; battleId?: string; turn?: number; command?: string };
+    const body = (await req.json().catch(() => ({}))) as { dx?: number; dy?: number; battleId?: string; turn?: number; command?: string };
     try {
       if (isTurn) {
         if (typeof body.battleId !== 'string' || typeof body.turn !== 'number' || typeof body.command !== 'string') {
@@ -126,8 +126,8 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
         }
         return cors(json(await handleTurn(env, did, body.battleId, body.turn, body.command as Command, nowSec())), allowedOrigin);
       }
-      if (typeof body.x !== 'number' || typeof body.y !== 'number') return cors(json({ error: 'bad_request' }, 400), allowedOrigin);
-      return cors(json(await handleEncounter(env, did, body.x, body.y, nowSec())), allowedOrigin);
+      if (typeof body.dx !== 'number' || typeof body.dy !== 'number') return cors(json({ error: 'bad_request' }, 400), allowedOrigin);
+      return cors(json(await handleMove(env, did, body.dx, body.dy, nowSec())), allowedOrigin);
     } catch (e) {
       return cors(battleError(e), allowedOrigin);
     }
@@ -155,6 +155,8 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
 function battleError(e: unknown): Response {
   if (e instanceof ResolverError) return json({ error: 'battle_error', message: e.message }, e.status);
   if (e instanceof ServerWriteError) return json({ error: 'server_write_unavailable', reason: e.reason }, 503);
+  // 失効/無効トークンで PDS が 401/403 を返した場合も **fail-closed 503** (報酬なし。500 で誤魔化さない)。
+  if (e instanceof PdsError && (e.status === 401 || e.status === 403)) return json({ error: 'server_write_unavailable', reason: 'auth' }, 503);
   return json({ error: 'internal' }, 500);
 }
 

--- a/apps/edge/test/battle-guard.test.ts
+++ b/apps/edge/test/battle-guard.test.ts
@@ -1,18 +1,37 @@
 import { describe, it, expect, afterEach } from 'vitest';
+import { p256 } from '@noble/curves/p256';
+import { base64urlnopad } from '@scure/base';
 import { readGuard, createGuard, advanceGuard, deleteGuard, BATTLE_GUARD_COLLECTION, type BattleGuard } from '../src/battle-guard';
 import { rkeyForDid } from '../src/game-state';
-import type { PdsSession } from '../src/pds';
+import { writeServerTokens } from '../src/oauth-store';
+import type { ServerPdsEnv } from '../src/server-pds';
 
-const session: PdsSession = { pdsUrl: 'https://pds.example', accessJwt: 'A', refreshJwt: 'R', did: 'did:plc:server' };
 const DID = 'did:plc:alice';
-const NOW = '2026-07-19T00:00:00.000Z';
+const SERVER_DID = 'did:plc:kojira';
+const PDS = 'https://pds.example';
+const NOW = 1_700_000_000;
+
+function jwkJson(fill: number): string {
+  const d = new Uint8Array(32).fill(fill);
+  const pub = p256.getPublicKey(d, false);
+  return JSON.stringify({ kty: 'EC', crv: 'P-256', x: base64urlnopad.encode(pub.slice(1, 33)), y: base64urlnopad.encode(pub.slice(33, 65)), d: base64urlnopad.encode(d), kid: `k${fill}` });
+}
+function mockKv() {
+  const m = new Map<string, string>();
+  return { get: async (k: string) => m.get(k) ?? null, put: async (k: string, v: string) => { m.set(k, v); }, delete: async (k: string) => { m.delete(k); } } as unknown as KVNamespace;
+}
+async function makeEnv(): Promise<ServerPdsEnv> {
+  const kv = mockKv();
+  await writeServerTokens(kv, { did: SERVER_DID, accessToken: 'AT', refreshToken: 'RT', tokenType: 'DPoP', expiresAt: NOW + 3600, pdsUrl: PDS, authServer: 'https://bsky.social', updatedAt: NOW });
+  return { OAUTH_CLIENT_PRIVATE_JWK: jwkJson(3), OAUTH_DPOP_PRIVATE_JWK: jwkJson(5), SERVER_DID, WORKER_DID: 'did:web:edge.aozoraquest.app', OAUTH_TOKENS: kv };
+}
 
 const guard = (turn: number): BattleGuard => ({
   did: DID, battleId: 'btl-1', turn, sealed: { s: 1 }, state: { hp: 10 }, pendingTurnSeed: 0x12345678, rewarded: true,
-  expiresAt: NOW, createdAt: NOW, updatedAt: NOW,
+  expiresAt: '', createdAt: '', updatedAt: '',
 });
 
-/** バトルガードのステートフル PDS モック (put/get/delete の swapRecord CAS を実装)。 */
+/** getRecord(public GET) + DPoP putRecord/deleteRecord の swapRecord CAS を実装するモック。 */
 function guardPds() {
   const store = new Map<string, { value: unknown; cid: string }>();
   let counter = 0;
@@ -42,46 +61,45 @@ function guardPds() {
   return { fn, store };
 }
 
-describe('battle-guard', () => {
+describe('battle-guard (OAuth 権威書き込み)', () => {
   const orig = globalThis.fetch;
   afterEach(() => { globalThis.fetch = orig; });
 
-  it('無ければ null / 作成後は読める (rkey は DID ハッシュ)', async () => {
+  it('無ければ null / 作成後は読める (rkey は DID ハッシュ・repo はサーバー DID)', async () => {
+    const env = await makeEnv();
     const m = guardPds();
     globalThis.fetch = m.fn;
-    expect(await readGuard(session, DID)).toBeNull();
-    await createGuard(session, guard(0));
-    const r = await readGuard(session, DID);
+    expect(await readGuard(env, DID)).toBeNull();
+    await createGuard(env, NOW, guard(0));
+    const r = await readGuard(env, DID);
     expect(r?.guard.battleId).toBe('btl-1');
     expect(m.store.has(rkeyForDid(DID))).toBe(true);
     expect(BATTLE_GUARD_COLLECTION).toBe('app.aozoraquest.battleGuard');
   });
 
   it('既存があると createGuard は InvalidSwap (二重戦闘を作らせない)', async () => {
-    const m = guardPds();
-    globalThis.fetch = m.fn;
-    await createGuard(session, guard(0));
-    await expect(createGuard(session, guard(0))).rejects.toMatchObject({ xrpcError: 'InvalidSwap' });
+    const env = await makeEnv();
+    globalThis.fetch = guardPds().fn;
+    await createGuard(env, NOW, guard(0));
+    await expect(createGuard(env, NOW, guard(0))).rejects.toMatchObject({ xrpcError: 'InvalidSwap' });
   });
 
   it('advanceGuard は正しい CID でのみ進む / 古い CID は InvalidSwap (やり直し封じ)', async () => {
-    const m = guardPds();
-    globalThis.fetch = m.fn;
-    const { cid: c0 } = await createGuard(session, guard(0));
-    const { cid: c1 } = await advanceGuard(session, guard(1), c0);
+    const env = await makeEnv();
+    globalThis.fetch = guardPds().fn;
+    const { cid: c0 } = await createGuard(env, NOW, guard(0));
+    const { cid: c1 } = await advanceGuard(env, NOW, guard(1), c0);
     expect(c1).not.toBe(c0);
-    // 同じターンを古い CID で引き直そうとすると弾かれる
-    await expect(advanceGuard(session, guard(1), c0)).rejects.toMatchObject({ xrpcError: 'InvalidSwap' });
-    // 正しい CID なら進める
-    await expect(advanceGuard(session, guard(2), c1)).resolves.toBeTruthy();
+    await expect(advanceGuard(env, NOW, guard(1), c0)).rejects.toMatchObject({ xrpcError: 'InvalidSwap' });
+    await expect(advanceGuard(env, NOW, guard(2), c1)).resolves.toBeTruthy();
   });
 
   it('deleteGuard は CID 一致で削除 / 不一致は InvalidSwap', async () => {
-    const m = guardPds();
-    globalThis.fetch = m.fn;
-    const { cid } = await createGuard(session, guard(0));
-    await expect(deleteGuard(session, DID, 'wrong')).rejects.toMatchObject({ xrpcError: 'InvalidSwap' });
-    await deleteGuard(session, DID, cid);
-    expect(await readGuard(session, DID)).toBeNull();
+    const env = await makeEnv();
+    globalThis.fetch = guardPds().fn;
+    const { cid } = await createGuard(env, NOW, guard(0));
+    await expect(deleteGuard(env, NOW, DID, 'wrong')).rejects.toMatchObject({ xrpcError: 'InvalidSwap' });
+    await deleteGuard(env, NOW, DID, cid);
+    expect(await readGuard(env, DID)).toBeNull();
   });
 });

--- a/apps/edge/test/battle-resolver.test.ts
+++ b/apps/edge/test/battle-resolver.test.ts
@@ -1,24 +1,16 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { p256 } from '@noble/curves/p256';
 import { base64urlnopad } from '@scure/base';
-import { handleEncounter, handleTurn, ResolverError, type ResolverEnv } from '../src/battle-resolver';
+import { sealEncounter, handleMove, handleTurn, ResolverError, GUARD_TTL_SEC, type ResolverEnv } from '../src/battle-resolver';
 import { writeServerTokens } from '../src/oauth-store';
+import { terrainAt, isWalkable, type Command } from '@aozoraquest/core';
+import type { GameState } from '../src/game-state';
 
 const USER = 'did:plc:alice';
 const SERVER_DID = 'did:plc:kojira';
 const SERVER_PDS = 'https://server-pds.example';
 const USER_PDS = 'https://user-pds.example';
 const NOW = 1_700_000_000;
-// 陸地・非 town の座標を探す (terrainAt に依存)。0,0 が town/water の可能性があるので数点試す。
-import { terrainAt, isWalkable } from '@aozoraquest/core';
-function landCoord(): { x: number; y: number } {
-  for (let x = 0; x < 200; x += 7) for (let y = 0; y < 200; y += 7) {
-    const t = terrainAt(x, y);
-    if (isWalkable(t) && t !== 'town') return { x, y };
-  }
-  throw new Error('no land coord');
-}
-const { x: LX, y: LY } = landCoord();
 
 function jwkJson(fill: number): string {
   const d = new Uint8Array(32).fill(fill);
@@ -35,38 +27,39 @@ async function makeEnv(): Promise<ResolverEnv> {
   return { OAUTH_CLIENT_PRIVATE_JWK: jwkJson(3), OAUTH_DPOP_PRIVATE_JWK: jwkJson(5), SERVER_DID, WORKER_DID: 'did:web:edge.aozoraquest.app', OAUTH_TOKENS: kv };
 }
 
-/** 診断・GameState を種にした統合モック (ユーザー DID 解決 + 診断 + サーバー PDS CAS)。 */
-function resolverMock(opts: { diagnosis?: unknown; gameState?: unknown } = {}) {
+const DIAG = { archetype: 'warrior', rpgStats: { atk: 30, def: 25, agi: 15, int: 15, luk: 15 } };
+const GS = (over: Partial<GameState> = {}): GameState => ({ did: USER, power: 5, playerXp: 100, jobXp: { warrior: 50 }, materials: {}, gear: [], x: 0, y: 0, version: 1, updatedAt: '', ...over });
+
+/** 診断 + サーバー PDS (gameState + guard) の CAS を実装する統合モック。 */
+function resolverMock(opts: { diagnosis?: unknown; gameState?: GameState } = {}) {
   const store = new Map<string, { value: unknown; cid: string }>();
-  if (opts.gameState) store.set('app.aozoraquest.gameState/' + 'u', { value: opts.gameState, cid: 'gs0' }); // rkey は下で正規化
+  if (opts.gameState) store.set('gs', { value: opts.gameState, cid: 'gs0' });
+  const guardKey = 'guard';
   let counter = 0;
   const json = (s: number, b: unknown) => new Response(JSON.stringify(b), { status: s, headers: { 'content-type': 'application/json' } });
-  const key = (col: string, rk: string) => `${col}/${rk}`;
+  const which = (col: string) => (col === 'app.aozoraquest.gameState' ? 'gs' : col === 'app.aozoraquest.battleGuard' ? guardKey : col);
   const fn = (async (url: string, init: RequestInit = {}) => {
     if (url.includes('plc.directory')) return json(200, { id: USER, service: [{ id: '#atproto_pds', type: 'AtprotoPersonalDataServer', serviceEndpoint: USER_PDS }] });
     if (url.includes('getRecord')) {
       const u = new URL(url);
       const col = u.searchParams.get('collection')!;
-      const rk = u.searchParams.get('rkey')!;
       if (col === 'app.aozoraquest.analysis') return opts.diagnosis ? json(200, { uri: 'x', cid: 'd', value: opts.diagnosis }) : json(400, { error: 'RecordNotFound' });
-      // gameState は rkey が sha256(DID) 依存なので col だけで拾う
-      const hit = [...store.entries()].find(([k]) => k.startsWith(col + '/'));
-      return hit ? json(200, { uri: 'x', cid: hit[1].cid, value: hit[1].value }) : json(400, { error: 'RecordNotFound' });
+      const rec = store.get(which(col));
+      return rec ? json(200, { uri: 'x', cid: rec.cid, value: rec.value }) : json(400, { error: 'RecordNotFound' });
     }
-    const b = JSON.parse(init.body as string) as { collection: string; rkey: string; record?: unknown; swapRecord?: string | null };
-    const k = key(b.collection, b.rkey);
-    const cur = store.get(k) ?? [...store.entries()].find(([kk]) => kk.startsWith(b.collection + '/'))?.[1];
+    const b = JSON.parse(init.body as string) as { collection: string; record?: unknown; swapRecord?: string | null };
+    const k = which(b.collection);
+    const cur = store.get(k);
     if (url.includes('putRecord')) {
       if (b.swapRecord === null && cur) return json(400, { error: 'InvalidSwap' });
       if (typeof b.swapRecord === 'string' && (!cur || cur.cid !== b.swapRecord)) return json(400, { error: 'InvalidSwap' });
-      // 既存を消して新規で置く (rkey 正規化のズレを吸収)
-      for (const kk of [...store.keys()]) if (kk.startsWith(b.collection + '/')) store.delete(kk);
       const cid = `c${++counter}`;
       store.set(k, { value: b.record, cid });
       return json(200, { uri: 'x', cid });
     }
     if (url.includes('deleteRecord')) {
-      for (const kk of [...store.keys()]) if (kk.startsWith(b.collection + '/')) store.delete(kk);
+      if (typeof b.swapRecord === 'string' && (!cur || cur.cid !== b.swapRecord)) return json(400, { error: 'InvalidSwap' });
+      store.delete(k);
       return json(200, {});
     }
     return json(404, { error: 'nf' });
@@ -74,82 +67,95 @@ function resolverMock(opts: { diagnosis?: unknown; gameState?: unknown } = {}) {
   return { fn, store };
 }
 
-const DIAG = { archetype: 'warrior', rpgStats: { atk: 30, def: 25, agi: 15, int: 15, luk: 15 } };
-const GS = (over: Record<string, unknown> = {}) => ({ did: USER, power: 5, playerXp: 100, jobXp: { warrior: 50 }, materials: {}, gear: [], x: 0, y: 0, version: 1, updatedAt: '', ...over });
-
-describe('battle-resolver (サーバー権威 戦闘)', () => {
+describe('battle-resolver (サーバー権威 移動/戦闘)', () => {
   const orig = globalThis.fetch;
   afterEach(() => { globalThis.fetch = orig; });
 
-  it('encounter: monster を返すが **seed は返さない** (先読み防止) + rewarded は power で決まる', async () => {
+  it('sealEncounter: monster を返すが **seed は返さない** + rewarded は power で決まる', async () => {
     const env = await makeEnv();
-    globalThis.fetch = resolverMock({ diagnosis: DIAG, gameState: GS({ power: 5 }) }).fn;
-    const r = await handleEncounter(env, USER, LX, LY, NOW);
+    globalThis.fetch = resolverMock({ diagnosis: DIAG, gameState: GS() }).fn;
+    const r = await sealEncounter(env, USER, GS({ power: 5 }), 5, 5, NOW);
     expect(r.battleId).toMatch(/^b[0-9a-f]{24}$/);
     expect(r.monsterId).toBeTruthy();
-    expect(r.rewarded).toBe(true); // power 5 >= 1
-    expect('seed' in r.state).toBe(false); // ★ 内部 seed は client に返らない
-    expect(r.state.monster).toBeTruthy();
-    expect(r.state.player.hp).toBeGreaterThan(0);
+    expect(r.rewarded).toBe(true);
+    expect('seed' in r.state).toBe(false); // ★ 内部 seed 非漏洩
+    expect(await sealEncounter(env, USER, GS(), 5, 5, NOW).catch((e) => e)).toBeInstanceOf(Error); // 二重戦闘 (guard 既存)
   });
 
-  it('encounter: power 0 なら rewarded=false (パワー無し=練習)', async () => {
-    const env = await makeEnv();
+  it('sealEncounter: power 0 → rewarded=false / 診断なし → 409', async () => {
+    let env = await makeEnv();
     globalThis.fetch = resolverMock({ diagnosis: DIAG, gameState: GS({ power: 0 }) }).fn;
-    const r = await handleEncounter(env, USER, LX, LY, NOW);
-    expect(r.rewarded).toBe(false);
-  });
-
-  it('encounter: 診断が無ければ 409 (snapshot を封印できない)', async () => {
-    const env = await makeEnv();
+    expect((await sealEncounter(env, USER, GS({ power: 0 }), 5, 5, NOW)).rewarded).toBe(false);
+    env = await makeEnv();
     globalThis.fetch = resolverMock({ diagnosis: undefined, gameState: GS() }).fn;
-    await expect(handleEncounter(env, USER, LX, LY, NOW)).rejects.toMatchObject({ status: 409 });
+    await expect(sealEncounter(env, USER, GS(), 5, 5, NOW)).rejects.toMatchObject({ status: 409 });
   });
 
-  it('encounter: town/水域では遭遇しない (400)', async () => {
+  it('move: 隣接1マスだけ許可 (斜め2マス/同地は 400) + 権威位置を更新', async () => {
     const env = await makeEnv();
-    globalThis.fetch = resolverMock({ diagnosis: DIAG, gameState: GS() }).fn;
-    // town を探す
-    let tx = -1, ty = -1;
-    for (let x = 0; x < 300 && tx < 0; x += 3) for (let y = 0; y < 300; y += 3) { if (terrainAt(x, y) === 'town') { tx = x; ty = y; break; } }
-    if (tx >= 0) await expect(handleEncounter(env, USER, tx, ty, NOW)).rejects.toMatchObject({ status: 400 });
+    globalThis.fetch = resolverMock({ diagnosis: DIAG, gameState: GS({ x: 10, y: 10 }) }).fn;
+    await expect(handleMove(env, USER, 0, 0, NOW)).rejects.toMatchObject({ status: 400 });
+    await expect(handleMove(env, USER, 2, 0, NOW)).rejects.toMatchObject({ status: 400 });
+    // 歩ける隣接方向を探して 1 マス動く
+    let moved = false;
+    for (const [dx, dy] of [[1, 0], [0, 1], [-1, 0], [0, -1], [1, 1]] as const) {
+      if (isWalkable(terrainAt(10 + dx, 10 + dy))) {
+        const r = await handleMove(env, USER, dx, dy, NOW);
+        expect(r.x).toBe(10 + dx);
+        expect(r.y).toBe(10 + dy);
+        moved = true;
+        break;
+      }
+    }
+    expect(moved).toBe(true);
   });
 
-  it('二重戦闘不可: encounter 中に再 encounter は 409', async () => {
+  it('move: 戦闘中 (期限内ガード) は 409 / 期限切れガードは flush して移動できる', async () => {
     const env = await makeEnv();
-    globalThis.fetch = resolverMock({ diagnosis: DIAG, gameState: GS() }).fn;
-    await handleEncounter(env, USER, LX, LY, NOW);
-    await expect(handleEncounter(env, USER, LX, LY, NOW)).rejects.toMatchObject({ status: 409 });
+    const m = resolverMock({ diagnosis: DIAG, gameState: GS({ x: 10, y: 10 }) });
+    globalThis.fetch = m.fn;
+    await sealEncounter(env, USER, GS({ x: 10, y: 10 }), 10, 10, NOW); // guard 作成 (expiresAt=NOW+TTL)
+    // 期限内: 移動不可
+    for (const [dx, dy] of [[1, 0], [0, 1], [-1, 0]] as const) {
+      if (isWalkable(terrainAt(10 + dx, 10 + dy))) { await expect(handleMove(env, USER, dx, dy, NOW)).rejects.toMatchObject({ status: 409 }); break; }
+    }
+    // 期限切れ (now > expiresAt): flush して移動できる
+    for (const [dx, dy] of [[1, 0], [0, 1], [-1, 0]] as const) {
+      if (isWalkable(terrainAt(10 + dx, 10 + dy))) { const r = await handleMove(env, USER, dx, dy, NOW + GUARD_TTL_SEC + 10); expect(r.x).toBe(10 + dx); break; }
+    }
+    expect(m.store.has('guard')).toBe(false); // flush 済み
   });
 
-  it('turn: battleId/turn 不一致は 409 (やり直し/リプレイ封じ)', async () => {
+  it('turn: battleId/turn 不一致は 409 / 不正コマンド 400 / 戦闘中でなければ 409', async () => {
     const env = await makeEnv();
     globalThis.fetch = resolverMock({ diagnosis: DIAG, gameState: GS() }).fn;
-    const enc = await handleEncounter(env, USER, LX, LY, NOW);
-    await expect(handleTurn(env, USER, 'wrong-id', 0, 'attack', NOW)).rejects.toMatchObject({ status: 409 });
+    await expect(handleTurn(env, USER, 'x', 0, 'attack', NOW)).rejects.toMatchObject({ status: 409 }); // guard なし
+    const enc = await sealEncounter(env, USER, GS(), 5, 5, NOW);
+    await expect(handleTurn(env, USER, 'wrong', 0, 'attack', NOW)).rejects.toMatchObject({ status: 409 });
     await expect(handleTurn(env, USER, enc.battleId, 5, 'attack', NOW)).rejects.toMatchObject({ status: 409 });
+    await expect(handleTurn(env, USER, enc.battleId, 0, 'hack' as Command, NOW)).rejects.toMatchObject({ status: 400 });
   });
 
-  it('turn: 戦闘中でなければ 409', async () => {
+  it('決着まで戦うと **報酬が権威 state に確定**しガードが消える (二重報酬なし)', async () => {
     const env = await makeEnv();
-    globalThis.fetch = resolverMock({ diagnosis: DIAG, gameState: GS() }).fn;
-    await expect(handleTurn(env, USER, 'x', 0, 'attack', NOW)).rejects.toMatchObject({ status: 409 });
-  });
-
-  it('turn: 1 コマンドを解決し seed 無し state を返す (未決着なら outcome=ongoing)', async () => {
-    const env = await makeEnv();
-    globalThis.fetch = resolverMock({ diagnosis: DIAG, gameState: GS() }).fn;
-    const enc = await handleEncounter(env, USER, LX, LY, NOW);
-    const t = await handleTurn(env, USER, enc.battleId, 0, 'guard', NOW);
-    expect('seed' in t.state).toBe(false);
-    expect(['ongoing', 'win', 'lose', 'draw', 'fled']).toContain(t.outcome);
-    expect(Array.isArray(t.events)).toBe(true);
-  });
-
-  it('不正コマンドは 400', async () => {
-    const env = await makeEnv();
-    globalThis.fetch = resolverMock({ diagnosis: DIAG, gameState: GS() }).fn;
-    const enc = await handleEncounter(env, USER, LX, LY, NOW);
-    await expect(handleTurn(env, USER, enc.battleId, 0, 'hack' as never, NOW)).rejects.toMatchObject({ status: 400 });
+    const m = resolverMock({ diagnosis: DIAG, gameState: GS({ power: 5, playerXp: 100, materials: { ore: 5 } }) });
+    globalThis.fetch = m.fn;
+    const enc = await sealEncounter(env, USER, GS({ power: 5, playerXp: 100, materials: { ore: 5 } }), 5, 5, NOW);
+    let outcome = 'ongoing';
+    let last;
+    for (let turn = 0; turn < 40 && outcome === 'ongoing'; turn++) {
+      last = await handleTurn(env, USER, enc.battleId, turn, 'attack', NOW);
+      outcome = last.outcome;
+    }
+    expect(['win', 'lose', 'draw']).toContain(outcome); // 30 ターンで必ず決着
+    expect(m.store.has('guard')).toBe(false); // ガードは決着で消える
+    const gs = m.store.get('gs')!.value as GameState;
+    if (outcome === 'win') {
+      expect(gs.playerXp).toBeGreaterThan(100); // XP が権威 state に加算された
+      expect(gs.power).toBe(4); // パワー 1 消費
+      expect(last!.awarded?.xp).toBeGreaterThan(0);
+    }
+    // 決着後に同じターンを再送 → guard 無し = 409 (二重報酬不可)
+    await expect(handleTurn(env, USER, enc.battleId, 0, 'attack', NOW)).rejects.toMatchObject({ status: 409 });
   });
 });

--- a/apps/edge/test/battle-resolver.test.ts
+++ b/apps/edge/test/battle-resolver.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { p256 } from '@noble/curves/p256';
+import { base64urlnopad } from '@scure/base';
+import { handleEncounter, handleTurn, ResolverError, type ResolverEnv } from '../src/battle-resolver';
+import { writeServerTokens } from '../src/oauth-store';
+
+const USER = 'did:plc:alice';
+const SERVER_DID = 'did:plc:kojira';
+const SERVER_PDS = 'https://server-pds.example';
+const USER_PDS = 'https://user-pds.example';
+const NOW = 1_700_000_000;
+// 陸地・非 town の座標を探す (terrainAt に依存)。0,0 が town/water の可能性があるので数点試す。
+import { terrainAt, isWalkable } from '@aozoraquest/core';
+function landCoord(): { x: number; y: number } {
+  for (let x = 0; x < 200; x += 7) for (let y = 0; y < 200; y += 7) {
+    const t = terrainAt(x, y);
+    if (isWalkable(t) && t !== 'town') return { x, y };
+  }
+  throw new Error('no land coord');
+}
+const { x: LX, y: LY } = landCoord();
+
+function jwkJson(fill: number): string {
+  const d = new Uint8Array(32).fill(fill);
+  const pub = p256.getPublicKey(d, false);
+  return JSON.stringify({ kty: 'EC', crv: 'P-256', x: base64urlnopad.encode(pub.slice(1, 33)), y: base64urlnopad.encode(pub.slice(33, 65)), d: base64urlnopad.encode(d), kid: `k${fill}` });
+}
+function mockKv() {
+  const m = new Map<string, string>();
+  return { get: async (k: string) => m.get(k) ?? null, put: async (k: string, v: string) => { m.set(k, v); }, delete: async (k: string) => { m.delete(k); } } as unknown as KVNamespace;
+}
+async function makeEnv(): Promise<ResolverEnv> {
+  const kv = mockKv();
+  await writeServerTokens(kv, { did: SERVER_DID, accessToken: 'AT', refreshToken: 'RT', tokenType: 'DPoP', expiresAt: NOW + 3600, pdsUrl: SERVER_PDS, authServer: 'https://bsky.social', updatedAt: NOW });
+  return { OAUTH_CLIENT_PRIVATE_JWK: jwkJson(3), OAUTH_DPOP_PRIVATE_JWK: jwkJson(5), SERVER_DID, WORKER_DID: 'did:web:edge.aozoraquest.app', OAUTH_TOKENS: kv };
+}
+
+/** 診断・GameState を種にした統合モック (ユーザー DID 解決 + 診断 + サーバー PDS CAS)。 */
+function resolverMock(opts: { diagnosis?: unknown; gameState?: unknown } = {}) {
+  const store = new Map<string, { value: unknown; cid: string }>();
+  if (opts.gameState) store.set('app.aozoraquest.gameState/' + 'u', { value: opts.gameState, cid: 'gs0' }); // rkey は下で正規化
+  let counter = 0;
+  const json = (s: number, b: unknown) => new Response(JSON.stringify(b), { status: s, headers: { 'content-type': 'application/json' } });
+  const key = (col: string, rk: string) => `${col}/${rk}`;
+  const fn = (async (url: string, init: RequestInit = {}) => {
+    if (url.includes('plc.directory')) return json(200, { id: USER, service: [{ id: '#atproto_pds', type: 'AtprotoPersonalDataServer', serviceEndpoint: USER_PDS }] });
+    if (url.includes('getRecord')) {
+      const u = new URL(url);
+      const col = u.searchParams.get('collection')!;
+      const rk = u.searchParams.get('rkey')!;
+      if (col === 'app.aozoraquest.analysis') return opts.diagnosis ? json(200, { uri: 'x', cid: 'd', value: opts.diagnosis }) : json(400, { error: 'RecordNotFound' });
+      // gameState は rkey が sha256(DID) 依存なので col だけで拾う
+      const hit = [...store.entries()].find(([k]) => k.startsWith(col + '/'));
+      return hit ? json(200, { uri: 'x', cid: hit[1].cid, value: hit[1].value }) : json(400, { error: 'RecordNotFound' });
+    }
+    const b = JSON.parse(init.body as string) as { collection: string; rkey: string; record?: unknown; swapRecord?: string | null };
+    const k = key(b.collection, b.rkey);
+    const cur = store.get(k) ?? [...store.entries()].find(([kk]) => kk.startsWith(b.collection + '/'))?.[1];
+    if (url.includes('putRecord')) {
+      if (b.swapRecord === null && cur) return json(400, { error: 'InvalidSwap' });
+      if (typeof b.swapRecord === 'string' && (!cur || cur.cid !== b.swapRecord)) return json(400, { error: 'InvalidSwap' });
+      // 既存を消して新規で置く (rkey 正規化のズレを吸収)
+      for (const kk of [...store.keys()]) if (kk.startsWith(b.collection + '/')) store.delete(kk);
+      const cid = `c${++counter}`;
+      store.set(k, { value: b.record, cid });
+      return json(200, { uri: 'x', cid });
+    }
+    if (url.includes('deleteRecord')) {
+      for (const kk of [...store.keys()]) if (kk.startsWith(b.collection + '/')) store.delete(kk);
+      return json(200, {});
+    }
+    return json(404, { error: 'nf' });
+  }) as unknown as typeof fetch;
+  return { fn, store };
+}
+
+const DIAG = { archetype: 'warrior', rpgStats: { atk: 30, def: 25, agi: 15, int: 15, luk: 15 } };
+const GS = (over: Record<string, unknown> = {}) => ({ did: USER, power: 5, playerXp: 100, jobXp: { warrior: 50 }, materials: {}, gear: [], x: 0, y: 0, version: 1, updatedAt: '', ...over });
+
+describe('battle-resolver (サーバー権威 戦闘)', () => {
+  const orig = globalThis.fetch;
+  afterEach(() => { globalThis.fetch = orig; });
+
+  it('encounter: monster を返すが **seed は返さない** (先読み防止) + rewarded は power で決まる', async () => {
+    const env = await makeEnv();
+    globalThis.fetch = resolverMock({ diagnosis: DIAG, gameState: GS({ power: 5 }) }).fn;
+    const r = await handleEncounter(env, USER, LX, LY, NOW);
+    expect(r.battleId).toMatch(/^b[0-9a-f]{24}$/);
+    expect(r.monsterId).toBeTruthy();
+    expect(r.rewarded).toBe(true); // power 5 >= 1
+    expect('seed' in r.state).toBe(false); // ★ 内部 seed は client に返らない
+    expect(r.state.monster).toBeTruthy();
+    expect(r.state.player.hp).toBeGreaterThan(0);
+  });
+
+  it('encounter: power 0 なら rewarded=false (パワー無し=練習)', async () => {
+    const env = await makeEnv();
+    globalThis.fetch = resolverMock({ diagnosis: DIAG, gameState: GS({ power: 0 }) }).fn;
+    const r = await handleEncounter(env, USER, LX, LY, NOW);
+    expect(r.rewarded).toBe(false);
+  });
+
+  it('encounter: 診断が無ければ 409 (snapshot を封印できない)', async () => {
+    const env = await makeEnv();
+    globalThis.fetch = resolverMock({ diagnosis: undefined, gameState: GS() }).fn;
+    await expect(handleEncounter(env, USER, LX, LY, NOW)).rejects.toMatchObject({ status: 409 });
+  });
+
+  it('encounter: town/水域では遭遇しない (400)', async () => {
+    const env = await makeEnv();
+    globalThis.fetch = resolverMock({ diagnosis: DIAG, gameState: GS() }).fn;
+    // town を探す
+    let tx = -1, ty = -1;
+    for (let x = 0; x < 300 && tx < 0; x += 3) for (let y = 0; y < 300; y += 3) { if (terrainAt(x, y) === 'town') { tx = x; ty = y; break; } }
+    if (tx >= 0) await expect(handleEncounter(env, USER, tx, ty, NOW)).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('二重戦闘不可: encounter 中に再 encounter は 409', async () => {
+    const env = await makeEnv();
+    globalThis.fetch = resolverMock({ diagnosis: DIAG, gameState: GS() }).fn;
+    await handleEncounter(env, USER, LX, LY, NOW);
+    await expect(handleEncounter(env, USER, LX, LY, NOW)).rejects.toMatchObject({ status: 409 });
+  });
+
+  it('turn: battleId/turn 不一致は 409 (やり直し/リプレイ封じ)', async () => {
+    const env = await makeEnv();
+    globalThis.fetch = resolverMock({ diagnosis: DIAG, gameState: GS() }).fn;
+    const enc = await handleEncounter(env, USER, LX, LY, NOW);
+    await expect(handleTurn(env, USER, 'wrong-id', 0, 'attack', NOW)).rejects.toMatchObject({ status: 409 });
+    await expect(handleTurn(env, USER, enc.battleId, 5, 'attack', NOW)).rejects.toMatchObject({ status: 409 });
+  });
+
+  it('turn: 戦闘中でなければ 409', async () => {
+    const env = await makeEnv();
+    globalThis.fetch = resolverMock({ diagnosis: DIAG, gameState: GS() }).fn;
+    await expect(handleTurn(env, USER, 'x', 0, 'attack', NOW)).rejects.toMatchObject({ status: 409 });
+  });
+
+  it('turn: 1 コマンドを解決し seed 無し state を返す (未決着なら outcome=ongoing)', async () => {
+    const env = await makeEnv();
+    globalThis.fetch = resolverMock({ diagnosis: DIAG, gameState: GS() }).fn;
+    const enc = await handleEncounter(env, USER, LX, LY, NOW);
+    const t = await handleTurn(env, USER, enc.battleId, 0, 'guard', NOW);
+    expect('seed' in t.state).toBe(false);
+    expect(['ongoing', 'win', 'lose', 'draw', 'fled']).toContain(t.outcome);
+    expect(Array.isArray(t.events)).toBe(true);
+  });
+
+  it('不正コマンドは 400', async () => {
+    const env = await makeEnv();
+    globalThis.fetch = resolverMock({ diagnosis: DIAG, gameState: GS() }).fn;
+    const enc = await handleEncounter(env, USER, LX, LY, NOW);
+    await expect(handleTurn(env, USER, enc.battleId, 0, 'hack' as never, NOW)).rejects.toMatchObject({ status: 400 });
+  });
+});

--- a/apps/edge/test/battle-reward.test.ts
+++ b/apps/edge/test/battle-reward.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { applyBattleOutcome, type BattleOutcomeInput } from '../src/battle-reward';
+import { MONSTERS, battleXpFor } from '@aozoraquest/core';
+import { emptyState, type GameState } from '../src/game-state';
+
+const base = (over: Partial<GameState> = {}): GameState => ({ ...emptyState('did:plc:alice', '2026-07-19T00:00:00.000Z'), power: 5, ...over });
+// tier1 の実在モンスター (ドロップ表を持つ) を使う。
+const mon = MONSTERS.find((m) => m.tier === 1 && m.drops.length > 0)!;
+const input = (over: Partial<BattleOutcomeInput> = {}): BattleOutcomeInput => ({ outcome: 'win', monsterId: mon.id, archetype: 'warrior', luk: 10, rewardSeed: 12345, lossSeed: 67890, rewarded: true, ...over });
+
+describe('battle-reward (fail-closed 報酬確定)', () => {
+  it('rewarded=false は勝敗どちらも何も変えない (パワー無し=練習)', () => {
+    const s = base({ power: 0, playerXp: 100 });
+    for (const outcome of ['win', 'lose', 'draw', 'fled'] as const) {
+      const { next, awarded } = applyBattleOutcome(s, input({ outcome, rewarded: false }));
+      expect(next).toBe(s); // 参照ごと不変
+      expect(awarded).toEqual({});
+    }
+  });
+
+  it('勝ち: +XP (player/job 両方) + ドロップ + パワー1消費', () => {
+    const s = base({ power: 3, playerXp: 50, jobXp: { warrior: 20 } });
+    const { next, awarded } = applyBattleOutcome(s, input({ outcome: 'win' }));
+    const xp = battleXpFor(mon.id);
+    expect(next.playerXp).toBe(50 + xp);
+    expect(next.jobXp.warrior).toBe(20 + xp);
+    expect(next.power).toBe(2); // 3-1
+    expect(awarded.xp).toBe(xp);
+    expect(awarded.powerSpent).toBe(1);
+    // ドロップは materials に加算 (item→個数)
+    for (const item of awarded.drops ?? []) expect(next.materials[item]).toBeGreaterThanOrEqual(1);
+  });
+
+  it('勝ち: 決定的 (同じ seed なら同じドロップ) = リトライ安全', () => {
+    const s = base();
+    const a = applyBattleOutcome(s, input({ outcome: 'win' }));
+    const b = applyBattleOutcome(s, input({ outcome: 'win' }));
+    expect(a.awarded.drops).toEqual(b.awarded.drops);
+    expect(a.next).toEqual(b.next);
+  });
+
+  it('負け: 素材ロス + パワー1消費 (XP は変えない)', () => {
+    const s = base({ power: 2, playerXp: 80, materials: { herb: 3, ore: 2 } });
+    const { next, awarded } = applyBattleOutcome(s, input({ outcome: 'lose' }));
+    expect(next.playerXp).toBe(80); // XP 不変
+    expect(next.power).toBe(1); // 2-1
+    expect(awarded.powerSpent).toBe(1);
+    // materialsLost があれば materials が減っている
+    if ((awarded.materialsLost ?? []).length) {
+      const totalBefore = 3 + 2;
+      const totalAfter = Object.values(next.materials).reduce((a, b) => a + b, 0);
+      expect(totalAfter).toBeLessThan(totalBefore);
+    }
+  });
+
+  it('素材が 0 になったらキーごと消す (負の在庫を作らない)', () => {
+    const s = base({ materials: { herb: 1 } });
+    const { next } = applyBattleOutcome(s, input({ outcome: 'lose', luk: 0 }));
+    for (const v of Object.values(next.materials)) expect(v).toBeGreaterThan(0);
+  });
+
+  it('引き分け / 逃走は決着扱いにしない (パワーも消費しない)', () => {
+    const s = base({ power: 3 });
+    for (const outcome of ['draw', 'fled'] as const) {
+      const { next, awarded } = applyBattleOutcome(s, input({ outcome }));
+      expect(next.power).toBe(3);
+      expect(awarded).toEqual({});
+    }
+  });
+});

--- a/apps/edge/test/router.test.ts
+++ b/apps/edge/test/router.test.ts
@@ -92,8 +92,8 @@ describe('edge router', () => {
     expect(res.status).toBe(503);
   });
 
-  it('POST /api/battle/encounter は JWT 無しなら 401 (毎回 Worker 認証)', async () => {
-    const res = await handleRequest(new Request('https://x/api/battle/encounter', { method: 'POST' }), env);
+  it('POST /api/world/move は JWT 無しなら 401 (移動も毎回 Worker 認証)', async () => {
+    const res = await handleRequest(new Request('https://x/api/world/move', { method: 'POST' }), env);
     expect(res.status).toBe(401);
     expect(((await res.json()) as { error: string }).error).toBe('missing_token');
   });

--- a/apps/edge/test/router.test.ts
+++ b/apps/edge/test/router.test.ts
@@ -92,6 +92,17 @@ describe('edge router', () => {
     expect(res.status).toBe(503);
   });
 
+  it('POST /api/battle/encounter は JWT 無しなら 401 (毎回 Worker 認証)', async () => {
+    const res = await handleRequest(new Request('https://x/api/battle/encounter', { method: 'POST' }), env);
+    expect(res.status).toBe(401);
+    expect(((await res.json()) as { error: string }).error).toBe('missing_token');
+  });
+
+  it('POST /api/battle/turn は JWT 無しなら 401', async () => {
+    const res = await handleRequest(new Request('https://x/api/battle/turn', { method: 'POST' }), env);
+    expect(res.status).toBe(401);
+  });
+
   it('GET /oauth/callback は code 欠落なら 400 (HTML)', async () => {
     const res = await handleRequest(new Request('https://x/oauth/callback'), env);
     expect(res.status).toBe(400);


### PR DESCRIPTION
## 目的
**移動遭遇も攻撃も毎ターン Worker が処理**し、報酬 (XP/パワー/素材) をサーバーが権威 state に確定する = クライアントを改造しても偽造できない (docs/21 §5)。オーナーが当初から求めていたアンチチートの本丸の**サーバー側**。

## 変更
- **`battle-reward.ts`**: 決着報酬を GameState に適用する純関数。fail-closed パワーモデル (rewarded=false→何もなし)、seed 秘匿 (ドロップ/敗北ロスはサーバー独立エントロピー)。
- **`battle-resolver.ts`**: encounter は state+診断+(x,y)tier から startBattle 入力を**サーバー封印** (playerSnapshot は client から受けない §5 C1)、**内部 seed を client に返さない** (#348)。turn は確定 pendingTurnSeed で resolveTurn → 決着で報酬を **readModifyWrite で fail-closed 確定** (トークン切れ→throw=報酬なし、**クライアント権威フォールバック無し** §3-6) + ガード削除。未決着は CAS で turn 確定してから応答 (並行二重解決/引き直しを 409)。
- **`battle-guard.ts`**: OAuth (server-pds) 書込へ。**`router.ts`**: /api/battle/encounter・turn (毎回 JWT 認証)、ServerWriteError→503 fail-closed。

## テスト (edge 138 緑)
resolver 9 (seed 非漏洩 / rewarded gating / 診断なし409 / town不可 / 二重戦闘409 / turn不一致409 / seed非漏洩 / 不正コマンド400) + guard 4 + reward 6 + router +2。dry-run build 89KB gzip (Free plan 内)。

## Review (要点)
**§1.5 3並列 + 敵対的で「クライアント権威へのフォールバックが無いこと」「seed 非漏洩」「fail-closed」「二重報酬/やり直し不可」を検証してほしい。**

## 次 (別 PR)
クライアント (world.tsx) をこのエンドポイント経由に繋ぎ、**旧クライアント権威の直書き (battle-log/awardBattleXp/points) を削除** = アンチチート発動。

🤖 Generated with [Claude Code](https://claude.com/claude-code)