### PR TITLE
feat(world): しらべるをサーバー権威化 — 拾ったアイテムを在庫に付与

### DIFF
--- a/apps/edge/src/battle-resolver.ts
+++ b/apps/edge/src/battle-resolver.ts
@@ -11,7 +11,7 @@
  *     (同一ターンの並行二重解決/引き直しを弾く)。
  */
 import {
-  startBattle, resolveTurn, statVectorToArray, jobLevelFromXp, playerLevelFromXp, playerCombatant,
+  startBattle, resolveTurn, statVectorToArray, jobLevelFromXp, playerLevelFromXp, playerCombatant, rollSearch,
   terrainAt, isWalkable, wrap, townAt, regionOf, regionDanger, tierForDanger, encounterRateFor, worldOverlay, BATTLE_TUNING,
   type BattleState, type Command, type Archetype, type StatVector, type GearSelection,
 } from '@aozoraquest/core';
@@ -296,6 +296,32 @@ export async function handleItem(env: ResolverEnv, userDid: string, item: 'herb'
     return { ...cur, materials: m, carryMp: newMp >= c.maxMp ? undefined : newMp };
   }, { now, init: (d, iso) => migrateInitState(d, iso, ns, fetchImpl) });
   return { carryHp: written.carryHp, carryMp: written.carryMp, materials: written.materials, healed };
