### PR TITLE
feat(world): オンボード用リセット + 初期アイテム/はじまりの祝福 (P1)

### DIFF
--- a/apps/edge/src/battle-resolver.ts
+++ b/apps/edge/src/battle-resolver.ts
@@ -17,7 +17,8 @@ import {
 } from '@aozoraquest/core';
 import { entropyU32 } from './kuda';
 import { readGuard, createGuard, advanceGuard, deleteGuard, type BattleGuard } from './battle-guard';
-import { readState, readModifyWrite, emptyState, type GameStateEnv, type GameState } from './game-state';
+import { readState, readModifyWrite, emptyState, rkeyForDid, GAME_STATE_COLLECTION, type GameStateEnv, type GameState } from './game-state';
+import { serverDeleteRecord } from './server-pds';
 import { signPosition, verifyPosition, enemyWindow, tileEncounter } from './world-token';
 import { applyBattleOutcome, type AwardBreakdown, type BattleDecision } from './battle-reward';
 import { resolveDidDocument } from './service-auth';
@@ -106,7 +107,8 @@ export const WORLD_COLLECTION = 'app.aozoraquest.world';
  */
 export async function migrateInitState(userDid: string, nowIso: string, ns: string = DEFAULT_NS, fetchImpl?: typeof fetch): Promise<GameState> {
   const base = emptyState(userDid, nowIso);
-  base.materials = { 'sky-feather': 1 }; // 冒険はじめに そらのはね 1 個 (困ったら街へ戻れる。Option B リセット)
+  // 冒険はじめの持ち物: やくそう 1 (最初の回復) + そらのはね 1 (困ったら街へ戻れる)。
+  base.materials = { herb: 1, 'sky-feather': 1 };
   try {
     const { pds } = await resolveUserPds(userDid, fetchImpl);
     const [powerRec, analysisRec, worldRec] = await Promise.all([
@@ -134,6 +136,23 @@ export async function migrateInitState(userDid: string, nowIso: string, ns: stri
     }
   } catch { /* 読めない/未診断は power 0・Lv1 で開始 (読取のみ = 無害) */ }
   return base;
+}
+
+/**
+ * オンボード用リセット: サーバー権威データ (gameState + 戦闘ガード) を消す。
+ * 次の move/state で migrateInitState が走り、初期状態 (spawn + やくそう&そらのはね + Lv1) から再開する。
+ * client 側の PDS レコード (制作/装備/世界/パワー/分析XP) の初期化は client が本人トークンで行う
+ * (自分の repo は本人が書ける)。ここはユーザーが書けない権威データだけを担当する。
+ * **認証済み本人 (userDid) の state しか消せない** = 破壊範囲は呼び出し本人に限定 (他人を初期化できない)。
+ */
+export async function handleReset(env: ResolverEnv, userDid: string, now: number): Promise<{ ok: true }> {
+  // 進行中の戦闘ガードがあれば破棄 (未報酬なので二重報酬にはならない)。
+  const guard = await readGuard<SealedMeta, BattleState>(env, userDid);
+  if (guard) await deleteGuard(env, now, userDid, guard.cid);
+  // gameState レコードを削除 → 次の move/state で migrateInitState が初期状態を生成する。
+  const existing = await readState(env, userDid);
+  if (existing) await serverDeleteRecord(env, now, GAME_STATE_COLLECTION, rkeyForDid(userDid), existing.cid);
+  return { ok: true };
 }
 
 /** バトルガードの寿命 (秒)。各ターンで更新。切れたガードは move 時に flush = クラッシュしても

--- a/apps/edge/src/router.ts
+++ b/apps/edge/src/router.ts
@@ -13,7 +13,7 @@ import { verifyServiceAuth, ServiceAuthError } from './service-auth';
 import { PdsError } from './pds';
 import { readState } from './game-state';
 import { handleClientMetadata, handleOAuthStart, handleOAuthCallback, type OAuthRoutesEnv } from './oauth-routes';
-import { handleMove, handleTurn, handleTeleport, handleItem, handleGear, handleSearch, migrateInitState, ResolverError } from './battle-resolver';
+import { handleMove, handleTurn, handleTeleport, handleItem, handleGear, handleSearch, handleReset, migrateInitState, ResolverError } from './battle-resolver';
 import { signPosition } from './world-token';
 import { ServerWriteError } from './server-pds';
 import type { Command } from '@aozoraquest/core';
@@ -47,6 +47,7 @@ const LXM_WORLD_TELEPORT = 'app.aozoraquest.world.teleport';
 const LXM_WORLD_ITEM = 'app.aozoraquest.world.item';
 const LXM_WORLD_GEAR = 'app.aozoraquest.world.gear';
 const LXM_WORLD_SEARCH = 'app.aozoraquest.world.search';
+const LXM_WORLD_RESET = 'app.aozoraquest.world.reset';
 const LXM_BATTLE_TURN = 'app.aozoraquest.battle.turn';
 
 const AOZORA_ORIGINS = new Set([
@@ -230,6 +231,25 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
     const body = (await req.json().catch(() => ({}))) as { token?: string };
     try {
       return cors(json(await handleSearch(env, did, typeof body.token === 'string' ? body.token : undefined, nowSec(), nsFromOrigin(req))), allowedOrigin);
+    } catch (e) {
+      return cors(battleError(e), allowedOrigin);
+    }
+  }
+
+  // オンボード用リセット: 認証済み本人の権威 gameState + 戦闘ガードを削除する (他人は消せない)。
+  // client 側 PDS レコードの初期化は client が本人トークンで行う。UI は dev + 管理者に限定。
+  if (req.method === 'POST' && url.pathname === '/api/world/reset') {
+    const token = bearer(req);
+    if (!token) return cors(json({ error: 'missing_token' }, 401), allowedOrigin);
+    const audience = env.WORKER_DID ?? 'did:web:edge.aozoraquest.app';
+    let did: string;
+    try {
+      ({ iss: did } = await verifyServiceAuth(token, { audience, lxm: LXM_WORLD_RESET }));
+    } catch (e) {
+      return cors(json({ error: 'unauthorized', reason: e instanceof ServiceAuthError ? e.message : 'verify_failed' }, 401), allowedOrigin);
+    }
+    try {
+      return cors(json(await handleReset(env, did, nowSec())), allowedOrigin);
     } catch (e) {
       return cors(battleError(e), allowedOrigin);
     }

--- a/apps/edge/test/battle-resolver.test.ts
+++ b/apps/edge/test/battle-resolver.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { p256 } from '@noble/curves/p256';
 import { base64urlnopad } from '@scure/base';
-import { sealEncounter, handleMove, handleTurn, migrateInitState, ResolverError, GUARD_TTL_SEC, type ResolverEnv } from '../src/battle-resolver';
+import { sealEncounter, handleMove, handleTurn, handleReset, migrateInitState, ResolverError, GUARD_TTL_SEC, type ResolverEnv } from '../src/battle-resolver';
 import { writeServerTokens } from '../src/oauth-store';
 import { terrainAt, isWalkable, type Command } from '@aozoraquest/core';
 import type { GameState } from '../src/game-state';
@@ -210,5 +210,25 @@ describe('battle-resolver (サーバー権威 移動/戦闘)', () => {
     expect(s3.power).toBe(0);
     expect(s3.playerXp).toBe(0);
     expect(s3.jobXp).toEqual({});
+    // 冒険はじめの持ち物: やくそう 1 + そらのはね 1 (どのケースでも初期付与される)。
+    expect(s3.materials).toEqual({ herb: 1, 'sky-feather': 1 });
+    expect(s1.materials).toEqual({ herb: 1, 'sky-feather': 1 });
+  });
+
+  it('handleReset: 認証済み本人の権威 gameState + 戦闘ガードを削除する (次入場で初期化)', async () => {
+    const env = await makeEnv();
+    const mock = resolverMock({ diagnosis: DIAG, gameState: GS() });
+    globalThis.fetch = mock.fn;
+    // 遭遇でガードを作る → gameState と guard が store に居る状態を作る
+    await sealEncounter(env, USER, GS(), 5, 5, 12345, NOW);
+    expect(mock.store.has('gs')).toBe(true);
+    expect(mock.store.has('guard')).toBe(true);
+    // リセット: 両方消える
+    const r = await handleReset(env, USER, NOW);
+    expect(r).toEqual({ ok: true });
+    expect(mock.store.has('gs')).toBe(false);
+    expect(mock.store.has('guard')).toBe(false);
+    // 冪等: state/guard 無しでも例外を投げない
+    await expect(handleReset(env, USER, NOW)).resolves.toEqual({ ok: true });
   });
 });

--- a/apps/web/src/components/welcome-blessing.tsx
+++ b/apps/web/src/components/welcome-blessing.tsx
@@ -16,25 +16,38 @@ export function notifyWelcome(ev: WelcomeEvent) {
   }
 }
 
-const WELCOME_DURATION_MS = 3200;
+/** 演出の見せ時間 (フェード開始まで) と フェードの尺。合計 ≈ 3.3s。
+ *  呼び出し側の reload はこの合計より後 (余韻込み) にずらすこと (パッと消えて即リロードだと締まらない)。 */
+export const WELCOME_VISIBLE_MS = 2800;
+export const WELCOME_FADE_MS = 500;
+export const WELCOME_TOTAL_MS = WELCOME_VISIBLE_MS + WELCOME_FADE_MS;
 
 /**
  * オンボード完了時に「はじまりの祝福」を全面オーバーレイで演出する
  * (level-up-overlay と同じ作法。旅立ちの祝福 + 付与パワーを一度だけ流す)。
+ * **単一マウント前提** (world ルートに 1 つ)。複数マウントすると notifyWelcome が全 listener に
+ * 配られ二重演出になる (cleanup はしているので実害は薄いが 1 箇所に留めること)。
  */
 export function WelcomeBlessingOverlay() {
   const [current, setCurrent] = useState<WelcomeEvent | null>(null);
-  const timerRef = useRef<number | null>(null);
+  const [leaving, setLeaving] = useState(false); // フェードアウト中 (opacity→0)
+  const fadeRef = useRef<number | null>(null);
+  const endRef = useRef<number | null>(null);
   useEffect(() => {
     const listener: Listener = (ev) => {
+      if (fadeRef.current) window.clearTimeout(fadeRef.current);
+      if (endRef.current) window.clearTimeout(endRef.current);
       setCurrent(ev);
-      if (timerRef.current) window.clearTimeout(timerRef.current);
-      timerRef.current = window.setTimeout(() => setCurrent(null), WELCOME_DURATION_MS);
+      setLeaving(false);
+      // 見せ切ってからフェード → 消灯 (パッと消えず、余韻を残す)
+      fadeRef.current = window.setTimeout(() => setLeaving(true), WELCOME_VISIBLE_MS);
+      endRef.current = window.setTimeout(() => setCurrent(null), WELCOME_TOTAL_MS);
     };
     listeners.add(listener);
     return () => {
       listeners.delete(listener);
-      if (timerRef.current) window.clearTimeout(timerRef.current);
+      if (fadeRef.current) window.clearTimeout(fadeRef.current);
+      if (endRef.current) window.clearTimeout(endRef.current);
     };
   }, []);
 
@@ -52,6 +65,8 @@ export function WelcomeBlessingOverlay() {
         justifyContent: 'center',
         pointerEvents: 'none',
         zIndex: 1100,
+        opacity: leaving ? 0 : 1,
+        transition: `opacity ${WELCOME_FADE_MS}ms ease`,
       }}
     >
       <style>{WELCOME_KEYFRAMES}</style>

--- a/apps/web/src/components/welcome-blessing.tsx
+++ b/apps/web/src/components/welcome-blessing.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useRef, useState } from 'react';
+
+/** はじまりの祝福 (オンボード) の演出イベント。 */
+export interface WelcomeEvent {
+  /** 付与したあおぞらパワー。 */
+  power: number;
+}
+
+type Listener = (ev: WelcomeEvent) => void;
+const listeners = new Set<Listener>();
+
+/** オンボード完了 (リセット直後) に「はじまりの祝福」を演出する。 */
+export function notifyWelcome(ev: WelcomeEvent) {
+  for (const cb of listeners) {
+    try { cb(ev); } catch (e) { console.warn('welcome listener failed', e); }
+  }
+}
+
+const WELCOME_DURATION_MS = 3200;
+
+/**
+ * オンボード完了時に「はじまりの祝福」を全面オーバーレイで演出する
+ * (level-up-overlay と同じ作法。旅立ちの祝福 + 付与パワーを一度だけ流す)。
+ */
+export function WelcomeBlessingOverlay() {
+  const [current, setCurrent] = useState<WelcomeEvent | null>(null);
+  const timerRef = useRef<number | null>(null);
+  useEffect(() => {
+    const listener: Listener = (ev) => {
+      setCurrent(ev);
+      if (timerRef.current) window.clearTimeout(timerRef.current);
+      timerRef.current = window.setTimeout(() => setCurrent(null), WELCOME_DURATION_MS);
+    };
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+      if (timerRef.current) window.clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  if (!current) return null;
+
+  return (
+    <div
+      aria-live="polite"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        pointerEvents: 'none',
+        zIndex: 1100,
+      }}
+    >
+      <style>{WELCOME_KEYFRAMES}</style>
+      <div
+        style={{
+          padding: '1.2em 1.8em',
+          background: 'rgba(10, 21, 40, 0.92)',
+          border: '3px solid var(--color-accent)',
+          borderRadius: 6,
+          textAlign: 'center',
+          animation: 'welcome-pop 420ms cubic-bezier(0.2, 0.9, 0.4, 1.4) both',
+          boxShadow: '0 0 24px rgba(159, 215, 255, 0.5)',
+        }}
+      >
+        <div
+          style={{
+            fontFamily: 'ui-monospace, monospace',
+            fontSize: '1.5em',
+            fontWeight: 700,
+            letterSpacing: '0.08em',
+            color: 'var(--color-accent)',
+            textShadow: '0 0 12px rgba(159, 215, 255, 0.7)',
+          }}
+        >
+          はじまりの祝福
+        </div>
+        <div style={{ marginTop: '0.6em', fontSize: '0.95em', color: '#ffffff', lineHeight: 1.7 }}>
+          <div>やくそう と そらのはね を手にした</div>
+          <div style={{ marginTop: '0.2em' }}>
+            あおぞらパワー{' '}
+            <span style={{ fontFamily: 'ui-monospace, monospace', color: 'var(--color-accent)', fontWeight: 700 }}>
+              +{current.power}
+            </span>
+          </div>
+        </div>
+      </div>
+      {/* 後光的な光る粒 (level-up-overlay と同系統) */}
+      <div
+        aria-hidden
+        style={{
+          position: 'absolute',
+          width: 0,
+          height: 0,
+          animation: 'welcome-burst 1.6s ease-out both',
+          borderRadius: '50%',
+          boxShadow:
+            '0 0 0 6px rgba(255,255,255,0.55), 0 0 0 18px rgba(159,215,255,0.35), 0 0 0 42px rgba(159,215,255,0.15)',
+          zIndex: -1,
+        }}
+      />
+    </div>
+  );
+}
+
+const WELCOME_KEYFRAMES = `
+@keyframes welcome-pop { 0% { transform: scale(0.6); opacity: 0; } 100% { transform: scale(1); opacity: 1; } }
+@keyframes welcome-burst { 0% { opacity: 0.9; transform: scale(0.2); } 100% { opacity: 0; transform: scale(1.6); } }
+`;

--- a/apps/web/src/lib/onboarding-reset.ts
+++ b/apps/web/src/lib/onboarding-reset.ts
@@ -2,38 +2,47 @@
  * オンボード用リセット (docs/19)。あおぞらワールドを「はじめから」体験するための完全ワイプ。
  *
  * 権威 gameState (所持品・装備・位置・レベル) はサーバーが持つのでサーバー経由で消し、
- * client 所有の PDS レコード (制作/装備/世界/パワー/分析XP) は本人トークンで消す。
- * **投稿で貯めたパワー残高は消さず**、world の消費/獲得だけを 0 に再集計してから
- * 歓迎の +20 パワーを加算する。次のワールド入場で初期状態
+ * client 所有の PDS レコード (制作/戦闘/装備/世界/パワー/分析XP) は本人トークンで消す。
+ * **投稿で貯めたパワー残高は保持**し、world 由来の消費/獲得 (battles/craft/sale/search) を
+ * 0 に戻したうえで歓迎の +20 パワーを載せる。次のワールド入場で初期状態
  * (spawn + やくそう&そらのはね + Lv1 + 投稿由来パワー +20) から再開する。
+ *
+ * **順序の要点**: gameState 削除 (serverReset) を**最後**に行う。migrateInitState は次入場で
+ * analysis(XP)/world(位置)/power(残高) を読んで初期状態を作るので、それらを先に掃除してから
+ * gameState を消す。こうすると途中失敗しても「gameState は残る=旧状態のまま」で止まり、
+ * 半端に古い Lv/位置で復帰しない。各ステップは冪等 (削除は no-op 安全、power は絶対値書き込み)
+ * なので、失敗時は同じ操作を再実行すれば収束する (doReset がエラーを拾ってリトライ導線にする)。
  *
  * dev + 管理者のみが UI から呼べる。自分の repo と自分の gameState しか触らない。
  */
 import type { Agent } from '@atproto/api';
 import { getRecord, putRecord } from './atproto';
 import { COL } from './collections';
-import { bumpPower } from './points';
+import { resetWorldPower } from './points';
 import { serverReset } from './world-server';
 
 /** 歓迎付与するあおぞらパワー (演出とともに加算)。 */
 export const WELCOME_POWER = 20;
 
-/** あるコレクションの全レコードを削除 (最大 500 件)。未作成コレクションは何もしない。 */
+/** あるコレクションの全レコードを削除。records が尽きるまでページングする
+ *  (途中で打ち切ると「完全ワイプ」にならず、直後の power 再集計に残留分が混ざる)。
+ *  未作成コレクションは何もしない。安全上限 10000 件 (暴走防止)。 */
 async function deleteAllRecords(agent: Agent, did: string, collection: string): Promise<void> {
   let cursor: string | undefined;
-  for (let page = 0; page < 5; page++) {
+  for (let page = 0; page < 100; page++) {
     let res;
     try {
       res = await agent.com.atproto.repo.listRecords({ repo: did, collection, limit: 100, ...(cursor ? { cursor } : {}) });
     } catch {
       return; // 未作成
     }
+    if (res.data.records.length === 0) break;
     for (const r of res.data.records) {
       const rkey = r.uri.split('/').pop();
       if (rkey) await agent.com.atproto.repo.deleteRecord({ repo: did, collection, rkey }).catch(() => {});
     }
     const next = res.data.cursor;
-    if (!next || next === cursor || res.data.records.length === 0) break;
+    if (!next || next === cursor) break;
     cursor = next;
   }
 }
@@ -56,20 +65,21 @@ async function zeroAnalysisXp(agent: Agent, did: string): Promise<void> {
 }
 
 /**
- * 完全ワイプ → 初期状態へ。順序が重要:
- * 1. 所有物 (COL.craft = 制作/合成/売却)・装備中 (COL.gear)・旧世界記録 (COL.world) を削除。
- * 2. 分析 XP を 0 に (Lv1)。
- * 3. パワーキャッシュ (COL.power) を削除 → 次の集計で world 消費/獲得が 0 に再計算される
- *    (投稿由来の残高は post/spiritChat 走査で保持される)。
- * 4. 歓迎の +20 パワーを加算 (キャッシュ無し → scanFullPoints でクリーン集計 → +20)。
- * 5. サーバー権威 gameState + 戦闘ガードを削除 → 次のワールド入場で初期状態を生成。
+ * 完全ワイプ → 初期状態へ。
+ * 1. 所有物 (COL.craft = 制作/合成/売却)・戦闘履歴 (COL.battle) を全削除。
+ *    battle も消すのは、power の battles 消費を 0 に戻す (resetWorldPower) のと整合させ、
+ *    将来 power キャッシュが再集計されても battles が復活しないようにするため。
+ * 2. 装備中 (COL.gear)・旧世界記録 (COL.world) を削除。
+ * 3. 分析 XP を 0 に (Lv1)。
+ * 4. power を絶対値で書き直す: world 消費/獲得を 0、歓迎 +20 を salePowerEarned に (冪等)。
+ * 5. サーバー権威 gameState + 戦闘ガードを削除 → 次のワールド入場で初期状態を生成 (最後に実行)。
  */
 export async function resetOnboarding(agent: Agent, did: string): Promise<void> {
   await deleteAllRecords(agent, did, COL.craft);
+  await deleteAllRecords(agent, did, COL.battle);
   await deleteSelf(agent, did, COL.gear);
   await deleteSelf(agent, did, COL.world);
   await zeroAnalysisXp(agent, did);
-  await deleteSelf(agent, did, COL.power);
-  await bumpPower(agent, did, { salePowerEarned: WELCOME_POWER });
+  await resetWorldPower(agent, did, WELCOME_POWER);
   await serverReset(agent);
 }

--- a/apps/web/src/lib/onboarding-reset.ts
+++ b/apps/web/src/lib/onboarding-reset.ts
@@ -1,0 +1,75 @@
+/**
+ * オンボード用リセット (docs/19)。あおぞらワールドを「はじめから」体験するための完全ワイプ。
+ *
+ * 権威 gameState (所持品・装備・位置・レベル) はサーバーが持つのでサーバー経由で消し、
+ * client 所有の PDS レコード (制作/装備/世界/パワー/分析XP) は本人トークンで消す。
+ * **投稿で貯めたパワー残高は消さず**、world の消費/獲得だけを 0 に再集計してから
+ * 歓迎の +20 パワーを加算する。次のワールド入場で初期状態
+ * (spawn + やくそう&そらのはね + Lv1 + 投稿由来パワー +20) から再開する。
+ *
+ * dev + 管理者のみが UI から呼べる。自分の repo と自分の gameState しか触らない。
+ */
+import type { Agent } from '@atproto/api';
+import { getRecord, putRecord } from './atproto';
+import { COL } from './collections';
+import { bumpPower } from './points';
+import { serverReset } from './world-server';
+
+/** 歓迎付与するあおぞらパワー (演出とともに加算)。 */
+export const WELCOME_POWER = 20;
+
+/** あるコレクションの全レコードを削除 (最大 500 件)。未作成コレクションは何もしない。 */
+async function deleteAllRecords(agent: Agent, did: string, collection: string): Promise<void> {
+  let cursor: string | undefined;
+  for (let page = 0; page < 5; page++) {
+    let res;
+    try {
+      res = await agent.com.atproto.repo.listRecords({ repo: did, collection, limit: 100, ...(cursor ? { cursor } : {}) });
+    } catch {
+      return; // 未作成
+    }
+    for (const r of res.data.records) {
+      const rkey = r.uri.split('/').pop();
+      if (rkey) await agent.com.atproto.repo.deleteRecord({ repo: did, collection, rkey }).catch(() => {});
+    }
+    const next = res.data.cursor;
+    if (!next || next === cursor || res.data.records.length === 0) break;
+    cursor = next;
+  }
+}
+
+/** rkey='self' の 1 レコードを削除 (無ければ無視)。 */
+async function deleteSelf(agent: Agent, did: string, collection: string): Promise<void> {
+  await agent.com.atproto.repo.deleteRecord({ repo: did, collection, rkey: 'self' }).catch(() => {});
+}
+
+/** 分析レコードの XP を 0 に (= Lv1)。archetype / cognitiveScores / rpgStats 等は保持。 */
+async function zeroAnalysisXp(agent: Agent, did: string): Promise<void> {
+  const a = await getRecord<Record<string, unknown>>(agent, did, COL.analysis, 'self').catch(() => null);
+  if (!a) return;
+  const next: Record<string, unknown> = { ...a };
+  const pl = a.playerLevel;
+  if (pl && typeof pl === 'object') next.playerLevel = { ...(pl as object), xp: 0, streakDays: 0 };
+  const jl = a.jobLevel;
+  if (jl && typeof jl === 'object') next.jobLevel = { ...(jl as object), xp: 0 };
+  await putRecord(agent, COL.analysis, 'self', next);
+}
+
+/**
+ * 完全ワイプ → 初期状態へ。順序が重要:
+ * 1. 所有物 (COL.craft = 制作/合成/売却)・装備中 (COL.gear)・旧世界記録 (COL.world) を削除。
+ * 2. 分析 XP を 0 に (Lv1)。
+ * 3. パワーキャッシュ (COL.power) を削除 → 次の集計で world 消費/獲得が 0 に再計算される
+ *    (投稿由来の残高は post/spiritChat 走査で保持される)。
+ * 4. 歓迎の +20 パワーを加算 (キャッシュ無し → scanFullPoints でクリーン集計 → +20)。
+ * 5. サーバー権威 gameState + 戦闘ガードを削除 → 次のワールド入場で初期状態を生成。
+ */
+export async function resetOnboarding(agent: Agent, did: string): Promise<void> {
+  await deleteAllRecords(agent, did, COL.craft);
+  await deleteSelf(agent, did, COL.gear);
+  await deleteSelf(agent, did, COL.world);
+  await zeroAnalysisXp(agent, did);
+  await deleteSelf(agent, did, COL.power);
+  await bumpPower(agent, did, { salePowerEarned: WELCOME_POWER });
+  await serverReset(agent);
+}

--- a/apps/web/src/lib/points.test.ts
+++ b/apps/web/src/lib/points.test.ts
@@ -183,3 +183,42 @@ describe('loadPointsState', () => {
     expect(p.balance).toBe(0);
   });
 });
