### PR TITLE
chore(debug): 診断ボタンを撤去 (セッションハング解消済み)

### DIFF
--- a/apps/web/src/components/workspace.tsx
+++ b/apps/web/src/components/workspace.tsx
@@ -36,7 +36,6 @@ import { ComposeColumn } from '@/components/compose-modal';
 import { useComposePaneOpen, closeComposePane } from '@/lib/compose-pane';
 import { refreshQuestIndex } from '@/lib/quest-index-cache';
 import { invalidateProfile } from '@/lib/profile-cache';
-import { oauthDebugEnabled, dumpOAuthState } from '@/lib/oauth-debug';
 
 /** picker の表示位置: 'end' = 末尾タイル、数値 = そのカラムの直右 */
 type PickerAnchor = number | 'end' | null;
@@ -183,21 +182,8 @@ export function Workspace() {
   // `/` 離脱時は投稿カラムを閉じる (ルート跨ぎ・モバイル幅で開きっぱなしを防ぐ)
   useEffect(() => () => closeComposePane(), []);
 
-  // dev 限定: 復元ハングの診断ダンプ (コンソールが CSP eval 不可な端末向け)。捕捉した未捕捉エラーは
-  // page load 以降ずっと保持されるので、8s タイムアウトで login に抜けた後でも「Script error.」を拾える。
-  const debugDumpButton = oauthDebugEnabled ? (
-    <button type="button" onClick={() => void dumpOAuthState()} style={{ marginTop: '2em', fontSize: '0.8em', opacity: 0.7 }}>
-      🔧 診断ダンプを保存
-    </button>
-  ) : null;
-
   if (session.status === 'loading') {
-    return (
-      <>
-        <p>準備しています...</p>
-        {debugDumpButton}
-      </>
-    );
+    return <p>準備しています...</p>;
   }
 
   if (session.status === 'signed-out') {
@@ -213,7 +199,6 @@ export function Workspace() {
         <p style={{ marginTop: '1.5em', fontSize: '0.85em' }}>
           <Link to="/board">ログインせずにクエスト掲示板をのぞく →</Link>
         </p>
-        {debugDumpButton}
       </div>
     );
   }

--- a/apps/web/src/lib/oauth-debug.ts
+++ b/apps/web/src/lib/oauth-debug.ts
@@ -138,32 +138,11 @@ export async function dumpOAuthState(): Promise<Record<string, unknown>> {
 export const oauthDebugEnabled =
   import.meta.env.DEV || (import.meta.env.VITE_NSID_ENV as string | undefined)?.trim() === 'dev';
 
-/** React の外に固定ボタンを直接生やす。どの画面 (準備しています / ログイン / リダイレクト中) で
- *  固まっても・React 自体が固まっても押せるようにする (route 配置漏れ・レンダリング停止に強い)。 */
-function injectFloatingButton(): void {
-  if (typeof document === 'undefined') return;
-  const add = () => {
-    if (document.getElementById('__aozora-oauth-dump-btn')) return;
-    if (!document.body) return;
-    const btn = document.createElement('button');
-    btn.id = '__aozora-oauth-dump-btn';
-    btn.textContent = '🔧診断';
-    btn.style.cssText =
-      'position:fixed;right:8px;bottom:76px;z-index:2147483647;padding:10px 12px;' +
-      'font-size:13px;background:#c0392b;color:#fff;border:none;border-radius:10px;opacity:0.9;box-shadow:0 2px 8px rgba(0,0,0,.4)';
-    btn.addEventListener('click', (e) => { e.preventDefault(); void dumpOAuthState(); });
-    document.body.appendChild(btn);
-  };
-  if (document.body) add();
-  else document.addEventListener('DOMContentLoaded', add, { once: true });
-}
-
-/** dev / dev 環境 / ローカルのみ: 未捕捉エラー捕捉を仕込み、固定診断ボタン + `window.__aozoraDumpOAuth()`
- *  を生やす (本番では何もしない)。エラー捕捉は session 復元より前に効かせたいので import 直後に呼ぶ。 */
+/** dev / dev 環境 / ローカルのみ: 未捕捉エラー捕捉を仕込み、`window.__aozoraDumpOAuth()` を生やす
+ *  (本番では何もしない)。エラー捕捉は session 復元より前に効かせたいので import 直後に呼ぶ。 */
 export function installOAuthDebug(): void {
   if (!oauthDebugEnabled || typeof window === 'undefined') return;
   installErrorCapture();
-  injectFloatingButton();
+  // 固定診断ボタンは撤去 (セッションハング解消済み)。コンソールから __aozoraDumpOAuth() で必要時に採取可。
   (window as unknown as { __aozoraDumpOAuth?: () => Promise<unknown> }).__aozoraDumpOAuth = dumpOAuthState;
-  console.info('[oauth-debug] 右下の🔧診断ボタン (または __aozoraDumpOAuth()) でOAuth状態(伏字)をJSON保存できます');
 }


### PR DESCRIPTION
無限「準備しています」の根本修正が済んだので調査用の🔧診断ボタンを撤去。__aozoraDumpOAuth() は残す。web-only。