### PR TITLE
fix(session): restoreSession タイムアウトで無限「準備しています」を解消

### DIFF
--- a/apps/web/src/components/workspace.tsx
+++ b/apps/web/src/components/workspace.tsx
@@ -36,6 +36,7 @@ import { ComposeColumn } from '@/components/compose-modal';
 import { useComposePaneOpen, closeComposePane } from '@/lib/compose-pane';
 import { refreshQuestIndex } from '@/lib/quest-index-cache';
 import { invalidateProfile } from '@/lib/profile-cache';
+import { oauthDebugEnabled, dumpOAuthState } from '@/lib/oauth-debug';
 
 /** picker の表示位置: 'end' = 末尾タイル、数値 = そのカラムの直右 */
 type PickerAnchor = number | 'end' | null;
@@ -183,7 +184,22 @@ export function Workspace() {
   useEffect(() => () => closeComposePane(), []);
 
   if (session.status === 'loading') {
-    return <p>準備しています...</p>;
+    return (
+      <>
+        <p>準備しています...</p>
+        {oauthDebugEnabled && (
+          // dev のみ: 復元がハングして固まったとき、コンソール (CSP で eval 不可な端末) を使わずに
+          // OAuth 状態 (伏字) + 未捕捉エラーを JSON 保存するための診断ボタン。
+          <button
+            type="button"
+            onClick={() => void dumpOAuthState()}
+            style={{ marginTop: '2em', fontSize: '0.8em', opacity: 0.7 }}
+          >
+            🔧 診断ダンプを保存
+          </button>
+        )}
+      </>
+    );
   }
 
   if (session.status === 'signed-out') {

--- a/apps/web/src/lib/__tests__/session-timeout.test.ts
+++ b/apps/web/src/lib/__tests__/session-timeout.test.ts
@@ -67,4 +67,14 @@ describe('clearOAuthStorage (壊れた永続セッションの復旧)', () => {
     const { clearOAuthStorage } = await import('../oauth');
     await expect(clearOAuthStorage()).resolves.toBeUndefined();
   });
+
+  it('IDB が一切イベントを出さなくても 2s 保険で解決する (永久待ちしない)', async () => {
+    const del = vi.fn(() => ({} as unknown as IDBOpenDBRequest)); // ハンドラを一切呼ばない実装
+    vi.stubGlobal('indexedDB', { deleteDatabase: del } as unknown as IDBFactory);
+    const { clearOAuthStorage } = await import('../oauth');
+    vi.useFakeTimers();
+    const p = clearOAuthStorage();
+    await vi.advanceTimersByTimeAsync(2_000);
+    await expect(p).resolves.toBeUndefined();
+  });
 });

--- a/apps/web/src/lib/__tests__/session-timeout.test.ts
+++ b/apps/web/src/lib/__tests__/session-timeout.test.ts
@@ -4,6 +4,15 @@ import { withTimeout } from '../session';
 describe('withTimeout (warmup ハング対策)', () => {
   afterEach(() => vi.useRealTimers());
 
+  it('restore ラベルのハングは restore-timeout で reject (無限「準備しています」を防ぐ)', async () => {
+    vi.useFakeTimers();
+    const hang = new Promise<string>(() => {}); // 解決しない = 壊れたセッションの client.init()
+    const p = withTimeout(hang, 8_000, 'restore');
+    const assertion = expect(p).rejects.toThrow('restore-timeout');
+    await vi.advanceTimersByTimeAsync(8_000);
+    await assertion;
+  });
+
   it('期限内に解決すれば値を返す', async () => {
     await expect(withTimeout(Promise.resolve('ok'), 1000, 'warmup')).resolves.toBe('ok');
   });
@@ -27,5 +36,35 @@ describe('withTimeout (warmup ハング対策)', () => {
     await expect(p).resolves.toBe('done');
     // タイマーが残っていないこと (finally の clearTimeout)。進めても何も起きない。
     await vi.advanceTimersByTimeAsync(20_000);
+  });
+});
+
+describe('clearOAuthStorage (壊れた永続セッションの復旧)', () => {
+  afterEach(() => { vi.useRealTimers(); vi.unstubAllGlobals(); vi.resetModules(); });
+
+  it('IDB @atproto-oauth-client を削除する (onsuccess で解決)', async () => {
+    let opened: string | undefined;
+    const del = vi.fn((name: string) => {
+      opened = name;
+      const req: { onsuccess?: () => void; onerror?: () => void; onblocked?: () => void } = {};
+      queueMicrotask(() => req.onsuccess?.());
+      return req;
+    });
+    vi.stubGlobal('indexedDB', { deleteDatabase: del } as unknown as IDBFactory);
+    const { clearOAuthStorage } = await import('../oauth');
+    await clearOAuthStorage();
+    expect(del).toHaveBeenCalledOnce();
+    expect(opened).toBe('@atproto-oauth-client');
+  });
+
+  it('blocked (init が接続保持) でも待ち続けず解決する', async () => {
+    const del = vi.fn(() => {
+      const req: { onsuccess?: () => void; onerror?: () => void; onblocked?: () => void } = {};
+      queueMicrotask(() => req.onblocked?.()); // 接続保持で blocked
+      return req;
+    });
+    vi.stubGlobal('indexedDB', { deleteDatabase: del } as unknown as IDBFactory);
+    const { clearOAuthStorage } = await import('../oauth');
+    await expect(clearOAuthStorage()).resolves.toBeUndefined();
   });
 });