+
+describe('resetWorldPower (オンボードリセット)', () => {
+  test('world 消費/獲得を 0 にし、投稿由来 + summoned を保持、歓迎ボーナスを絶対値で載せる', async () => {
+    const { resetWorldPower } = await import('./points');
+    let written: any = null;
+    const agent = {
+      assertDid: 'did:test',
+      com: { atproto: { repo: {
+        getRecord: async () => ({ data: { value: {
+          viaPosts: 100, userMessages: 5, cardDraws: 3, battles: 7, craftPowerSpent: 40, salePowerEarned: 12, searchPowerSpent: 6,
+          summoned: true, updatedAt: 'x',
+        } } }),
+        putRecord: vi.fn(async (args: any) => { written = args.record; return { data: {} }; }),
+      } } },
+    } as any;
+    await resetWorldPower(agent, 'did:test', 20);
+    // 投稿由来 (viaPosts/userMessages/cardDraws) と summoned は保持
+    expect(written).toMatchObject({ viaPosts: 100, userMessages: 5, cardDraws: 3, summoned: true });
+    // world 由来の消費/獲得は全部 0、歓迎ボーナスだけ salePowerEarned に (絶対値)
+    expect(written.battles).toBe(0);
+    expect(written.craftPowerSpent).toBe(0);
+    expect(written.searchPowerSpent).toBe(0);
+    expect(written.salePowerEarned).toBe(20);
+  });
+
+  test('冪等: 書き込み後の record を読んで再実行しても +20 が二重にならない', async () => {
+    const { resetWorldPower } = await import('./points');
+    let written: any = { viaPosts: 100, userMessages: 5, cardDraws: 3, battles: 0, craftPowerSpent: 0, salePowerEarned: 20, searchPowerSpent: 0, summoned: true, updatedAt: 'x' };
+    const agent = {
+      assertDid: 'did:test',
+      com: { atproto: { repo: {
+        getRecord: async () => ({ data: { value: written } }),
+        putRecord: vi.fn(async (args: any) => { written = { ...args.record, updatedAt: 'y' }; return { data: {} }; }),
+      } } },
+    } as any;
+    await resetWorldPower(agent, 'did:test', 20);
+    expect(written.salePowerEarned).toBe(20); // += でなく絶対値なので二重加算しない
+  });
+});