+}
+
+export interface SearchResult { found: string | null; materials: Record<string, number> }
+
+/** しらべる: サーバーが luk (装備込み) + tier (位置) + 物理乱数で判定し、当たれば gameState.materials に付与。
+ *  これで拾ったアイテムがサーバー在庫の正になる (client のみの幻ではなくなる)。パワー消費は当面 client 側。 */
+export async function handleSearch(env: ResolverEnv, userDid: string, token: string | undefined, now: number, ns: string = DEFAULT_NS, fetchImpl?: typeof fetch): Promise<SearchResult> {
+  let x: number, y: number;
+  try {
+    const c = verifyPosition(env, token ?? '', userDid, now);
+    x = c.x; y = c.y;
+  } catch {
+    const rec = await readState(env, userDid);
+    const s = rec?.state ?? (await migrateInitState(userDid, new Date(now * 1000).toISOString(), ns, fetchImpl));
+    x = s.x; y = s.y;
+  }
+  const rec = await readState(env, userDid);
+  const state = rec?.state ?? (await migrateInitState(userDid, new Date(now * 1000).toISOString(), ns, fetchImpl));
+  const { archetype, baseStats, handle } = await readDiagnosis(userDid, ns, fetchImpl);
+  const luk = playerCombatant(archetype, jobLevelFromXp(state.jobXp[archetype] ?? 0), playerLevelFromXp(state.playerXp), handle, baseStats, state.gear, state.gearSel).luk;
+  const tier = tierForDanger(regionDanger(regionOf(x, y)));
+  const found = rollSearch((await entropyU32({ useKuda: true })).value, luk, tier);
+  if (!found) return { found: null, materials: state.materials };
+  const written = await readModifyWrite(env, userDid, (cur) => ({ ...cur, materials: { ...cur.materials, [found]: (cur.materials[found] ?? 0) + 1 } }),
+    { now, init: (d, iso) => migrateInitState(d, iso, ns, fetchImpl) });
+  return { found, materials: written.materials };
 }
 
 /** 装備ミラー: client が解決した GearSelection (強化値つき) を gameState に保存 (戦闘に反映)。

--- a/apps/edge/src/router.ts
+++ b/apps/edge/src/router.ts
@@ -13,7 +13,7 @@ import { verifyServiceAuth, ServiceAuthError } from './service-auth';
 import { PdsError } from './pds';
 import { readState } from './game-state';
 import { handleClientMetadata, handleOAuthStart, handleOAuthCallback, type OAuthRoutesEnv } from './oauth-routes';
-import { handleMove, handleTurn, handleTeleport, handleItem, handleGear, migrateInitState, ResolverError } from './battle-resolver';
+import { handleMove, handleTurn, handleTeleport, handleItem, handleGear, handleSearch, migrateInitState, ResolverError } from './battle-resolver';
 import { signPosition } from './world-token';
 import { ServerWriteError } from './server-pds';
 import type { Command } from '@aozoraquest/core';
@@ -46,6 +46,7 @@ const LXM_WORLD_MOVE = 'app.aozoraquest.world.move';
 const LXM_WORLD_TELEPORT = 'app.aozoraquest.world.teleport';
 const LXM_WORLD_ITEM = 'app.aozoraquest.world.item';
 const LXM_WORLD_GEAR = 'app.aozoraquest.world.gear';
+const LXM_WORLD_SEARCH = 'app.aozoraquest.world.search';
 const LXM_BATTLE_TURN = 'app.aozoraquest.battle.turn';
 
 const AOZORA_ORIGINS = new Set([
@@ -210,6 +211,25 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
     if (typeof body.gear !== 'object' || body.gear === null) return cors(json({ error: 'bad_request' }, 400), allowedOrigin);
     try {
       return cors(json(await handleGear(env, did, body.gear as Parameters<typeof handleGear>[2], nowSec(), nsFromOrigin(req))), allowedOrigin);
+    } catch (e) {
+      return cors(battleError(e), allowedOrigin);
+    }
+  }
+
+  // しらべる: サーバーがアイテムを判定して gameState 在庫に付与 (client のみの幻を解消)。
+  if (req.method === 'POST' && url.pathname === '/api/world/search') {
+    const token = bearer(req);
+    if (!token) return cors(json({ error: 'missing_token' }, 401), allowedOrigin);
+    const audience = env.WORKER_DID ?? 'did:web:edge.aozoraquest.app';
+    let did: string;
+    try {
+      ({ iss: did } = await verifyServiceAuth(token, { audience, lxm: LXM_WORLD_SEARCH }));
+    } catch (e) {
+      return cors(json({ error: 'unauthorized', reason: e instanceof ServiceAuthError ? e.message : 'verify_failed' }, 401), allowedOrigin);
+    }
+    const body = (await req.json().catch(() => ({}))) as { token?: string };
+    try {
+      return cors(json(await handleSearch(env, did, typeof body.token === 'string' ? body.token : undefined, nowSec(), nsFromOrigin(req))), allowedOrigin);
     } catch (e) {
       return cors(battleError(e), allowedOrigin);
     }

--- a/apps/web/src/lib/world-server.ts
+++ b/apps/web/src/lib/world-server.ts
@@ -15,6 +15,7 @@ const LXM_MOVE = 'app.aozoraquest.world.move';
 const LXM_TELEPORT = 'app.aozoraquest.world.teleport';
 const LXM_ITEM = 'app.aozoraquest.world.item';
 const LXM_GEAR = 'app.aozoraquest.world.gear';
+const LXM_SEARCH = 'app.aozoraquest.world.search';
 const LXM_TURN = 'app.aozoraquest.battle.turn';
 const LXM_STATE = 'app.aozoraquest.me.state';
 
@@ -109,6 +110,11 @@ export function serverItem(agent: Agent, item: 'herb' | 'tonic'): Promise<Server
 /** 装備ミラー: client が解決した装備 (GearSelection: 強化値つき) をサーバーへ送り、戦闘に反映させる (#377)。 */
 export function serverGear(agent: Agent, gear: unknown): Promise<{ ok: true }> {
   return callEdge<{ ok: true }>(agent, LXM_GEAR, '/api/world/gear', { gear });
+}
+
+/** しらべる: サーバーがアイテムを判定して gameState 在庫に付与。found (無ければ null) + 新 materials を返す。 */
+export function serverSearch(agent: Agent, token?: string): Promise<{ found: string | null; materials: Record<string, number> }> {
+  return callEdge<{ found: string | null; materials: Record<string, number> }>(agent, LXM_SEARCH, '/api/world/search', token ? { token } : {});
 }
 
 /** 権威 GameState を読む (表示用: パワー/XP/素材/位置)。GET だが lxm 付き JWT で本人確認。 */

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -32,7 +32,7 @@ import { COL } from '@/lib/collections';
 import { loadWorldState, saveWorldState } from '@/lib/world-state';
 import { loadBattleStats } from '@/lib/battle-log';
 import { bumpPower, loadPointsState, type PointsState } from '@/lib/points';
-import { serverMove, serverTurn, serverState, serverTeleport, serverItem, serverGear, worldServerEnabled, WorldServerError, type ServerBattleState, type ServerAward } from '@/lib/world-server';
+import { serverMove, serverTurn, serverState, serverTeleport, serverItem, serverGear, serverSearch, worldServerEnabled, WorldServerError, type ServerBattleState, type ServerAward } from '@/lib/world-server';
 import { craftItem, forgeItems, loadCraftInventory, newCraftRkey, newForgeRkey, newSaleRkey, sellMaterials, type CraftedPiece } from '@/lib/crafting';
 import { ShopModal, type LastShopAction } from '@/components/shop-modal';
 import { GearModal } from '@/components/gear-modal';