--- a/apps/web/src/lib/oauth-debug.ts
+++ b/apps/web/src/lib/oauth-debug.ts
@@ -12,6 +12,25 @@
  */
 const OAUTH_DB = '@atproto-oauth-client';
 
+/** 起動中に飛んだ未捕捉エラー (「Script error.」= cross-origin マスク含む) をためるリングバッファ。
+ *  console (Eruda) が CSP の unsafe-eval で使えない端末でも、ダンプ JSON に含めて拾えるようにする。 */
+interface CapturedError { kind: 'error' | 'unhandledrejection'; message?: string | undefined; source?: string | undefined; line?: number | undefined; col?: number | undefined; stack?: string | undefined; at: string }
+const errorLog: CapturedError[] = [];
+let errorHandlersInstalled = false;
+
+function installErrorCapture(): void {
+  if (errorHandlersInstalled || typeof window === 'undefined') return;
+  errorHandlersInstalled = true;
+  const push = (e: CapturedError) => { errorLog.push(e); if (errorLog.length > 50) errorLog.shift(); };
+  window.addEventListener('error', (ev) => {
+    push({ kind: 'error', message: ev.message, source: ev.filename, line: ev.lineno, col: ev.colno, stack: ev.error?.stack, at: new Date().toISOString() });
+  });
+  window.addEventListener('unhandledrejection', (ev) => {
+    const r = ev.reason as { message?: string; stack?: string } | undefined;
+    push({ kind: 'unhandledrejection', message: r?.message ?? String(ev.reason), stack: r?.stack, at: new Date().toISOString() });
+  });
+}
+
 /** 秘密になりうるキー名。値を伏字にする (構造は残す)。 */
 const SECRET_KEY = /(^d$)|token|secret|password|refresh|access|dpop|jwk|_jwt|privatekey|nonce|(^code$)/i;
 