--- a/apps/web/src/lib/points.ts
+++ b/apps/web/src/lib/points.ts
@@ -261,6 +261,32 @@ export async function bumpPower(agent: Agent, did: string, delta: PowerDelta): P
   }
 }
 
+/**
+ * オンボードリセット用: world 由来の消費/獲得 (battles / craftPowerSpent / salePowerEarned /
+ * searchPowerSpent) を 0 に戻し、歓迎ボーナスだけを salePowerEarned に載せた power レコードを
+ * **絶対値で書き込む**。投稿由来 (viaPosts / userMessages / cardDraws) と summoned は保持。
+ *
+ * 絶対値書き込みなので**冪等** — 途中失敗で再実行しても +welcome が二重に乗らない。
+ * bumpPower(+welcome) を使うと (a) 残存する battles 消費が引かれ続けて「投稿残高保持」が崩れ、
+ * (b) リトライで二重加算される、という問題があるため専用関数にした。失敗は throw する
+ * (呼び出し側の reset フローがエラーを検知してリトライ導線に載せられるように)。
+ */
+export async function resetWorldPower(agent: Agent, did: string, welcomeBonus: number): Promise<void> {
+  const cur = await readPowerRecord(agent, did);
+  const base: { viaPosts: number; userMessages: number; cardDraws: number; summoned: boolean } =
+    cur ?? (await scanFullPoints(agent, did));
+  await writePowerRecord(agent, {
+    viaPosts: base.viaPosts,
+    userMessages: base.userMessages,
+    cardDraws: base.cardDraws,
+    battles: 0,
+    craftPowerSpent: 0,
+    salePowerEarned: welcomeBonus,
+    searchPowerSpent: 0,
+    summoned: base.summoned,
+  });
+}
+
 export async function countViaPosts(agent: Agent, did: string): Promise<number> {
   let cursor: string | undefined;
   let count = 0;

--- a/apps/web/src/lib/world-server.ts
+++ b/apps/web/src/lib/world-server.ts
@@ -16,6 +16,7 @@ const LXM_TELEPORT = 'app.aozoraquest.world.teleport';
 const LXM_ITEM = 'app.aozoraquest.world.item';
 const LXM_GEAR = 'app.aozoraquest.world.gear';
 const LXM_SEARCH = 'app.aozoraquest.world.search';
+const LXM_RESET = 'app.aozoraquest.world.reset';
 const LXM_TURN = 'app.aozoraquest.battle.turn';
 const LXM_STATE = 'app.aozoraquest.me.state';
 
@@ -115,6 +116,12 @@ export function serverGear(agent: Agent, gear: unknown): Promise<{ ok: true }> {
 /** しらべる: サーバーがアイテムを判定して gameState 在庫に付与。found (無ければ null) + 新 materials を返す。 */
 export function serverSearch(agent: Agent, token?: string): Promise<{ found: string | null; materials: Record<string, number> }> {
   return callEdge<{ found: string | null; materials: Record<string, number> }>(agent, LXM_SEARCH, '/api/world/search', token ? { token } : {});
+}
+
+/** オンボード用リセット: 権威 gameState + 戦闘ガードをサーバーで削除する (本人のみ)。次の入場で初期状態に戻る。
+ *  client 側 PDS レコード (制作/装備/世界/パワー/分析XP) の初期化は呼び出し側 (resetOnboarding) が行う。 */
+export function serverReset(agent: Agent): Promise<{ ok: true }> {
+  return callEdge<{ ok: true }>(agent, LXM_RESET, '/api/world/reset', {});
 }
 
 /** 権威 GameState を読む (表示用: パワー/XP/素材/位置)。GET だが lxm 付き JWT で本人確認。 */

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -51,6 +51,9 @@ import { WorldHud, HUD_Z, OVERLAY_Z } from '@/components/world-hud';
 import { WorldMenu, type WorldMenuCommand } from '@/components/world-menu';
 import { ItemsModal, InventoryModal } from '@/components/world-item-modals';
 import { FeatherModal } from '@/components/feather-modal';
+import { WelcomeBlessingOverlay, notifyWelcome } from '@/components/welcome-blessing';
+import { resetOnboarding, WELCOME_POWER } from '@/lib/onboarding-reset';
+import { isAdminDid } from '@/lib/runtime-config';
 import type { DialogueLine } from '@/lib/dialogue';
 
 /**
@@ -131,6 +134,7 @@ export function World() {
   statusOpenRef.current = statusOpen;
   const [menuOpen, setMenuOpen] = useState(false);
   const menuOpenRef = useRef(false);
+  const [resetting, setResetting] = useState(false); // オンボード用リセット中 (dev+管理者)
   menuOpenRef.current = menuOpen;
   const [menuHint, setMenuHint] = useState(() => {
     try {
@@ -792,6 +796,24 @@ export function World() {
     }
   }, [agent, did]);
 
+  // オンボード用リセット (dev + 管理者のみ)。完全ワイプ → 初期状態 + はじまりの祝福 (+20 パワー)。
+  // 演出を見せてから再読込して確実に初期状態を反映する。
+  const doReset = useCallback(async () => {
+    if (!agent || !did || resetting) return;
+    if (!window.confirm('あおぞらワールドを「はじめから」やり直します。\n所持品・装備・レベル・位置がすべて初期化されます (投稿で貯めたパワー残高は残ります)。よろしいですか?')) return;
+    setResetting(true);
+    setMenuOpen(false);
+    try {
+      await resetOnboarding(agent, did);
+      notifyWelcome({ power: WELCOME_POWER });
+      window.setTimeout(() => window.location.reload(), 3400); // 演出 (3.2s) を見せてから初期状態で再入場
+    } catch (e) {
+      console.warn('[world] onboarding reset failed', e);
+      setNotice('リセットに失敗した (通信エラー)。もう一度どうぞ。');
+      setResetting(false);
+    }
+  }, [agent, did, resetting]);
+
   // なんでも屋で作ってもらう (docs/20 W6b)。支払い: パワー (craftPowerSpent 累積) +
   // 素材 (craft レコードの集計で差し引き)。品質は rkey + luk から決定的
   const onCraft = useCallback(
@@ -1002,6 +1024,10 @@ export function World() {
     ...(statusReady ? [{ key: 'status', label: 'つよさ', onSelect: () => setStatusOpen(true) } as WorldMenuCommand] : []),
     ...(inTown
       ? [{ key: 'shop', label: 'なんでも屋', onSelect: () => { setLastShopAction(null); setMaterialsView({ ...materialsRef.current }); setShopOpen(true); } } as WorldMenuCommand]
+      : []),
+    // 管理者用 (dev のみ): オンボードを体験するための「はじめから」。破壊的なので confirm 付き。
+    ...(did && isAdminDid(did)
+      ? [{ key: 'reset', label: resetting ? 'リセット中…' : '⟲ はじめから (管理)', onSelect: () => void doReset() } as WorldMenuCommand]
       : []),
   ];
 
@@ -1271,6 +1297,7 @@ export function World() {
         />
       )}
       {wipeOverlay}
+      <WelcomeBlessingOverlay />
     </div>
   );
 }

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -51,7 +51,7 @@ import { WorldHud, HUD_Z, OVERLAY_Z } from '@/components/world-hud';
 import { WorldMenu, type WorldMenuCommand } from '@/components/world-menu';
 import { ItemsModal, InventoryModal } from '@/components/world-item-modals';
 import { FeatherModal } from '@/components/feather-modal';
-import { WelcomeBlessingOverlay, notifyWelcome } from '@/components/welcome-blessing';
+import { WelcomeBlessingOverlay, notifyWelcome, WELCOME_TOTAL_MS } from '@/components/welcome-blessing';
 import { resetOnboarding, WELCOME_POWER } from '@/lib/onboarding-reset';
 import { isAdminDid } from '@/lib/runtime-config';
 import type { DialogueLine } from '@/lib/dialogue';
@@ -801,12 +801,13 @@ export function World() {
   const doReset = useCallback(async () => {
     if (!agent || !did || resetting) return;
     if (!window.confirm('あおぞらワールドを「はじめから」やり直します。\n所持品・装備・レベル・位置がすべて初期化されます (投稿で貯めたパワー残高は残ります)。よろしいですか?')) return;
-    setResetting(true);
+    setResetting(true); // 重い直列 I/O の間、進行オーバーレイを出す (無反応に見せない)
     setMenuOpen(false);
     try {
       await resetOnboarding(agent, did);
       notifyWelcome({ power: WELCOME_POWER });
-      window.setTimeout(() => window.location.reload(), 3400); // 演出 (3.2s) を見せてから初期状態で再入場
+      // 演出 (フェード込み ≈ 3.3s) を見せ切って余韻を残してから初期状態で再入場
+      window.setTimeout(() => window.location.reload(), WELCOME_TOTAL_MS + 900);
     } catch (e) {
       console.warn('[world] onboarding reset failed', e);
       setNotice('リセットに失敗した (通信エラー)。もう一度どうぞ。');
@@ -1025,7 +1026,9 @@ export function World() {
     ...(inTown
       ? [{ key: 'shop', label: 'なんでも屋', onSelect: () => { setLastShopAction(null); setMaterialsView({ ...materialsRef.current }); setShopOpen(true); } } as WorldMenuCommand]
       : []),
-    // 管理者用 (dev のみ): オンボードを体験するための「はじめから」。破壊的なので confirm 付き。
+    // 管理者用: オンボードを体験するための「はじめから」。破壊的なので confirm 付き。
+    // world ルート自体が WORLD_PREVIEW_ENABLED (dev/local 限定) で早期 return されるので、
+    // ここは追加で管理者 (isAdminDid) に絞るだけ = 実質 dev + 管理者。
     ...(did && isAdminDid(did)
       ? [{ key: 'reset', label: resetting ? 'リセット中…' : '⟲ はじめから (管理)', onSelect: () => void doReset() } as WorldMenuCommand]
       : []),
@@ -1297,6 +1300,19 @@ export function World() {
         />
       )}
       {wipeOverlay}
+      {/* リセット中の進行表示 (重い直列 I/O の間、無反応に見せない)。祝福演出 (z1100) の下に敷く。 */}
+      {resetting && (
+        <div
+          aria-live="polite"
+          style={{
+            position: 'fixed', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center',
+            background: 'rgba(6, 12, 24, 0.82)', color: 'var(--color-fg)', zIndex: 1050,
+            fontSize: '0.95em', letterSpacing: '0.04em',
+          }}
+        >
+          はじめの地へ もどしています…
+        </div>
+      )}
       <WelcomeBlessingOverlay />
     </div>
   );


