### PR TITLE
feat(world): そらのはねワープをサーバー権威化 (1歩で戻される問題を解消)

### DIFF
--- a/apps/edge/src/battle-resolver.ts
+++ b/apps/edge/src/battle-resolver.ts
@@ -12,7 +12,7 @@
  */
 import {
   startBattle, resolveTurn, statVectorToArray, jobLevelFromXp, playerLevelFromXp,
-  terrainAt, isWalkable, wrap, regionOf, regionDanger, tierForDanger, encounterRateFor, worldOverlay, BATTLE_TUNING,
+  terrainAt, isWalkable, wrap, townAt, regionOf, regionDanger, tierForDanger, encounterRateFor, worldOverlay, BATTLE_TUNING,
   type BattleState, type Command, type Archetype, type StatVector,
 } from '@aozoraquest/core';
 import { entropyU32 } from './kuda';
@@ -234,6 +234,24 @@ export async function handleMove(env: ResolverEnv, userDid: string, dx: number, 
     }
   }
   return { x: nx, y: ny, terrain, healed: healed || undefined, token: nextToken };
+}
+
+export interface TeleportResult { x: number; y: number; token: string }
+
+/**
+ * そらのはねワープ: 街タイルへテレポートし、権威位置 + トークンを更新する (client だけで飛ぶと 1 歩で
+ * サーバーの旧位置に戻される)。**街タイルのみ許可**なので高tier地帯への任意ワープはできない (街=安全地帯)。
+ * 全回復 + lastTown 更新 (街到着なので)。孤立ガードがあれば破棄。消費 (そらのはね) は当面 client 側 (#372)。
+ */
+export async function handleTeleport(env: ResolverEnv, userDid: string, x: number, y: number, now: number, ns: string = DEFAULT_NS, fetchImpl?: typeof fetch): Promise<TeleportResult> {
+  const tx = wrap(x), ty = wrap(y);
+  if (!townAt(tx, ty)) throw new ResolverError('そこは街ではない (そらのはねは街へのみ)', 400);
+  const g = await readGuard<SealedMeta, BattleState>(env, userDid);
+  if (g) await deleteGuard(env, now, userDid, g.cid); // 念のため孤立ガードを破棄
+  await readModifyWrite(env, userDid, (cur) => ({ ...cur, x: tx, y: ty, carryHp: undefined, carryMp: undefined, lastTown: { x: tx, y: ty } }),
+    { now, init: (d, iso) => migrateInitState(d, iso, ns, fetchImpl) });
+  const token = signPosition(env, { did: userDid, x: tx, y: ty, counter: 0, iat: now });
+  return { x: tx, y: ty, token };
 }
 
 export interface TurnResult {

--- a/apps/edge/src/router.ts
+++ b/apps/edge/src/router.ts
@@ -13,7 +13,7 @@ import { verifyServiceAuth, ServiceAuthError } from './service-auth';
 import { PdsError } from './pds';
 import { readState } from './game-state';
 import { handleClientMetadata, handleOAuthStart, handleOAuthCallback, type OAuthRoutesEnv } from './oauth-routes';
-import { handleMove, handleTurn, migrateInitState, ResolverError } from './battle-resolver';
+import { handleMove, handleTurn, handleTeleport, migrateInitState, ResolverError } from './battle-resolver';
 import { signPosition } from './world-token';
 import { ServerWriteError } from './server-pds';
 import type { Command } from '@aozoraquest/core';
@@ -43,6 +43,7 @@ function nsFromOrigin(req: Request): string {
 const LXM_WHOAMI = 'app.aozoraquest.whoami';
 const LXM_ME_STATE = 'app.aozoraquest.me.state';
 const LXM_WORLD_MOVE = 'app.aozoraquest.world.move';
+const LXM_WORLD_TELEPORT = 'app.aozoraquest.world.teleport';
 const LXM_BATTLE_TURN = 'app.aozoraquest.battle.turn';
 
 const AOZORA_ORIGINS = new Set([
@@ -147,6 +148,26 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
       }
       if (typeof body.dx !== 'number' || typeof body.dy !== 'number') return cors(json({ error: 'bad_request' }, 400), allowedOrigin);
       return cors(json(await handleMove(env, did, body.dx, body.dy, typeof body.token === 'string' ? body.token : undefined, nowSec(), nsFromOrigin(req))), allowedOrigin);
+    } catch (e) {
+      return cors(battleError(e), allowedOrigin);
+    }
+  }
+
+  // そらのはねワープ: 街タイルへテレポート (位置トークンを更新して 1 歩で戻されないようにする)。
+  if (req.method === 'POST' && url.pathname === '/api/world/teleport') {
+    const token = bearer(req);
+    if (!token) return cors(json({ error: 'missing_token' }, 401), allowedOrigin);
+    const audience = env.WORKER_DID ?? 'did:web:edge.aozoraquest.app';
+    let did: string;
+    try {
+      ({ iss: did } = await verifyServiceAuth(token, { audience, lxm: LXM_WORLD_TELEPORT }));
+    } catch (e) {
+      return cors(json({ error: 'unauthorized', reason: e instanceof ServiceAuthError ? e.message : 'verify_failed' }, 401), allowedOrigin);
+    }
+    const body = (await req.json().catch(() => ({}))) as { x?: number; y?: number };
+    if (typeof body.x !== 'number' || typeof body.y !== 'number') return cors(json({ error: 'bad_request' }, 400), allowedOrigin);
+    try {
+      return cors(json(await handleTeleport(env, did, body.x, body.y, nowSec(), nsFromOrigin(req))), allowedOrigin);
     } catch (e) {
       return cors(battleError(e), allowedOrigin);
     }

--- a/apps/web/src/lib/world-server.ts
+++ b/apps/web/src/lib/world-server.ts
@@ -12,6 +12,7 @@ const EDGE_URL = (import.meta.env.VITE_EDGE_URL as string | undefined)?.trim();
 const EDGE_DID = (import.meta.env.VITE_EDGE_DID as string | undefined)?.trim();
 
 const LXM_MOVE = 'app.aozoraquest.world.move';
+const LXM_TELEPORT = 'app.aozoraquest.world.teleport';
 const LXM_TURN = 'app.aozoraquest.battle.turn';
 const LXM_STATE = 'app.aozoraquest.me.state';
 
@@ -89,6 +90,11 @@ export function serverMove(agent: Agent, dx: number, dy: number, token?: string)
 /** 攻撃 (1ターン): battleId + turn + command。解決 + 決着報酬はサーバー。 */
 export function serverTurn(agent: Agent, battleId: string, turn: number, command: string): Promise<ServerTurnResult> {
   return callEdge<ServerTurnResult>(agent, LXM_TURN, '/api/battle/turn', { battleId, turn, command });
+}
+
+/** そらのはねワープ: 街 (x,y) へテレポート。位置と署名トークンをサーバーが更新して返す (1歩で戻されない)。 */
+export function serverTeleport(agent: Agent, x: number, y: number): Promise<{ x: number; y: number; token: string }> {
+  return callEdge<{ x: number; y: number; token: string }>(agent, LXM_TELEPORT, '/api/world/teleport', { x, y });
 }
 
 /** 権威 GameState を読む (表示用: パワー/XP/素材/位置)。GET だが lxm 付き JWT で本人確認。 */

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -32,7 +32,7 @@ import { COL } from '@/lib/collections';
 import { loadWorldState, saveWorldState } from '@/lib/world-state';
 import { loadBattleStats } from '@/lib/battle-log';
 import { bumpPower, loadPointsState, type PointsState } from '@/lib/points';
-import { serverMove, serverTurn, serverState, worldServerEnabled, WorldServerError, type ServerBattleState, type ServerAward } from '@/lib/world-server';
+import { serverMove, serverTurn, serverState, serverTeleport, worldServerEnabled, WorldServerError, type ServerBattleState, type ServerAward } from '@/lib/world-server';
 import { craftItem, forgeItems, loadCraftInventory, newCraftRkey, newForgeRkey, newSaleRkey, sellMaterials, type CraftedPiece } from '@/lib/crafting';
 import { ShopModal, type LastShopAction } from '@/components/shop-modal';
 import { GearModal } from '@/components/gear-modal';
@@ -626,11 +626,24 @@ export function World() {
       scheduleSave();
       setNotice(`そらのはねで「${name}」へ舞いもどった!`);
       setWipe('reveal');
+      // サーバー権威の位置 + トークンも更新 (しないと 1 歩でサーバーの旧位置に戻される)。
+      // 同期完了まで移動をブロックし、古いトークンで move されないようにする。
+      if (agent) {
+        moveBusyRef.current = true;
+        void serverTeleport(agent, dest.x, dest.y)
+          .then((res) => {
+            tokenRef.current = res.token;
+            wsRef.current = wsRef.current ? { ...wsRef.current, x: res.x, y: res.y } : wsRef.current;
+            setWs(wsRef.current);
+          })
+          .catch((e) => { console.warn('[world] teleport sync failed', e); setNotice('ワープをサーバーに反映できなかった (通信エラー)。'); })
+          .finally(() => { moveBusyRef.current = false; });
+      }
       return;
     }
     // エンカウントは serverMove が既に封印済み (battle は準備完了) なので覆い切ったら開くだけ。
     setWipe('reveal');
-  }, [scheduleSave]);
+  }, [scheduleSave, agent]);
   const onRevealDone = useCallback(() => setWipe(null), []);
   // hold タイムアウト (通常は到達しない。serverMove は遭遇 state を同期で返すので hold に入らない)。
   // 保険としてマップに開き直す。


### PR DESCRIPTION
そらのはねがクライアントだけで飛んでサーバー位置トークンが古いまま→1歩で旧位置へ戻されていた。/api/world/teleport (街タイルのみ) で位置+lastTown確定・新トークン返却、client が onCoverDone で同期。edge 143 / web 348 green。