### PR TITLE
feat(world): kuda 有効化 + 位置永続/初期トークンで再同期ワープ解消

### DIFF
--- a/apps/edge/src/battle-resolver.ts
+++ b/apps/edge/src/battle-resolver.ts
@@ -150,7 +150,7 @@ export async function sealEncounter(env: ResolverEnv, userDid: string, state: Ga
     baseStats, equipIds: state.gear, tonics: state.tonics ?? 0, vitalsVariance: BATTLE_TUNING.monsterVitalsVariance,
   });
   const rewarded = state.power >= BATTLE_TUNING.powerCost;
-  const pendingTurnSeed = (await entropyU32()).value;
+  const pendingTurnSeed = (await entropyU32({ useKuda: true })).value;
   const battleId = 'b' + [...crypto.getRandomValues(new Uint8Array(12))].map((b) => b.toString(16).padStart(2, '0')).join('');
   const nowIso = new Date(now * 1000).toISOString();
   // move では毎歩ガードを読まない (ステートレス高速化)。ここで、期限切れの古いガードが残っていたら
@@ -263,8 +263,8 @@ export async function handleTurn(env: ResolverEnv, userDid: string, battleId: st
       throw e; // ServerWriteError(token 切れ) 等 → 上位で 503 (報酬なし)
     }
     // ここに来られるのはガードを消せた 1 リクエストだけ → 報酬を fail-closed で確定。
-    const rewardSeed = (await entropyU32()).value;
-    const lossSeed = (await entropyU32()).value;
+    const rewardSeed = (await entropyU32({ useKuda: true })).value;
+    const lossSeed = (await entropyU32({ useKuda: true })).value;
     let awarded: AwardBreakdown = {};
     const window = enemyWindow(now);
     await readModifyWrite(env, userDid, (cur: GameState): GameState => {
@@ -279,9 +279,14 @@ export async function handleTurn(env: ResolverEnv, userDid: string, battleId: st
       const defeated = decision === 'win' && guard.sealed.tile
         ? [...prevDefeated.filter((t) => t !== guard.sealed.tile), guard.sealed.tile].slice(-256)
         : prevDefeated;
+      // 位置も権威 state に確定 (歩行では書かないので、戦闘のたびにここで同期 = トークン失効時の
+      // 再同期先が「最後の街」でなく「直近の戦闘地点」になり、ワープを防ぐ)。tile は "x,y"。
+      const [tx, ty] = guard.sealed.tile.split(',').map(Number);
+      const pos = Number.isFinite(tx) && Number.isFinite(ty) ? { x: tx, y: ty } : {};
       // 戦闘をまたぐ HP/MP・消費アイテムも権威 state に反映 (負けは全快で復帰)。
       return {
         ...r.next,
+        ...pos,
         carryHp: decision === 'lose' ? undefined : next.player.hp,
         carryMp: decision === 'lose' ? undefined : next.player.mp,
         herbs: next.herbs,
@@ -295,7 +300,7 @@ export async function handleTurn(env: ResolverEnv, userDid: string, battleId: st
 
   // ── 未決着: turn+1・新 pendingTurnSeed を CAS で確定してから応答 (並行二重解決/引き直しを弾く) ──
   // expiresAt も更新し、長い戦闘が move の flush 対象にならないようにする (ターンごとに寿命を延ばす)。
-  const nextPending = (await entropyU32()).value;
+  const nextPending = (await entropyU32({ useKuda: true })).value;
   const nowIso = new Date(now * 1000).toISOString();
   const advanced: Guard = { ...guard, turn: turn + 1, state: next, pendingTurnSeed: nextPending, expiresAt: new Date((now + GUARD_TTL_SEC) * 1000).toISOString(), updatedAt: nowIso };
   try {

--- a/apps/edge/src/router.ts
+++ b/apps/edge/src/router.ts
@@ -14,6 +14,7 @@ import { PdsError } from './pds';
 import { readState } from './game-state';
 import { handleClientMetadata, handleOAuthStart, handleOAuthCallback, type OAuthRoutesEnv } from './oauth-routes';
 import { handleMove, handleTurn, migrateInitState, ResolverError } from './battle-resolver';
+import { signPosition } from './world-token';
 import { ServerWriteError } from './server-pds';
 import type { Command } from '@aozoraquest/core';
 
@@ -106,7 +107,9 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
     try {
       const rec = await readState(env, did);
       const state = rec?.state ?? (await migrateInitState(did, new Date().toISOString()));
-      return cors(json({ state, initialized: rec !== null }), allowedOrigin);
+      // 位置トークンも一緒に返す → client は初回から有効トークンを持て、初手 move の再同期/ワープを防ぐ。
+      const token = signPosition(env, { did, x: state.x, y: state.y, counter: 0, iat: nowSec() });
+      return cors(json({ state, initialized: rec !== null, token }), allowedOrigin);
     } catch (e) {
       return cors(battleError(e), allowedOrigin);
     }

--- a/apps/web/src/lib/world-server.ts
+++ b/apps/web/src/lib/world-server.ts
@@ -76,7 +76,7 @@ export interface ServerEncounter { battleId: string; monsterId: string; state: S
 export interface ServerMoveResult { x: number; y: number; terrain: string; healed?: boolean; token: string; encounter?: ServerEncounter }
 /** 権威 GameState (パワー/XP/素材/位置/carry HP-MP 等)。表示はこれを正とする。 */
 export interface ServerGameState { did: string; power: number; playerXp: number; jobXp: Record<string, number>; materials: Record<string, number>; gear: string[]; x: number; y: number; carryHp?: number; carryMp?: number; herbs?: number; tonics?: number; version: number; updatedAt: string }
-export interface ServerStateResult { state: ServerGameState; initialized: boolean }
+export interface ServerStateResult { state: ServerGameState; initialized: boolean; token?: string }
 export interface ServerAward { xp?: number; drops?: string[]; materialsLost?: string[]; powerSpent?: number }
 export interface ServerTurnResult { state: ServerBattleState; events: { actor: string; text: string }[]; outcome: string; awarded?: ServerAward }
 

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -267,7 +267,12 @@ export function World() {
         let px = state.x, py = state.y;
         try {
           const ss = await serverState(agent);
-          if (!cancelled && Number.isFinite(ss.state.x) && Number.isFinite(ss.state.y)) { px = ss.state.x; py = ss.state.y; }
+          if (!cancelled && Number.isFinite(ss.state.x) && Number.isFinite(ss.state.y)) {
+            px = ss.state.x; py = ss.state.y;
+            // 初期トークンも受け取る → 初手 move から有効トークンを送れて、表示位置=トークン位置が保証され
+            // 再同期・ワープが起きない (impl レビュー指摘)。
+            if (ss.token) tokenRef.current = ss.token;
+          }
         } catch (e) { console.warn('[world] serverState failed; using local position', e); }
         if (cancelled) return;
         // 今いる場所が街 (spawn 含む) なら訪問済みに含める。歩いて入る move 経路だけ


### PR DESCRIPTION
kuda を戦闘 seed に有効化 (ANU 量子乱数 ~50ms・CSPRNG fallback)。§1.5 実装レビュー ★★★#2 (初期ワープ) 対応: 決着で位置永続 + /api/me/state が位置トークンを返し client 初手から有効トークンを持つ。残存レビュー指摘は #368 (単調性) / #369 (defeated溢れ・位置偽造) に issue 化。edge 143 / web 348 green。