### PR TITLE
fix(session): OAuth ロック詰まりを steal で解除 — 無限ハングの根本対策

### DIFF
--- a/apps/web/src/lib/__tests__/session-timeout.test.ts
+++ b/apps/web/src/lib/__tests__/session-timeout.test.ts
@@ -78,3 +78,39 @@ describe('clearOAuthStorage (壊れた永続セッションの復旧)', () => {
     await expect(p).resolves.toBeUndefined();
   });
 });
+
+describe('breakStaleOAuthLock (多重タブ/凍結タブのロック詰まり解除)', () => {
+  const DID = 'did:plc:abc';
+  const NAME = `@atproto-oauth-client-${DID}`;
+  afterEach(() => { vi.unstubAllGlobals(); vi.resetModules(); });
+
+  function stubLocks(held: { name: string }[]) {
+    const request = vi.fn(async (_n: string, _o: unknown, cb: () => Promise<void>) => { await cb(); });
+    vi.stubGlobal('navigator', { locks: { query: async () => ({ held, pending: [] }), request } } as unknown as Navigator);
+    vi.stubGlobal('localStorage', { getItem: (k: string) => (k === '@@atproto/oauth-client-browser(sub)' ? DID : null) } as unknown as Storage);
+    return request;
+  }
+
+  it('他コンテキストがセッションロックを held のとき steal で解放する', async () => {
+    const request = stubLocks([{ name: NAME }]);
+    const { breakStaleOAuthLock } = await import('../oauth');
+    await expect(breakStaleOAuthLock()).resolves.toBe(true);
+    expect(request).toHaveBeenCalledWith(NAME, { steal: true }, expect.any(Function));
+  });
+
+  it('ロックが held でなければ何もしない (通常時は無干渉)', async () => {
+    const request = stubLocks([]); // 誰も握っていない
+    const { breakStaleOAuthLock } = await import('../oauth');
+    await expect(breakStaleOAuthLock()).resolves.toBe(false);
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it('sub が localStorage に無ければ何もしない', async () => {
+    const request = vi.fn();
+    vi.stubGlobal('navigator', { locks: { query: async () => ({ held: [{ name: NAME }], pending: [] }), request } } as unknown as Navigator);
+    vi.stubGlobal('localStorage', { getItem: () => null } as unknown as Storage);
+    const { breakStaleOAuthLock } = await import('../oauth');
+    await expect(breakStaleOAuthLock()).resolves.toBe(false);
+    expect(request).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/oauth.ts
+++ b/apps/web/src/lib/oauth.ts
@@ -110,6 +110,41 @@ export async function restoreSession(): Promise<OAuthSession | null> {
   return initPromise;
 }
 
+/** @atproto/oauth-client-browser が sub (DID) を控える localStorage キー。ロック名の算出に使う。 */
+const OAUTH_SUB_LS_KEY = '@@atproto/oauth-client-browser(sub)';
+
+/**
+ * **無限「準備しています」/「リダイレクト中」の根本対策** (2026-07-19、実機 dump で確定)。
+ *
+ * トークン期限切れ時、`client.init()` はリフレッシュを排他ロック `@atproto-oauth-client-<sub>` で囲む
+ * (session-getter.js)。**ロック取得待ちには上限が無い**。iOS はバックグラウンドタブの JS/タイマーを凍結
+ * するため、別タブ (や凍結した前のタブ) がこのロックを握ったままだと、その中の 30s abort も凍結されて
+ * **ロックが永久に解放されず**、前面タブの init()/getSession が無限ハングする (dump: held×1 + pending×2)。
+ *
+ * 起動時、**まだ自分が何も acquire していない時点**でロックが held なら、それは他コンテキストの掴みっぱなし
+ * なので `navigator.locks` の **steal** で強制解放する (holder の callback は AbortError で reject → @atproto は
+ * refresh の並行性から回復する設計)。取得後は即手放し、待機者と自分の復元が進めるようにする。best-effort。
+ *
+ * @returns steal を実行したら true。
+ */
+export async function breakStaleOAuthLock(): Promise<boolean> {
+  try {
+    if (typeof navigator === 'undefined' || !navigator.locks?.query || !navigator.locks?.request) return false;
+    const sub = localStorage.getItem(OAUTH_SUB_LS_KEY);
+    if (!sub) return false;
+    const name = `@atproto-oauth-client-${sub}`;
+    const q = await navigator.locks.query();
+    // 自分はまだ acquire していないので、held = 他コンテキスト (凍結タブ等) の掴みっぱなし。
+    if (!q.held?.some((l) => l.name === name)) return false;
+    console.warn('[oauth] stale session lock held by another context; stealing to break deadlock', { name });
+    await navigator.locks.request(name, { steal: true }, async () => { /* 取れたら即解放 */ });
+    return true;
+  } catch (e) {
+    console.warn('[oauth] breakStaleOAuthLock failed', e);
+    return false;
+  }
+}
+
 /** 壊れた/不整合な永続 OAuth セッションを消す (init() がハングして無限「準備しています」になる
  *  ケースからの復旧用)。`@atproto/oauth-client-browser` は IndexedDB `@atproto-oauth-client` に
  *  session/token を保存する。**best-effort**: init() が接続を掴んでいると deleteDatabase は blocked に

--- a/apps/web/src/lib/session.ts
+++ b/apps/web/src/lib/session.ts
@@ -1,7 +1,7 @@
 import { Agent, AtpAgent } from '@atproto/api';
 import type { OAuthSession } from '@atproto/oauth-client-browser';
 import { createContext, useContext, useEffect, useState } from 'react';
-import { clearOAuthStorage, onSessionDeleted, restoreSession, signOut } from './oauth';
+import { breakStaleOAuthLock, clearOAuthStorage, onSessionDeleted, restoreSession, signOut } from './oauth';
 
 /**
  * 公開 AppView エンドポイント。OAuth セッションの PDS は app.bsky.* を
@@ -110,6 +110,11 @@ export function useSessionLoader(): SessionState {
       const onOAuthCallback = typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('code');
       const startedAt = Date.now();
       try {
+        // **根本対策**: 復元前に、他コンテキスト (凍結した背景タブ等) が OAuth セッションロックを握った
+        // ままなら steal で解放する。これをしないと期限切れトークンのリフレッシュがロック取得待ちで
+        // 無限ハングする (実機 dump で確定)。callback (新規ログイン) では既存ロックは無関係なので触らない。
+        // 自身の 2s 上限付き best-effort (ここで固まらせない)。
+        if (!onOAuthCallback) await withTimeout(breakStaleOAuthLock(), 2_000, 'lockcheck').catch(() => {});
         const session = onOAuthCallback
           ? await restoreSession()
           : await withTimeout(restoreSession(), RESTORE_TIMEOUT_MS, 'restore');


### PR DESCRIPTION
## 根本原因 (実機 dump で確定 2026-07-19)
無限「準備しています」/「リダイレクト中」は **network でも IDB 破損でもなく、`navigator.locks` の詰まり**だった:
- dump: `locks.held` = `@atproto-oauth-client-<did>` (exclusive, 別 clientId) + `pending`×2
- `session.expires_at` < 採取時刻 = **トークン期限切れ** → `init()` がリフレッシュのためこのロックを取得しようとする
- @atproto は refresh を `usingLock('@atproto-oauth-client-<sub>')` で囲む (**取得待ちに上限なし**)。iOS は
  **バックグラウンドタブの JS/タイマーを凍結**するので、別タブが握ったロック内の 30s abort も凍結され
  **ロックが永久に解放されない** → 前面タブの復元が無限ハング。
- dev だけなのは dev タブを複数開いているから。private/本番は単一タブなので正常 (= オーナー報告と一致)。

## 対策
`breakStaleOAuthLock()`: 復元前、**自分がまだ何も acquire していない起動時点**でロックが held なら他コンテキストの
掴みっぱなしと判断し `navigator.locks` の **steal** で強制解放してから復元する。holder の callback は AbortError で
reject され、@atproto は refresh 並行性から回復する設計。期限切れセッションもロック解放後にリフレッシュされ、
**ログインし直さず signed-in に復帰**する。callback (新規ログイン) は既存ロックと無関係なので触らない。2s best-effort。
#364 の 8s タイムアウト + IDB クリアは backstop として残す。

## 検証
- web 348 tests green (held→steal / not-held→無干渉 / sub 不在→無干渉 を追加)。typecheck/build green。
- **要 dev 実機確認**: dev タブを複数開いた状態で再発させ、**リロードで自動復帰 (ログイン画面に落ちず signed-in)** するか。
  console に `[oauth] stale session lock held by another context; stealing` が出れば steal 発動。

## 留意
- steal は「起動時に他コンテキストが held」の時だけ発動。別タブが**正当に**リフレッシュ中 (稀・短時間) に重なると
  そのリフレッシュを中断するが、@atproto が再試行で回復する。誤爆コストは低い。
- login 全ユーザー影響のため dev 実機確認後に dev→main。

## Review
(§1.5 レビュー結果を追記)