### PR TITLE
feat(M3): あおぞらワールドをサーバー権威化 — 移動・攻撃を毎回 Worker 経由にしてチート不可に

### DIFF
--- a/apps/edge/src/battle-resolver.ts
+++ b/apps/edge/src/battle-resolver.ts
@@ -103,6 +103,8 @@ export interface MoveResult {
   x: number;
   y: number;
   terrain: string;
+  /** 街に入って全回復した (HP/MP が権威なのでサーバーが回復)。 */
+  healed?: boolean;
   /** サーバーが遭遇を判定した場合のみ。 */
   encounter?: EncounterInfo;
 }
@@ -122,12 +124,16 @@ export async function handleMove(env: ResolverEnv, userDid: string, dx: number, 
   }
 
   // 権威位置を CAS 更新。移動先の歩行可否は mutate 内で検証 (CAS リトライで再検証される)。
-  const committed = { x: 0, y: 0 };
+  // 街に入ったら HP/MP を全回復 (carry を消す = 次戦全快。HP が権威なのでサーバーが行う)。
+  const committed = { x: 0, y: 0, healed: false };
   const moved = await readModifyWrite(env, userDid, (cur: GameState): GameState => {
     const tx = cur.x + dx, ty = cur.y + dy;
-    if (!isWalkable(terrainAt(tx, ty))) throw new ResolverError('進めない地形', 400);
-    committed.x = tx; committed.y = ty;
-    return { ...cur, x: tx, y: ty };
+    const t = terrainAt(tx, ty);
+    if (!isWalkable(t)) throw new ResolverError('進めない地形', 400);
+    committed.x = tx; committed.y = ty; committed.healed = t === 'town';
+    const next: GameState = { ...cur, x: tx, y: ty };
+    if (t === 'town') { next.carryHp = undefined; next.carryMp = undefined; }
+    return next;
   }, { now });
 
   const terrain = terrainAt(committed.x, committed.y);
@@ -138,7 +144,7 @@ export async function handleMove(env: ResolverEnv, userDid: string, dx: number, 
       return { x: committed.x, y: committed.y, terrain, encounter };
     }
   }
-  return { x: committed.x, y: committed.y, terrain };
+  return { x: committed.x, y: committed.y, terrain, healed: committed.healed || undefined };
 }
 
 export interface TurnResult {

--- a/apps/edge/src/battle-resolver.ts
+++ b/apps/edge/src/battle-resolver.ts
@@ -37,9 +37,9 @@ interface SealedMeta {
 
 type Guard = BattleGuard<SealedMeta, BattleState>;
 
-/** 解決エラー。上位が HTTP status に振り分ける。 */
+/** 解決エラー。上位が HTTP status に振り分ける。code はクライアントが文言を出し分ける用 (任意)。 */
 export class ResolverError extends Error {
-  constructor(message: string, readonly status: number) {
+  constructor(message: string, readonly status: number, readonly code?: string) {
     super(message);
   }
 }
@@ -60,15 +60,16 @@ async function resolveUserPds(userDid: string, fetchImpl?: typeof fetch): Promis
 async function readDiagnosis(userDid: string, fetchImpl?: typeof fetch): Promise<{ archetype: Archetype; baseStats: ReturnType<typeof statVectorToArray> }> {
   const pds = await resolveUserPds(userDid, fetchImpl);
   const rec = await getRecord<{ archetype: Archetype; rpgStats: StatVector }>(pds, userDid, ANALYSIS_COLLECTION, 'self');
-  if (!rec?.value?.archetype || !rec.value.rpgStats) throw new ResolverError('診断が未実施 (先に気質診断が必要)', 409);
+  if (!rec?.value?.archetype || !rec.value.rpgStats) throw new ResolverError('診断が未実施 (先に気質診断が必要)', 409, 'diagnosis_required');
   return { archetype: rec.value.archetype, baseStats: statVectorToArray(rec.value.rpgStats) };
 }
 
 export const POWER_COLLECTION = 'app.aozoraquest.power';
 
 /** §6-4 移行の上限クランプ (偽造済みかもしれない PDS 現値を切り詰める)。**dev=owner は無害・一般ユーザー
- *  移行は M5 で再検討 (§9-4 未解決)**。値の根拠はコミットメッセージ参照。 */
-export const MAX_MIGRATE_POWER = 1000;
+ *  移行は M5 で再検討 (§9-4 未解決)**。真の偽造対策は M4 の投稿 XP 権威化で、これは絶対値の暴走を切る
+ *  緩いサニティ上限。長期ユーザーの正当残高 (viaPosts 累積) を切り詰めない大きさにする。値の根拠はコミット参照。 */
+export const MAX_MIGRATE_POWER = 100_000; // 正当ユーザー (投稿数=残高上限) を十分上回る緩い上限
 export const MAX_MIGRATE_PLAYER_XP = 500_000; // lvl 99 ≈ 457k を上回る安全上限
 export const MAX_MIGRATE_JOB_XP = 50_000; // lvl 50 ≈ 40k を上回る安全上限
 
@@ -248,7 +249,7 @@ export async function handleTurn(env: ResolverEnv, userDid: string, battleId: st
         herbs: next.herbs,
         tonics: next.tonics,
       };
-    }, { now });
+    }, { now, init: (did, nowIso) => migrateInitState(did, nowIso) });
     return { state: stripState(next), events: next.lastEvents, outcome: next.outcome, awarded };
   }
 

--- a/apps/edge/src/battle-resolver.ts
+++ b/apps/edge/src/battle-resolver.ts
@@ -64,6 +64,55 @@ async function readDiagnosis(userDid: string, fetchImpl?: typeof fetch): Promise
   return { archetype: rec.value.archetype, baseStats: statVectorToArray(rec.value.rpgStats) };
 }
 
+export const POWER_COLLECTION = 'app.aozoraquest.power';
+
+/** §6-4 移行の上限クランプ (偽造済みかもしれない PDS 現値を切り詰める)。**dev=owner は無害・一般ユーザー
+ *  移行は M5 で再検討 (§9-4 未解決)**。値の根拠はコミットメッセージ参照。 */
+export const MAX_MIGRATE_POWER = 1000;
+export const MAX_MIGRATE_PLAYER_XP = 500_000; // lvl 99 ≈ 457k を上回る安全上限
+export const MAX_MIGRATE_JOB_XP = 50_000; // lvl 50 ≈ 40k を上回る安全上限
+
+const finiteNum = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) && v > 0 ? v : 0);
+
+/** ユーザー PDS の power/self 累積カウンタ (points.ts と同じ形)。残高は client の deriveState と同式。 */
+interface MigratablePowerRecord {
+  viaPosts?: number; userMessages?: number; cardDraws?: number; battles?: number;
+  craftPowerSpent?: number; salePowerEarned?: number; searchPowerSpent?: number;
+}
+interface MigratableAnalysisRecord {
+  playerLevel?: { xp?: number };
+  jobLevel?: { archetype?: string; xp?: number };
+}
+
+/**
+ * 初回 gameState 生成時の移行 (§6-4)。ユーザー PDS の **既存 power 残高と分析 Lv を上限クランプして取り込む**
+ * (取り込まないと power=0 → 常に rewarded=false = 報酬が出ず、Lv=1 で弱すぎる)。**読取専用** (PDS へは書かない)
+ * ので、読めない/未診断でも fail-open で emptyState に倒す (書込 fail-closed とは別物)。**state が null の
+ * ときだけ**呼ばれる (readModifyWrite) = 通常経路にコストを乗せない。
+ */
+export async function migrateInitState(userDid: string, nowIso: string, fetchImpl?: typeof fetch): Promise<GameState> {
+  const base = emptyState(userDid, nowIso);
+  try {
+    const pds = await resolveUserPds(userDid, fetchImpl);
+    const [powerRec, analysisRec] = await Promise.all([
+      getRecord<MigratablePowerRecord>(pds, userDid, POWER_COLLECTION, 'self').catch(() => null),
+      getRecord<MigratableAnalysisRecord>(pds, userDid, ANALYSIS_COLLECTION, 'self').catch(() => null),
+    ]);
+    const p = powerRec?.value;
+    if (p) {
+      const bal = Math.max(0, finiteNum(p.viaPosts) - finiteNum(p.userMessages) - finiteNum(p.cardDraws)
+        - finiteNum(p.battles) - finiteNum(p.craftPowerSpent) - finiteNum(p.searchPowerSpent) + finiteNum(p.salePowerEarned));
+      base.power = Math.min(bal, MAX_MIGRATE_POWER);
+    }
+    const a = analysisRec?.value;
+    if (a) {
+      base.playerXp = Math.min(finiteNum(a.playerLevel?.xp), MAX_MIGRATE_PLAYER_XP);
+      if (a.jobLevel?.archetype) base.jobXp = { [a.jobLevel.archetype]: Math.min(finiteNum(a.jobLevel.xp), MAX_MIGRATE_JOB_XP) };
+    }
+  } catch { /* 読めない/未診断は power 0・Lv1 で開始 (読取のみ = 無害) */ }
+  return base;
+}
+
 /** バトルガードの寿命 (秒)。各ターンで更新。切れたガードは move 時に flush = クラッシュしても
  *  永久ロックアウトしない (docs/21 §5 lazy 敗北)。 */
 export const GUARD_TTL_SEC = 900;
@@ -134,7 +183,7 @@ export async function handleMove(env: ResolverEnv, userDid: string, dx: number, 
     const next: GameState = { ...cur, x: tx, y: ty };
     if (t === 'town') { next.carryHp = undefined; next.carryMp = undefined; }
     return next;
-  }, { now });
+  }, { now, init: (did, nowIso) => migrateInitState(did, nowIso, fetchImpl) });
 
   const terrain = terrainAt(committed.x, committed.y);
   if (terrain !== 'town') {

--- a/apps/edge/src/battle-reward.ts
+++ b/apps/edge/src/battle-reward.ts
@@ -76,15 +76,20 @@ export function applyBattleOutcome(state: GameState, o: BattleOutcomeInput): { n
   }
 
   if (o.outcome === 'lose') {
+    // 負けでも僅かな XP (§5「負: xpLose+素材ロス」/ 旧クライアントと同値) + 素材ロス + パワー消費。
+    const xp = BATTLE_TUNING.xpLose;
     const materialsLost = rollDefeatLoss(state.materials, o.luk, o.lossSeed);
     const next: GameState = {
       ...state,
+      playerXp: state.playerXp + xp,
+      jobXp: { ...state.jobXp, [o.archetype]: (state.jobXp[o.archetype] ?? 0) + xp },
       materials: addItems(state.materials, materialsLost, -1),
       power: Math.max(0, state.power - POWER_COST),
     };
-    return { next, awarded: { materialsLost, powerSpent: POWER_COST } };
+    return { next, awarded: { xp, materialsLost, powerSpent: POWER_COST } };
   }
 
-  // draw / fled は決着扱いにしない (パワーも消費しない)。
+  // draw / fled は決着扱いにしない (パワー消費なし)。旧クライアントは draw にも xpLose を出したが、
+  // パワー消費のない draw を報酬対象にすると「ガードで引き分けを狙う無限 XP 稼ぎ」が成立するため付与しない。
   return { next: state, awarded: {} };
 }

