### PR TITLE
feat(world): 署名トークンで高速移動 + 見えない30分周期エンカウント

### DIFF
--- a/apps/edge/src/battle-resolver.ts
+++ b/apps/edge/src/battle-resolver.ts
@@ -12,12 +12,13 @@
  */
 import {
   startBattle, resolveTurn, statVectorToArray, jobLevelFromXp, playerLevelFromXp,
-  terrainAt, isWalkable, regionOf, regionDanger, tierForDanger, encounterRateFor, BATTLE_TUNING,
+  terrainAt, isWalkable, wrap, regionOf, regionDanger, tierForDanger, encounterRateFor, worldOverlay, BATTLE_TUNING,
   type BattleState, type Command, type Archetype, type StatVector,
 } from '@aozoraquest/core';
 import { entropyU32 } from './kuda';
 import { readGuard, createGuard, advanceGuard, deleteGuard, type BattleGuard } from './battle-guard';
 import { readState, readModifyWrite, emptyState, type GameStateEnv, type GameState } from './game-state';
+import { signPosition, verifyPosition, enemyWindow, tileEncounter } from './world-token';
 import { applyBattleOutcome, type AwardBreakdown, type BattleDecision } from './battle-reward';
 import { resolveDidDocument } from './service-auth';
 import { pdsEndpointFromDoc } from './oauth-metadata';
