### PR TITLE
feat(world): HP・在庫を server gameState に一元化 (#372)

### DIFF
--- a/apps/edge/src/battle-resolver.ts
+++ b/apps/edge/src/battle-resolver.ts
@@ -11,7 +11,7 @@
  *     (同一ターンの並行二重解決/引き直しを弾く)。
  */
 import {
-  startBattle, resolveTurn, statVectorToArray, jobLevelFromXp, playerLevelFromXp,
+  startBattle, resolveTurn, statVectorToArray, jobLevelFromXp, playerLevelFromXp, playerCombatant,
   terrainAt, isWalkable, wrap, townAt, regionOf, regionDanger, tierForDanger, encounterRateFor, worldOverlay, BATTLE_TUNING,
   type BattleState, type Command, type Archetype, type StatVector,
 } from '@aozoraquest/core';
@@ -103,6 +103,7 @@ export const WORLD_COLLECTION = 'app.aozoraquest.world';
  */
 export async function migrateInitState(userDid: string, nowIso: string, ns: string = DEFAULT_NS, fetchImpl?: typeof fetch): Promise<GameState> {
   const base = emptyState(userDid, nowIso);
+  base.materials = { 'sky-feather': 1 }; // 冒険はじめに そらのはね 1 個 (困ったら街へ戻れる。Option B リセット)
   try {
     const { pds } = await resolveUserPds(userDid, fetchImpl);
     const [powerRec, analysisRec, worldRec] = await Promise.all([
@@ -152,8 +153,9 @@ export async function sealEncounter(env: ResolverEnv, userDid: string, state: Ga
   const jobLevel = jobLevelFromXp(state.jobXp[archetype] ?? 0);
   const playerLevel = playerLevelFromXp(state.playerXp);
   // 戦闘ログの表示名は handle (DID ではなく)。startBattle の player 識別子に渡す。
-  const battle = startBattle(archetype, jobLevel, playerLevel, handle, tier, monsterSeed, state.herbs ?? 0, { hp: state.carryHp, mp: state.carryMp }, {
-    baseStats, equipIds: state.gear, tonics: state.tonics ?? 0, vitalsVariance: BATTLE_TUNING.monsterVitalsVariance,
+  // 在庫は materials マップに一本化 (client と同じモデル)。やくそう=herb / そらのしずく=sky-dew。
+  const battle = startBattle(archetype, jobLevel, playerLevel, handle, tier, monsterSeed, state.materials['herb'] ?? 0, { hp: state.carryHp, mp: state.carryMp }, {
+    baseStats, equipIds: state.gear, tonics: state.materials['sky-dew'] ?? 0, vitalsVariance: BATTLE_TUNING.monsterVitalsVariance,
   });
   const rewarded = state.power >= BATTLE_TUNING.powerCost;
   const pendingTurnSeed = (await entropyU32({ useKuda: true })).value;
@@ -236,7 +238,7 @@ export async function handleMove(env: ResolverEnv, userDid: string, dx: number, 
   return { x: nx, y: ny, terrain, healed: healed || undefined, token: nextToken };
 }
 
-export interface TeleportResult { x: number; y: number; token: string }
+export interface TeleportResult { x: number; y: number; token: string; materials: Record<string, number> }
 
 /**
  * そらのはねワープ: 街タイルへテレポートし、権威位置 + トークンを更新する (client だけで飛ぶと 1 歩で
@@ -248,10 +250,52 @@ export async function handleTeleport(env: ResolverEnv, userDid: string, x: numbe
   if (!townAt(tx, ty)) throw new ResolverError('そこは街ではない (そらのはねは街へのみ)', 400);
   const g = await readGuard<SealedMeta, BattleState>(env, userDid);
   if (g) await deleteGuard(env, now, userDid, g.cid); // 念のため孤立ガードを破棄
-  await readModifyWrite(env, userDid, (cur) => ({ ...cur, x: tx, y: ty, carryHp: undefined, carryMp: undefined, lastTown: { x: tx, y: ty } }),
-    { now, init: (d, iso) => migrateInitState(d, iso, ns, fetchImpl) });
+  // そらのはね (sky-feather) をサーバー在庫から 1 消費。持っていなければ 400。全回復 + lastTown 更新。
+  let materials: Record<string, number> = {};
+  const written = await readModifyWrite(env, userDid, (cur) => {
+    const have = cur.materials['sky-feather'] ?? 0;
+    if (have <= 0) throw new ResolverError('そらのはねを もっていない', 400);
+    const m: Record<string, number> = { ...cur.materials };
+    m['sky-feather'] = have - 1;
+    if (m['sky-feather'] <= 0) delete m['sky-feather'];
+    return { ...cur, x: tx, y: ty, carryHp: undefined, carryMp: undefined, lastTown: { x: tx, y: ty }, materials: m };
+  }, { now, init: (d, iso) => migrateInitState(d, iso, ns, fetchImpl) });
+  materials = written.materials;
   const token = signPosition(env, { did: userDid, x: tx, y: ty, counter: 0, iat: now });
-  return { x: tx, y: ty, token };
+  return { x: tx, y: ty, token, materials };
+}
+
+export interface ItemResult { carryHp?: number; carryMp?: number; materials: Record<string, number>; healed: number }
+
+/** フィールドの道具使用 (やくそう=herb / そらのしずく=tonic)。サーバー在庫を 1 消費して carryHp/Mp を回復。
+ *  maxHp/Mp はプレイヤーの archetype+Lv+装備から算出 (playerCombatant)。満タン/在庫切れは 400。 */
+export async function handleItem(env: ResolverEnv, userDid: string, item: 'herb' | 'tonic', now: number, ns: string = DEFAULT_NS, fetchImpl?: typeof fetch): Promise<ItemResult> {
+  const rec = await readState(env, userDid);
+  const state = rec?.state ?? (await migrateInitState(userDid, new Date(now * 1000).toISOString(), ns, fetchImpl));
+  const matId = item === 'herb' ? 'herb' : 'sky-dew';
+  if ((state.materials[matId] ?? 0) <= 0) throw new ResolverError(item === 'herb' ? 'やくそうを もっていない' : 'そらのしずくを もっていない', 400);
+  const { archetype, baseStats, handle } = await readDiagnosis(userDid, ns, fetchImpl);
+  const c = playerCombatant(archetype, jobLevelFromXp(state.jobXp[archetype] ?? 0), playerLevelFromXp(state.playerXp), handle, baseStats, state.gear);
+  let healed = 0;
+  const written = await readModifyWrite(env, userDid, (cur) => {
+    const have = cur.materials[matId] ?? 0;
+    if (have <= 0) throw new ResolverError('在庫切れ', 400);
+    const m = { ...cur.materials, [matId]: have - 1 };
+    if ((m[matId] ?? 0) <= 0) delete m[matId];
+    if (item === 'herb') {
+      const curHp = cur.carryHp ?? c.maxHp;
+      if (curHp >= c.maxHp) throw new ResolverError('HP は満タン', 400);
+      const newHp = Math.min(c.maxHp, curHp + Math.round(c.maxHp * BATTLE_TUNING.herbHealRatio));
+      healed = newHp - curHp;
+      return { ...cur, materials: m, carryHp: newHp >= c.maxHp ? undefined : newHp };
+    }
+    const curMp = cur.carryMp ?? c.maxMp;
+    if (curMp >= c.maxMp) throw new ResolverError('MP は満タン', 400);
+    const newMp = Math.min(c.maxMp, curMp + Math.max(1, Math.round(c.maxMp * BATTLE_TUNING.tonicMpRatio)));
+    healed = newMp - curMp;
+    return { ...cur, materials: m, carryMp: newMp >= c.maxMp ? undefined : newMp };
+  }, { now, init: (d, iso) => migrateInitState(d, iso, ns, fetchImpl) });
+  return { carryHp: written.carryHp, carryMp: written.carryMp, materials: written.materials, healed };
 }
 
 export interface TurnResult {
@@ -263,6 +307,10 @@ export interface TurnResult {
   position?: { x: number; y: number };
   /** 決着後の位置に対応する新しい署名トークン (敗北帰還で位置が変わるため)。 */
   token?: string;
+  /** 決着後の権威在庫/HP (client は表示をこれで同期。materials 一本化 = やくそう herb / しずく sky-dew)。 */
+  materials?: Record<string, number>;
+  carryHp?: number;
+  carryMp?: number;
 }
 
 /**
@@ -298,8 +346,13 @@ export async function handleTurn(env: ResolverEnv, userDid: string, battleId: st
     let awarded: AwardBreakdown = {};
     let finalPos = { x: 0, y: 0 };
     const window = enemyWindow(now);
-    await readModifyWrite(env, userDid, (cur: GameState): GameState => {
-      const r = applyBattleOutcome(cur, {
+    const written = await readModifyWrite(env, userDid, (cur: GameState): GameState => {
+      // 戦闘中に消費したやくそう/しずくを materials に反映してから報酬 (ドロップ/ロス) を適用。
+      const consumedMaterials = { ...cur.materials };
+      const setCount = (id: string, n: number) => { if (n > 0) consumedMaterials[id] = n; else delete consumedMaterials[id]; };
+      setCount('herb', next.herbs ?? 0);
+      setCount('sky-dew', next.tonics ?? 0);
+      const r = applyBattleOutcome({ ...cur, materials: consumedMaterials }, {
         outcome: decision, monsterId: next.monsterId, archetype: guard.sealed.archetype,
         luk: next.player.luk, rewardSeed, lossSeed, rewarded: guard.rewarded,
       });
@@ -320,15 +373,14 @@ export async function handleTurn(env: ResolverEnv, userDid: string, battleId: st
         y: finalPos.y,
         carryHp: decision === 'lose' ? undefined : next.player.hp,
         carryMp: decision === 'lose' ? undefined : next.player.mp,
-        herbs: next.herbs,
-        tonics: next.tonics,
         defeated,
         defeatedWindow: window,
       };
     }, { now, init: (did, nowIso) => migrateInitState(did, nowIso, ns) });
     // 決着後の位置に対応する新トークンを発行 (敗北帰還で位置が変わるので client はこれで同期)。
     const token = signPosition(env, { did: userDid, x: finalPos.x, y: finalPos.y, counter: 0, iat: now });
-    return { state: stripState(next), events: next.lastEvents, outcome: next.outcome, awarded, position: finalPos, token };
+    return { state: stripState(next), events: next.lastEvents, outcome: next.outcome, awarded, position: finalPos, token,
+      materials: written.materials, carryHp: written.carryHp, carryMp: written.carryMp };
   }
 
   // ── 未決着: turn+1・新 pendingTurnSeed を CAS で確定してから応答 (並行二重解決/引き直しを弾く) ──

--- a/apps/edge/src/router.ts
+++ b/apps/edge/src/router.ts
@@ -13,7 +13,7 @@ import { verifyServiceAuth, ServiceAuthError } from './service-auth';
 import { PdsError } from './pds';
 import { readState } from './game-state';
 import { handleClientMetadata, handleOAuthStart, handleOAuthCallback, type OAuthRoutesEnv } from './oauth-routes';
-import { handleMove, handleTurn, handleTeleport, migrateInitState, ResolverError } from './battle-resolver';
+import { handleMove, handleTurn, handleTeleport, handleItem, migrateInitState, ResolverError } from './battle-resolver';
 import { signPosition } from './world-token';
 import { ServerWriteError } from './server-pds';
 import type { Command } from '@aozoraquest/core';
@@ -44,6 +44,7 @@ const LXM_WHOAMI = 'app.aozoraquest.whoami';
 const LXM_ME_STATE = 'app.aozoraquest.me.state';
 const LXM_WORLD_MOVE = 'app.aozoraquest.world.move';
 const LXM_WORLD_TELEPORT = 'app.aozoraquest.world.teleport';
+const LXM_WORLD_ITEM = 'app.aozoraquest.world.item';
 const LXM_BATTLE_TURN = 'app.aozoraquest.battle.turn';
 
 const AOZORA_ORIGINS = new Set([
@@ -168,6 +169,26 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
     if (typeof body.x !== 'number' || typeof body.y !== 'number') return cors(json({ error: 'bad_request' }, 400), allowedOrigin);
     try {
       return cors(json(await handleTeleport(env, did, body.x, body.y, nowSec(), nsFromOrigin(req))), allowedOrigin);
+    } catch (e) {
+      return cors(battleError(e), allowedOrigin);
+    }
+  }
+
+  // フィールドの道具使用 (やくそう/そらのしずく)。サーバー在庫を消費して HP/MP を回復。
+  if (req.method === 'POST' && url.pathname === '/api/world/item') {
+    const token = bearer(req);
+    if (!token) return cors(json({ error: 'missing_token' }, 401), allowedOrigin);
+    const audience = env.WORKER_DID ?? 'did:web:edge.aozoraquest.app';
+    let did: string;
+    try {
+      ({ iss: did } = await verifyServiceAuth(token, { audience, lxm: LXM_WORLD_ITEM }));
+    } catch (e) {
+      return cors(json({ error: 'unauthorized', reason: e instanceof ServiceAuthError ? e.message : 'verify_failed' }, 401), allowedOrigin);
+    }
+    const body = (await req.json().catch(() => ({}))) as { item?: string };
+    if (body.item !== 'herb' && body.item !== 'tonic') return cors(json({ error: 'bad_request' }, 400), allowedOrigin);
+    try {
+      return cors(json(await handleItem(env, did, body.item, nowSec(), nsFromOrigin(req))), allowedOrigin);
     } catch (e) {
       return cors(battleError(e), allowedOrigin);
     }

--- a/apps/web/src/lib/world-server.ts
+++ b/apps/web/src/lib/world-server.ts
@@ -13,6 +13,7 @@ const EDGE_DID = (import.meta.env.VITE_EDGE_DID as string | undefined)?.trim();
 
 const LXM_MOVE = 'app.aozoraquest.world.move';
 const LXM_TELEPORT = 'app.aozoraquest.world.teleport';
+const LXM_ITEM = 'app.aozoraquest.world.item';
 const LXM_TURN = 'app.aozoraquest.battle.turn';
 const LXM_STATE = 'app.aozoraquest.me.state';
 
@@ -79,7 +80,9 @@ export interface ServerMoveResult { x: number; y: number; terrain: string; heale
 export interface ServerGameState { did: string; power: number; playerXp: number; jobXp: Record<string, number>; materials: Record<string, number>; gear: string[]; x: number; y: number; carryHp?: number; carryMp?: number; herbs?: number; tonics?: number; version: number; updatedAt: string }
 export interface ServerStateResult { state: ServerGameState; initialized: boolean; token?: string }
 export interface ServerAward { xp?: number; drops?: string[]; materialsLost?: string[]; powerSpent?: number }
-export interface ServerTurnResult { state: ServerBattleState; events: { actor: string; text: string }[]; outcome: string; awarded?: ServerAward; position?: { x: number; y: number }; token?: string }
+export interface ServerTurnResult { state: ServerBattleState; events: { actor: string; text: string }[]; outcome: string; awarded?: ServerAward; position?: { x: number; y: number }; token?: string; materials?: Record<string, number>; carryHp?: number; carryMp?: number }
+export interface ServerItemResult { carryHp?: number; carryMp?: number; materials: Record<string, number>; healed: number }
+export interface ServerTeleportResult { x: number; y: number; token: string; materials: Record<string, number> }
 
 /** 移動: 隣接1マス (dx,dy ∈ {-1,0,1})。位置トークン (署名済み) を渡し、遭遇判定 + 新トークンをサーバーが返す。
  *  token 未指定 (初回) はサーバーが gameState から位置を再同期する。歩行では PDS を触らないので高速。 */
@@ -92,9 +95,14 @@ export function serverTurn(agent: Agent, battleId: string, turn: number, command
   return callEdge<ServerTurnResult>(agent, LXM_TURN, '/api/battle/turn', { battleId, turn, command });
 }
 
-/** そらのはねワープ: 街 (x,y) へテレポート。位置と署名トークンをサーバーが更新して返す (1歩で戻されない)。 */
-export function serverTeleport(agent: Agent, x: number, y: number): Promise<{ x: number; y: number; token: string }> {
-  return callEdge<{ x: number; y: number; token: string }>(agent, LXM_TELEPORT, '/api/world/teleport', { x, y });
+/** そらのはねワープ: 街 (x,y) へテレポート。位置・トークン・在庫 (そらのはね消費) をサーバーが返す。 */
+export function serverTeleport(agent: Agent, x: number, y: number): Promise<ServerTeleportResult> {
+  return callEdge<ServerTeleportResult>(agent, LXM_TELEPORT, '/api/world/teleport', { x, y });
+}
+
+/** フィールドの道具使用: やくそう=herb / そらのしずく=tonic。サーバー在庫を消費して HP/MP を回復。 */
+export function serverItem(agent: Agent, item: 'herb' | 'tonic'): Promise<ServerItemResult> {
+  return callEdge<ServerItemResult>(agent, LXM_ITEM, '/api/world/item', { item });
 }
 
 /** 権威 GameState を読む (表示用: パワー/XP/素材/位置)。GET だが lxm 付き JWT で本人確認。 */

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -32,7 +32,7 @@ import { COL } from '@/lib/collections';
 import { loadWorldState, saveWorldState } from '@/lib/world-state';
 import { loadBattleStats } from '@/lib/battle-log';
 import { bumpPower, loadPointsState, type PointsState } from '@/lib/points';
-import { serverMove, serverTurn, serverState, serverTeleport, worldServerEnabled, WorldServerError, type ServerBattleState, type ServerAward } from '@/lib/world-server';
+import { serverMove, serverTurn, serverState, serverTeleport, serverItem, worldServerEnabled, WorldServerError, type ServerBattleState, type ServerAward } from '@/lib/world-server';
 import { craftItem, forgeItems, loadCraftInventory, newCraftRkey, newForgeRkey, newSaleRkey, sellMaterials, type CraftedPiece } from '@/lib/crafting';
 import { ShopModal, type LastShopAction } from '@/components/shop-modal';
 import { GearModal } from '@/components/gear-modal';
@@ -197,6 +197,10 @@ export function World() {
     resultPos?: { x: number; y: number };
     /** 決着後の位置に対応する新トークン。 */
     resultToken?: string;
+    /** 決着後の権威在庫/HP (materials 一本化)。決着タップで表示を同期する。 */
+    resultMaterials?: Record<string, number>;
+    resultCarryHp?: number;
+    resultCarryMp?: number;
   } | null>(null);
   /** エンカウント演出 (DQ1 風ワイプ)。cover 中はマップの上でタイルが閉じ、覆い切ったら
    *  バトル画面に差し替えて reveal で開く。支払い通信が長い場合は hold でつなぐ。 */
@@ -258,6 +262,8 @@ export function World() {
     let cancelled = false;
     setLoadErr(false);
     let grantStarter = false;
+    // サーバー gameState の在庫/HP (取得できれば表示の正)。try の内外で使うのでここで宣言。
+    let serverInv: { materials: Record<string, number>; carryHp?: number | undefined; carryMp?: number | undefined } | null = null;
     (async () => {
       try {
         const state = await loadWorldState(agent, did);
@@ -269,13 +275,17 @@ export function World() {
         // 使うことで、初回移動でクライアント位置とサーバー位置がズレて「ワープ」するのを防ぐ。
         // 街/地図/HP 等の探索メモは従来どおり client の world-record を使う。取得失敗時は world-record 位置。
         let px = state.x, py = state.y;
+        // サーバー gameState を在庫/HP/位置の**唯一の正**とする (#372)。取得失敗時のみ world-record にフォールバック。
         try {
           const ss = await serverState(agent);
-          if (!cancelled && Number.isFinite(ss.state.x) && Number.isFinite(ss.state.y)) {
-            px = ss.state.x; py = ss.state.y;
-            // 初期トークンも受け取る → 初手 move から有効トークンを送れて、表示位置=トークン位置が保証され
-            // 再同期・ワープが起きない (impl レビュー指摘)。
-            if (ss.token) tokenRef.current = ss.token;
+          if (!cancelled) {
+            serverInv = { materials: ss.state.materials ?? {}, carryHp: ss.state.carryHp, carryMp: ss.state.carryMp };
+            if (Number.isFinite(ss.state.x) && Number.isFinite(ss.state.y)) {
+              px = ss.state.x; py = ss.state.y;
+              // 初期トークンも受け取る → 初手 move から有効トークンを送れて、表示位置=トークン位置が保証され
+              // 再同期・ワープが起きない (impl レビュー指摘)。
+              if (ss.token) tokenRef.current = ss.token;
+            }
           }
         } catch (e) { console.warn('[world] serverState failed; using local position', e); }
         if (cancelled) return;
@@ -288,8 +298,9 @@ export function World() {
         const initialWs = {
           x: px,
           y: py,
-          hp: state.hp,
-          mp: state.mp,
+          // HP/MP はサーバー権威 (carryHp/Mp)。undefined=満タンなので null に。取得失敗時のみ world-record。
+          hp: serverInv ? (serverInv.carryHp ?? null) : state.hp,
+          mp: serverInv ? (serverInv.carryMp ?? null) : state.mp,
           lastTown: state.lastTown,
           regions: state.regions,
           visitedTowns: seededVisited,
@@ -332,19 +343,23 @@ export function World() {
       setAvatarUrl(profile?.data.avatar ?? null);
       setPlayerName(profile?.data.displayName || profile?.data.handle || '');
       setDiag(d);
-      setHerbStock(stats?.materials['herb'] ?? 0);
-      setTonicStock(stats?.materials['sky-dew'] ?? 0);
-      setFeatherStock((stats?.materials['sky-feather'] ?? 0) + (grantStarter ? 1 : 0));
-      {
-        const m = { ...(stats?.materials ?? {}) };
+      // 在庫はサーバー gameState を正とする (#372)。やくそう=herb / しずく=sky-dew / はね=sky-feather。
+      // サーバー取得失敗時のみ従来のクライアント集計 (stats+craft) にフォールバック。
+      let inv: Record<string, number>;
+      if (serverInv) {
+        inv = { ...serverInv.materials };
+      } else {
+        inv = { ...(stats?.materials ?? {}) };
         for (const [id, n] of Object.entries(craftInv.materialsSpent)) {
-          const left = Math.max(0, (m[id] ?? 0) - n);
-          if (left > 0) m[id] = left;
-          else delete m[id];
+          const left = Math.max(0, (inv[id] ?? 0) - n);
+          if (left > 0) inv[id] = left; else delete inv[id];
         }
-        materialsRef.current = m;
-        setMaterialsView({ ...m });
       }
+      setHerbStock(inv['herb'] ?? 0);
+      setTonicStock(inv['sky-dew'] ?? 0);
+      setFeatherStock(inv['sky-feather'] ?? 0);
+      materialsRef.current = inv;
+      setMaterialsView({ ...inv });
       setCraftedPieces(craftInv.pieces);
       setGearRefs(refs);
       setPoints(pts);
@@ -492,7 +507,8 @@ export function World() {
           const acting = { ...bClean, state: asBattleState(res.state), phase: 'message' as BattlePhase, busy: false,
             ...(res.awarded ? { awarded: res.awarded } : {}),
             ...(res.position ? { resultPos: res.position } : {}),
-            ...(res.token ? { resultToken: res.token } : {}) };
+            ...(res.token ? { resultToken: res.token } : {}),
+            ...(res.materials ? { resultMaterials: res.materials, resultCarryHp: res.carryHp, resultCarryMp: res.carryMp } : {}) };
           battleRef.current = acting;
           setBattle(acting);
         } catch (e) {
@@ -545,32 +561,29 @@ export function World() {
       // 決着後の権威位置 (敗北は最後の街へ帰還) に移動し、対応トークンで同期する。
       const resultPos = b.resultPos;
       if (b.resultToken) tokenRef.current = b.resultToken;
-      // HP/MP をフィールドに持ち帰る (持続)。敗北はサーバーが carry を消す = 全快なので null に。
+      // HP/MP + 在庫はサーバー権威 (turn 結果)。carry は undefined=満タン → null。敗北は最後の街へ帰還。
       if (next.outcome === 'lose') {
-        // 敗北: 最後の街へ帰還 + 全回復。lastTown を更新して次の敗北帰還先も揃える。
-        setWs((s) => (s ? { ...s, hp: null, mp: null, ...(resultPos ? { x: resultPos.x, y: resultPos.y, lastTown: resultPos } : {}) } : s));
+        setWs((s) => (s ? { ...s, hp: b.resultCarryHp ?? null, mp: b.resultCarryMp ?? null, ...(resultPos ? { x: resultPos.x, y: resultPos.y, lastTown: resultPos } : {}) } : s));
         if (resultPos) { const t = townAt(resultPos.x, resultPos.y); setNotice(t ? `気がつくと「${t.name}」に はこばれていた…` : '気がつくと 街に はこばれていた…'); }
       } else {
-        // 満タンは null に正規化 (絶対値で焼くと後のレベルアップで「減って見える」)。
-        const hp = next.player.hp >= next.player.maxHp ? null : Math.max(1, next.player.hp);
-        const mp = next.player.mp >= next.player.maxMp ? null : next.player.mp;
-        setWs((s) => (s ? { ...s, hp, mp, ...(resultPos ? { x: resultPos.x, y: resultPos.y } : {}) } : s));
+        setWs((s) => (s ? { ...s, hp: b.resultCarryHp ?? null, mp: b.resultCarryMp ?? null, ...(resultPos ? { x: resultPos.x, y: resultPos.y } : {}) } : s));
       }
       scheduleSave();
-      // クライアント在庫はサーバー報酬 (awarded) をミラーするだけ (表示用。正はサーバー state)。
-      // TODO: 在庫表示もサーバー state を正にする移行 (別 PR)。ここは UX を合わせる best-effort。
-      const countOf = (arr: readonly string[], id: string) => arr.filter((x) => x === id).length;
-      setHerbStock((n) => Math.max(0, n - countOf(lost, 'herb')) + countOf(drops, 'herb'));
-      setTonicStock((n) => Math.max(0, n - countOf(lost, 'sky-dew')) + countOf(drops, 'sky-dew'));
-      setFeatherStock((n) => Math.max(0, n - countOf(lost, 'sky-feather')) + countOf(drops, 'sky-feather'));
-      {
+      // 在庫表示をサーバー権威 (turn 結果の materials) で同期。取得できなければ従来のミラーで best-effort。
+      if (b.resultMaterials) {
+        const m = b.resultMaterials;
+        setHerbStock(m['herb'] ?? 0);
+        setTonicStock(m['sky-dew'] ?? 0);
+        setFeatherStock(m['sky-feather'] ?? 0);
+        materialsRef.current = { ...m };
+      } else {
+        const countOf = (arr: readonly string[], id: string) => arr.filter((x) => x === id).length;
+        setHerbStock((n) => Math.max(0, n - countOf(lost, 'herb')) + countOf(drops, 'herb'));
+        setTonicStock((n) => Math.max(0, n - countOf(lost, 'sky-dew')) + countOf(drops, 'sky-dew'));
+        setFeatherStock((n) => Math.max(0, n - countOf(lost, 'sky-feather')) + countOf(drops, 'sky-feather'));
         const m = { ...materialsRef.current };
         for (const d of drops) m[d] = (m[d] ?? 0) + 1;
-        for (const id of lost) {
-          const left = Math.max(0, (m[id] ?? 0) - 1);
-          if (left > 0) m[id] = left;
-          else delete m[id];
-        }
+        for (const id of lost) { const left = Math.max(0, (m[id] ?? 0) - 1); if (left > 0) m[id] = left; else delete m[id]; }
         materialsRef.current = m;
       }
       // 報酬を「同じ固定サイズのメッセージ窓」に畳んで出す (別パネルを出すと枠が
@@ -635,6 +648,10 @@ export function World() {
             tokenRef.current = res.token;
             wsRef.current = wsRef.current ? { ...wsRef.current, x: res.x, y: res.y } : wsRef.current;
             setWs(wsRef.current);
+            // そらのはね消費はサーバー確定 → 在庫を応答で同期。
+            setFeatherStock(res.materials['sky-feather'] ?? 0);
+            materialsRef.current = res.materials;
+            setMaterialsView({ ...res.materials });
           })
           .catch((e) => { console.warn('[world] teleport sync failed', e); setNotice('ワープをサーバーに反映できなかった (通信エラー)。'); })
           .finally(() => { moveBusyRef.current = false; });
@@ -664,14 +681,21 @@ export function World() {
     }
     const heal = Math.round(combat.maxHp * BATTLE_TUNING.herbHealRatio);
     const healed = Math.min(combat.maxHp, hpNow + heal);
+    // 楽観更新 (即応) → サーバー権威で確定 (在庫消費 + HP 回復を gameState に)。失敗ならロールバック。
     setHerbStock((n) => n - 1);
     subtractMaterial('herb', 1);
     setWs({ ...cur, hp: healed >= combat.maxHp ? null : healed });
+    if (agent) void serverItem(agent, 'herb').then((res) => {
+      setHerbStock(res.materials['herb'] ?? 0);
+      materialsRef.current = res.materials;
+      setMaterialsView({ ...res.materials });
+      setWs((s) => (s ? { ...s, hp: res.carryHp ?? null } : s));
+    }).catch((e) => { console.warn('[world] herb use failed', e); setHerbStock((n) => n + 1); setNotice('やくそうを つかえなかった (通信エラー)。'); });
     const m = `やくそうを使った! HP が ${healed - hpNow} 回復。`;
     setNotice(m);
     scheduleSave();
     return m;
-  }, [combat, herbStock, scheduleSave]);
+  }, [combat, herbStock, agent, scheduleSave, subtractMaterial]);
 
   // フィールドでそらのしずくを使う (MP 回復)
   const useTonicOnField = useCallback((): string | void => {
@@ -688,11 +712,17 @@ export function World() {
     setTonicStock((n) => n - 1);
     subtractMaterial('sky-dew', 1);
     setWs({ ...cur, mp: restored >= combat.maxMp ? null : restored });
+    if (agent) void serverItem(agent, 'tonic').then((res) => {
+      setTonicStock(res.materials['sky-dew'] ?? 0);
+      materialsRef.current = res.materials;
+      setMaterialsView({ ...res.materials });
+      setWs((s) => (s ? { ...s, mp: res.carryMp ?? null } : s));
+    }).catch((e) => { console.warn('[world] tonic use failed', e); setTonicStock((n) => n + 1); setNotice('そらのしずくを つかえなかった (通信エラー)。'); });
     const m = `そらのしずくを使った! MP が ${restored - mpNow} 回復。`;
     setNotice(m);
     scheduleSave();
     return m;
-  }, [combat, tonicStock, scheduleSave]);
+  }, [combat, tonicStock, agent, scheduleSave, subtractMaterial]);
 
   // そらのはねを使う: 訪問済みの街から行き先を選ぶ (オーナー要望 2026-07-18)。
   // フィールド専用 (戦闘中はにげるを使う)。消費の保存は TODO(W3) で DO に
@@ -716,8 +746,9 @@ export function World() {
       setNotice('もうその街にいる。');
       return;
     }
-    setFeatherStock((n) => n - 1);
-    subtractMaterial('sky-feather', 1);
+    // そらのはねの消費はサーバー (handleTeleport) が行う → onCoverDone の serverTeleport 応答で在庫更新。
+    // ここでは楽観的に featherStock だけ即減らす (材料 map はサーバー応答で確定)。
+    setFeatherStock((n) => Math.max(0, n - 1));
     featherDestRef.current = dest;
     // cover が画面を覆うまでの間に「自分の操作の結果」と分かる一言を出す
     // (エンカウント演出と同一のワイプなので、無言だと戦闘が始まると誤解する)


### PR DESCRIPTION
フィールド↔戦闘の食い違い(薬草・HP)の本丸。HP と在庫を gameState 一本化 (materials マップ統一)。/api/world/item でフィールドの道具使用をサーバー消費、handleTurn が在庫/HP を返す、クライアントは serverState/turn 結果で表示同期。そらのはねワープもサーバー消費。edge 143 / web 348 green。closes #372