### PR TITLE
feat(world): 装備 (gear) を戦闘に反映 — gear-sync (#377)

### DIFF
--- a/apps/edge/src/battle-resolver.ts
+++ b/apps/edge/src/battle-resolver.ts
@@ -13,7 +13,7 @@
 import {
   startBattle, resolveTurn, statVectorToArray, jobLevelFromXp, playerLevelFromXp, playerCombatant,
   terrainAt, isWalkable, wrap, townAt, regionOf, regionDanger, tierForDanger, encounterRateFor, worldOverlay, BATTLE_TUNING,
-  type BattleState, type Command, type Archetype, type StatVector,
+  type BattleState, type Command, type Archetype, type StatVector, type GearSelection,
 } from '@aozoraquest/core';
 import { entropyU32 } from './kuda';
 import { readGuard, createGuard, advanceGuard, deleteGuard, type BattleGuard } from './battle-guard';
@@ -155,7 +155,7 @@ export async function sealEncounter(env: ResolverEnv, userDid: string, state: Ga
   // 戦闘ログの表示名は handle (DID ではなく)。startBattle の player 識別子に渡す。
   // 在庫は materials マップに一本化 (client と同じモデル)。やくそう=herb / そらのしずく=sky-dew。
   const battle = startBattle(archetype, jobLevel, playerLevel, handle, tier, monsterSeed, state.materials['herb'] ?? 0, { hp: state.carryHp, mp: state.carryMp }, {
-    baseStats, equipIds: state.gear, tonics: state.materials['sky-dew'] ?? 0, vitalsVariance: BATTLE_TUNING.monsterVitalsVariance,
+    baseStats, equipIds: state.gear, gear: state.gearSel, tonics: state.materials['sky-dew'] ?? 0, vitalsVariance: BATTLE_TUNING.monsterVitalsVariance,
   });
   const rewarded = state.power >= BATTLE_TUNING.powerCost;
   const pendingTurnSeed = (await entropyU32({ useKuda: true })).value;
@@ -296,6 +296,13 @@ export async function handleItem(env: ResolverEnv, userDid: string, item: 'herb'
     return { ...cur, materials: m, carryMp: newMp >= c.maxMp ? undefined : newMp };
   }, { now, init: (d, iso) => migrateInitState(d, iso, ns, fetchImpl) });
   return { carryHp: written.carryHp, carryMp: written.carryMp, materials: written.materials, healed };
+}
+
+/** 装備ミラー: client が解決した GearSelection (強化値つき) を gameState に保存 (戦闘に反映)。
+ *  forgeable だが §6-4 dev 無害・archetype と同じ信用レベル (M5 で再検討)。 */
+export async function handleGear(env: ResolverEnv, userDid: string, gear: GearSelection, now: number, ns: string = DEFAULT_NS, fetchImpl?: typeof fetch): Promise<{ ok: true }> {
+  await readModifyWrite(env, userDid, (cur) => ({ ...cur, gearSel: gear }), { now, init: (d, iso) => migrateInitState(d, iso, ns, fetchImpl) });
+  return { ok: true };
 }
 
 export interface TurnResult {

--- a/apps/edge/src/game-state.ts
+++ b/apps/edge/src/game-state.ts
@@ -9,6 +9,7 @@
  * 読み取りは public getRecord (SERVER_PDS_URL/SERVER_DID、認証不要)。**書き込みは M2.5 の OAuth
  * (DPoP) トークン経由** (server-pds)。ユーザー由来のリクエストは書き込みトークンを持てない。
  */
+import type { GearSelection } from '@aozoraquest/core';
 import { sha256 } from '@noble/hashes/sha256';
 import { bytesToHex } from '@noble/hashes/utils';
 import { getRecord, PdsError } from './pds';
@@ -34,6 +35,8 @@ export interface GameState {
   materials: Record<string, number>;
   /** 装備中の gear id。 */
   gear: string[];
+  /** 装備中の個体 (強化値つき GearSelection)。client がミラー送信。戦闘の実効装備はこちら (#377)。 */
+  gearSel?: GearSelection;
   /** 位置。 */
   x: number;
   y: number;

--- a/apps/edge/src/router.ts
+++ b/apps/edge/src/router.ts
@@ -13,7 +13,7 @@ import { verifyServiceAuth, ServiceAuthError } from './service-auth';
 import { PdsError } from './pds';
 import { readState } from './game-state';
 import { handleClientMetadata, handleOAuthStart, handleOAuthCallback, type OAuthRoutesEnv } from './oauth-routes';
-import { handleMove, handleTurn, handleTeleport, handleItem, migrateInitState, ResolverError } from './battle-resolver';
+import { handleMove, handleTurn, handleTeleport, handleItem, handleGear, migrateInitState, ResolverError } from './battle-resolver';
 import { signPosition } from './world-token';
 import { ServerWriteError } from './server-pds';
 import type { Command } from '@aozoraquest/core';
@@ -45,6 +45,7 @@ const LXM_ME_STATE = 'app.aozoraquest.me.state';
 const LXM_WORLD_MOVE = 'app.aozoraquest.world.move';
 const LXM_WORLD_TELEPORT = 'app.aozoraquest.world.teleport';
 const LXM_WORLD_ITEM = 'app.aozoraquest.world.item';
+const LXM_WORLD_GEAR = 'app.aozoraquest.world.gear';
 const LXM_BATTLE_TURN = 'app.aozoraquest.battle.turn';
 
 const AOZORA_ORIGINS = new Set([
@@ -189,6 +190,26 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
     if (body.item !== 'herb' && body.item !== 'tonic') return cors(json({ error: 'bad_request' }, 400), allowedOrigin);
     try {
       return cors(json(await handleItem(env, did, body.item, nowSec(), nsFromOrigin(req))), allowedOrigin);
+    } catch (e) {
+      return cors(battleError(e), allowedOrigin);
+    }
+  }
+
+  // 装備ミラー: client が解決した GearSelection (強化値つき) を gameState に保存 (戦闘に反映)。
+  if (req.method === 'POST' && url.pathname === '/api/world/gear') {
+    const token = bearer(req);
+    if (!token) return cors(json({ error: 'missing_token' }, 401), allowedOrigin);
+    const audience = env.WORKER_DID ?? 'did:web:edge.aozoraquest.app';
+    let did: string;
+    try {
+      ({ iss: did } = await verifyServiceAuth(token, { audience, lxm: LXM_WORLD_GEAR }));
+    } catch (e) {
+      return cors(json({ error: 'unauthorized', reason: e instanceof ServiceAuthError ? e.message : 'verify_failed' }, 401), allowedOrigin);
+    }
+    const body = (await req.json().catch(() => ({}))) as { gear?: unknown };
+    if (typeof body.gear !== 'object' || body.gear === null) return cors(json({ error: 'bad_request' }, 400), allowedOrigin);
+    try {
+      return cors(json(await handleGear(env, did, body.gear as Parameters<typeof handleGear>[2], nowSec(), nsFromOrigin(req))), allowedOrigin);
     } catch (e) {
       return cors(battleError(e), allowedOrigin);
     }

--- a/apps/web/src/lib/world-server.ts
+++ b/apps/web/src/lib/world-server.ts
@@ -14,6 +14,7 @@ const EDGE_DID = (import.meta.env.VITE_EDGE_DID as string | undefined)?.trim();
 const LXM_MOVE = 'app.aozoraquest.world.move';
 const LXM_TELEPORT = 'app.aozoraquest.world.teleport';
 const LXM_ITEM = 'app.aozoraquest.world.item';
+const LXM_GEAR = 'app.aozoraquest.world.gear';
 const LXM_TURN = 'app.aozoraquest.battle.turn';
 const LXM_STATE = 'app.aozoraquest.me.state';
 
@@ -103,6 +104,11 @@ export function serverTeleport(agent: Agent, x: number, y: number): Promise<Serv
 /** フィールドの道具使用: やくそう=herb / そらのしずく=tonic。サーバー在庫を消費して HP/MP を回復。 */
 export function serverItem(agent: Agent, item: 'herb' | 'tonic'): Promise<ServerItemResult> {
   return callEdge<ServerItemResult>(agent, LXM_ITEM, '/api/world/item', { item });
+}
+
+/** 装備ミラー: client が解決した装備 (GearSelection: 強化値つき) をサーバーへ送り、戦闘に反映させる (#377)。 */
+export function serverGear(agent: Agent, gear: unknown): Promise<{ ok: true }> {
+  return callEdge<{ ok: true }>(agent, LXM_GEAR, '/api/world/gear', { gear });
 }
 
 /** 権威 GameState を読む (表示用: パワー/XP/素材/位置)。GET だが lxm 付き JWT で本人確認。 */

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -32,7 +32,7 @@ import { COL } from '@/lib/collections';
 import { loadWorldState, saveWorldState } from '@/lib/world-state';
 import { loadBattleStats } from '@/lib/battle-log';
 import { bumpPower, loadPointsState, type PointsState } from '@/lib/points';
-import { serverMove, serverTurn, serverState, serverTeleport, serverItem, worldServerEnabled, WorldServerError, type ServerBattleState, type ServerAward } from '@/lib/world-server';
+import { serverMove, serverTurn, serverState, serverTeleport, serverItem, serverGear, worldServerEnabled, WorldServerError, type ServerBattleState, type ServerAward } from '@/lib/world-server';
 import { craftItem, forgeItems, loadCraftInventory, newCraftRkey, newForgeRkey, newSaleRkey, sellMaterials, type CraftedPiece } from '@/lib/crafting';
 import { ShopModal, type LastShopAction } from '@/components/shop-modal';
 import { GearModal } from '@/components/gear-modal';
@@ -232,6 +232,13 @@ export function World() {
   const archetype = diag?.archetype ?? null;
   // ジョブ/レベル由来の最大値 (フィールド HP/MP バーの分母)
   const resolvedGear = archetype ? resolveGear(gearRefs, craftedPieces, archetype) : null;
+  // 装備をサーバーにミラー (戦闘に反映 #377)。解決結果が変わるたび送る = 初回ロード + 装備変更を一括カバー。
+  // 参照でなく内容キーで発火 (resolveGear は毎回新オブジェクトを返すため)。
+  const gearKey = JSON.stringify(resolvedGear?.selection ?? null);
+  useEffect(() => {
+    if (!agent || !worldServerEnabled || gearKey === 'null') return;
+    void serverGear(agent, JSON.parse(gearKey)).catch((e) => console.warn('[world] gear sync failed', e));
+  }, [agent, gearKey]);
   // combat (装備込み) と combatBase (装備なし) は gear 引数だけが違う。base 引数を
   // 共有タプルにして「そうび +N = combat − combatBase」の不変条件を構造的に守る
   // (5 行コピペだと片方の base 導出変更で内訳が黙って壊れる — レビュー ★★)


### PR DESCRIPTION
装備はクライアントのみでサーバー未送信=戦闘に効いていなかった。gameState.gearSel + /api/world/gear + client のミラー送信で、装備・強化値を戦闘に反映。edge 143 / web 348 green。closes #377