--- a/apps/edge/src/game-state.ts
+++ b/apps/edge/src/game-state.ts
@@ -75,8 +75,9 @@ export interface RmwOptions {
   now: number;
   /** CAS 競合時の最大リトライ回数。 */
   retries?: number;
-  /** state が無いときの初期値 (移行値など)。省略時 emptyState。 */
-  init?: (did: string, nowIso: string) => GameState;
+  /** state が無いときの初期値 (移行値など)。省略時 emptyState。**state が null のときだけ**呼ばれるので、
+   *  PDS 読取など非同期の移行 (§6-4) も可 (共通経路にはコストを乗せない)。 */
+  init?: (did: string, nowIso: string) => GameState | Promise<GameState>;
 }
 
 /**
@@ -98,7 +99,7 @@ export async function readModifyWrite(
   const nowIso = new Date(opts.now * 1000).toISOString();
   for (let attempt = 0; attempt <= retries; attempt++) {
     const existing = await readState(env, targetDid);
-    const current = existing?.state ?? init(targetDid, nowIso);
+    const current = existing?.state ?? (await init(targetDid, nowIso));
     const next: GameState = { ...mutate(current), did: targetDid, version: GAME_STATE_VERSION, updatedAt: nowIso };
     // 既存があればその CID を期待 (CAS)、無ければ null (新規作成のみ) で二重作成も防ぐ。
     const swap = existing ? existing.cid : null;

--- a/apps/edge/src/router.ts
+++ b/apps/edge/src/router.ts
@@ -11,9 +11,9 @@
  */
 import { verifyServiceAuth, ServiceAuthError } from './service-auth';
 import { PdsError } from './pds';
-import { readState, emptyState } from './game-state';
+import { readState } from './game-state';
 import { handleClientMetadata, handleOAuthStart, handleOAuthCallback, type OAuthRoutesEnv } from './oauth-routes';
-import { handleMove, handleTurn, ResolverError } from './battle-resolver';
+import { handleMove, handleTurn, migrateInitState, ResolverError } from './battle-resolver';
 import { ServerWriteError } from './server-pds';
 import type { Command } from '@aozoraquest/core';
 
@@ -101,9 +101,12 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
       return cors(json({ error: 'unauthorized', reason: e instanceof ServiceAuthError ? e.message : 'verify_failed' }, 401), allowedOrigin);
     }
     // 読み書きとも repo はトークン由来 (readState)。未 bootstrap は 503 fail-closed。
+    // 未初期化 (レコード無し) は §6-4 移行値を read-only で返す (power=0/Lv1 で表示が割れないように。
+    // PDS へは書かない = 初回 move で確定)。initialized はレコード実在を表す。
     try {
       const rec = await readState(env, did);
-      return cors(json({ state: rec?.state ?? emptyState(did, new Date().toISOString()), initialized: rec !== null }), allowedOrigin);
+      const state = rec?.state ?? (await migrateInitState(did, new Date().toISOString()));
+      return cors(json({ state, initialized: rec !== null }), allowedOrigin);
     } catch (e) {
       return cors(battleError(e), allowedOrigin);
     }
@@ -156,7 +159,7 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
 /** 戦闘エラーを HTTP に振り分ける。**トークン切れ/未設定 (ServerWriteError) は 503 で fail-closed**
  *  (報酬は付かない・クライアント権威へのフォールバックは無い §3-6)。ResolverError はその status。 */
 function battleError(e: unknown): Response {
-  if (e instanceof ResolverError) return json({ error: 'battle_error', message: e.message }, e.status);
+  if (e instanceof ResolverError) return json({ error: e.code ?? 'battle_error', message: e.message }, e.status);
   if (e instanceof ServerWriteError) return json({ error: 'server_write_unavailable', reason: e.reason }, 503);
   // 失効/無効トークンで PDS が 401/403 を返した場合も **fail-closed 503** (報酬なし。500 で誤魔化さない)。
   if (e instanceof PdsError && (e.status === 401 || e.status === 403)) return json({ error: 'server_write_unavailable', reason: 'auth' }, 503);

--- a/apps/edge/src/router.ts
+++ b/apps/edge/src/router.ts
@@ -10,8 +10,8 @@
  *   /api/battle/* /api/xp/* /api/me/state (M2〜)。依頼クエスト集約 (docs/15) も。
  */
 import { verifyServiceAuth, ServiceAuthError } from './service-auth';
-import { getRecord, PdsError } from './pds';
-import { GAME_STATE_COLLECTION, rkeyForDid, emptyState } from './game-state';
+import { PdsError } from './pds';
+import { readState, emptyState } from './game-state';
 import { handleClientMetadata, handleOAuthStart, handleOAuthCallback, type OAuthRoutesEnv } from './oauth-routes';
 import { handleMove, handleTurn, ResolverError } from './battle-resolver';
 import { ServerWriteError } from './server-pds';
@@ -100,10 +100,13 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
     } catch (e) {
       return cors(json({ error: 'unauthorized', reason: e instanceof ServiceAuthError ? e.message : 'verify_failed' }, 401), allowedOrigin);
     }
-    if (!env.SERVER_PDS_URL || !env.SERVER_DID) return cors(json({ error: 'server_not_configured' }, 503), allowedOrigin);
-    const rec = await getRecord(env.SERVER_PDS_URL, env.SERVER_DID, GAME_STATE_COLLECTION, rkeyForDid(did));
-    // 未作成なら初期値を返す (実 state 化は初回の書込み = M3 で。移行はそこでクランプ)
-    return cors(json({ state: rec?.value ?? emptyState(did, new Date().toISOString()), initialized: rec !== null }), allowedOrigin);
+    // 読み書きとも repo はトークン由来 (readState)。未 bootstrap は 503 fail-closed。
+    try {
+      const rec = await readState(env, did);
+      return cors(json({ state: rec?.state ?? emptyState(did, new Date().toISOString()), initialized: rec !== null }), allowedOrigin);
+    } catch (e) {
+      return cors(battleError(e), allowedOrigin);
+    }
   }
 
   // ── サーバー権威 ワールド/戦闘 (docs/21 §5) ── 移動も攻撃も毎回 Worker が処理 = チート不可 ──

--- a/apps/edge/test/battle-resolver.test.ts
+++ b/apps/edge/test/battle-resolver.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { p256 } from '@noble/curves/p256';
 import { base64urlnopad } from '@scure/base';
-import { sealEncounter, handleMove, handleTurn, ResolverError, GUARD_TTL_SEC, type ResolverEnv } from '../src/battle-resolver';
+import { sealEncounter, handleMove, handleTurn, migrateInitState, ResolverError, GUARD_TTL_SEC, type ResolverEnv } from '../src/battle-resolver';
 import { writeServerTokens } from '../src/oauth-store';
 import { terrainAt, isWalkable, type Command } from '@aozoraquest/core';
 import type { GameState } from '../src/game-state';