### PR DESCRIPTION
あおぞらワールド改善エピック **P1 (リセット & オンボード)**。オーナー要望「オンボードを体験するため一度すべてリセット + 開始時に やくそう&そらのはね + 演出付き +20 パワー」。

## 変更点
- **migrateInitState**: 初期持ち物に やくそう 1 を追加 (そらのはね 1 と合わせ 2 種)。全新規プレイヤーに効く。
- **`POST /api/world/reset` (handleReset)**: 認証済み本人の権威 gameState + 戦闘ガードを削除。次の入場で `migrateInitState` が初期状態を生成。**本人の state しか消せない**。
- **client `resetOnboarding`**: 完全ワイプ。`COL.craft`(制作/合成/売却)・`COL.battle`・`gear`・`world` を削除 → 分析 XP を 0 (Lv1) → `resetWorldPower` で world 消費/獲得を 0・歓迎 +20 を**絶対値**で書き込み → `serverReset` で gameState 削除 (最後)。**投稿由来のパワー残高は保持**。
- **演出**: `WelcomeBlessingOverlay`（「はじまりの祝福 +20」、フェードアウト付き）。
- **UI**: world メニューに管理者専用「⟲ はじめから」(confirm + 進行オーバーレイ)。

## 検証
- edge/web typecheck ✅ / edge test ✅ (144) / web test ✅ (338) / web build ✅ / web-ci ✅