@@ -85,6 +104,8 @@ export async function collectOAuthState(): Promise<Record<string, unknown>> {
   return {
     capturedAt: new Date().toISOString(),
     href: location.href,
+    userAgent: navigator.userAgent,
+    capturedErrors: errorLog.slice(),
     databases: dbNames?.map((d) => d.name),
     locks: {
       held: locks?.held?.map((l) => ({ name: l.name, mode: l.mode, clientId: l.clientId })),
@@ -95,8 +116,8 @@ export async function collectOAuthState(): Promise<Record<string, unknown>> {
   };
 }
 
-/** dev 専用: 収集 → コンソール出力 + JSON ダウンロード。固まっていてもコンソールから叩ける。 */
-async function dumpOAuthState(): Promise<Record<string, unknown>> {
+/** dev 専用: 収集 → コンソール出力 + JSON ダウンロード。固まっていてもボタン/コンソールから叩ける。 */
+export async function dumpOAuthState(): Promise<Record<string, unknown>> {
   const state = await collectOAuthState();
   console.warn('[oauth-debug] state dump (tokens redacted)', state);
   try {
@@ -113,10 +134,15 @@ async function dumpOAuthState(): Promise<Record<string, unknown>> {
   return state;
 }
 
-/** dev / dev 環境 / ローカルのみ `window.__aozoraDumpOAuth()` を生やす (本番では何もしない)。 */
+/** dev 環境か (この debug 機能を出す条件)。 */
+export const oauthDebugEnabled =
+  import.meta.env.DEV || (import.meta.env.VITE_NSID_ENV as string | undefined)?.trim() === 'dev';
+
+/** dev / dev 環境 / ローカルのみ: 未捕捉エラー捕捉を仕込み、`window.__aozoraDumpOAuth()` を生やす
+ *  (本番では何もしない)。エラー捕捉は session 復元より前に効かせたいので import 直後に呼ぶ。 */
 export function installOAuthDebug(): void {
-  const enabled = import.meta.env.DEV || (import.meta.env.VITE_NSID_ENV as string | undefined)?.trim() === 'dev';
-  if (!enabled || typeof window === 'undefined') return;
+  if (!oauthDebugEnabled || typeof window === 'undefined') return;
+  installErrorCapture();
   (window as unknown as { __aozoraDumpOAuth?: () => Promise<unknown> }).__aozoraDumpOAuth = dumpOAuthState;
-  console.info('[oauth-debug] 固まったら DevTools コンソールで __aozoraDumpOAuth() を実行するとOAuth状態(伏字)をJSON保存できます');
+  console.info('[oauth-debug] 固まったら「準備しています」画面の診断ボタン (または __aozoraDumpOAuth()) でOAuth状態(伏字)をJSON保存できます');
 }

--- a/apps/web/src/lib/oauth-debug.ts
+++ b/apps/web/src/lib/oauth-debug.ts
@@ -1,0 +1,122 @@
+/**
+ * 無限「準備しています」(restore/init ハング) の**根本原因を実機で確定する**ための dev 専用ダンプ。
+ *
+ * アプリがスプラッシュで固まっていても、ブラウザのコンソールで `__aozoraDumpOAuth()` を叩けば、
+ *   - IndexedDB `@atproto-oauth-client` の全レコード (**トークン/鍵は伏字**・構造/期限/sub は残す)
+ *   - `navigator.locks.query()` (= `@atproto-oauth-client-<sub>` の exclusive lock が held のままか)
+ *   - localStorage の @atproto 系キー (伏字)
+ * を 1 つの JSON にまとめて**ダウンロード**する (共有用)。lock が held なら詰まりは Web Locks 取得待ち、
+ * IDB のトークンが壊れていれば IDB 主因、と切り分けられる。読み取りのみ・副作用なし。
+ *
+ * **本番では登録しない** (dev / VITE_NSID_ENV=dev / ローカルのみ)。トークン実体は決してダンプしない。
+ */
+const OAUTH_DB = '@atproto-oauth-client';
+
+/** 秘密になりうるキー名。値を伏字にする (構造は残す)。 */
+const SECRET_KEY = /(^d$)|token|secret|password|refresh|access|dpop|jwk|_jwt|privatekey|nonce|(^code$)/i;
+
+/** 値を再帰的に伏字化。DID/URL/期限/scope 等の非秘密は残し、トークン・鍵・長い base64 だけ潰す。 */
+function redact(value: unknown, keyHint = ''): unknown {
+  if (typeof value === 'string') {
+    if (SECRET_KEY.test(keyHint)) return `<redacted:${value.length}>`;
+    if (value.length > 100) return `<long:${value.length}>`; // JWT/トークンは長い
+    return value;
+  }
+  if (Array.isArray(value)) return value.map((v) => redact(v, keyHint));
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) out[k] = redact(v, k);
+    return out;
+  }
+  return value;
+}
+
+/** IDB を read-only で開いて全 objectStore の全レコードを読む (init が接続を握っていても read は並行可)。 */
+async function readAllRecords(dbName: string): Promise<unknown> {
+  return await new Promise((resolve) => {
+    let settled = false;
+    const done = (v: unknown) => { if (!settled) { settled = true; resolve(v); } };
+    setTimeout(() => done({ error: 'open-timeout' }), 3_000); // ハングしても諦める
+    let req: IDBOpenDBRequest;
+    try {
+      req = indexedDB.open(dbName);
+    } catch (e) {
+      return done({ error: String(e) });
+    }
+    req.onerror = () => done({ error: 'open-error' });
+    req.onsuccess = () => {
+      const db = req.result;
+      const result: Record<string, unknown> = {};
+      const stores = Array.from(db.objectStoreNames);
+      if (stores.length === 0) { db.close(); return done({ stores: [], records: {} }); }
+      try {
+        const tx = db.transaction(stores, 'readonly');
+        let remaining = stores.length;
+        for (const name of stores) {
+          const getAll = tx.objectStore(name).getAll();
+          getAll.onsuccess = () => {
+            result[name] = redact(getAll.result);
+            if (--remaining === 0) { db.close(); done({ stores, records: result }); }
+          };
+          getAll.onerror = () => {
+            result[name] = { error: 'getAll-error' };
+            if (--remaining === 0) { db.close(); done({ stores, records: result }); }
+          };
+        }
+      } catch (e) {
+        db.close();
+        done({ error: String(e) });
+      }
+    };
+  });
+}
+
+/** OAuth の永続状態 (IDB + locks + localStorage) を伏字付きで集めて返す。 */
+export async function collectOAuthState(): Promise<Record<string, unknown>> {
+  const locks = await navigator.locks?.query?.().catch(() => undefined);
+  const ls: Record<string, unknown> = {};
+  try {
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i);
+      if (k && /atproto|oauth/i.test(k)) ls[k] = redact(localStorage.getItem(k), k);
+    }
+  } catch { /* localStorage 不可なら省略 */ }
+  const dbNames = await (indexedDB as { databases?: () => Promise<{ name?: string }[]> }).databases?.().catch(() => undefined);
+  return {
+    capturedAt: new Date().toISOString(),
+    href: location.href,
+    databases: dbNames?.map((d) => d.name),
+    locks: {
+      held: locks?.held?.map((l) => ({ name: l.name, mode: l.mode, clientId: l.clientId })),
+      pending: locks?.pending?.map((l) => ({ name: l.name, mode: l.mode })),
+    },
+    localStorage: ls,
+    oauthDb: await readAllRecords(OAUTH_DB),
+  };
+}
+
+/** dev 専用: 収集 → コンソール出力 + JSON ダウンロード。固まっていてもコンソールから叩ける。 */
+async function dumpOAuthState(): Promise<Record<string, unknown>> {
+  const state = await collectOAuthState();
+  console.warn('[oauth-debug] state dump (tokens redacted)', state);
+  try {
+    const blob = new Blob([JSON.stringify(state, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `oauth-state-${Date.now()}.json`;
+    a.click();
+    setTimeout(() => URL.revokeObjectURL(url), 1_000);
+  } catch (e) {
+    console.warn('[oauth-debug] download failed (state is logged above)', e);
+  }
+  return state;
+}
+
+/** dev / dev 環境 / ローカルのみ `window.__aozoraDumpOAuth()` を生やす (本番では何もしない)。 */
+export function installOAuthDebug(): void {
+  const enabled = import.meta.env.DEV || (import.meta.env.VITE_NSID_ENV as string | undefined)?.trim() === 'dev';
+  if (!enabled || typeof window === 'undefined') return;
+  (window as unknown as { __aozoraDumpOAuth?: () => Promise<unknown> }).__aozoraDumpOAuth = dumpOAuthState;
+  console.info('[oauth-debug] 固まったら DevTools コンソールで __aozoraDumpOAuth() を実行するとOAuth状態(伏字)をJSON保存できます');
+}

--- a/apps/web/src/lib/oauth.ts
+++ b/apps/web/src/lib/oauth.ts
@@ -110,6 +110,29 @@ export async function restoreSession(): Promise<OAuthSession | null> {
   return initPromise;
 }
 
+/** 壊れた/不整合な永続 OAuth セッションを消す (init() がハングして無限「準備しています」になる
+ *  ケースからの復旧用)。`@atproto/oauth-client-browser` は IndexedDB `@atproto-oauth-client` に
+ *  session/token を保存する。**best-effort**: init() が接続を掴んでいると deleteDatabase は blocked に
+ *  なるが、その場合も待たずに返す (次回リロードで実際に消える)。キャッシュした client/init も破棄して
+ *  次の restoreSession がクリーンな client を作り直せるようにする。 */
+export async function clearOAuthStorage(): Promise<void> {
+  initPromise = null;
+  clientPromise = null;
+  await new Promise<void>((resolve) => {
+    let settled = false;
+    const finish = () => { if (!settled) { settled = true; resolve(); } };
+    try {
+      const req = indexedDB.deleteDatabase('@atproto-oauth-client');
+      req.onsuccess = finish;
+      req.onerror = finish;
+      req.onblocked = finish; // 開いた接続で blocked でも永久待ちしない (次回リロードで消える)
+    } catch {
+      finish();
+    }
+    setTimeout(finish, 2_000); // 保険: イベントが来なくても 2s で諦める
+  });
+}
+
 /** ログインフローを開始 (authorize 画面にリダイレクト) */
 export async function signIn(handle: string): Promise<never> {
   const client = await getOAuthClient();

--- a/apps/web/src/lib/oauth.ts
+++ b/apps/web/src/lib/oauth.ts
@@ -116,6 +116,10 @@ export async function restoreSession(): Promise<OAuthSession | null> {
  *  なるが、その場合も待たずに返す (次回リロードで実際に消える)。キャッシュした client/init も破棄して
  *  次の restoreSession がクリーンな client を作り直せるようにする。 */
 export async function clearOAuthStorage(): Promise<void> {
+  // キャッシュを捨てて次の restoreSession が client を作り直せるようにする。ハング中の init() 自体は
+  // abort できないので orphan として裏で走り続けるが、UI はもうログイン画面なので無害
+  // (真の復旧レバーは下の IDB 削除)。IDB '@atproto-oauth-client' は全アカウント共通の単一 DB なので
+  // これは「このブラウザの全 Bluesky OAuth セッション」を消す (現状シングルアカウントなので実害なし)。
   initPromise = null;
   clientPromise = null;
   await new Promise<void>((resolve) => {

--- a/apps/web/src/lib/session.ts
+++ b/apps/web/src/lib/session.ts
@@ -30,6 +30,23 @@ export function withTimeout<T>(promise: Promise<T>, ms: number, label = 'op'): P
   return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
 }
 
+/** restore タイムアウト時、ハングの主因 (Web Locks 取得待ち vs 壊れた IDB) を次回で確定するための
+ *  診断ダンプ。読み取りのみ・best-effort。held に `@atproto-oauth-client-<sub>` が残っていれば lock 主因。 */
+async function logStorageDiagnostics(): Promise<void> {
+  try {
+    const locks = await navigator.locks?.query?.();
+    const dbs = await (indexedDB as { databases?: () => Promise<{ name?: string }[]> }).databases?.();
+    console.warn('[session] restore-timeout diagnostics', {
+      locksHeld: locks?.held?.map((l) => l.name),
+      locksPending: locks?.pending?.map((l) => l.name),
+      databases: dbs?.map((d) => d.name),
+      timestamp: new Date().toISOString(),
+    });
+  } catch (e) {
+    console.warn('[session] diagnostics failed', e);
+  }
+}
+
 export interface SessionState {
   status: 'loading' | 'signed-in' | 'signed-out';
   did?: string;
@@ -85,9 +102,17 @@ export function useSessionLoader(): SessionState {
       });
     });
     (async () => {
+      // OAuth callback (URL に ?code=... 在り) は client.init() が **single-use code を消費してトークン
+      // 交換 (auth server への実ネットワーク往復)** をする。ここに短い timeout + IDB 削除をかけると、
+      // 遅い回線で valid な初回ログインを 8s で打ち切り code を巻き込んで壊す (回帰リスク)。
+      // 無限「準備しています」のバグは**通常ロードで既存セッションを復元する restore** が対象なので、
+      // callback は従来どおり (本 PR 前と同じ) timeout 無しで通す。
+      const onOAuthCallback = typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('code');
+      const startedAt = Date.now();
       try {
-        // restore を必ずタイムアウトさせる (無応答ハングで「準備しています」が永久に消えないのを防ぐ)。
-        const session = await withTimeout(restoreSession(), RESTORE_TIMEOUT_MS, 'restore');
+        const session = onOAuthCallback
+          ? await restoreSession()
+          : await withTimeout(restoreSession(), RESTORE_TIMEOUT_MS, 'restore');
         if (cancelled) return;
         if (!session) {
           setState({ status: 'signed-out' });
@@ -96,10 +121,17 @@ export function useSessionLoader(): SessionState {
         await setStateFromSession(session, setState, () => cancelled);
       } catch (err) {
         const timedOut = err instanceof Error && err.message === 'restore-timeout';
-        console.warn('[session] restore failed/timed out; signing out', { timedOut, err });
-        // タイムアウト = 壊れた/不整合な永続セッションで init() がハング。**IDB を消して**次回リロードや
-        // 再ログインがクリーンに通るようにする (did 不明なので warmup 側の revoke は使えない)。待たない。
-        if (timedOut) void clearOAuthStorage();
+        // 経過時間も出す (誤爆=遅いだけの valid セッションか、真のハングかを後で切り分けられるように)。
+        console.warn('[session] restore failed/timed out; signing out', { timedOut, elapsedMs: Date.now() - startedAt, onOAuthCallback, err });
+        if (timedOut) {
+          // ハングの主因を次回で確定するための診断 (読み取りのみ)。navigator.locks が held のままなら
+          // 詰まりは Web Locks 取得待ち (@atproto は token refresh を `@atproto-oauth-client-<sub>` の
+          // exclusive lock で囲み、取得待ちに上限が無い) = IDB 削除では解けない、と判別できる。
+          void logStorageDiagnostics();
+          // 壊れた永続 token が主因のケースの自己修復 (best-effort。lock 主因なら効かないが無害)。
+          // 次回 restore は空 IDB を読んで即 signed-out に落ちる (lock を取りに行かない)。待たない。
+          void clearOAuthStorage();
+        }
         if (!cancelled) setState({ status: 'signed-out' });
       }
     })();

--- a/apps/web/src/lib/session.ts
+++ b/apps/web/src/lib/session.ts
@@ -1,7 +1,7 @@
 import { Agent, AtpAgent } from '@atproto/api';
 import type { OAuthSession } from '@atproto/oauth-client-browser';
 import { createContext, useContext, useEffect, useState } from 'react';
-import { onSessionDeleted, restoreSession, signOut } from './oauth';
+import { clearOAuthStorage, onSessionDeleted, restoreSession, signOut } from './oauth';
 
 /**
  * 公開 AppView エンドポイント。OAuth セッションの PDS は app.bsky.* を
@@ -13,6 +13,12 @@ const PUBLIC_APPVIEW = 'https://api.bsky.app';
 /** warmup (getSession) の上限。復元は本来 <1s なので、これを超えたら「ハングした古い/壊れた
  *  セッション」とみなし signed-out へ倒す (遅いだけの valid セッションを誤って切らない余裕を持たせる)。 */
 const WARMUP_TIMEOUT_MS = 10_000;
+
+/** restoreSession (OAuth client.init) の上限。init は本来 <1s だが、**壊れた/不整合な永続セッションや
+ *  navigator.locks の詰まりで無応答ハング**すると、warmup 手前で止まり無限「準備しています」になる
+ *  (warmup と違い restore には従来タイムアウトが無かった)。超えたら壊れた OAuth ストレージを消して
+ *  signed-out に倒す (= ログイン画面へ抜け、再ログインでクリーン復帰)。 */
+const RESTORE_TIMEOUT_MS = 8_000;
 
 /** `promise` を `ms` でタイムアウトさせる。超えたら `Error('<label>-timeout')` で reject。
  *  勝敗どちらでもタイマーを片付ける (保留タイマー/unhandled rejection を残さない)。 */
@@ -80,7 +86,8 @@ export function useSessionLoader(): SessionState {
     });
     (async () => {
       try {
-        const session = await restoreSession();
+        // restore を必ずタイムアウトさせる (無応答ハングで「準備しています」が永久に消えないのを防ぐ)。
+        const session = await withTimeout(restoreSession(), RESTORE_TIMEOUT_MS, 'restore');
         if (cancelled) return;
         if (!session) {
           setState({ status: 'signed-out' });
@@ -88,7 +95,11 @@ export function useSessionLoader(): SessionState {
         }
         await setStateFromSession(session, setState, () => cancelled);
       } catch (err) {
-        console.error('session restore failed', err);
+        const timedOut = err instanceof Error && err.message === 'restore-timeout';
+        console.warn('[session] restore failed/timed out; signing out', { timedOut, err });
+        // タイムアウト = 壊れた/不整合な永続セッションで init() がハング。**IDB を消して**次回リロードや
+        // 再ログインがクリーンに通るようにする (did 不明なので warmup 側の revoke は使えない)。待たない。
+        if (timedOut) void clearOAuthStorage();
         if (!cancelled) setState({ status: 'signed-out' });
       }
     })();

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -2,6 +2,10 @@ import { StrictMode, lazy } from 'react';
 import { createRoot } from 'react-dom/client';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import { Workspace } from '@/components/workspace';
+import { installOAuthDebug } from '@/lib/oauth-debug';
+
+// dev のみ: 固まったらコンソールで __aozoraDumpOAuth() を叩ける (session 復元前に登録)。
+installOAuthDebug();
 // 初回に必要な shell + workspace(ホーム) だけ eager。それ以外のルートは lazy 分割して
 // 初期バンドルから外す (初回表示の JS を軽くする)。named export を default に写す。
 const Profile = lazy(() => import('@/routes/profile').then(m => ({ default: m.Profile })));


### PR DESCRIPTION
## 症状 (オーナー報告 2026-07-19, dev 実機)
スプラッシュ 10〜20 秒後、**「準備しています…」(session.status==='loading') のまま進まない**。
コンソールにエラーなし。**プライベートモード・本番は正常**。ネットワークは全 200 で完了。
→ 通常ブラウザの**永続 OAuth セッション (IndexedDB `@atproto-oauth-client`) に依存**する再現。

## 原因
session ロード (`useSessionLoader` → `setStateFromSession`) で**唯一タイムアウトの無い await が
`restoreSession()` = OAuth `client.init()`**。warmup (`getSession`) は #354 で 10s 上限済みだが、その手前の
restore が「壊れた/不整合な永続セッション」や `navigator.locks` の詰まりで**無応答ハング**すると、warmup に
到達せず `status='loading'` のまま = **無限「準備しています」**(warmup の 10s 上限も効かない)。

## 修正
- `restoreSession` を `withTimeout(8s, 'restore')` でラップ。超えたら signed-out (ログイン画面) に倒す。
  **正常経路は restore が <1s で解決するので素通り = 挙動不変** (ハング時だけ作用)。
- タイムアウト時は `clearOAuthStorage()` で IDB `@atproto-oauth-client` を削除 (best-effort。init が接続保持で
  blocked でも待たない)。壊れた永続状態を消して再ログイン/次回リロードをクリーンに通す (**同じハングのループを断つ**)。
- これで restore(8s)+warmup(10s) 両方に上限 → session ロードは必ず有限時間で signed-in/signed-out に決まる。

## 検証
- web typecheck / 344 tests / build green。`session-timeout.test.ts` に restore ラベル + clearOAuthStorage を追加。
- **要 dev 実機確認 (再現環境がオーナー端末)**: dev で再発時に 8s で「準備しています」を抜けてログイン画面に落ち、
  再ログイン後は正常か。console に `[session] restore failed/timed out {timedOut:true}` が出れば restore ハング確定。

## 留意
- init() が**なぜ**ハングするか (壊れた token / lock 詰まり等) の precise root cause は再現環境が無く未確定。
  本 PR は「必ず有限時間で抜ける + 壊れた状態を自己修復する」防御的修正。再発時の新ログで更に切り分け可能。
- login 経路 = 全ユーザー影響のため、dev 実機で確認後に dev→main を判断 (本番も同じ latent bug を持つ)。

## Review
§1.5 3並列レビュー (実装/回帰/根本原因) 実施。★★★2件(根本原因: navigator.locks が主因でIDB削除では解けない → timeoutを「必ず有限時間で抜ける保証」に位置づけ+診断ダンプ追加/listRecordsは無認証公開読みで診断を否定しないと確認)、★★1件(callback除外)を対応。CSPでコンソールeval不可の実機向けに「準備しています」画面へ診断ボタン+未捕捉エラー捕捉を追加 (dev限定)。