### PR TITLE
fix(world): 遭遇時の孤立ガードを破棄して「移動できなかった」を解消

### DIFF
--- a/apps/edge/src/battle-resolver.ts
+++ b/apps/edge/src/battle-resolver.ts
@@ -159,10 +159,12 @@ export async function sealEncounter(env: ResolverEnv, userDid: string, state: Ga
   const pendingTurnSeed = (await entropyU32({ useKuda: true })).value;
   const battleId = 'b' + [...crypto.getRandomValues(new Uint8Array(12))].map((b) => b.toString(16).padStart(2, '0')).join('');
   const nowIso = new Date(now * 1000).toISOString();
-  // move では毎歩ガードを読まない (ステートレス高速化)。ここで、期限切れの古いガードが残っていたら
-  // flush してから作る (クラッシュ復帰)。期限内の生きたガードが残っていれば createGuard が InvalidSwap → 409。
+  // move では毎歩ガードを読まない (ステートレス高速化)。**client は戦闘中は move しない**ので、ここに
+  // 来た時点で既存ガードは必ず孤立 (戦闘を終えず離脱した残骸)。期限内でも破棄して新しい遭遇を成立させる。
+  // これをしないと、離脱後にエンカウントタイル (30分固定=特定の場所) を踏むたび createGuard が InvalidSwap
+  // → 500「移動できなかった」で詰まる。孤立ガードの戦闘は未報酬なので破棄しても二重報酬にならない。
   const existing = await readGuard<SealedMeta, BattleState>(env, userDid);
-  if (existing && now * 1000 >= Date.parse(existing.guard.expiresAt)) await deleteGuard(env, now, userDid, existing.cid);
+  if (existing) await deleteGuard(env, now, userDid, existing.cid);
   const guard: Guard = {
     did: userDid, battleId, turn: 0, sealed: { archetype, tier, tile: `${x},${y}` }, state: battle, pendingTurnSeed, rewarded,
     expiresAt: new Date((now + GUARD_TTL_SEC) * 1000).toISOString(), createdAt: nowIso, updatedAt: nowIso,

--- a/apps/edge/test/battle-resolver.test.ts
+++ b/apps/edge/test/battle-resolver.test.ts
@@ -79,7 +79,11 @@ describe('battle-resolver (サーバー権威 移動/戦闘)', () => {
     expect(r.monsterId).toBeTruthy();
     expect(r.rewarded).toBe(true);
     expect('seed' in r.state).toBe(false); // ★ 内部 seed 非漏洩
-    expect(await sealEncounter(env, USER, GS(), 5, 5, 12345, NOW).catch((e) => e)).toBeInstanceOf(Error); // 二重戦闘 (guard 既存)
+    // 既存ガードがあっても、新しい遭遇は**孤立ガードを破棄して成立**する (離脱後にエンカウントタイルで
+    // 詰まる=「移動できなかった」の解消)。client は戦闘中は move しないので既存ガードは必ず孤立。
+    const r2 = await sealEncounter(env, USER, GS(), 5, 5, 12345, NOW);
+    expect(r2.battleId).toMatch(/^b[0-9a-f]{24}$/);
+    expect(r2.battleId).not.toBe(r.battleId);
   });
 
   it('sealEncounter: power 0 → rewarded=false / 診断なし → 409', async () => {


### PR DESCRIPTION
歩行高速化で move が毎歩ガードを読まなくなったため、戦闘を終えず離脱するとガードが残り、その後エンカウントタイルで createGuard が InvalidSwap → 500「移動できなかった」で詰まっていた。遭遇時に孤立ガード(必ず未報酬)を破棄して新遭遇を成立。edge 143 green。