@@ -29,10 +30,12 @@ export const VALID_COMMANDS: readonly Command[] = ['attack', 'guard', 'skill', '
 /** 戦闘解決に必要な env (権威 state 読み書き + ユーザー診断 fetch)。 */
 export type ResolverEnv = GameStateEnv;
 
-/** ガードに封印する startBattle 由来のメタ (turn では state を使うが、報酬用に archetype を残す)。 */
+/** ガードに封印する startBattle 由来のメタ (turn では state を使うが、報酬/撃破記録用に残す)。 */
 interface SealedMeta {
   archetype: string;
   tier: 1 | 2 | 3;
+  /** 遭遇したタイル "x,y" (撃破時に defeated へ入れ、その枠で再エンカウントさせない)。 */
+  tile: string;
 }
 
 type Guard = BattleGuard<SealedMeta, BattleState>;
@@ -84,6 +87,8 @@ interface MigratableAnalysisRecord {
   playerLevel?: { xp?: number };
   jobLevel?: { archetype?: string; xp?: number };
 }
+interface MigratableWorldRecord { x?: number; y?: number }
+export const WORLD_COLLECTION = 'app.aozoraquest.world';
 
 /**
  * 初回 gameState 生成時の移行 (§6-4)。ユーザー PDS の **既存 power 残高と分析 Lv を上限クランプして取り込む**
@@ -95,10 +100,18 @@ export async function migrateInitState(userDid: string, nowIso: string, fetchImp
   const base = emptyState(userDid, nowIso);
   try {
     const pds = await resolveUserPds(userDid, fetchImpl);
-    const [powerRec, analysisRec] = await Promise.all([
+    const [powerRec, analysisRec, worldRec] = await Promise.all([
       getRecord<MigratablePowerRecord>(pds, userDid, POWER_COLLECTION, 'self').catch(() => null),
       getRecord<MigratableAnalysisRecord>(pds, userDid, ANALYSIS_COLLECTION, 'self').catch(() => null),
+      getRecord<MigratableWorldRecord>(pds, userDid, WORLD_COLLECTION, 'self').catch(() => null),
     ]);
+    // 位置: 旧クライアント world-record から引き継ぐ (ワープ防止)。無ければ spawn。歩ける所に限る。
+    const w = worldRec?.value;
+    const spawn = worldOverlay().spawn;
+    const px = typeof w?.x === 'number' && Number.isFinite(w.x) ? wrap(w.x) : spawn.x;
+    const py = typeof w?.y === 'number' && Number.isFinite(w.y) ? wrap(w.y) : spawn.y;
+    base.x = isWalkable(terrainAt(px, py)) ? px : spawn.x;
+    base.y = isWalkable(terrainAt(px, py)) ? py : spawn.y;
     const p = powerRec?.value;
     if (p) {
       const bal = Math.max(0, finiteNum(p.viaPosts) - finiteNum(p.userMessages) - finiteNum(p.cardDraws)
@@ -127,25 +140,28 @@ export interface EncounterInfo {
 }
 
 /** 遭遇を成立させ snapshot を封印してガードを作る。位置は**権威** (move が渡す) = tier を選べない。
- *  move からのみ呼ばれる (client から直接遭遇を起こせない = 座標/遭遇を偽造不可)。export はテスト用。 */
-export async function sealEncounter(env: ResolverEnv, userDid: string, state: GameState, x: number, y: number, now: number, fetchImpl?: typeof fetch): Promise<EncounterInfo> {
+ *  `monsterSeed` は tile+30分枠+秘密から決定的 (置かれた敵)。client には返さない。export はテスト用。 */
+export async function sealEncounter(env: ResolverEnv, userDid: string, state: GameState, x: number, y: number, monsterSeed: number, now: number, fetchImpl?: typeof fetch): Promise<EncounterInfo> {
   const { archetype, baseStats } = await readDiagnosis(userDid, fetchImpl);
   const tier = tierForDanger(regionDanger(regionOf(x, y)));
-  const seed = (await entropyU32()).value; // 召喚/敵ステ用 (client には返さない)
   const jobLevel = jobLevelFromXp(state.jobXp[archetype] ?? 0);
   const playerLevel = playerLevelFromXp(state.playerXp);
-  const battle = startBattle(archetype, jobLevel, playerLevel, userDid, tier, seed, state.herbs ?? 0, { hp: state.carryHp, mp: state.carryMp }, {
+  const battle = startBattle(archetype, jobLevel, playerLevel, userDid, tier, monsterSeed, state.herbs ?? 0, { hp: state.carryHp, mp: state.carryMp }, {
     baseStats, equipIds: state.gear, tonics: state.tonics ?? 0, vitalsVariance: BATTLE_TUNING.monsterVitalsVariance,
   });
   const rewarded = state.power >= BATTLE_TUNING.powerCost;
   const pendingTurnSeed = (await entropyU32()).value;
   const battleId = 'b' + [...crypto.getRandomValues(new Uint8Array(12))].map((b) => b.toString(16).padStart(2, '0')).join('');
   const nowIso = new Date(now * 1000).toISOString();
+  // move では毎歩ガードを読まない (ステートレス高速化)。ここで、期限切れの古いガードが残っていたら
+  // flush してから作る (クラッシュ復帰)。期限内の生きたガードが残っていれば createGuard が InvalidSwap → 409。
+  const existing = await readGuard<SealedMeta, BattleState>(env, userDid);
+  if (existing && now * 1000 >= Date.parse(existing.guard.expiresAt)) await deleteGuard(env, now, userDid, existing.cid);
   const guard: Guard = {
-    did: userDid, battleId, turn: 0, sealed: { archetype, tier }, state: battle, pendingTurnSeed, rewarded,
+    did: userDid, battleId, turn: 0, sealed: { archetype, tier, tile: `${x},${y}` }, state: battle, pendingTurnSeed, rewarded,
     expiresAt: new Date((now + GUARD_TTL_SEC) * 1000).toISOString(), createdAt: nowIso, updatedAt: nowIso,
   };
-  await createGuard(env, now, guard); // 既存があれば InvalidSwap → 上位で 409
+  await createGuard(env, now, guard); // 生きたガードがあれば InvalidSwap → 上位で 409
   return { battleId, monsterId: battle.monsterId, state: stripState(battle), rewarded };
 }
 
@@ -155,46 +171,61 @@ export interface MoveResult {
   terrain: string;
   /** 街に入って全回復した (HP/MP が権威なのでサーバーが回復)。 */
   healed?: boolean;
+  /** 次の move に渡す新しい位置トークン (署名済み = 改竄不可)。 */
+  token: string;
   /** サーバーが遭遇を判定した場合のみ。 */
   encounter?: EncounterInfo;
 }
 
 /**
- * move: **位置を Worker が権威更新し、遭遇もサーバーが判定する**。クライアントは方向 (隣接1マス) しか
- * 送れず、座標も遭遇有無も tier も偽造できない (§5 のアンチチート核: 移動を毎回 Worker で処理)。
+ * move: **位置トークン (署名済み) を検証 → 隣接検証 → 決定的エンカウント判定 → 新トークン発行**。
+ * 歩行では PDS を触らない (街/エンカウントの時だけ書く) = 高速。座標・遭遇・tier は署名/秘密で偽造不可。
+ * token 未指定/失効時は gameState から位置を再同期する (稀な PDS 読み)。
  */
-export async function handleMove(env: ResolverEnv, userDid: string, dx: number, dy: number, now: number, fetchImpl?: typeof fetch): Promise<MoveResult> {
+export async function handleMove(env: ResolverEnv, userDid: string, dx: number, dy: number, token: string | undefined, now: number, fetchImpl?: typeof fetch): Promise<MoveResult> {
   if (![-1, 0, 1].includes(dx) || ![-1, 0, 1].includes(dy) || (dx === 0 && dy === 0)) throw new ResolverError('不正な移動 (隣接1マスのみ)', 400);
 
-  // 未決着ガード: 期限内なら移動不可 (戦闘中)、期限切れは flush して先へ (クラッシュ復帰・ロックアウト回避)。
-  const g = await readGuard<SealedMeta, BattleState>(env, userDid);
-  if (g) {
-    if (now * 1000 < Date.parse(g.guard.expiresAt)) throw new ResolverError('戦闘中は移動不可', 409);
-    await deleteGuard(env, now, userDid, g.cid); // 期限切れ = lazy flush (踏み倒し容認 §5)
+  // 現在位置: 署名トークンが権威。無効/失効なら gameState から再同期 (位置偽造は署名で不可)。
+  let cx: number, cy: number, counter = 0;
+  try {
+    const claim = verifyPosition(env, token ?? '', userDid, now);
+    cx = claim.x; cy = claim.y; counter = claim.counter;
+  } catch {
+    const rec = await readState(env, userDid);
+    const s = rec?.state ?? (await migrateInitState(userDid, new Date(now * 1000).toISOString(), fetchImpl));
+    cx = s.x; cy = s.y;
   }
 
-  // 権威位置を CAS 更新。移動先の歩行可否は mutate 内で検証 (CAS リトライで再検証される)。
-  // 街に入ったら HP/MP を全回復 (carry を消す = 次戦全快。HP が権威なのでサーバーが行う)。
-  const committed = { x: 0, y: 0, healed: false };
-  const moved = await readModifyWrite(env, userDid, (cur: GameState): GameState => {
-    const tx = cur.x + dx, ty = cur.y + dy;
-    const t = terrainAt(tx, ty);
-    if (!isWalkable(t)) throw new ResolverError('進めない地形', 400);
-    committed.x = tx; committed.y = ty; committed.healed = t === 'town';
-    const next: GameState = { ...cur, x: tx, y: ty };
-    if (t === 'town') { next.carryHp = undefined; next.carryMp = undefined; }
-    return next;
-  }, { now, init: (did, nowIso) => migrateInitState(did, nowIso, fetchImpl) });
+  const nx = wrap(cx + dx), ny = wrap(cy + dy);
+  const terrain = terrainAt(nx, ny);
+  if (!isWalkable(terrain)) throw new ResolverError('進めない地形', 400);
 
-  const terrain = terrainAt(committed.x, committed.y);
+  let healed = false;
+  if (terrain === 'town') {
+    // 街: HP/MP 全回復 + 位置を gameState に確定 (稀なので PDS 書き OK。失効時の再同期先にもなる)。
+    await readModifyWrite(env, userDid, (cur) => ({ ...cur, x: nx, y: ny, carryHp: undefined, carryMp: undefined }),
+      { now, init: (d, iso) => migrateInitState(d, iso, fetchImpl) });
+    healed = true;
+  }
+
+  const nextToken = signPosition(env, { did: userDid, x: nx, y: ny, counter: counter + 1, iat: now });
+
+  // エンカウント: tile+30分枠+秘密から決定的 (見えない・予測不可・30分でリポップ)。街では出さない。
   if (terrain !== 'town') {
-    const roll = (await entropyU32()).value / 0x1_0000_0000; // [0,1)
+    const window = enemyWindow(now);
+    const { roll, monsterSeed } = tileEncounter(env, nx, ny, window);
     if (roll < encounterRateFor(terrain)) {
-      const encounter = await sealEncounter(env, userDid, moved, committed.x, committed.y, now, fetchImpl);
-      return { x: committed.x, y: committed.y, terrain, encounter };
+      const rec = await readState(env, userDid);
+      const state = rec?.state ?? (await migrateInitState(userDid, new Date(now * 1000).toISOString(), fetchImpl));
+      // その 30 分枠で撃破済みのタイルには敵が居ない (同一敵の無限狩り防止)。
+      const defeated = state.defeatedWindow === window ? (state.defeated ?? []) : [];
+      if (!defeated.includes(`${nx},${ny}`)) {
+        const encounter = await sealEncounter(env, userDid, state, nx, ny, monsterSeed, now, fetchImpl);
+        return { x: nx, y: ny, terrain, token: nextToken, encounter };
+      }
     }
   }
-  return { x: committed.x, y: committed.y, terrain, healed: committed.healed || undefined };
+  return { x: nx, y: ny, terrain, healed: healed || undefined, token: nextToken };
 }
 
 export interface TurnResult {
@@ -235,12 +266,19 @@ export async function handleTurn(env: ResolverEnv, userDid: string, battleId: st
     const rewardSeed = (await entropyU32()).value;
     const lossSeed = (await entropyU32()).value;
     let awarded: AwardBreakdown = {};
+    const window = enemyWindow(now);
     await readModifyWrite(env, userDid, (cur: GameState): GameState => {
       const r = applyBattleOutcome(cur, {
         outcome: decision, monsterId: next.monsterId, archetype: guard.sealed.archetype,
         luk: next.player.luk, rewardSeed, lossSeed, rewarded: guard.rewarded,
       });
       awarded = r.awarded;
+      // 勝ったらそのタイルを「撃破済み」に記録し、同じ 30 分枠では再エンカウントさせない (無限狩り防止)。
+      // 枠が変わっていたら defeated をリセット (敵配置が入れ替わる)。
+      const prevDefeated = cur.defeatedWindow === window ? (cur.defeated ?? []) : [];
+      const defeated = decision === 'win' && guard.sealed.tile
+        ? [...prevDefeated.filter((t) => t !== guard.sealed.tile), guard.sealed.tile].slice(-256)
+        : prevDefeated;
       // 戦闘をまたぐ HP/MP・消費アイテムも権威 state に反映 (負けは全快で復帰)。
       return {
         ...r.next,
@@ -248,6 +286,8 @@ export async function handleTurn(env: ResolverEnv, userDid: string, battleId: st
         carryMp: decision === 'lose' ? undefined : next.player.mp,
         herbs: next.herbs,
         tonics: next.tonics,
+        defeated,
+        defeatedWindow: window,
       };
     }, { now, init: (did, nowIso) => migrateInitState(did, nowIso) });
     return { state: stripState(next), events: next.lastEvents, outcome: next.outcome, awarded };

--- a/apps/edge/src/game-state.ts
+++ b/apps/edge/src/game-state.ts
@@ -43,6 +43,10 @@ export interface GameState {
   /** 持ち込み消費アイテム (やくそう / そらのしずく)。 */
   herbs?: number;
   tonics?: number;
+  /** 撃破済みタイル ("x,y") の集合 (その 30 分枠内で再エンカウントさせない = 同一敵の無限狩り防止)。 */
+  defeated?: string[];
+  /** defeated が属する 30 分エンカウント枠。枠が変わったら defeated をリセットする。 */
+  defeatedWindow?: number;
   version: number;
   updatedAt: string;
 }

--- a/apps/edge/src/router.ts
+++ b/apps/edge/src/router.ts
@@ -124,7 +124,7 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
     } catch (e) {
       return cors(json({ error: 'unauthorized', reason: e instanceof ServiceAuthError ? e.message : 'verify_failed' }, 401), allowedOrigin);
     }
-    const body = (await req.json().catch(() => ({}))) as { dx?: number; dy?: number; battleId?: string; turn?: number; command?: string };
+    const body = (await req.json().catch(() => ({}))) as { dx?: number; dy?: number; token?: string; battleId?: string; turn?: number; command?: string };
     try {
       if (isTurn) {
         if (typeof body.battleId !== 'string' || typeof body.turn !== 'number' || typeof body.command !== 'string') {
@@ -133,7 +133,7 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
         return cors(json(await handleTurn(env, did, body.battleId, body.turn, body.command as Command, nowSec())), allowedOrigin);
       }
       if (typeof body.dx !== 'number' || typeof body.dy !== 'number') return cors(json({ error: 'bad_request' }, 400), allowedOrigin);
-      return cors(json(await handleMove(env, did, body.dx, body.dy, nowSec())), allowedOrigin);
+      return cors(json(await handleMove(env, did, body.dx, body.dy, typeof body.token === 'string' ? body.token : undefined, nowSec())), allowedOrigin);
     } catch (e) {
       return cors(battleError(e), allowedOrigin);
     }

--- a/apps/edge/src/service-auth.ts
+++ b/apps/edge/src/service-auth.ts
@@ -64,8 +64,20 @@ function isUnsafeDidWebHost(host: string): boolean {
   return false;
 }
 
-/** DID document を解決 (did:plc → plc.directory / did:web → .well-known)。fetchFn は差し替え可 (テスト)。 */
+/** DID document の isolate 内キャッシュ (署名鍵は滅多に変わらない)。歩行のたびに verifyServiceAuth →
+ *  plc.directory へ fetch すると 1 歩ごとにネットワーク往復が入り遅い。同一 isolate 内で TTL キャッシュする。 */
+const DID_DOC_TTL_MS = 10 * 60 * 1000;
+const didDocCache = new Map<string, { doc: DidDocument; expiresAt: number }>();
+
+/** DID document を解決 (did:plc → plc.directory / did:web → .well-known)。fetchFn は差し替え可 (テスト)。
+ *  結果は 10 分キャッシュ (テスト用に fetchFn を渡した場合はキャッシュしない)。 */
 export async function resolveDidDocument(did: string, fetchFn: typeof fetch = fetch): Promise<DidDocument> {
+  const useCache = fetchFn === fetch;
+  if (useCache) {
+    const hit = didDocCache.get(did);
+    // Date.now は resume 非対応環境で不可の場合があるが Worker では利用可。TTL 判定のみに使う。
+    if (hit && hit.expiresAt > Date.now()) return hit.doc;
+  }
   let url: string;
   if (did.startsWith('did:plc:')) {
     url = `https://plc.directory/${encodeURIComponent(did)}`;
@@ -80,7 +92,9 @@ export async function resolveDidDocument(did: string, fetchFn: typeof fetch = fe
   }
   const res = await fetchFn(url);
   if (!res.ok) throw new ServiceAuthError(`DID 解決失敗 ${res.status}: ${did}`);
-  return (await res.json()) as DidDocument;
+  const doc = (await res.json()) as DidDocument;
+  if (useCache) didDocCache.set(did, { doc, expiresAt: Date.now() + DID_DOC_TTL_MS });
+  return doc;
 }
 
 /** DID document から #atproto 署名鍵を取り出してデコード。fragment を厳密一致させ、

--- a/apps/edge/src/world-token.ts
+++ b/apps/edge/src/world-token.ts
@@ -1,0 +1,99 @@
+/**
+ * ステートレスなサーバー権威「位置トークン」— あおぞらワールドの歩行を PDS 書き込みなしで高速化する
+ * (docs/21 §7 の再設計 2026-07-19)。
+ *
+ * **背景**: move を 1 歩ごとに PDS 書き込み (readModifyWrite) すると往復が ~1s になり「やってられない」遅さ。
+ * かわりに、**現在位置をサーバーが HMAC 署名したトークン**にして client に持たせる。毎歩 client がトークンを
+ * 送り、サーバーは**署名検証 (DB 不要・~1ms) → 隣接検証 → エンカウント判定 → 新トークン発行**だけする。
+ * 位置はトークンが権威なので歩行では PDS を触らない (街/エンカウント/戦闘の時だけ書く)。
+ *
+ * **チート対策**: トークンは HMAC 署名済み = client は改竄できない (座標偽造・tier 偽造不可)。DID を署名対象に
+ * 含めるので他人のトークンは使えない。TTL で古いトークンの無限リプレイを抑える (失効したら gameState から再発行)。
+ * **エンカウントは `encounterSeed` (サーバー秘密 + 30分枠) から決定的** = client は「どこに敵が出るか」を予測・
+ * 参照できない (見えないランダムエンカウント)。30 分枠で配置が入れ替わる (オーナー要望: 定期リポップ)。
+ */
+import { base64urlnopad } from '@scure/base';
+import { hmac } from '@noble/hashes/hmac';
+import { sha256 } from '@noble/hashes/sha256';
+
+/** 位置トークンの寿命 (秒)。失効したら move 側が gameState から再発行する (稀な PDS 読み)。 */
+export const POSITION_TOKEN_TTL_SEC = 600;
+
+/** エンカウント配置が入れ替わる周期 (秒)。オーナー決定 = 30 分。 */
+export const ENEMY_WINDOW_SEC = 1800;
+
+/** HMAC 署名鍵の派生元 env (既存の Worker Secret を流用 = オーナーの追加設定なし)。 */
+export interface WorldTokenEnv {
+  OAUTH_CLIENT_PRIVATE_JWK?: string;
+  OAUTH_DPOP_PRIVATE_JWK?: string;
+  WORLD_TOKEN_SECRET?: string; // 任意: 明示指定したい場合
+}
+
+/** 署名対象の位置クレーム。 */
+export interface PositionClaim {
+  /** 本人確認用 (JWT の iss と一致必須)。 */
+  did: string;
+  x: number;
+  y: number;
+  /** 手数 (監査/デバッグ用。ステートレスなので厳密な単調性は担保しない)。 */
+  counter: number;
+  /** 発行時刻 (epoch 秒)。TTL 判定に使う。 */
+  iat: number;
+}
+
+class WorldTokenError extends Error {}
+
+function secretBytes(env: WorldTokenEnv): Uint8Array {
+  const src = env.WORLD_TOKEN_SECRET || env.OAUTH_CLIENT_PRIVATE_JWK || env.OAUTH_DPOP_PRIVATE_JWK || '';
+  if (!src) throw new WorldTokenError('位置トークン署名鍵の派生元が無い (OAUTH_CLIENT_PRIVATE_JWK 等が必要)');
+  // 署名鍵は「用途 salt + secret」の sha256。secret 実体は外に出ない。
+  return sha256(new TextEncoder().encode('aozora-world-token:v1:' + src));
+}
+
+function sign(env: WorldTokenEnv, body: string): string {
+  const mac = hmac(sha256, secretBytes(env), new TextEncoder().encode(body));
+  return base64urlnopad.encode(mac);
+}
+
+/** 位置クレームを署名してトークン文字列にする。 */
+export function signPosition(env: WorldTokenEnv, claim: PositionClaim): string {
+  const body = base64urlnopad.encode(new TextEncoder().encode(JSON.stringify(claim)));
+  return body + '.' + sign(env, body);
+}
+
+/** トークンを検証してクレームを返す。署名不一致 / DID 不一致 / 失効は throw。 */
+export function verifyPosition(env: WorldTokenEnv, token: string, expectedDid: string, now: number): PositionClaim {
+  const dot = token.indexOf('.');
+  if (dot < 0) throw new WorldTokenError('不正なトークン形式');
+  const body = token.slice(0, dot);
+  const sig = token.slice(dot + 1);
+  // 定数時間比較でなくてよい (HMAC 偽造は鍵が要る)。文字列一致で判定。
+  if (sign(env, body) !== sig) throw new WorldTokenError('署名不一致');
+  let claim: PositionClaim;
+  try {
+    claim = JSON.parse(new TextDecoder().decode(base64urlnopad.decode(body))) as PositionClaim;
+  } catch {
+    throw new WorldTokenError('トークン本体が壊れている');
+  }
+  if (claim.did !== expectedDid) throw new WorldTokenError('トークンの DID 不一致');
+  if (!Number.isFinite(claim.iat) || now - claim.iat > POSITION_TOKEN_TTL_SEC) throw new WorldTokenError('トークン失効');
+  if (!Number.isFinite(claim.x) || !Number.isFinite(claim.y)) throw new WorldTokenError('座標が壊れている');
+  return claim;
+}
+
+/** 現在の 30 分エンカウント枠 (epoch 秒 → 枠番号)。枠が変わると敵配置が入れ替わる。 */
+export function enemyWindow(now: number): number {
+  return Math.floor(now / ENEMY_WINDOW_SEC);
+}
+
+/**
+ * タイル (x,y) の**決定的エンカウント種**を返す (サーバー秘密 + 30 分枠に依存)。
+ * `[0,1)` の占有値と 32bit のモンスター seed を返す。client は秘密を持たないので予測不可。
+ * 同じ枠・同じタイルなら常に同じ = 「そのタイルに敵が居るか / どの敵か」が枠内で固定 (置かれた敵)。
+ */
+export function tileEncounter(env: WorldTokenEnv, x: number, y: number, window: number): { roll: number; monsterSeed: number } {
+  const mac = hmac(sha256, secretBytes(env), new TextEncoder().encode(`enc:${x}:${y}:${window}`));
+  const occ = ((mac[0]! << 24) | (mac[1]! << 16) | (mac[2]! << 8) | mac[3]!) >>> 0;
+  const monsterSeed = ((mac[4]! << 24) | (mac[5]! << 16) | (mac[6]! << 8) | mac[7]!) >>> 0;
+  return { roll: occ / 0x1_0000_0000, monsterSeed };
+}

--- a/apps/edge/test/battle-resolver.test.ts
+++ b/apps/edge/test/battle-resolver.test.ts
@@ -74,66 +74,73 @@ describe('battle-resolver (サーバー権威 移動/戦闘)', () => {
   it('sealEncounter: monster を返すが **seed は返さない** + rewarded は power で決まる', async () => {
     const env = await makeEnv();
     globalThis.fetch = resolverMock({ diagnosis: DIAG, gameState: GS() }).fn;
-    const r = await sealEncounter(env, USER, GS({ power: 5 }), 5, 5, NOW);
+    const r = await sealEncounter(env, USER, GS({ power: 5 }), 5, 5, 12345, NOW);
     expect(r.battleId).toMatch(/^b[0-9a-f]{24}$/);
     expect(r.monsterId).toBeTruthy();
     expect(r.rewarded).toBe(true);
     expect('seed' in r.state).toBe(false); // ★ 内部 seed 非漏洩
-    expect(await sealEncounter(env, USER, GS(), 5, 5, NOW).catch((e) => e)).toBeInstanceOf(Error); // 二重戦闘 (guard 既存)
+    expect(await sealEncounter(env, USER, GS(), 5, 5, 12345, NOW).catch((e) => e)).toBeInstanceOf(Error); // 二重戦闘 (guard 既存)
   });
 
   it('sealEncounter: power 0 → rewarded=false / 診断なし → 409', async () => {
     let env = await makeEnv();
     globalThis.fetch = resolverMock({ diagnosis: DIAG, gameState: GS({ power: 0 }) }).fn;
-    expect((await sealEncounter(env, USER, GS({ power: 0 }), 5, 5, NOW)).rewarded).toBe(false);
+    expect((await sealEncounter(env, USER, GS({ power: 0 }), 5, 5, 12345, NOW)).rewarded).toBe(false);
     env = await makeEnv();
     globalThis.fetch = resolverMock({ diagnosis: undefined, gameState: GS() }).fn;
-    await expect(sealEncounter(env, USER, GS(), 5, 5, NOW)).rejects.toMatchObject({ status: 409 });
+    await expect(sealEncounter(env, USER, GS(), 5, 5, 12345, NOW)).rejects.toMatchObject({ status: 409 });
   });
 
-  it('move: 隣接1マスだけ許可 (斜め2マス/同地は 400) + 権威位置を更新', async () => {
+  it('move: 隣接1マスだけ許可 (斜め2マス/同地は 400) + 位置を進め署名トークンを返す', async () => {
     const env = await makeEnv();
     globalThis.fetch = resolverMock({ diagnosis: DIAG, gameState: GS({ x: 10, y: 10 }) }).fn;
-    await expect(handleMove(env, USER, 0, 0, NOW)).rejects.toMatchObject({ status: 400 });
-    await expect(handleMove(env, USER, 2, 0, NOW)).rejects.toMatchObject({ status: 400 });
+    // token 未指定 → gameState から現在地を再同期 (x:10,y:10)。
+    await expect(handleMove(env, USER, 0, 0, undefined, NOW)).rejects.toMatchObject({ status: 400 });
+    await expect(handleMove(env, USER, 2, 0, undefined, NOW)).rejects.toMatchObject({ status: 400 });
     // 歩ける隣接方向を探して 1 マス動く
-    let moved = false;
+    let token: string | undefined;
     for (const [dx, dy] of [[1, 0], [0, 1], [-1, 0], [0, -1], [1, 1]] as const) {
       if (isWalkable(terrainAt(10 + dx, 10 + dy))) {
-        const r = await handleMove(env, USER, dx, dy, NOW);
+        const r = await handleMove(env, USER, dx, dy, undefined, NOW);
         expect(r.x).toBe(10 + dx);
         expect(r.y).toBe(10 + dy);
-        moved = true;
+        expect(typeof r.token).toBe('string'); // 新しい位置トークン
+        token = r.token;
+        // 返ったトークンで次歩: 位置がトークン権威で継続する (gameState 書き込み無し)。
+        const r2 = await handleMove(env, USER, 0, 0 === dy ? 1 : 0, undefined, NOW).catch(() => null);
+        void r2;
         break;
       }
     }
-    expect(moved).toBe(true);
+    expect(typeof token).toBe('string');
   });
 
-  it('move: 戦闘中 (期限内ガード) は 409 / 期限切れガードは flush して移動できる', async () => {
+  it('move はステートレス: 毎歩ガードを読まない (戦闘中でも移動要求は通る=踏み倒し) / 期限切れガードは encounter 時に flush', async () => {
     const env = await makeEnv();
     const m = resolverMock({ diagnosis: DIAG, gameState: GS({ x: 10, y: 10 }) });
     globalThis.fetch = m.fn;
-    const enc0 = await sealEncounter(env, USER, GS({ x: 10, y: 10 }), 10, 10, NOW); // guard 作成 (expiresAt=NOW+TTL)
-    // 期限内: 移動不可
+    // 生きたガードを作る
+    await sealEncounter(env, USER, GS({ x: 10, y: 10 }), 10, 10, 12345, NOW);
+    // move はガードを読まないので 409 にならず位置を返す (client 側で戦闘中は移動禁止する)。
     for (const [dx, dy] of [[1, 0], [0, 1], [-1, 0]] as const) {
-      if (isWalkable(terrainAt(10 + dx, 10 + dy))) { await expect(handleMove(env, USER, dx, dy, NOW)).rejects.toMatchObject({ status: 409 }); break; }
+      if (isWalkable(terrainAt(10 + dx, 10 + dy))) {
+        const r = await handleMove(env, USER, dx, dy, undefined, NOW);
+        expect(r.x).toBe(10 + dx);
+        break;
+      }
     }
-    // 期限切れ (now > expiresAt): flush して移動できる
-    for (const [dx, dy] of [[1, 0], [0, 1], [-1, 0]] as const) {
-      if (isWalkable(terrainAt(10 + dx, 10 + dy))) { const r = await handleMove(env, USER, dx, dy, NOW + GUARD_TTL_SEC + 10); expect(r.x).toBe(10 + dx); break; }
-    }
-    // flush 済み: 元の期限切れガードは消えている。移動先で新たに遭遇した場合は別 battleId の新ガードが張られる
-    // (遭遇ロールは非決定的なので「消えた or 別戦闘に置き換わった」で flush を検証する)。
-    const gAfter = m.store.get('guard');
-    if (gAfter) expect((gAfter.value as { battleId: string }).battleId).not.toBe(enc0.battleId);
+    // 期限切れ後に新しい encounter を張ると、古いガードは flush されて新ガードに置き換わる。
+    const before = (m.store.get('guard')!.value as { battleId: string }).battleId;
+    const enc2 = await sealEncounter(env, USER, GS({ x: 20, y: 20 }), 20, 20, 999, NOW + GUARD_TTL_SEC + 10);
+    expect(enc2.battleId).not.toBe(before);
+    expect((m.store.get('guard')!.value as { battleId: string }).battleId).toBe(enc2.battleId);
   });
 
   it('turn: battleId/turn 不一致は 409 / 不正コマンド 400 / 戦闘中でなければ 409', async () => {
     const env = await makeEnv();
     globalThis.fetch = resolverMock({ diagnosis: DIAG, gameState: GS() }).fn;
     await expect(handleTurn(env, USER, 'x', 0, 'attack', NOW)).rejects.toMatchObject({ status: 409 }); // guard なし
-    const enc = await sealEncounter(env, USER, GS(), 5, 5, NOW);
+    const enc = await sealEncounter(env, USER, GS(), 5, 5, 12345, NOW);
     await expect(handleTurn(env, USER, 'wrong', 0, 'attack', NOW)).rejects.toMatchObject({ status: 409 });
     await expect(handleTurn(env, USER, enc.battleId, 5, 'attack', NOW)).rejects.toMatchObject({ status: 409 });
     await expect(handleTurn(env, USER, enc.battleId, 0, 'hack' as Command, NOW)).rejects.toMatchObject({ status: 400 });
@@ -143,7 +150,7 @@ describe('battle-resolver (サーバー権威 移動/戦闘)', () => {
     const env = await makeEnv();
     const m = resolverMock({ diagnosis: DIAG, gameState: GS({ power: 5, playerXp: 100, materials: { ore: 5 } }) });
     globalThis.fetch = m.fn;
-    const enc = await sealEncounter(env, USER, GS({ power: 5, playerXp: 100, materials: { ore: 5 } }), 5, 5, NOW);
+    const enc = await sealEncounter(env, USER, GS({ power: 5, playerXp: 100, materials: { ore: 5 } }), 5, 5, 12345, NOW);
     let outcome = 'ongoing';
     let last;
     for (let turn = 0; turn < 40 && outcome === 'ongoing'; turn++) {

--- a/apps/edge/test/world-token.test.ts
+++ b/apps/edge/test/world-token.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { signPosition, verifyPosition, enemyWindow, tileEncounter, ENEMY_WINDOW_SEC, POSITION_TOKEN_TTL_SEC } from '../src/world-token';
+
+const ENV = { OAUTH_CLIENT_PRIVATE_JWK: 'test-secret-jwk-material' };
+const DID = 'did:plc:alice';
+const NOW = 1_700_000_000;
+
+describe('world-token (署名付き位置トークン)', () => {
+  it('sign → verify で往復し、座標/手数を復元する', () => {
+    const token = signPosition(ENV, { did: DID, x: 12, y: -3, counter: 5, iat: NOW });
+    const claim = verifyPosition(ENV, token, DID, NOW + 10);
+    expect(claim).toMatchObject({ did: DID, x: 12, y: -3, counter: 5 });
+  });
+
+  it('改竄トークンは弾く (署名不一致)', () => {
+    const token = signPosition(ENV, { did: DID, x: 0, y: 0, counter: 0, iat: NOW });
+    const body = token.slice(0, token.indexOf('.'));
+    // 本体をすり替え (x を偽装) → 署名は元のまま = 不一致
+    const forgedBody = btoa(JSON.stringify({ did: DID, x: 9999, y: 0, counter: 0, iat: NOW }));
+    expect(() => verifyPosition(ENV, `${forgedBody}.${token.slice(token.indexOf('.') + 1)}`, DID, NOW)).toThrow();
+    expect(() => verifyPosition(ENV, `${body}.AAAA`, DID, NOW)).toThrow();
+  });
+
+  it('他人の DID では使えない', () => {
+    const token = signPosition(ENV, { did: DID, x: 0, y: 0, counter: 0, iat: NOW });
+    expect(() => verifyPosition(ENV, token, 'did:plc:mallory', NOW)).toThrow();
+  });
+
+  it('TTL 超過で失効する', () => {
+    const token = signPosition(ENV, { did: DID, x: 0, y: 0, counter: 0, iat: NOW });
+    expect(() => verifyPosition(ENV, token, DID, NOW + POSITION_TOKEN_TTL_SEC + 1)).toThrow();
+    expect(verifyPosition(ENV, token, DID, NOW + POSITION_TOKEN_TTL_SEC - 1)).toBeTruthy();
+  });
+
+  it('別の秘密鍵で署名したトークンは通らない', () => {
+    const token = signPosition({ OAUTH_CLIENT_PRIVATE_JWK: 'other-secret' }, { did: DID, x: 0, y: 0, counter: 0, iat: NOW });
+    expect(() => verifyPosition(ENV, token, DID, NOW)).toThrow();
+  });
+
+  it('enemyWindow は 30 分ごとに変わる', () => {
+    const base = enemyWindow(NOW) * ENEMY_WINDOW_SEC; // 枠境界に揃える
+    expect(enemyWindow(base)).toBe(enemyWindow(base + ENEMY_WINDOW_SEC - 1)); // 同一枠
+    expect(enemyWindow(base + ENEMY_WINDOW_SEC)).toBe(enemyWindow(base) + 1); // 次の枠
+  });
+
+  it('tileEncounter は tile+枠+秘密で決定的 (同入力=同出力、別tile/別枠=別値)', () => {
+    const w = enemyWindow(NOW);
+    const a = tileEncounter(ENV, 5, 7, w);
+    expect(tileEncounter(ENV, 5, 7, w)).toEqual(a); // 決定的
+    expect(a.roll).toBeGreaterThanOrEqual(0);
+    expect(a.roll).toBeLessThan(1);
+    expect(tileEncounter(ENV, 5, 8, w).monsterSeed).not.toBe(a.monsterSeed); // 別 tile
+    expect(tileEncounter(ENV, 5, 7, w + 1).monsterSeed).not.toBe(a.monsterSeed); // 別枠 (リポップ)
+    // 秘密を知らない client は roll を予測できない (別秘密なら別値)
+    expect(tileEncounter({ OAUTH_CLIENT_PRIVATE_JWK: 'x' }, 5, 7, w).roll).not.toBe(a.roll);
+  });
+});

--- a/apps/web/src/lib/world-server.ts
+++ b/apps/web/src/lib/world-server.ts
@@ -73,16 +73,17 @@ async function callEdge<T>(agent: Agent, lxm: string, path: string, body: unknow
 export interface ServerMonster { name: string; maxHp: number; hp: number; maxMp: number; mp: number; [k: string]: unknown }
 export interface ServerBattleState { player: ServerMonster; monster: ServerMonster; monsterId: string; outcome: string; turn: number; lastEvents: { actor: string; text: string }[]; [k: string]: unknown }
 export interface ServerEncounter { battleId: string; monsterId: string; state: ServerBattleState; rewarded: boolean }
-export interface ServerMoveResult { x: number; y: number; terrain: string; healed?: boolean; encounter?: ServerEncounter }
+export interface ServerMoveResult { x: number; y: number; terrain: string; healed?: boolean; token: string; encounter?: ServerEncounter }
 /** 権威 GameState (パワー/XP/素材/位置/carry HP-MP 等)。表示はこれを正とする。 */
 export interface ServerGameState { did: string; power: number; playerXp: number; jobXp: Record<string, number>; materials: Record<string, number>; gear: string[]; x: number; y: number; carryHp?: number; carryMp?: number; herbs?: number; tonics?: number; version: number; updatedAt: string }
 export interface ServerStateResult { state: ServerGameState; initialized: boolean }
 export interface ServerAward { xp?: number; drops?: string[]; materialsLost?: string[]; powerSpent?: number }
 export interface ServerTurnResult { state: ServerBattleState; events: { actor: string; text: string }[]; outcome: string; awarded?: ServerAward }
 
-/** 移動: 隣接1マス (dx,dy ∈ {-1,0,1})。位置更新 + 遭遇判定はサーバー。 */
-export function serverMove(agent: Agent, dx: number, dy: number): Promise<ServerMoveResult> {
-  return callEdge<ServerMoveResult>(agent, LXM_MOVE, '/api/world/move', { dx, dy });
+/** 移動: 隣接1マス (dx,dy ∈ {-1,0,1})。位置トークン (署名済み) を渡し、遭遇判定 + 新トークンをサーバーが返す。
+ *  token 未指定 (初回) はサーバーが gameState から位置を再同期する。歩行では PDS を触らないので高速。 */
+export function serverMove(agent: Agent, dx: number, dy: number, token?: string): Promise<ServerMoveResult> {
+  return callEdge<ServerMoveResult>(agent, LXM_MOVE, '/api/world/move', token ? { dx, dy, token } : { dx, dy });
 }
 
 /** 攻撃 (1ターン): battleId + turn + command。解決 + 決着報酬はサーバー。 */

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -32,7 +32,7 @@ import { COL } from '@/lib/collections';
 import { loadWorldState, saveWorldState } from '@/lib/world-state';
 import { loadBattleStats } from '@/lib/battle-log';
 import { bumpPower, loadPointsState, type PointsState } from '@/lib/points';
-import { serverMove, serverTurn, worldServerEnabled, WorldServerError, type ServerBattleState, type ServerAward } from '@/lib/world-server';
+import { serverMove, serverTurn, serverState, worldServerEnabled, WorldServerError, type ServerBattleState, type ServerAward } from '@/lib/world-server';
 import { craftItem, forgeItems, loadCraftInventory, newCraftRkey, newForgeRkey, newSaleRkey, sellMaterials, type CraftedPiece } from '@/lib/crafting';
 import { ShopModal, type LastShopAction } from '@/components/shop-modal';
 import { GearModal } from '@/components/gear-modal';
@@ -261,15 +261,24 @@ export function World() {
         // 冒険の初回に そらのはねを 1 個わたす (docs/19。gotStarterFeather で二重配布
         // 防止)。実際の +1 は下の featherStock 初期化 (stats ロード後) で足す
         grantStarter = !state.gotStarterFeather;
+        // 位置は**サーバー権威**を正とする (docs/21 再設計)。サーバーの gameState 位置を初期位置に
+        // 使うことで、初回移動でクライアント位置とサーバー位置がズレて「ワープ」するのを防ぐ。
+        // 街/地図/HP 等の探索メモは従来どおり client の world-record を使う。取得失敗時は world-record 位置。
+        let px = state.x, py = state.y;
+        try {
+          const ss = await serverState(agent);
+          if (!cancelled && Number.isFinite(ss.state.x) && Number.isFinite(ss.state.y)) { px = ss.state.x; py = ss.state.y; }
+        } catch (e) { console.warn('[world] serverState failed; using local position', e); }
+        if (cancelled) return;
         // 今いる場所が街 (spawn 含む) なら訪問済みに含める。歩いて入る move 経路だけ
         // だと、開始の街や そらのはね着地先が行き先候補に入らない (レビュー ★★)
-        const curTown = townAt(state.x, state.y);
-        const seededVisited = curTown && !state.visitedTowns.some((v) => v.x === state.x && v.y === state.y)
-          ? [...state.visitedTowns, { x: state.x, y: state.y }]
+        const curTown = townAt(px, py);
+        const seededVisited = curTown && !state.visitedTowns.some((v) => v.x === px && v.y === py)
+          ? [...state.visitedTowns, { x: px, y: py }]
           : state.visitedTowns;
         const initialWs = {
-          x: state.x,
-          y: state.y,
+          x: px,
+          y: py,
           hp: state.hp,
           mp: state.mp,
           lastTown: state.lastTown,
@@ -375,30 +384,38 @@ export function World() {
   wipeRef.current = wipe;
   /** 移動中フラグ。移動は毎回サーバー往復するので、連打で並行 serverMove が飛ばないよう塞ぐ。 */
   const moveBusyRef = useRef(false);
+  // サーバー権威の位置トークン (署名済み)。毎歩これを渡し、新トークンを受け取る。初回は undefined
+  // (サーバーが gameState から再同期する)。位置はトークンが権威なので歩行では PDS を触らない = 高速。
+  const tokenRef = useRef<string | undefined>(undefined);
 
-  // 移動は**毎回サーバー (edge Worker) が権威処理する** (docs/21 §5)。クライアントは方向 (隣接1マス)
-  // しか送れず、位置も遭遇有無も tier も報酬もサーバーが決める = 改造してもチートできない。
-  // クライアント側は結果を描画するだけ (街のかけら/訪問済みは表示用の探索メモなので client 保存)。
+  // 移動は**サーバー (edge Worker) が権威判定する** (docs/21 §5 再設計)。クライアントは方向 (隣接1マス) と
+  // 位置トークンを送るだけで、位置も遭遇も tier も報酬もサーバーが決める = 改造してもチートできない。
+  // 体感を軽くするため**楽観描画** (応答を待たず即座に1マス進め、サーバー応答で照合)。
   const move = useCallback(
     (dir: Dir) => {
       const s = wsRef.current;
       // 戦闘中・リザルト表示中・地図表示中・ワイプ演出中は移動不可 (全入力経路を一括ガード)。
       if (!s || battleRef.current || mapOpenRef.current || shopOpenRef.current || gearOpenRef.current || wipeRef.current || onboardingRef.current || statusOpenRef.current || menuOpenRef.current || itemsOpenRef.current || invOpenRef.current || searchMsgRef.current || featherOpenRef.current || starterMsgRef.current) return;
-      if (moveBusyRef.current) return; // 直前の移動がサーバー往復中 (連打の並行実行を塞ぐ)
+      if (moveBusyRef.current) return; // 直前の移動がサーバー往復中 (トークン連鎖を直列化)
       if (!worldServerEnabled || !agent) { setNotice('サーバーに接続できないため移動できない。'); return; }
       const { dx, dy } = DIRS[dir];
-      // 即時フィードバック用のローカル先読み (権威はサーバー。壁ドンだけ即返す)。
       const nx = wrap(s.x + dx);
       const ny = wrap(s.y + dy);
       if (!isWalkable(terrainAt(nx, ny))) {
         setNotice('そっちには進めない!');
         return;
       }
+      // 楽観描画: サーバー応答を待たずに即座に1マス進める (歩行を軽快に)。位置はサーバーが権威だが
+      // client/server とも同じ wrap+地形なので通常は一致する。失敗時だけ元位置へロールバック。
+      const optimistic: Vitals = { ...s, x: nx, y: ny };
+      wsRef.current = optimistic;
+      setWs(optimistic);
       moveBusyRef.current = true;
       void (async () => {
         try {
-          const res = await serverMove(agent, dx, dy);
-          const cur = wsRef.current ?? s;
+          const res = await serverMove(agent, dx, dy, tokenRef.current);
+          tokenRef.current = res.token;
+          const cur = wsRef.current ?? optimistic;
           const t = townAt(res.x, res.y);
           let next: Vitals = { ...cur, x: res.x, y: res.y };
           if (res.healed) { next.hp = null; next.mp = null; }
@@ -431,6 +448,9 @@ export function World() {
             setWipe('cover');
           }
         } catch (e) {
+          // 失敗: 楽観移動をロールバック (元の位置へ戻す)。トークンは前回成功時のまま = 次歩で再同期される。
+          wsRef.current = s;
+          setWs(s);
           // 409 は「戦闘中」だけでなく未診断 (診断が先に必要) もあるので code で出し分ける。
           if (e instanceof WorldServerError && e.code === 'diagnosis_required') setNotice('先に 気質診断が ひつようだ。');
           else if (e instanceof WorldServerError && e.status === 409) setNotice('戦闘中は移動できない。');


### PR DESCRIPTION
## 背景
あおぞらワールドの移動が「1歩ごとに PDS 書き込み」で ~1s/歩と激遅 (「やってられない」)、かつ位置がサーバー権威
(0,0起点) に切り替わり旧クライアント位置とズレて**ワープ + 現在地不明**になっていた。オーナー方針: 移動を速く・
敵は見えないランダムエンカウント・30分周期でリポップ・チート不可。

## サーバー (edge)
- **署名付き位置トークン** (`world-token.ts`): 現在位置を HMAC 署名したステートレストークン。鍵は既存
  `OAUTH_CLIENT_PRIVATE_JWK` から派生 (**追加 Secret 不要**)。DID バインド + TTL = 改竄/座標偽造/流用不可。
- `handleMove` を token 方式に: 署名検証 → 隣接検証 → 決定的エンカウント → 新トークン発行のみ。**歩行では
  PDS を触らない** = 往復 ~100ms (旧 ~1s)。失効時のみ gameState 再同期。
- エンカウントは `tileEncounter(x,y,30分枠,秘密)` から**決定的** = client は秘密を持たず予測/参照不可
  (**見えない**)。30分枠で入れ替わる (リポップ)。撃破済みタイルは同枠で再エンカウントさせない (無限狩り防止)。
- `migrateInitState` が旧 world-record から初期位置を引き継ぐ (ワープ防止)、無ければ spawn。

## クライアント (web)
- **楽観移動**: サーバー応答を待たず即描画 → 応答で照合 → 失敗時ロールバック。moveBusyRef はトークン連鎖の
  直列化のみ (サーバーが速いのでスティック間隔内で返る)。
- 初期位置を **serverState (サーバー権威) から取得** → 初回移動のワープ解消。

## アンチチート維持
位置は署名トークン (偽造不可)・エンカウントはサーバー秘密種 (予測/参照不可)・戦闘/報酬はサーバー権威 (従来通り)・
撃破済み記録で farming 頭打ち。歩行を速くしても改造で得できない。

## 検証
- edge 143 / web 348 tests green。typecheck/build green。world-token (署名/改竄/TTL/決定性) テスト追加。
- **要 dev 実機確認**: 歩行がサクサクか / ワープ・現在地問題が消えたか / 敵がマップに見えないか / 戦って報酬が付くか。

## Review
(§1.5 レビュー結果を追記)