### PR TITLE
feat(world): 敗北時に最後の街へ帰還 (サーバー権威)

### DIFF
--- a/apps/edge/src/battle-resolver.ts
+++ b/apps/edge/src/battle-resolver.ts
@@ -208,8 +208,8 @@ export async function handleMove(env: ResolverEnv, userDid: string, dx: number, 
 
   let healed = false;
   if (terrain === 'town') {
-    // 街: HP/MP 全回復 + 位置を gameState に確定 (稀なので PDS 書き OK。失効時の再同期先にもなる)。
-    await readModifyWrite(env, userDid, (cur) => ({ ...cur, x: nx, y: ny, carryHp: undefined, carryMp: undefined }),
+    // 街: HP/MP 全回復 + 位置 + 最後の街 (敗北帰還先) を gameState に確定 (稀なので PDS 書き OK)。
+    await readModifyWrite(env, userDid, (cur) => ({ ...cur, x: nx, y: ny, carryHp: undefined, carryMp: undefined, lastTown: { x: nx, y: ny } }),
       { now, init: (d, iso) => migrateInitState(d, iso, ns, fetchImpl) });
     healed = true;
   }
@@ -239,6 +239,10 @@ export interface TurnResult {
   events: BattleState['lastEvents'];
   outcome: BattleState['outcome'];
   awarded?: AwardBreakdown;
+  /** 決着後の権威位置 (敗北は最後の街へ帰還)。client はここへ移動。 */
+  position?: { x: number; y: number };
+  /** 決着後の位置に対応する新しい署名トークン (敗北帰還で位置が変わるため)。 */
+  token?: string;
 }
 
 /**
@@ -272,6 +276,7 @@ export async function handleTurn(env: ResolverEnv, userDid: string, battleId: st
     const rewardSeed = (await entropyU32({ useKuda: true })).value;
     const lossSeed = (await entropyU32({ useKuda: true })).value;
     let awarded: AwardBreakdown = {};
+    let finalPos = { x: 0, y: 0 };
     const window = enemyWindow(now);
     await readModifyWrite(env, userDid, (cur: GameState): GameState => {
       const r = applyBattleOutcome(cur, {
@@ -280,19 +285,19 @@ export async function handleTurn(env: ResolverEnv, userDid: string, battleId: st
       });
       awarded = r.awarded;
       // 勝ったらそのタイルを「撃破済み」に記録し、同じ 30 分枠では再エンカウントさせない (無限狩り防止)。
-      // 枠が変わっていたら defeated をリセット (敵配置が入れ替わる)。
       const prevDefeated = cur.defeatedWindow === window ? (cur.defeated ?? []) : [];
       const defeated = decision === 'win' && guard.sealed.tile
         ? [...prevDefeated.filter((t) => t !== guard.sealed.tile), guard.sealed.tile].slice(-256)
         : prevDefeated;
-      // 位置も権威 state に確定 (歩行では書かないので、戦闘のたびにここで同期 = トークン失効時の
-      // 再同期先が「最後の街」でなく「直近の戦闘地点」になり、ワープを防ぐ)。tile は "x,y"。
+      // 位置を権威 state に確定。**敗北は最後の街へ帰還** (無ければ spawn)。勝ち/引き分けは戦闘タイルに留まる。
       const [tx, ty] = guard.sealed.tile.split(',').map(Number);
-      const pos = Number.isFinite(tx) && Number.isFinite(ty) ? { x: tx, y: ty } : {};
-      // 戦闘をまたぐ HP/MP・消費アイテムも権威 state に反映 (負けは全快で復帰)。
+      const battleTile = Number.isFinite(tx) && Number.isFinite(ty) ? { x: tx, y: ty } : { x: cur.x, y: cur.y };
+      const spawn = worldOverlay().spawn;
+      finalPos = decision === 'lose' ? (cur.lastTown ?? { x: spawn.x, y: spawn.y }) : battleTile;
       return {
         ...r.next,
-        ...pos,
+        x: finalPos.x,
+        y: finalPos.y,
         carryHp: decision === 'lose' ? undefined : next.player.hp,
         carryMp: decision === 'lose' ? undefined : next.player.mp,
         herbs: next.herbs,
@@ -301,7 +306,9 @@ export async function handleTurn(env: ResolverEnv, userDid: string, battleId: st
         defeatedWindow: window,
       };
     }, { now, init: (did, nowIso) => migrateInitState(did, nowIso, ns) });
-    return { state: stripState(next), events: next.lastEvents, outcome: next.outcome, awarded };
+    // 決着後の位置に対応する新トークンを発行 (敗北帰還で位置が変わるので client はこれで同期)。
+    const token = signPosition(env, { did: userDid, x: finalPos.x, y: finalPos.y, counter: 0, iat: now });
+    return { state: stripState(next), events: next.lastEvents, outcome: next.outcome, awarded, position: finalPos, token };
   }
 
   // ── 未決着: turn+1・新 pendingTurnSeed を CAS で確定してから応答 (並行二重解決/引き直しを弾く) ──

--- a/apps/edge/src/game-state.ts
+++ b/apps/edge/src/game-state.ts
@@ -43,6 +43,8 @@ export interface GameState {
   /** 持ち込み消費アイテム (やくそう / そらのしずく)。 */
   herbs?: number;
   tonics?: number;
+  /** 最後に立ち寄った街 (敗北時の帰還先)。街に入るたびに更新。 */
+  lastTown?: { x: number; y: number };
   /** 撃破済みタイル ("x,y") の集合 (その 30 分枠内で再エンカウントさせない = 同一敵の無限狩り防止)。 */
   defeated?: string[];
   /** defeated が属する 30 分エンカウント枠。枠が変わったら defeated をリセットする。 */

--- a/apps/web/src/lib/world-server.ts
+++ b/apps/web/src/lib/world-server.ts
@@ -78,7 +78,7 @@ export interface ServerMoveResult { x: number; y: number; terrain: string; heale
 export interface ServerGameState { did: string; power: number; playerXp: number; jobXp: Record<string, number>; materials: Record<string, number>; gear: string[]; x: number; y: number; carryHp?: number; carryMp?: number; herbs?: number; tonics?: number; version: number; updatedAt: string }
 export interface ServerStateResult { state: ServerGameState; initialized: boolean; token?: string }
 export interface ServerAward { xp?: number; drops?: string[]; materialsLost?: string[]; powerSpent?: number }
-export interface ServerTurnResult { state: ServerBattleState; events: { actor: string; text: string }[]; outcome: string; awarded?: ServerAward }
+export interface ServerTurnResult { state: ServerBattleState; events: { actor: string; text: string }[]; outcome: string; awarded?: ServerAward; position?: { x: number; y: number }; token?: string }
 
 /** 移動: 隣接1マス (dx,dy ∈ {-1,0,1})。位置トークン (署名済み) を渡し、遭遇判定 + 新トークンをサーバーが返す。
  *  token 未指定 (初回) はサーバーが gameState から位置を再同期する。歩行では PDS を触らないので高速。 */

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -193,6 +193,10 @@ export function World() {
     /** コマンド送信失敗 (503/409/通信断) をバトル画面内に表示する一行。notice は戦闘中は
      *  描画されない (戦闘オーバーレイの外) ので、fail-closed のエラーはここに出す。 */
     errorText?: string;
+    /** 決着後の権威位置 (敗北は最後の街へ帰還)。決着タップでここへ移動する。 */
+    resultPos?: { x: number; y: number };
+    /** 決着後の位置に対応する新トークン。 */
+    resultToken?: string;
   } | null>(null);
   /** エンカウント演出 (DQ1 風ワイプ)。cover 中はマップの上でタイルが閉じ、覆い切ったら
    *  バトル画面に差し替えて reveal で開く。支払い通信が長い場合は hold でつなぐ。 */
@@ -485,7 +489,10 @@ export function World() {
       void (async () => {
         try {
           const res = await serverTurn(agent, b.battleId, b.state.turn, command);
-          const acting = { ...bClean, state: asBattleState(res.state), phase: 'message' as BattlePhase, busy: false, ...(res.awarded ? { awarded: res.awarded } : {}) };
+          const acting = { ...bClean, state: asBattleState(res.state), phase: 'message' as BattlePhase, busy: false,
+            ...(res.awarded ? { awarded: res.awarded } : {}),
+            ...(res.position ? { resultPos: res.position } : {}),
+            ...(res.token ? { resultToken: res.token } : {}) };
           battleRef.current = acting;
           setBattle(acting);
         } catch (e) {
@@ -535,16 +542,19 @@ export function World() {
       const awarded = b.awarded ?? {};
       const drops = awarded.drops ?? [];
       const lost = awarded.materialsLost ?? [];
+      // 決着後の権威位置 (敗北は最後の街へ帰還) に移動し、対応トークンで同期する。
+      const resultPos = b.resultPos;
+      if (b.resultToken) tokenRef.current = b.resultToken;
       // HP/MP をフィールドに持ち帰る (持続)。敗北はサーバーが carry を消す = 全快なので null に。
-      // (注: サーバーは敗北で位置を街へ戻さない。街帰還は今後のサーバー実装課題。ここでは
-      //  その場で回復させ、次の serverMove がサーバー権威の位置を返す。)
       if (next.outcome === 'lose') {
-        setWs((s) => (s ? { ...s, hp: null, mp: null } : s));
+        // 敗北: 最後の街へ帰還 + 全回復。lastTown を更新して次の敗北帰還先も揃える。
+        setWs((s) => (s ? { ...s, hp: null, mp: null, ...(resultPos ? { x: resultPos.x, y: resultPos.y, lastTown: resultPos } : {}) } : s));
+        if (resultPos) { const t = townAt(resultPos.x, resultPos.y); setNotice(t ? `気がつくと「${t.name}」に はこばれていた…` : '気がつくと 街に はこばれていた…'); }
       } else {
         // 満タンは null に正規化 (絶対値で焼くと後のレベルアップで「減って見える」)。
         const hp = next.player.hp >= next.player.maxHp ? null : Math.max(1, next.player.hp);
         const mp = next.player.mp >= next.player.maxMp ? null : next.player.mp;
-        setWs((s) => (s ? { ...s, hp, mp } : s));
+        setWs((s) => (s ? { ...s, hp, mp, ...(resultPos ? { x: resultPos.x, y: resultPos.y } : {}) } : s));
       }
       scheduleSave();
       // クライアント在庫はサーバー報酬 (awarded) をミラーするだけ (表示用。正はサーバー state)。
@@ -575,7 +585,10 @@ export function World() {
       if (awarded.xp && awarded.xp > 0) resultLines.push(`けいけんち を ${awarded.xp} かくとく！`);
       for (const [id, n] of dropCounts) resultLines.push(`${nameOf(id)}${n > 1 ? ` ×${n}` : ''} を てにいれた！`);
       for (const [id, n] of lostCounts) resultLines.push(`${nameOf(id)}${n > 1 ? ` ×${n}` : ''} を おとしてしまった…`);
-      if (next.outcome === 'lose') resultLines.push('たおれてしまった… 気がつくと きずが いえていた。');
+      if (next.outcome === 'lose') {
+        const t = b.resultPos ? townAt(b.resultPos.x, b.resultPos.y) : null;
+        resultLines.push(t ? `たおれてしまった… 気がつくと「${t.name}」で 手当てされていた。` : 'たおれてしまった… 気がつくと 街で 手当てされていた。');
+      }
       if (resultLines.length === 0) {
         battleRef.current = null;
         setBattle(null);


### PR DESCRIPTION
サーバー権威化で「その場回復」になっていた敗北を、旧仕様どおり最後に立ち寄った街へ帰還に戻す。gameState.lastTown を街入場で更新、決着で負けは lastTown へ確定+新トークン返却、client が決着タップで移動。edge 143 / web 348 green。