@@ -765,29 +765,31 @@ export function World() {
 
   // しらべる: パワー 1 を使って足元を調べる。luk 連動でアイテムが手に入ることがある
   // (見つからないこともある)。発見物はセッション内在庫に加える (消費の正は TODO(W3))。
-  const searchHere = useCallback((): string => {
+  // しらべる: **サーバーがアイテムを判定して gameState 在庫に付与** (client のみの幻を解消)。パワー消費は
+  // 当面 client (points 経済)。結果 (found/materials) はサーバー応答で確定し表示を同期する。
+  const searchHere = useCallback(async (): Promise<void> => {
     const s = wsRef.current;
     const pts = pointsRef.current;
-    if (!s || !agent || !did) return 'いま しらべられない (つうしんを かくにんして)。';
-    if (!pts || pts.balance < SEARCH_TUNING.powerCost) return `パワーが たりない (しらべるには ${SEARCH_TUNING.powerCost} いる)。とうこうすると ふえるよ。`;
-    const luk = combatRef.current?.luk ?? 0;
-    const tier = tierForDanger(regionDanger(regionOf(s.x, s.y)));
-    const seed = Math.floor(Math.random() * 0xffffffff) >>> 0;
-    const found = rollSearch(seed, luk, tier);
-    // パワーを 1 消費 (見つかっても見つからなくても。無料の無限試行を作らない)
+    if (!s || !agent || !did) { setSearchMsg('いま しらべられない (つうしんを かくにんして)。'); return; }
+    if (!pts || pts.balance < SEARCH_TUNING.powerCost) { setSearchMsg(`パワーが たりない (しらべるには ${SEARCH_TUNING.powerCost} いる)。とうこうすると ふえるよ。`); return; }
     const left = Math.max(0, pts.balance - SEARCH_TUNING.powerCost);
     void bumpPower(agent, did, { searchPowerSpent: SEARCH_TUNING.powerCost });
     setPoints((p) => (p ? { ...p, searchPowerSpent: p.searchPowerSpent + SEARCH_TUNING.powerCost, balance: Math.max(0, p.balance - SEARCH_TUNING.powerCost) } : p));
-    if (!found) return `あたりを しらべたが、なにも なかった… (のこりパワー ${left})`;
-    // 在庫に加える。消耗品 (やくそう/しずく) は「どうぐ」で使え、素材は「もちもの」に入る
-    const isConsumable = found === 'herb' || found === 'sky-dew';
-    if (found === 'herb') setHerbStock((n) => n + 1);
-    else if (found === 'sky-dew') setTonicStock((n) => n + 1);
-    const m = materialsRef.current;
-    m[found] = (m[found] ?? 0) + 1;
-    setMaterialsView({ ...m });
-    const where = isConsumable ? 'どうぐ' : 'もちもの';
-    return `しらべると、${ITEMS[found]?.name ?? found} を 1 つ 見つけた! (${where}で かくにん / のこりパワー ${left})`;
+    setSearchMsg('あたりを しらべている…');
+    try {
+      const res = await serverSearch(agent, tokenRef.current);
+      setHerbStock(res.materials['herb'] ?? 0);
+      setTonicStock(res.materials['sky-dew'] ?? 0);
+      setFeatherStock(res.materials['sky-feather'] ?? 0);
+      materialsRef.current = res.materials;
+      setMaterialsView({ ...res.materials });
+      if (!res.found) { setSearchMsg(`あたりを しらべたが、なにも なかった… (のこりパワー ${left})`); return; }
+      const isConsumable = res.found === 'herb' || res.found === 'sky-dew';
+      setSearchMsg(`しらべると、${ITEMS[res.found]?.name ?? res.found} を 1 つ 見つけた! (${isConsumable ? 'どうぐ' : 'もちもの'}で かくにん / のこりパワー ${left})`);
+    } catch (e) {
+      console.warn('[world] search failed', e);
+      setSearchMsg('しらべられなかった (通信エラー)。もういちどどうぞ。');
+    }
   }, [agent, did]);
 
   // なんでも屋で作ってもらう (docs/20 W6b)。支払い: パワー (craftPowerSpent 累積) +
@@ -992,7 +994,7 @@ export function World() {
   const menuCommands: WorldMenuCommand[] = [
     { key: 'items', label: 'どうぐ', onSelect: () => setItemsOpen(true) },
     // しらべるは街の外だけ (街=安全地帯で地方素材は出ない)。コストをラベルに明記
-    ...(inTown ? [] : [{ key: 'search', label: `しらべる (パワー${SEARCH_TUNING.powerCost})`, onSelect: () => setSearchMsg(searchHere()) } as WorldMenuCommand]),
+    ...(inTown ? [] : [{ key: 'search', label: `しらべる (パワー${SEARCH_TUNING.powerCost})`, onSelect: () => void searchHere() } as WorldMenuCommand]),
     { key: 'gear', label: 'そうび', onSelect: () => setGearOpen(true) },
     { key: 'map', label: 'ちず', onSelect: () => setMapOpen(true) },
     { key: 'inventory', label: 'もちもの', onSelect: () => setInvOpen(true) },


### PR DESCRIPTION
しらべるで拾ったアイテムが client-only の幻だった。/api/world/search でサーバーが判定・付与、client は応答で在庫同期。edge 143 / web 348 green。