## Review (§1.5 3 並列: 設計 / 実装 / UX)
- **設計 ★★★**: 「投稿残高保持」が `battles` 消費の残留で崩れ、`delete power + bumpPower(+20)` が非冪等だった → **`resetWorldPower`(絶対値・冪等) に置換**し `COL.battle` も削除。doc/UI 文言とコードを一致 (commit `2fbab98`)。
- **設計 ★★**: `deleteAllRecords` の 500 件打ち切り → records が尽きるまでページング。
- **実装 ★★**: 部分失敗の原子性 → `serverReset` を最後に置く順序の根拠 (migrateInitState が掃除済みレコードを読む) + 各ステップ冪等でリトライ収束を doc 明記。
- **実装 ★★**: 「dev のみ」表記の不一致 → world ルートが `WORLD_PREVIEW_ENABLED` で dev 限定なのでコメント修正。
- **UX ★★**: 無反応時間 → リセット中の進行オーバーレイ追加。
- **UX ★★**: 演出が瞬間消灯 → フェードアウト + reload を余韻後にずらす。
- **★ (issue/後続)**: 新規プレイヤーへの祝福自動付与は本 PR スコープ外 (world 本番解禁時に対応)。`salePowerEarned` を歓迎ボーナス器に流用する点はコメントで明記。

すべて PR 内で対応済み。

## スコープ外 (後続 P2〜P4)
敵の多様化・序盤バランス (スライム弱小化 xp3・herb ドロップ↓)、段階装備 (armor/charm grade3)、クラフト刷新 (複数素材レシピ + 素材交換のサーバー権威化)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)