@@ -114,7 +114,7 @@ describe('battle-resolver (サーバー権威 移動/戦闘)', () => {
     const env = await makeEnv();
     const m = resolverMock({ diagnosis: DIAG, gameState: GS({ x: 10, y: 10 }) });
     globalThis.fetch = m.fn;
-    await sealEncounter(env, USER, GS({ x: 10, y: 10 }), 10, 10, NOW); // guard 作成 (expiresAt=NOW+TTL)
+    const enc0 = await sealEncounter(env, USER, GS({ x: 10, y: 10 }), 10, 10, NOW); // guard 作成 (expiresAt=NOW+TTL)
     // 期限内: 移動不可
     for (const [dx, dy] of [[1, 0], [0, 1], [-1, 0]] as const) {
       if (isWalkable(terrainAt(10 + dx, 10 + dy))) { await expect(handleMove(env, USER, dx, dy, NOW)).rejects.toMatchObject({ status: 409 }); break; }
@@ -123,7 +123,10 @@ describe('battle-resolver (サーバー権威 移動/戦闘)', () => {
     for (const [dx, dy] of [[1, 0], [0, 1], [-1, 0]] as const) {
       if (isWalkable(terrainAt(10 + dx, 10 + dy))) { const r = await handleMove(env, USER, dx, dy, NOW + GUARD_TTL_SEC + 10); expect(r.x).toBe(10 + dx); break; }
     }
-    expect(m.store.has('guard')).toBe(false); // flush 済み
+    // flush 済み: 元の期限切れガードは消えている。移動先で新たに遭遇した場合は別 battleId の新ガードが張られる
+    // (遭遇ロールは非決定的なので「消えた or 別戦闘に置き換わった」で flush を検証する)。
+    const gAfter = m.store.get('guard');
+    if (gAfter) expect((gAfter.value as { battleId: string }).battleId).not.toBe(enc0.battleId);
   });
 
   it('turn: battleId/turn 不一致は 409 / 不正コマンド 400 / 戦闘中でなければ 409', async () => {
@@ -157,5 +160,44 @@ describe('battle-resolver (サーバー権威 移動/戦闘)', () => {
     }
     // 決着後に同じターンを再送 → guard 無し = 409 (二重報酬不可)
     await expect(handleTurn(env, USER, enc.battleId, 0, 'attack', NOW)).rejects.toMatchObject({ status: 409 });
+  });
+
+  it('migrateInitState: PDS の power 残高と分析 Lv を上限クランプして初回 state に取り込む (§6-4)', async () => {
+    const json = (s: number, b: unknown) => new Response(JSON.stringify(b), { status: s, headers: { 'content-type': 'application/json' } });
+    const migrateFetch = (power: unknown, analysis: unknown) => (async (url: string) => {
+      if (url.includes('plc.directory')) return json(200, { id: USER, service: [{ id: '#atproto_pds', type: 'AtprotoPersonalDataServer', serviceEndpoint: USER_PDS }] });
+      const col = new URL(url).searchParams.get('collection');
+      if (col === 'app.aozoraquest.power') return power ? json(200, { uri: 'x', cid: 'p', value: power }) : json(400, { error: 'RecordNotFound' });
+      if (col === 'app.aozoraquest.analysis') return analysis ? json(200, { uri: 'x', cid: 'a', value: analysis }) : json(400, { error: 'RecordNotFound' });
+      return json(400, { error: 'RecordNotFound' });
+    }) as unknown as typeof fetch;
+
+    // getRecord は globalThis.fetch を使う (fetchImpl 引数は DID 解決のみ) ので mock を差し込む。
+    // 残高 = viaPosts - userMessages - cardDraws - battles - craft - search + sale = 100-10-5-3-2-1+6 = 85
+    globalThis.fetch = migrateFetch(
+      { viaPosts: 100, userMessages: 10, cardDraws: 5, battles: 3, craftPowerSpent: 2, searchPowerSpent: 1, salePowerEarned: 6 },
+      { playerLevel: { xp: 1234 }, jobLevel: { archetype: 'warrior', xp: 567 } },
+    );
+    const s1 = await migrateInitState(USER, '');
+    expect(s1.power).toBe(85);
+    expect(s1.playerXp).toBe(1234);
+    expect(s1.jobXp).toEqual({ warrior: 567 });
+
+    // 偽造された巨大値は上限クランプされる (MAX_MIGRATE_*)
+    globalThis.fetch = migrateFetch(
+      { viaPosts: 9_999_999 },
+      { playerLevel: { xp: 9_999_999 }, jobLevel: { archetype: 'mage', xp: 9_999_999 } },
+    );
+    const s2 = await migrateInitState(USER, '');
+    expect(s2.power).toBe(1000); // MAX_MIGRATE_POWER
+    expect(s2.playerXp).toBe(500_000); // MAX_MIGRATE_PLAYER_XP
+    expect(s2.jobXp).toEqual({ mage: 50_000 }); // MAX_MIGRATE_JOB_XP
+
+    // レコード無し (未診断・power 無し) は power 0・Lv1 で fail-open
+    globalThis.fetch = migrateFetch(null, null);
+    const s3 = await migrateInitState(USER, '');
+    expect(s3.power).toBe(0);
+    expect(s3.playerXp).toBe(0);
+    expect(s3.jobXp).toEqual({});
   });
 });

--- a/apps/edge/test/battle-resolver.test.ts
+++ b/apps/edge/test/battle-resolver.test.ts
@@ -189,7 +189,7 @@ describe('battle-resolver (サーバー権威 移動/戦闘)', () => {
       { playerLevel: { xp: 9_999_999 }, jobLevel: { archetype: 'mage', xp: 9_999_999 } },
     );
     const s2 = await migrateInitState(USER, '');
-    expect(s2.power).toBe(1000); // MAX_MIGRATE_POWER
+    expect(s2.power).toBe(100_000); // MAX_MIGRATE_POWER
     expect(s2.playerXp).toBe(500_000); // MAX_MIGRATE_PLAYER_XP
     expect(s2.jobXp).toEqual({ mage: 50_000 }); // MAX_MIGRATE_JOB_XP
 

--- a/apps/edge/test/battle-reward.test.ts
+++ b/apps/edge/test/battle-reward.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { applyBattleOutcome, type BattleOutcomeInput } from '../src/battle-reward';
-import { MONSTERS, battleXpFor } from '@aozoraquest/core';
+import { MONSTERS, battleXpFor, BATTLE_TUNING } from '@aozoraquest/core';
 import { emptyState, type GameState } from '../src/game-state';
 
 const base = (over: Partial<GameState> = {}): GameState => ({ ...emptyState('did:plc:alice', '2026-07-19T00:00:00.000Z'), power: 5, ...over });
@@ -39,10 +39,12 @@ describe('battle-reward (fail-closed 報酬確定)', () => {
     expect(a.next).toEqual(b.next);
   });
 
-  it('負け: 素材ロス + パワー1消費 (XP は変えない)', () => {
-    const s = base({ power: 2, playerXp: 80, materials: { herb: 3, ore: 2 } });
+  it('負け: 素材ロス + パワー1消費 + 僅かな xpLose (§5)', () => {
+    const s = base({ power: 2, playerXp: 80, jobXp: { warrior: 20 }, materials: { herb: 3, ore: 2 } });
     const { next, awarded } = applyBattleOutcome(s, input({ outcome: 'lose' }));
-    expect(next.playerXp).toBe(80); // XP 不変
+    expect(next.playerXp).toBe(80 + BATTLE_TUNING.xpLose); // 負けでも少し XP (player/job 両方)
+    expect(next.jobXp.warrior).toBe(20 + BATTLE_TUNING.xpLose);
+    expect(awarded.xp).toBe(BATTLE_TUNING.xpLose);
     expect(next.power).toBe(1); // 2-1
     expect(awarded.powerSpent).toBe(1);
     // materialsLost があれば materials が減っている

--- a/apps/web/src/lib/__tests__/world-server.test.ts
+++ b/apps/web/src/lib/__tests__/world-server.test.ts
@@ -64,6 +64,25 @@ describe('world-server (サーバー権威 API クライアント)', () => {
     expect(calls()).toBe(1); // 同一 lxm はキャッシュ再利用
   });
 
+  it('タイムアウト/通信断は WorldServerError(status 0, code timeout/network) で throw (fail-closed)', async () => {
+    const { serverMove, WorldServerError } = await import('../world-server');
+    const { agent } = mockAgent(Date.now() / 1000 + 300);
+    globalThis.fetch = (async () => { throw new DOMException('timed out', 'TimeoutError'); }) as unknown as typeof fetch;
+    const err = await serverMove(agent, 1, 0).catch((e) => e);
+    expect(err).toBeInstanceOf(WorldServerError);
+    expect(err.status).toBe(0);
+    expect(err.code).toBe('timeout');
+  });
+
+  it('401 応答は該当 lxm のトークンキャッシュを捨てて次回再取得する (401 ループ回避)', async () => {
+    const { serverMove } = await import('../world-server');
+    const { agent, calls } = mockAgent(Date.now() / 1000 + 300);
+    globalThis.fetch = (async () => new Response(JSON.stringify({ error: 'unauthorized' }), { status: 401 })) as unknown as typeof fetch;
+    await serverMove(agent, 1, 0).catch(() => {});
+    await serverMove(agent, 0, 1).catch(() => {});
+    expect(calls()).toBe(2); // 401 で evict → 2 回目も getServiceAuth し直す (キャッシュなら 1)
+  });
+
   it('worldServerEnabled は env 有無で決まる', async () => {
     const mod = await import('../world-server');
     expect(mod.worldServerEnabled).toBe(true);

--- a/apps/web/src/lib/__tests__/world-server.test.ts
+++ b/apps/web/src/lib/__tests__/world-server.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Agent } from '@atproto/api';
+
+/** exp 付きの偽 JWT (キャッシュ用に exp を読ませる)。 */
+function fakeJwt(exp: number): string {
+  return `h.${btoa(JSON.stringify({ exp }))}.s`;
+}
+/** getServiceAuth をカウントするモック agent。 */
+function mockAgent(exp: number) {
+  let calls = 0;
+  const agent = { com: { atproto: { server: { getServiceAuth: async () => { calls++; return { data: { token: fakeJwt(exp) } }; } } } } } as unknown as Agent;
+  return { agent, calls: () => calls };
+}
+
+describe('world-server (サーバー権威 API クライアント)', () => {
+  const origFetch = globalThis.fetch;
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv('VITE_EDGE_URL', 'https://edge.test');
+    vi.stubEnv('VITE_EDGE_DID', 'did:web:edge.test');
+  });
+  afterEach(() => { globalThis.fetch = origFetch; vi.unstubAllEnvs(); });
+
+  it('serverMove: Bearer + {dx,dy} を /api/world/move に POST し結果を返す', async () => {
+    const { serverMove } = await import('../world-server');
+    const { agent } = mockAgent(Date.now() / 1000 + 300);
+    let seen: { url: string; headers: Headers; body: unknown } | undefined;
+    globalThis.fetch = (async (url: string, init: RequestInit) => {
+      seen = { url, headers: new Headers(init.headers), body: JSON.parse(init.body as string) };
+      return new Response(JSON.stringify({ x: 3, y: 4, terrain: 'plains' }), { status: 200 });
+    }) as unknown as typeof fetch;
+    const r = await serverMove(agent, 1, 0);
+    expect(r).toMatchObject({ x: 3, y: 4, terrain: 'plains' });
+    expect(seen!.url).toBe('https://edge.test/api/world/move');
+    expect(seen!.headers.get('authorization')).toMatch(/^Bearer /);
+    expect(seen!.body).toEqual({ dx: 1, dy: 0 });
+  });
+
+  it('serverTurn: /api/battle/turn に POST', async () => {
+    const { serverTurn } = await import('../world-server');
+    const { agent } = mockAgent(Date.now() / 1000 + 300);
+    let body: unknown;
+    globalThis.fetch = (async (_u: string, init: RequestInit) => { body = JSON.parse(init.body as string); return new Response(JSON.stringify({ state: {}, events: [], outcome: 'ongoing' }), { status: 200 }); }) as unknown as typeof fetch;
+    const r = await serverTurn(agent, 'btl-1', 2, 'attack');
+    expect(r.outcome).toBe('ongoing');
+    expect(body).toEqual({ battleId: 'btl-1', turn: 2, command: 'attack' });
+  });
+
+  it('エラー応答は WorldServerError (status 付き)', async () => {
+    const { serverMove, WorldServerError } = await import('../world-server');
+    const { agent } = mockAgent(Date.now() / 1000 + 300);
+    globalThis.fetch = (async () => new Response(JSON.stringify({ error: 'server_write_unavailable', reason: 'auth' }), { status: 503 })) as unknown as typeof fetch;
+    const err = await serverMove(agent, 1, 0).catch((e) => e);
+    expect(err).toBeInstanceOf(WorldServerError);
+    expect(err.status).toBe(503);
+  });
+
+  it('service auth トークンは lxm ごとにキャッシュ (2回呼んでも getServiceAuth 1回)', async () => {
+    const { serverMove } = await import('../world-server');
+    const { agent, calls } = mockAgent(Date.now() / 1000 + 300);
+    globalThis.fetch = (async () => new Response(JSON.stringify({ x: 0, y: 0, terrain: 'plains' }), { status: 200 })) as unknown as typeof fetch;
+    await serverMove(agent, 1, 0);
+    await serverMove(agent, 0, 1);
+    expect(calls()).toBe(1); // 同一 lxm はキャッシュ再利用
+  });
+
+  it('worldServerEnabled は env 有無で決まる', async () => {
+    const mod = await import('../world-server');
+    expect(mod.worldServerEnabled).toBe(true);
+  });
+});

--- a/apps/web/src/lib/world-server.ts
+++ b/apps/web/src/lib/world-server.ts
@@ -13,6 +13,7 @@ const EDGE_DID = (import.meta.env.VITE_EDGE_DID as string | undefined)?.trim();
 
 const LXM_MOVE = 'app.aozoraquest.world.move';
 const LXM_TURN = 'app.aozoraquest.battle.turn';
+const LXM_STATE = 'app.aozoraquest.me.state';
 
 /** edge URL / DID が設定されていればサーバー権威モードを使える。 */
 export const worldServerEnabled = Boolean(EDGE_URL && EDGE_DID);
@@ -59,7 +60,10 @@ async function callEdge<T>(agent: Agent, lxm: string, path: string, body: unknow
 export interface ServerMonster { name: string; maxHp: number; hp: number; maxMp: number; mp: number; [k: string]: unknown }
 export interface ServerBattleState { player: ServerMonster; monster: ServerMonster; monsterId: string; outcome: string; turn: number; lastEvents: { actor: string; text: string }[]; [k: string]: unknown }
 export interface ServerEncounter { battleId: string; monsterId: string; state: ServerBattleState; rewarded: boolean }
-export interface ServerMoveResult { x: number; y: number; terrain: string; encounter?: ServerEncounter }
+export interface ServerMoveResult { x: number; y: number; terrain: string; healed?: boolean; encounter?: ServerEncounter }
+/** 権威 GameState (パワー/XP/素材/位置/carry HP-MP 等)。表示はこれを正とする。 */
+export interface ServerGameState { did: string; power: number; playerXp: number; jobXp: Record<string, number>; materials: Record<string, number>; gear: string[]; x: number; y: number; carryHp?: number; carryMp?: number; herbs?: number; tonics?: number; version: number; updatedAt: string }
+export interface ServerStateResult { state: ServerGameState; initialized: boolean }
 export interface ServerAward { xp?: number; drops?: string[]; materialsLost?: string[]; powerSpent?: number }
 export interface ServerTurnResult { state: ServerBattleState; events: { actor: string; text: string }[]; outcome: string; awarded?: ServerAward }
 
@@ -71,4 +75,14 @@ export function serverMove(agent: Agent, dx: number, dy: number): Promise<Server
 /** 攻撃 (1ターン): battleId + turn + command。解決 + 決着報酬はサーバー。 */
 export function serverTurn(agent: Agent, battleId: string, turn: number, command: string): Promise<ServerTurnResult> {
   return callEdge<ServerTurnResult>(agent, LXM_TURN, '/api/battle/turn', { battleId, turn, command });
+}
+
+/** 権威 GameState を読む (表示用: パワー/XP/素材/位置)。GET だが lxm 付き JWT で本人確認。 */
+export async function serverState(agent: Agent): Promise<ServerStateResult> {
+  if (!EDGE_URL || !EDGE_DID) throw new WorldServerError('サーバー権威 API 未設定', 0, 'not_configured');
+  const token = await serviceToken(agent, LXM_STATE);
+  const res = await fetch(`${EDGE_URL}/api/me/state`, { headers: { authorization: `Bearer ${token}` } });
+  const data = (await res.json().catch(() => ({}))) as ServerStateResult & { error?: string };
+  if (!res.ok) throw new WorldServerError(data.error ?? `edge ${res.status}`, res.status, data.error);
+  return data;
 }

--- a/apps/web/src/lib/world-server.ts
+++ b/apps/web/src/lib/world-server.ts
@@ -25,6 +25,10 @@ export class WorldServerError extends Error {
   }
 }
 
+/** edge への 1 リクエストのタイムアウト (ms)。応答が返らずハングしても busy が永久固着しないよう、
+ *  必ず fail-closed で throw させる (通信断/無応答でも報酬は付かない・クライアント権威にフォールバックしない)。 */
+const EDGE_TIMEOUT_MS = 8000;
+
 /** service auth JWT を lxm ごとにキャッシュ (毎アクション PDS 往復を避ける。exp 30s 前まで再利用)。 */
 const tokenCache = new Map<string, { token: string; exp: number }>();
 
@@ -44,13 +48,22 @@ async function serviceToken(agent: Agent, lxm: string): Promise<string> {
 async function callEdge<T>(agent: Agent, lxm: string, path: string, body: unknown): Promise<T> {
   if (!EDGE_URL || !EDGE_DID) throw new WorldServerError('サーバー権威 API 未設定', 0, 'not_configured');
   const token = await serviceToken(agent, lxm);
-  const res = await fetch(`${EDGE_URL}${path}`, {
-    method: 'POST',
-    headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
-    body: JSON.stringify(body),
-  });
+  let res: Response;
+  try {
+    res = await fetch(`${EDGE_URL}${path}`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(EDGE_TIMEOUT_MS),
+    });
+  } catch (e) {
+    // タイムアウト/通信断 = fail-closed (報酬なし)。status 0 で catch 側が busy を必ず解除できるようにする。
+    const timedOut = e instanceof DOMException && (e.name === 'TimeoutError' || e.name === 'AbortError');
+    throw new WorldServerError(timedOut ? 'サーバーが応答しません' : '通信に失敗しました', 0, timedOut ? 'timeout' : 'network');
+  }
   const data = (await res.json().catch(() => ({}))) as T & { error?: string; message?: string; reason?: string };
   if (!res.ok) {
+    if (res.status === 401) tokenCache.delete(lxm); // 失効トークンを捨てて次アクションで再取得 (401 ループ回避)
     throw new WorldServerError(data.message ?? data.reason ?? data.error ?? `edge ${res.status}`, res.status, data.error);
   }
   return data as T;
@@ -81,8 +94,17 @@ export function serverTurn(agent: Agent, battleId: string, turn: number, command
 export async function serverState(agent: Agent): Promise<ServerStateResult> {
   if (!EDGE_URL || !EDGE_DID) throw new WorldServerError('サーバー権威 API 未設定', 0, 'not_configured');
   const token = await serviceToken(agent, LXM_STATE);
-  const res = await fetch(`${EDGE_URL}/api/me/state`, { headers: { authorization: `Bearer ${token}` } });
+  let res: Response;
+  try {
+    res = await fetch(`${EDGE_URL}/api/me/state`, { headers: { authorization: `Bearer ${token}` }, signal: AbortSignal.timeout(EDGE_TIMEOUT_MS) });
+  } catch (e) {
+    const timedOut = e instanceof DOMException && (e.name === 'TimeoutError' || e.name === 'AbortError');
+    throw new WorldServerError(timedOut ? 'サーバーが応答しません' : '通信に失敗しました', 0, timedOut ? 'timeout' : 'network');
+  }
   const data = (await res.json().catch(() => ({}))) as ServerStateResult & { error?: string };
-  if (!res.ok) throw new WorldServerError(data.error ?? `edge ${res.status}`, res.status, data.error);
+  if (!res.ok) {
+    if (res.status === 401) tokenCache.delete(LXM_STATE);
+    throw new WorldServerError(data.error ?? `edge ${res.status}`, res.status, data.error);
+  }
   return data;
 }

--- a/apps/web/src/lib/world-server.ts
+++ b/apps/web/src/lib/world-server.ts
@@ -1,0 +1,74 @@
+/**
+ * あおぞらワールドのサーバー権威 API クライアント — docs/21 §5。
+ *
+ * **移動も攻撃も毎回 edge Worker が権威処理する**ためのクライアント側呼び出し。ユーザー自身の
+ * service auth JWT (aud=edge Worker) を発行して edge に渡す。edge が本人確認 → 権威 state を読み書き
+ * → 結果を返す。**クライアントは結果を描画するだけで、権威データ (パワー/XP/素材/位置) を自分の PDS
+ * に書かない** = 改造してもチートできない。
+ */
+import type { Agent } from '@atproto/api';
+
+const EDGE_URL = (import.meta.env.VITE_EDGE_URL as string | undefined)?.trim();
+const EDGE_DID = (import.meta.env.VITE_EDGE_DID as string | undefined)?.trim();
+
+const LXM_MOVE = 'app.aozoraquest.world.move';
+const LXM_TURN = 'app.aozoraquest.battle.turn';
+
+/** edge URL / DID が設定されていればサーバー権威モードを使える。 */
+export const worldServerEnabled = Boolean(EDGE_URL && EDGE_DID);
+
+/** サーバー権威エンドポイントのエラー (status 付き。503=書込不能で報酬なし fail-closed 等)。 */
+export class WorldServerError extends Error {
+  constructor(message: string, readonly status: number, readonly code?: string) {
+    super(message);
+  }
+}
+
+/** service auth JWT を lxm ごとにキャッシュ (毎アクション PDS 往復を避ける。exp 30s 前まで再利用)。 */
+const tokenCache = new Map<string, { token: string; exp: number }>();
+
+async function serviceToken(agent: Agent, lxm: string): Promise<string> {
+  const nowSec = Date.now() / 1000;
+  const cached = tokenCache.get(lxm);
+  if (cached && cached.exp - 30 > nowSec) return cached.token;
+  const { data } = await agent.com.atproto.server.getServiceAuth({ aud: EDGE_DID!, lxm });
+  let exp = nowSec + 60;
+  try {
+    exp = (JSON.parse(atob(data.token.split('.')[1]!)) as { exp?: number }).exp ?? exp;
+  } catch { /* exp 取れなければ 60s 後 */ }
+  tokenCache.set(lxm, { token: data.token, exp });
+  return data.token;
+}
+
+async function callEdge<T>(agent: Agent, lxm: string, path: string, body: unknown): Promise<T> {
+  if (!EDGE_URL || !EDGE_DID) throw new WorldServerError('サーバー権威 API 未設定', 0, 'not_configured');
+  const token = await serviceToken(agent, lxm);
+  const res = await fetch(`${EDGE_URL}${path}`, {
+    method: 'POST',
+    headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const data = (await res.json().catch(() => ({}))) as T & { error?: string; message?: string; reason?: string };
+  if (!res.ok) {
+    throw new WorldServerError(data.message ?? data.reason ?? data.error ?? `edge ${res.status}`, res.status, data.error);
+  }
+  return data as T;
+}
+
+// ── DTO (edge の返り値。seed は含まれない = 先読み不可) ──
+export interface ServerMonster { name: string; maxHp: number; hp: number; maxMp: number; mp: number; [k: string]: unknown }
+export interface ServerBattleState { player: ServerMonster; monster: ServerMonster; monsterId: string; outcome: string; turn: number; lastEvents: { actor: string; text: string }[]; [k: string]: unknown }
+export interface ServerEncounter { battleId: string; monsterId: string; state: ServerBattleState; rewarded: boolean }
+export interface ServerMoveResult { x: number; y: number; terrain: string; encounter?: ServerEncounter }
+export interface ServerAward { xp?: number; drops?: string[]; materialsLost?: string[]; powerSpent?: number }
+export interface ServerTurnResult { state: ServerBattleState; events: { actor: string; text: string }[]; outcome: string; awarded?: ServerAward }
+
+/** 移動: 隣接1マス (dx,dy ∈ {-1,0,1})。位置更新 + 遭遇判定はサーバー。 */
+export function serverMove(agent: Agent, dx: number, dy: number): Promise<ServerMoveResult> {
+  return callEdge<ServerMoveResult>(agent, LXM_MOVE, '/api/world/move', { dx, dy });
+}
+
+/** 攻撃 (1ターン): battleId + turn + command。解決 + 決着報酬はサーバー。 */
+export function serverTurn(agent: Agent, battleId: string, turn: number, command: string): Promise<ServerTurnResult> {
+  return callEdge<ServerTurnResult>(agent, LXM_TURN, '/api/battle/turn', { battleId, turn, command });
+}

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -190,6 +190,9 @@ export function World() {
     awarded?: ServerAward;
     /** result フェーズで出す報酬行 (経験値・素材など) */
     resultLines?: readonly string[];
+    /** コマンド送信失敗 (503/409/通信断) をバトル画面内に表示する一行。notice は戦闘中は
+     *  描画されない (戦闘オーバーレイの外) ので、fail-closed のエラーはここに出す。 */
+    errorText?: string;
   } | null>(null);
   /** エンカウント演出 (DQ1 風ワイプ)。cover 中はマップの上でタイルが閉じ、覆い切ったら
    *  バトル画面に差し替えて reveal で開く。支払い通信が長い場合は hold でつなぐ。 */
@@ -428,8 +431,11 @@ export function World() {
             setWipe('cover');
           }
         } catch (e) {
-          if (e instanceof WorldServerError && e.status === 409) setNotice('戦闘中は移動できない。');
+          // 409 は「戦闘中」だけでなく未診断 (診断が先に必要) もあるので code で出し分ける。
+          if (e instanceof WorldServerError && e.code === 'diagnosis_required') setNotice('先に 気質診断が ひつようだ。');
+          else if (e instanceof WorldServerError && e.status === 409) setNotice('戦闘中は移動できない。');
           else if (e instanceof WorldServerError && e.status === 400) setNotice('そっちには進めない!');
+          else if (e instanceof WorldServerError && (e.code === 'timeout' || e.code === 'network')) setNotice('サーバーが応答しない。すこし まってから もう一度。');
           else { console.warn('[world] serverMove failed', e); setNotice('移動できなかった (通信エラー)。'); }
         } finally {
           moveBusyRef.current = false;
@@ -446,27 +452,30 @@ export function World() {
     (command: Command) => {
       const b = battleRef.current;
       if (!b || b.busy || b.phase !== 'input') return;
-      if (!agent) { setNotice('サーバーに接続できないため戦えない。'); return; }
-      const busy = { ...b, busy: true };
+      if (!agent) { setBattle({ ...b, errorText: 'サーバーに接続できず 戦えない。' }); return; }
+      const { errorText: _clear, ...bClean } = b; // 再送時は前回エラーを消す (exactOptional のため省略で落とす)
+      const busy = { ...bClean, busy: true };
       battleRef.current = busy;
       setBattle(busy);
       void (async () => {
         try {
           const res = await serverTurn(agent, b.battleId, b.state.turn, command);
-          const acting = { ...b, state: asBattleState(res.state), phase: 'message' as BattlePhase, busy: false, ...(res.awarded ? { awarded: res.awarded } : {}) };
+          const acting = { ...bClean, state: asBattleState(res.state), phase: 'message' as BattlePhase, busy: false, ...(res.awarded ? { awarded: res.awarded } : {}) };
           battleRef.current = acting;
           setBattle(acting);
         } catch (e) {
           // 失敗しても**クライアント側で報酬を付けない** (fail-closed。busy を戻して再送させる)。
+          // エラーは戦闘オーバーレイ内に出す (notice は戦闘中は描画されない = 無言失敗になる)。
           const cur = battleRef.current;
-          if (cur) {
-            const revert = { ...cur, busy: false };
-            battleRef.current = revert;
-            setBattle(revert);
-          }
-          if (e instanceof WorldServerError && e.status === 503) setNotice('サーバーに記録できなかった (報酬なし)。でんぱのよい ばしょで もう一度どうぞ。');
-          else if (e instanceof WorldServerError && e.status === 409) setNotice('ターンが ずれた。もう一度どうぞ。');
-          else { console.warn('[world] serverTurn failed', e); setNotice('こうげきを 送れなかった (通信エラー)。'); }
+          if (!cur) return;
+          let errorText = 'こうげきを 送れなかった (通信エラー)。もう一度どうぞ。';
+          if (e instanceof WorldServerError && e.status === 503) errorText = 'サーバーに記録できなかった (報酬なし)。でんぱのよい ばしょで もう一度どうぞ。';
+          else if (e instanceof WorldServerError && e.status === 409) errorText = 'ターンが ずれた。もう一度どうぞ。';
+          else if (e instanceof WorldServerError && (e.code === 'timeout' || e.code === 'network')) errorText = 'サーバーが応答しない。でんぱのよい ばしょで もう一度どうぞ。';
+          else console.warn('[world] serverTurn failed', e);
+          const revert = { ...cur, busy: false, errorText };
+          battleRef.current = revert;
+          setBattle(revert);
         }
       })();
     },
@@ -1041,6 +1050,12 @@ export function World() {
                 onCommand={onBattleCommand}
                 onAdvance={() => void onMessageAdvance()}
               />
+              {/* コマンド送信失敗 (fail-closed = 報酬なし) を戦闘画面内に表示。notice はここには出ない。 */}
+              {battle.errorText && (
+                <p aria-live="assertive" style={{ textAlign: 'center', fontSize: '0.8em', color: 'var(--color-danger, #ff6b6b)', margin: '0.4em 0 0' }}>
+                  {battle.errorText}
+                </p>
+              )}
             </div>
           )}
         </div>

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -4,14 +4,10 @@ import type { BattleState, Command, DiagnosisResult } from '@aozoraquest/core';
 import {
   tierForDanger,
   BATTLE_TUNING,
-  battleXpFor,
   canSeeEnemyVitals,
   ITEMS,
-  jobDisplayName,
-  levelUpGains,
   townShopStock,
   type EquipmentDef,
-  encounterRateFor,
   favoredMonsterFor,
   isWalkable,
   jobLevelFromXp,
@@ -21,12 +17,8 @@ import {
   regionDanger,
   regionOf,
   regionsAround,
-  resolveTurn,
-  rollDefeatLoss,
-  rollDrops,
   rollSearch,
   SEARCH_TUNING,
-  startBattle,
   statVectorToArray,
   terrainAt,
   tileDetailAt,
@@ -38,9 +30,9 @@ import { useSession } from '@/lib/session';
 import { getRecord } from '@/lib/atproto';
 import { COL } from '@/lib/collections';
 import { loadWorldState, saveWorldState } from '@/lib/world-state';
-import { awardBattleXp, finishBattleRecord, loadBattleStats, startBattleRecord } from '@/lib/battle-log';
-import { notifyLevelUp } from '@/components/level-up-overlay';
+import { loadBattleStats } from '@/lib/battle-log';
 import { bumpPower, loadPointsState, type PointsState } from '@/lib/points';
+import { serverMove, serverTurn, worldServerEnabled, WorldServerError, type ServerBattleState, type ServerAward } from '@/lib/world-server';
 import { craftItem, forgeItems, loadCraftInventory, newCraftRkey, newForgeRkey, newSaleRkey, sellMaterials, type CraftedPiece } from '@/lib/crafting';
 import { ShopModal, type LastShopAction } from '@/components/shop-modal';
 import { GearModal } from '@/components/gear-modal';
@@ -85,6 +77,9 @@ const DIRS: Record<Dir, { dx: number; dy: number }> = {
 };
 
 const DANGER_LABELS = ['おだやか', 'すこし危険', '危険', 'とても危険'] as const;
+
+/** サーバーの ServerBattleState を描画用 BattleState として扱う (seed は実行時に存在しない = UI 未使用)。 */
+const asBattleState = (s: ServerBattleState): BattleState => s as unknown as BattleState;
 
 interface Vitals {
   x: number;
@@ -183,15 +178,16 @@ export function World() {
   const featherDestRef = useRef<{ x: number; y: number } | null>(null);
   const [points, setPoints] = useState<PointsState | null>(null);
   const [battle, setBattle] = useState<{
+    /** サーバー権威の戦闘 state (seed は含まれない = 先読み不可)。描画のみに使う。 */
     state: BattleState;
     busy: boolean;
     /** DQ 風の交互表示。message=メッセージ窓 / input=コマンド入力 / result=決着後の報酬メッセージ
      *  (別パネルを出さず同じ固定サイズのメッセージ窓に畳む = 枠が伸縮せず敵の位置も動かない) */
     phase: BattlePhase;
-    rkey: string;
-    tier: 1 | 2 | 3;
-    /** 敗北した場合に落とす素材 (開戦時に seed から確定済み) */
-    materialsLost: string[];
+    /** サーバーが採番した戦闘 ID (ターン送信に必須)。 */
+    battleId: string;
+    /** 決着ターンでサーバーが確定した報酬 (result フェーズの表示に使う)。 */
+    awarded?: ServerAward;
     /** result フェーズで出す報酬行 (経験値・素材など) */
     resultLines?: readonly string[];
   } | null>(null);
@@ -370,161 +366,111 @@ export function World() {
   battleRef.current = battle;
   const pointsRef = useRef(points);
   pointsRef.current = points;
-  const resolvedGearRef = useRef(resolvedGear);
-  resolvedGearRef.current = resolvedGear;
   const combatRef = useRef(combat);
   combatRef.current = combat;
-  const diagRef = useRef(diag);
-  diagRef.current = diag;
   const wipeRef = useRef(wipe);
   wipeRef.current = wipe;
+  /** 移動中フラグ。移動は毎回サーバー往復するので、連打で並行 serverMove が飛ばないよう塞ぐ。 */
+  const moveBusyRef = useRef(false);
 
+  // 移動は**毎回サーバー (edge Worker) が権威処理する** (docs/21 §5)。クライアントは方向 (隣接1マス)
+  // しか送れず、位置も遭遇有無も tier も報酬もサーバーが決める = 改造してもチートできない。
+  // クライアント側は結果を描画するだけ (街のかけら/訪問済みは表示用の探索メモなので client 保存)。
   const move = useCallback(
     (dir: Dir) => {
       const s = wsRef.current;
-      // 戦闘中・リザルト表示中・地図表示中・ワイプ演出中は移動不可。
-      // wipe ガードが必要なのは そらのはね帰還が「wipe あり・battle なし」状態を
-      // 作るため — キャプチャ済みスティックの interval はイベント非依存で、
-      // cover 中も歩けてしまい、テレポート直後に戦闘が開く / featherDestRef が
-      // 残留して次のエンカウントをハイジャックする (レビュー指摘)。
-      // move() 冒頭で塞ぐことでキーボード・スティック・AT ボタン全経路を一括ガード
+      // 戦闘中・リザルト表示中・地図表示中・ワイプ演出中は移動不可 (全入力経路を一括ガード)。
       if (!s || battleRef.current || mapOpenRef.current || shopOpenRef.current || gearOpenRef.current || wipeRef.current || onboardingRef.current || statusOpenRef.current || menuOpenRef.current || itemsOpenRef.current || invOpenRef.current || searchMsgRef.current || featherOpenRef.current || starterMsgRef.current) return;
+      if (moveBusyRef.current) return; // 直前の移動がサーバー往復中 (連打の並行実行を塞ぐ)
+      if (!worldServerEnabled || !agent) { setNotice('サーバーに接続できないため移動できない。'); return; }
       const { dx, dy } = DIRS[dir];
+      // 即時フィードバック用のローカル先読み (権威はサーバー。壁ドンだけ即返す)。
       const nx = wrap(s.x + dx);
       const ny = wrap(s.y + dy);
-      const terrain = terrainAt(nx, ny);
-      if (!isWalkable(terrain)) {
+      if (!isWalkable(terrainAt(nx, ny))) {
         setNotice('そっちには進めない!');
-        return; // 位置不変なので保存もしない
+        return;
       }
-      // 街に入ったら全回復 + 「最後に立ち寄った街」を更新 (敗北時の帰還先)
-      if (terrain === 'town') {
-        const t = townAt(nx, ny);
-        // ちずのかけら: 街に入るとその街の地方一帯 (3×3 リージョン) が地図に加わる
-        const around = regionsAround(regionOf(nx, ny));
-        const gained = around.some((r) => !s.regions.includes(r));
-        const regions = gained ? [...new Set([...s.regions, ...around])].sort((a, b) => a - b) : s.regions;
-        // 訪問済みの街に追加 (そらのはねの行き先候補。重複しない)
-        const newlyVisited = !s.visitedTowns.some((v) => v.x === nx && v.y === ny);
-        const visitedTowns = newlyVisited ? [...s.visitedTowns, { x: nx, y: ny }] : s.visitedTowns;
-        setNotice(
-          t
-            ? `「${t.name}」で休んで、すっかり元気になった!${gained ? ' ちずのかけらを 手に入れた!' : ''}`
-            : null,
-        );
-        // wsRef を即時更新 (長押し連打で render 前の tick が同座標から二重計算しないように)
-        wsRef.current = { x: nx, y: ny, hp: null, mp: null, lastTown: { x: nx, y: ny }, regions, visitedTowns, gotStarterFeather: s.gotStarterFeather };
-        setWs(wsRef.current);
-        scheduleSave();
-        // かけら入手/初訪問は離散イベントなのでデバウンスを待たず即時にも保存する
-        // (通知を見た直後のリロードで入手が消えない。二重保存は同内容の put で無害)
-        if ((gained || newlyVisited) && agent) void saveWorldState(agent, wsRef.current);
-        return; // 街では遭遇しない
-      }
-      setNotice(null);
-      wsRef.current = { ...s, x: nx, y: ny };
-      setWs(wsRef.current);
-      scheduleSave();
-      // 野外遭遇 (遭遇判定はプレビュー: Math.random。PR-W3 で Worker の署名付き seed に)。
-      // 1 戦 = パワー 1 消費 + 戦闘レコード (試練と同じ機構)。パワー不足なら遭遇しない
-      // (= 散歩だけならタダ。無料戦闘で報酬だけ稼げる穴を作らない)。
-      const d = diag;
-      const pts = pointsRef.current;
-      if (!agent || !did || !d || !pts || pts.balance < BATTLE_TUNING.powerCost) return;
-      if (Math.random() < encounterRateFor(terrain)) {
-        const danger = regionDanger(regionOf(nx, ny));
-        const tier = tierForDanger(danger);
-        const seed = Math.floor(Math.random() * 0xffffffff) >>> 0;
-        const jobLv = jobLevelFromXp(d.jobLevel?.xp ?? 0);
-        const playerLv = playerLevelFromXp(d.playerLevel?.xp ?? 0);
-        const herbs = Math.min(BATTLE_TUNING.herbCarryMax, herbStock);
-        const tonics = Math.min(BATTLE_TUNING.tonicCarryMax, tonicStock);
-        const cHp = wsRef.current?.hp;
-        const cMp = wsRef.current?.mp;
-        const state = startBattle(
-          d.archetype,
-          jobLv,
-          playerLv,
-          session.handle?.split('.')[0] ?? 'あなた',
-          tier,
-          seed,
-          herbs,
-          // フィールドの現在 HP/MP を引き継ぐ (戦闘をまたいで持続)
-          { ...(cHp !== null && cHp !== undefined ? { hp: cHp } : {}), ...(cMp !== null && cMp !== undefined ? { mp: cMp } : {}) },
-          {
-            tonics,
-            ...(d.rpgStats ? { baseStats: statVectorToArray(d.rpgStats) } : {}),
-            ...(resolvedGearRef.current ? { gear: resolvedGearRef.current.selection } : {}),
-            // 地域の相性: その地方で出やすいモンスターの型を偏らせる (顔ぶれ・素材が変わる)
-            affinity: regionAffinity(regionOf(nx, ny)),
-            // 敵 HP/MP に遭遇ごとの分散 (値を覚えられないように = 予想させる。world のみ)
-            vitalsVariance: BATTLE_TUNING.monsterVitalsVariance,
-          },
-        );
-        // 敗北ペナルティの素材ロスを開戦時に確定 (seed から決定的)。持ち込み分の
-        // 消耗品は母集団から除外 (herbsUsed/tonicsUsed と二重減算しないように)。
-        // 仮レコードに書いておくことで「負けそうになったら閉じる」でもペナルティが効く
-        const lossPool = { ...materialsRef.current };
-        const subtractPool = (id: string, n: number) => {
-          if (!n) return;
-          const left = Math.max(0, (lossPool[id] ?? 0) - n);
-          if (left > 0) lossPool[id] = left;
-          else delete lossPool[id];
-        };
-        subtractPool('herb', herbs);
-        subtractPool('sky-dew', tonics);
-        const materialsLost = rollDefeatLoss(lossPool, state.player.luk, seed);
-        // 遭遇成立: ワイプ演出でマップを覆いながら支払いを進める (busy = コマンド不可)。
-        // battleRef は即時更新して長押し連打の次 tick が移動 + 二重遭遇しないようにする。
-        // 開幕は「あらわれた！」メッセージから (DQ 風)。支払い中は busy でタップ送りを止める。
-        const pending = { state, busy: true, phase: 'message' as BattlePhase, rkey: '', tier, materialsLost };
-        battleRef.current = pending;
-        setBattle(pending);
-        setWipe('cover');
-        void (async () => {
-          try {
-            // 支払い + 仮レコード (途中離脱 = 棄権 = 敗北)。失敗したら遭遇なしに戻す。
-            const rkey = await startBattleRecord(agent, { seed, tier, monsterId: state.monsterId, materialsLost, source: 'world' });
-            void bumpPower(agent, did, { battles: 1 });
-            setPoints((p) => (p ? { ...p, battles: p.battles + 1, balance: p.balance - BATTLE_TUNING.powerCost } : p));
-            setBattle((b) => {
-              if (!(b && b.state.seed === seed)) return b;
-              // battleRef も即時更新 (onCoverDone のタイマーが render flush 前に
-              // 発火しても準備完了を読めるように。pending 生成時と同じ流儀)
-              const ready = { ...b, rkey, busy: false };
-              battleRef.current = ready;
-              return ready;
-            });
-            // 覆い切って待機中 (hold) なら開く。cover 中なら onCoverDone 側が拾う。
-            setWipe((w) => (w === 'hold' ? 'reveal' : w));
-          } catch (e) {
-            console.warn('[world] field battle start failed', e);
-            setNotice('モンスターの気配がしたが、見失った… (通信エラー)');
-            setBattle((b) => (b && b.state.seed === seed ? null : b));
-            // マップに向かって開き直す (注: CSS の都合で「いったん全面黒に跳んでから
-            // 開く」見え方になる。稀な経路なので許容 — レビュー確認済み)
-            setWipe((w) => (w ? 'reveal' : w));
+      moveBusyRef.current = true;
+      void (async () => {
+        try {
+          const res = await serverMove(agent, dx, dy);
+          const cur = wsRef.current ?? s;
+          const t = townAt(res.x, res.y);
+          let next: Vitals = { ...cur, x: res.x, y: res.y };
+          if (res.healed) { next.hp = null; next.mp = null; }
+          if (res.terrain === 'town') {
+            // ちずのかけら: 街に入るとその街の地方一帯 (3×3 リージョン) が地図に加わる。
+            // 訪問済みの街 (そらのはねの行き先候補) も積む。どちらも表示用の探索メモ。
+            const around = regionsAround(regionOf(res.x, res.y));
+            const gained = around.some((r) => !cur.regions.includes(r));
+            const regions = gained ? [...new Set([...cur.regions, ...around])].sort((a, b) => a - b) : cur.regions;
+            const newlyVisited = !cur.visitedTowns.some((v) => v.x === res.x && v.y === res.y);
+            const visitedTowns = newlyVisited ? [...cur.visitedTowns, { x: res.x, y: res.y }] : cur.visitedTowns;
+            next = { ...next, hp: null, mp: null, lastTown: { x: res.x, y: res.y }, regions, visitedTowns };
+            setNotice(t ? `「${t.name}」で休んで、すっかり元気になった!${gained ? ' ちずのかけらを 手に入れた!' : ''}` : null);
+            wsRef.current = next;
+            setWs(next);
+            scheduleSave();
+            // 離散イベント (かけら/初訪問) はデバウンスを待たず即時にも保存する
+            if ((gained || newlyVisited) && agent) void saveWorldState(agent, next);
+          } else {
+            setNotice(null);
+            wsRef.current = next;
+            setWs(next);
+            scheduleSave();
           }
-        })();
-      }
+          // 遭遇: サーバーが封印済み (guard 作成・seed 非公開)。ワイプで覆ってからバトルへ。
+          if (res.encounter) {
+            const pending = { state: asBattleState(res.encounter.state), busy: false, phase: 'message' as BattlePhase, battleId: res.encounter.battleId };
+            battleRef.current = pending;
+            setBattle(pending);
+            setWipe('cover');
+          }
+        } catch (e) {
+          if (e instanceof WorldServerError && e.status === 409) setNotice('戦闘中は移動できない。');
+          else if (e instanceof WorldServerError && e.status === 400) setNotice('そっちには進めない!');
+          else { console.warn('[world] serverMove failed', e); setNotice('移動できなかった (通信エラー)。'); }
+        } finally {
+          moveBusyRef.current = false;
+        }
+      })();
     },
-    [scheduleSave, diag, session.handle, herbStock, tonicStock, agent, did],
+    [scheduleSave, agent],
   );
 
-  // 戦闘コマンド (戦闘解決はクライアント。W3/W4 でサーバー権威に置換)
-  // コマンド選択 → ターン解決 → メッセージ窓へ (コマンドを消す)。決着処理はタップ送り
-  // (onMessageAdvance) 側で行う (DQ 風: 「〜のダメージ！」を読んでから結果に進む)。
+  // 戦闘コマンドも**毎回サーバーが解決する** (docs/21 §5)。クライアントは battleId + turn + command を送るだけ。
+  // 決着ターンの報酬 (XP/ドロップ/素材ロス) はサーバーが権威 state に確定し、awarded として返す。
+  // タップ送り (onMessageAdvance) で「〜のダメージ！」を読んでから結果へ進む (DQ 風)。
   const onBattleCommand = useCallback(
     (command: Command) => {
       const b = battleRef.current;
       if (!b || b.busy || b.phase !== 'input') return;
-      const next = resolveTurn(b.state, command);
-      // battleRef も同期更新 (同一フレームの二重発火防止。move() と同じ流儀)
-      const acting = { ...b, state: next, phase: 'message' as BattlePhase };
-      battleRef.current = acting;
-      setBattle(acting);
+      if (!agent) { setNotice('サーバーに接続できないため戦えない。'); return; }
+      const busy = { ...b, busy: true };
+      battleRef.current = busy;
+      setBattle(busy);
+      void (async () => {
+        try {
+          const res = await serverTurn(agent, b.battleId, b.state.turn, command);
+          const acting = { ...b, state: asBattleState(res.state), phase: 'message' as BattlePhase, busy: false, ...(res.awarded ? { awarded: res.awarded } : {}) };
+          battleRef.current = acting;
+          setBattle(acting);
+        } catch (e) {
+          // 失敗しても**クライアント側で報酬を付けない** (fail-closed。busy を戻して再送させる)。
+          const cur = battleRef.current;
+          if (cur) {
+            const revert = { ...cur, busy: false };
+            battleRef.current = revert;
+            setBattle(revert);
+          }
+          if (e instanceof WorldServerError && e.status === 503) setNotice('サーバーに記録できなかった (報酬なし)。でんぱのよい ばしょで もう一度どうぞ。');
+          else if (e instanceof WorldServerError && e.status === 409) setNotice('ターンが ずれた。もう一度どうぞ。');
+          else { console.warn('[world] serverTurn failed', e); setNotice('こうげきを 送れなかった (通信エラー)。'); }
+        }
+      })();
     },
-    [],
+    [agent],
   );
 
   // メッセージ窓のタップ送り。開幕/継戦は入力へ、決着は確定処理してリザルトへ。
@@ -550,155 +496,52 @@ export function World() {
         setBattle(back);
         return;
       }
-      // 決着: 以降は確定処理。二重発火を busy で塞ぐ (レコード確定/XP の二重実行防止)
-      const acting = { ...b, busy: true };
-      battleRef.current = acting;
-      setBattle(acting);
-      // 決着: レコード確定 + XP + ドロップ (試練と同じ)。逃走は XP もドロップも無し。
-      const drops = next.outcome === 'win' ? rollDrops(next.monsterId, next.player.luk, next.seed) : [];
-      const xp = next.outcome === 'win' ? battleXpFor(next.monsterId) : next.outcome === 'fled' ? 0 : BATTLE_TUNING.xpLose;
-      const lost = next.outcome === 'lose' ? b.materialsLost : [];
-      const record = {
-        seed: next.seed,
-        tier: b.tier,
-        monsterId: next.monsterId,
-        outcome: next.outcome,
-        turns: next.turn,
-        drops,
-        herbsUsed: next.herbsUsed,
-        tonicsUsed: next.tonicsUsed,
-        materialsLost: lost,
-      };
-      // 保存は 1 回リトライ。失敗したらリザルトで明示 (仮レコードが敗北のまま残る)。
-      // agent/did は通常この時点で必ず在る (遭遇成立に必須) が、稀にセッションが切れて
-      // いても詰ませない: 保存/XP をスキップして saveFailed 扱いで結果まで進める。
-      let saveFailed = false;
-      if (agent && did) {
-        try {
-          await finishBattleRecord(agent, b.rkey, record);
-        } catch {
-          try {
-            await finishBattleRecord(agent, b.rkey, record);
-          } catch (e) {
-            console.warn('[world] battle finish record failed (after retry)', e);
-            saveFailed = true;
-          }
-        }
-      } else {
-        saveFailed = true;
-      }
-      if (xp > 0 && agent && did) {
-        void awardBattleXp(agent, did, xp).then((ups) => {
-          if (!ups) return;
-          // ステータス上昇量は再取得前の diag (レベルアップ前の基準) から計算する
-          const d = diagRef.current;
-          const base = d?.rpgStats ? statVectorToArray(d.rpgStats) : undefined;
-          const arch = d?.archetype;
-          const jNow = jobLevelFromXp(d?.jobLevel?.xp ?? 0);
-          const pNow = playerLevelFromXp(d?.playerLevel?.xp ?? 0);
-          const jFrom = ups.job?.from ?? jNow;
-          const jTo = ups.job?.to ?? jNow;
-          const pFrom = ups.player?.from ?? pNow;
-          const pTo = ups.player?.to ?? pNow;
-          // 表示レベル (HP/MP バー分母・次戦の戦闘値) を追従させる。演出だけ出して
-          // maxHp が増えないと「LEVEL UP! なのに強くなってない」に見える (レビュー指摘)
-          void getRecord<DiagnosisResult>(agent, did, COL.analysis, 'self')
-            .then((nd) => { if (nd) setDiag(nd); })
-            .catch(() => {});
-          // 発火順は投稿フロー (compose-modal) と同じ job → player
-          if (ups.job) {
-            notifyLevelUp({
-              kind: 'job',
-              from: ups.job.from,
-              to: ups.job.to,
-              jobName: jobDisplayName(ups.job.archetype, 'default'),
-              ...(arch ? { gains: levelUpGains(arch, { jobLevel: jFrom, playerLevel: pFrom }, { jobLevel: jTo, playerLevel: pFrom }, base) } : {}),
-            });
-          }
-          if (ups.player) {
-            notifyLevelUp({
-              kind: 'player',
-              from: ups.player.from,
-              to: ups.player.to,
-              ...(arch ? { gains: levelUpGains(arch, { jobLevel: jTo, playerLevel: pFrom }, { jobLevel: jTo, playerLevel: pTo }, base) } : {}),
-            });
-          }
-          // レベルアップ/ステータス上昇は notifyLevelUp の演出で出す (報酬メッセージ窓
-          // には載せない = 情報量を減らす。旧: リザルトパネルに追記していた)
-        });
-      }
-      // 手持ちを更新: 使った分を引き、ドロップ分を足す。
-      // TODO(W3): 在庫の正は Worker (DO) に移す (フィールド使用分が記録されない併走は
-      // プレビュー限定の割り切り)。
-      const lostOf = (id: string) => lost.filter((x) => x === id).length;
-      setHerbStock((n) => Math.max(0, n - next.herbsUsed - lostOf('herb')) + drops.filter((x) => x === 'herb').length);
-      setTonicStock((n) => Math.max(0, n - next.tonicsUsed - lostOf('sky-dew')) + drops.filter((x) => x === 'sky-dew').length);
-      setFeatherStock((n) => Math.max(0, n - lostOf('sky-feather')) + drops.filter((x) => x === 'sky-feather').length);
-      // 素材全体の在庫 (敗北ロス抽選の母集団) も追随
-      {
-        const m = { ...materialsRef.current };
-        for (const d of drops) m[d] = (m[d] ?? 0) + 1;
-        const sub = (id: string, n: number) => {
-          if (!n) return;
-          const left = Math.max(0, (m[id] ?? 0) - n);
-          if (left > 0) m[id] = left;
-          else delete m[id];
-        };
-        sub('herb', next.herbsUsed);
-        sub('sky-dew', next.tonicsUsed);
-        for (const id of lost) sub(id, 1);
-        materialsRef.current = m;
-      }
-      let movedToTown: string | null = null;
+      // 決着: 報酬は**サーバーが権威 state に確定済み** (onBattleCommand の serverTurn が返した
+      // awarded)。ここではクライアント表示を更新するだけ = 一切 XP/パワー/素材を書かない (改造不可)。
+      const awarded = b.awarded ?? {};
+      const drops = awarded.drops ?? [];
+      const lost = awarded.materialsLost ?? [];
+      // HP/MP をフィールドに持ち帰る (持続)。敗北はサーバーが carry を消す = 全快なので null に。
+      // (注: サーバーは敗北で位置を街へ戻さない。街帰還は今後のサーバー実装課題。ここでは
+      //  その場で回復させ、次の serverMove がサーバー権威の位置を返す。)
       if (next.outcome === 'lose') {
-        // 敗北: 最後に立ち寄った街 (無ければはじまりの街) へ。宿で介抱 = 全快。
-        // lastTown はワールド再生成で街が動くと無効になりうるので townAt で検証し、
-        // 無効なら座標・名前とも spawn に倒す (レビュー指摘)。
-        const s = wsRef.current;
-        const spawn = worldOverlay().spawn;
-        const lt = s?.lastTown;
-        const valid = lt && townAt(lt.x, lt.y) ? lt : null;
-        const back = valid ?? { x: spawn.x, y: spawn.y };
-        movedToTown = townAt(back.x, back.y)?.name ?? spawn.name;
-        // 帰還先の街のかけらも入手 (「街に入るとかけら入手」の一貫性 — 移行プレイヤーが
-        // spawn へ敗北帰還したとき「介抱された街が地図にない」を防ぐ。レビュー指摘)
-        setWs({
-          x: back.x,
-          y: back.y,
-          hp: null,
-          mp: null,
-          lastTown: valid,
-          regions: [...new Set([...(s?.regions ?? []), ...regionsAround(regionOf(back.x, back.y))])].sort((a, b) => a - b),
-          // 介抱された街も行き先候補に (lastTown 更新経路は visitedTowns も積む)
-          visitedTowns: (s?.visitedTowns ?? []).some((v) => v.x === back.x && v.y === back.y)
-            ? (s?.visitedTowns ?? [])
-            : [...(s?.visitedTowns ?? []), { x: back.x, y: back.y }],
-          gotStarterFeather: s?.gotStarterFeather ?? true,
-        });
+        setWs((s) => (s ? { ...s, hp: null, mp: null } : s));
       } else {
-        // 勝利/引き分け/逃走: 減った HP/MP をフィールドに持ち帰る (持続)。
         // 満タンは null に正規化 (絶対値で焼くと後のレベルアップで「減って見える」)。
         const hp = next.player.hp >= next.player.maxHp ? null : Math.max(1, next.player.hp);
         const mp = next.player.mp >= next.player.maxMp ? null : next.player.mp;
         setWs((s) => (s ? { ...s, hp, mp } : s));
       }
       scheduleSave();
+      // クライアント在庫はサーバー報酬 (awarded) をミラーするだけ (表示用。正はサーバー state)。
+      // TODO: 在庫表示もサーバー state を正にする移行 (別 PR)。ここは UX を合わせる best-effort。
+      const countOf = (arr: readonly string[], id: string) => arr.filter((x) => x === id).length;
+      setHerbStock((n) => Math.max(0, n - countOf(lost, 'herb')) + countOf(drops, 'herb'));
+      setTonicStock((n) => Math.max(0, n - countOf(lost, 'sky-dew')) + countOf(drops, 'sky-dew'));
+      setFeatherStock((n) => Math.max(0, n - countOf(lost, 'sky-feather')) + countOf(drops, 'sky-feather'));
+      {
+        const m = { ...materialsRef.current };
+        for (const d of drops) m[d] = (m[d] ?? 0) + 1;
+        for (const id of lost) {
+          const left = Math.max(0, (m[id] ?? 0) - 1);
+          if (left > 0) m[id] = left;
+          else delete m[id];
+        }
+        materialsRef.current = m;
+      }
       // 報酬を「同じ固定サイズのメッセージ窓」に畳んで出す (別パネルを出すと枠が
-      // でかくなり認知負荷 — オーナー指摘)。レベルアップ/ステータス上昇は notifyLevelUp
-      // の演出が別に出るのでここには載せない (情報量を減らす)。resultLines が空になる
-      // のは実質「逃走 (fled = 経験値もドロップも無し)」のみ。その時は報酬メッセージを
-      // 出さず即マップへ戻す (引き分け draw は経験値 xpLose が出るので窓が出る)。
+      // でかくなり認知負荷 — オーナー指摘)。resultLines が空になるのは実質「逃走
+      // (fled = 経験値もドロップも無し)」のみ。その時は即マップへ戻す。
       const dropCounts = new Map<string, number>();
       for (const d of drops) dropCounts.set(d, (dropCounts.get(d) ?? 0) + 1);
       const lostCounts = new Map<string, number>();
       for (const d of lost) lostCounts.set(d, (lostCounts.get(d) ?? 0) + 1);
       const nameOf = (id: string) => ITEMS[id]?.name ?? id;
       const resultLines: string[] = [];
-      if (xp > 0) resultLines.push(`けいけんち を ${xp} かくとく！`);
+      if (awarded.xp && awarded.xp > 0) resultLines.push(`けいけんち を ${awarded.xp} かくとく！`);
       for (const [id, n] of dropCounts) resultLines.push(`${nameOf(id)}${n > 1 ? ` ×${n}` : ''} を てにいれた！`);
       for (const [id, n] of lostCounts) resultLines.push(`${nameOf(id)}${n > 1 ? ` ×${n}` : ''} を おとしてしまった…`);
-      if (movedToTown) resultLines.push(`きがつくと「${movedToTown}」で かいほうされていた…`);
-      if (saveFailed) resultLines.push('※ けっかの ほぞんに しっぱいした (つうしんエラー)。でんぱのよい ばしょで ひらきなおしてね。');
+      if (next.outcome === 'lose') resultLines.push('たおれてしまった… 気がつくと きずが いえていた。');
       if (resultLines.length === 0) {
         battleRef.current = null;
         setBattle(null);
@@ -708,7 +551,7 @@ export function World() {
         setBattle(done);
       }
     },
-    [scheduleSave, agent, did],
+    [scheduleSave],
   );
 
   // ワイプ演出の進行。覆い切った時点で支払いがまだ終わっていなければ hold でつなぐ
@@ -738,16 +581,14 @@ export function World() {
       setWipe('reveal');
       return;
     }
-    const b = battleRef.current;
-    setWipe(b && b.rkey === '' && b.busy ? 'hold' : 'reveal');
+    // エンカウントは serverMove が既に封印済み (battle は準備完了) なので覆い切ったら開くだけ。
+    setWipe('reveal');
   }, [scheduleSave]);
   const onRevealDone = useCallback(() => setWipe(null), []);
-  // hold の上限 (10s) 到達 = 支払い通信ハング。遭遇をキャンセルしてマップに開き直す
-  // (全面黒でリロード以外の脱出手段がなくなるのを防ぐ。レコードが後から成立していた
-  // 場合は棄権 = 敗北の既存セマンティクスに落ちる)。
+  // hold タイムアウト (通常は到達しない。serverMove は遭遇 state を同期で返すので hold に入らない)。
+  // 保険としてマップに開き直す。
   const onHoldTimeout = useCallback(() => {
     setNotice('通信が不安定でモンスターを見失った…');
-    setBattle((b) => (b && b.busy && b.rkey === '' ? null : b));
     setWipe('reveal');
   }, []);
 


### PR DESCRIPTION
## 目的
あおぞらワールド (2D マップ探索 + モンスター戦闘) を**サーバー権威化してチートできないようにする** (docs/21 §5, M3-part2)。
これまで戦闘・報酬・パワー・素材・XP はクライアントで計算し**ユーザー自身の PDS に書いていた = 偽造可能**だった。
本 PR で**移動も攻撃も毎回 edge Worker が権威処理**し、クライアント権威の書き込みを戦闘経路から全廃する。

## 変更点
### クライアント (`apps/web`)
- **`lib/world-server.ts` (新規)**: サーバー権威 API クライアント。`serverMove(dx,dy)` / `serverTurn(battleId,turn,command)` /
  `serverState()`。ユーザーの service auth JWT (aud=edge) を lxm ごとにキャッシュして edge に渡す。
- **`routes/world.tsx` 全面改修**: 移動は毎回 `serverMove`、攻撃は毎回 `serverTurn`。クライアントの
  `Math.random` 遭遇ロール / `startBattle` / `resolveTurn` / `startBattleRecord` / `finishBattleRecord` /
  `awardBattleXp` / `rollDrops` / `rollDefeatLoss` / `bumpPower`(戦闘) を撤去。結果はサーバーの `awarded` から表示。
  エラー時はクライアント側で**何も付与しない (fail-closed)**。

### サーバー (`apps/edge`)
- **`/api/world/move`・`/api/battle/turn`**: 位置更新・遭遇判定・戦闘解決・報酬確定をすべて Worker が権威処理。
  seed はクライアントに一切返さない (先読み防止)。報酬は readModifyWrite で fail-closed 確定 (トークン切れ=503・報酬なし)。
- **街回復をサーバー側に** (`handleMove`): 街に入ったら carryHp/Mp をクリア = HP 全回復。
- **`/api/me/state`**: トークン由来 repo (`readState`) から権威 state を読む。
- **初回 state の移行 (§6-4)**: `migrateInitState` がユーザー PDS の power 残高と分析 Lv を**上限クランプして取り込む**
  (取り込まないと power=0 → 報酬が一切出ず Lv1 で弱すぎる)。読取専用 fail-open。

## テスト
- edge 136 / web 339 green。world-server クライアント + migrateInitState + 既存 resolver テスト。
- typecheck (edge/web) green、web production build green。

## 既知の範囲・フォローアップ (レビュー前に明示)
1. **env 名前空間**: edge は `app.aozoraquest.analysis/gameState` を固定参照するが、client は dev で
   `app.aozoraquest.dev.*` に書く。現状 dev=owner で prod レコードを読めるため動くが、**リリース (M5) 前に
   dev/prod の権威 state 分離が必要** (origin ベース名前空間 or 別 edge deploy)。→ 別 issue 化候補。
2. **投稿/カード/召喚のパワーは M4 で権威化**: `bumpPower`(viaPosts/cardDraws/summoned) は本 PR 対象外で
   client 権威のまま (docs/21 §8 M4)。search/craft/sell も同様。
3. **敗北時の街帰還なし**: サーバーはその場回復 (x,y 不変)。街帰還はサーバー変更が要る (別スコープ)。
4. 移動は 1 歩ごとに 1 往復 (サーバー権威の本質)。moveBusyRef で直列化。

## Review
§1.5 の 3 並列 subagent レビュー (設計 / 実装 / UX) を実施。

**★★★ (PR 内で必ず修正) — 2 件、すべて対応済み (commit 0559634)**
- [UX] 戦闘コマンド失敗が戦闘中は不可視 (setNotice が戦闘オーバーレイ外) → 戦闘画面内に `errorText` を表示。
- [UX] move/turn の fetch にタイムアウトが無くハングで恒久ソフトロック → 8s タイムアウト (fail-closed で throw)。

**★★ (PR 内対応 or issue 化)**
- [設計] 負け決着に xpLose 欠落 (docs §5 と不整合) → **PR 内修正** (0559634、負けに xpLose 付与・draw は稼ぎ防止で無し)。
- [実装] handleTurn 報酬 RMW の init 欠如 (state 消失時 0 リセット) → **PR 内修正** (init=migrateInitState)。
- [設計] /api/me/state 未初期化が power=0/Lv1 表示割れ → **PR 内修正** (移行値を read-only で返す)。
- [UX] move 409 が未診断でも「戦闘中」表示 → **PR 内修正** (code=diagnosis_required で出し分け)。
- [設計] 移行 power クランプ 1000 が正当ユーザーを切り詰め → **PR 内修正** (100000 に緩和・根拠は commit)。
- [UX/実装] 表示のサーバー権威化 (serverState 未接続・レベルアップ演出消失・在庫ドリフト・型キャスト) → **issue #361**。
- [UX] サーバー権威移動の RTT 律速 (楽観的移動なし) → **issue #362**。
- [設計] dev/prod 名前空間分離・再移行二重取得・移行信頼方針 (M5) → **issue #363**。

**★ (対応 or issue)**
- [実装] 401 でトークンキャッシュ evict → **PR 内対応** (0559634)。
- その他 (serviceToken exp クランプ・busy スピナー等) は #361/#362 に内包 or 低優先で見送り。

edge 136 / web 341 tests green、typecheck (edge/web) green、web build green。