### PR TITLE
feat(debug): 診断ボタンをログイン画面にも (8s タイムアウト後も採取可能)

### DIFF
--- a/apps/web/src/components/workspace.tsx
+++ b/apps/web/src/components/workspace.tsx
@@ -183,21 +183,19 @@ export function Workspace() {
   // `/` 離脱時は投稿カラムを閉じる (ルート跨ぎ・モバイル幅で開きっぱなしを防ぐ)
   useEffect(() => () => closeComposePane(), []);
 
+  // dev 限定: 復元ハングの診断ダンプ (コンソールが CSP eval 不可な端末向け)。捕捉した未捕捉エラーは
+  // page load 以降ずっと保持されるので、8s タイムアウトで login に抜けた後でも「Script error.」を拾える。
+  const debugDumpButton = oauthDebugEnabled ? (
+    <button type="button" onClick={() => void dumpOAuthState()} style={{ marginTop: '2em', fontSize: '0.8em', opacity: 0.7 }}>
+      🔧 診断ダンプを保存
+    </button>
+  ) : null;
+
   if (session.status === 'loading') {
     return (
       <>
         <p>準備しています...</p>
-        {oauthDebugEnabled && (
-          // dev のみ: 復元がハングして固まったとき、コンソール (CSP で eval 不可な端末) を使わずに
-          // OAuth 状態 (伏字) + 未捕捉エラーを JSON 保存するための診断ボタン。
-          <button
-            type="button"
-            onClick={() => void dumpOAuthState()}
-            style={{ marginTop: '2em', fontSize: '0.8em', opacity: 0.7 }}
-          >
-            🔧 診断ダンプを保存
-          </button>
-        )}
+        {debugDumpButton}
       </>
     );
   }
@@ -215,6 +213,7 @@ export function Workspace() {
         <p style={{ marginTop: '1.5em', fontSize: '0.85em' }}>
           <Link to="/board">ログインせずにクエスト掲示板をのぞく →</Link>
         </p>
+        {debugDumpButton}
       </div>
     );
   }

--- a/apps/web/src/lib/oauth-debug.ts
+++ b/apps/web/src/lib/oauth-debug.ts
@@ -138,11 +138,32 @@ export async function dumpOAuthState(): Promise<Record<string, unknown>> {
 export const oauthDebugEnabled =
   import.meta.env.DEV || (import.meta.env.VITE_NSID_ENV as string | undefined)?.trim() === 'dev';
 
-/** dev / dev 環境 / ローカルのみ: 未捕捉エラー捕捉を仕込み、`window.__aozoraDumpOAuth()` を生やす
- *  (本番では何もしない)。エラー捕捉は session 復元より前に効かせたいので import 直後に呼ぶ。 */
+/** React の外に固定ボタンを直接生やす。どの画面 (準備しています / ログイン / リダイレクト中) で
+ *  固まっても・React 自体が固まっても押せるようにする (route 配置漏れ・レンダリング停止に強い)。 */
+function injectFloatingButton(): void {
+  if (typeof document === 'undefined') return;
+  const add = () => {
+    if (document.getElementById('__aozora-oauth-dump-btn')) return;
+    if (!document.body) return;
+    const btn = document.createElement('button');
+    btn.id = '__aozora-oauth-dump-btn';
+    btn.textContent = '🔧診断';
+    btn.style.cssText =
+      'position:fixed;right:8px;bottom:76px;z-index:2147483647;padding:10px 12px;' +
+      'font-size:13px;background:#c0392b;color:#fff;border:none;border-radius:10px;opacity:0.9;box-shadow:0 2px 8px rgba(0,0,0,.4)';
+    btn.addEventListener('click', (e) => { e.preventDefault(); void dumpOAuthState(); });
+    document.body.appendChild(btn);
+  };
+  if (document.body) add();
+  else document.addEventListener('DOMContentLoaded', add, { once: true });
+}
+
+/** dev / dev 環境 / ローカルのみ: 未捕捉エラー捕捉を仕込み、固定診断ボタン + `window.__aozoraDumpOAuth()`
+ *  を生やす (本番では何もしない)。エラー捕捉は session 復元より前に効かせたいので import 直後に呼ぶ。 */
 export function installOAuthDebug(): void {
   if (!oauthDebugEnabled || typeof window === 'undefined') return;
   installErrorCapture();
+  injectFloatingButton();
   (window as unknown as { __aozoraDumpOAuth?: () => Promise<unknown> }).__aozoraDumpOAuth = dumpOAuthState;
-  console.info('[oauth-debug] 固まったら「準備しています」画面の診断ボタン (または __aozoraDumpOAuth()) でOAuth状態(伏字)をJSON保存できます');
+  console.info('[oauth-debug] 右下の🔧診断ボタン (または __aozoraDumpOAuth()) でOAuth状態(伏字)をJSON保存できます');
 }


### PR DESCRIPTION
restore の 8s タイムアウトで signed-out に抜けた後でも捕捉済みエラー (「Script error.」) を採れるよう、診断ダンプボタンを login 画面にも出す (dev 限定)。#364 の追補。web-ci のみ (dev debug)。