### PR TITLE
feat(battle): モンスター明示ステータス + 逃走(fleer) + はぐれスライム (P2a)

### DIFF
--- a/apps/edge/src/battle-resolver.ts
+++ b/apps/edge/src/battle-resolver.ts
@@ -389,7 +389,8 @@ export async function handleTurn(env: ResolverEnv, userDid: string, battleId: st
     // ガードを消せた 1 リクエストだけ = **二重報酬を防ぐ** (applyBattleOutcome は加算なので必須。§4.1c 冪等)。
     // token 切れで delete が失敗 → ServerWriteError が伝播し上位で 503 (報酬なし・guard 残る=リトライ可、
     // fail-closed)。この順序 (消費確定 → 報酬) が §4.1 の「CAS で先に確定 → その後 resolve/確定」。
-    const decision = next.outcome as BattleDecision;
+    // next.outcome は上の `!== 'ongoing'` で BattleDecision に絞り込み済み (キャスト不要 = 網羅を型で保証)。
+    const decision: BattleDecision = next.outcome;
     try {
       await deleteGuard(env, now, userDid, cid);
     } catch (e) {

--- a/apps/edge/src/battle-reward.ts
+++ b/apps/edge/src/battle-reward.ts
@@ -16,7 +16,8 @@
 import { battleXpFor, rollDrops, rollDefeatLoss, BATTLE_TUNING } from '@aozoraquest/core';
 import type { GameState } from './game-state';
 
-export type BattleDecision = 'win' | 'lose' | 'draw' | 'fled';
+/** BattleOutcome から 'ongoing' を除いた決着。'monster-fled' = 敵が逃げた (無報酬・無消費)。 */
+export type BattleDecision = 'win' | 'lose' | 'draw' | 'fled' | 'monster-fled';
 
 export interface BattleOutcomeInput {
   outcome: BattleDecision;
@@ -89,7 +90,9 @@ export function applyBattleOutcome(state: GameState, o: BattleOutcomeInput): { n
     return { next, awarded: { xp, materialsLost, powerSpent: POWER_COST } };
   }
 
-  // draw / fled は決着扱いにしない (パワー消費なし)。旧クライアントは draw にも xpLose を出したが、
-  // パワー消費のない draw を報酬対象にすると「ガードで引き分けを狙う無限 XP 稼ぎ」が成立するため付与しない。
+  // draw / fled / monster-fled は決着扱いにしない (XP もドロップもパワー消費も無し)。
+  // - draw: パワー消費のない draw を報酬対象にすると「ガードで引き分けを狙う無限 XP 稼ぎ」が成立するため付与しない。
+  // - fled (プレイヤーが逃走) / monster-fled (敵が逃走): どちらも決着していないので無報酬・無消費。
+  //   特にはぐれメタル型に逃げられたときはここに落ちる (高 XP をみすみす逃した = 悔しさが残る設計)。
   return { next: state, awarded: {} };
 }

--- a/apps/edge/test/battle-reward.test.ts
+++ b/apps/edge/test/battle-reward.test.ts
@@ -11,7 +11,7 @@ const input = (over: Partial<BattleOutcomeInput> = {}): BattleOutcomeInput => ({
 describe('battle-reward (fail-closed 報酬確定)', () => {
   it('rewarded=false は勝敗どちらも何も変えない (パワー無し=練習)', () => {
     const s = base({ power: 0, playerXp: 100 });
-    for (const outcome of ['win', 'lose', 'draw', 'fled'] as const) {
+    for (const outcome of ['win', 'lose', 'draw', 'fled', 'monster-fled'] as const) {
       const { next, awarded } = applyBattleOutcome(s, input({ outcome, rewarded: false }));
       expect(next).toBe(s); // 参照ごと不変
       expect(awarded).toEqual({});
@@ -61,11 +61,15 @@ describe('battle-reward (fail-closed 報酬確定)', () => {
     for (const v of Object.values(next.materials)) expect(v).toBeGreaterThan(0);
   });
 
-  it('引き分け / 逃走は決着扱いにしない (パワーも消費しない)', () => {
-    const s = base({ power: 3 });
-    for (const outcome of ['draw', 'fled'] as const) {
+  it('引き分け / 逃走 / 敵の逃走は決着扱いにしない (XP・ドロップ・パワー消費なし)', () => {
+    // rewarded=true でも monster-fled は無報酬 = はぐれメタルに逃げられたら XP も素材もゼロ。
+    const s = base({ power: 3, playerXp: 100, jobXp: { warrior: 20 }, materials: { herb: 2 } });
+    for (const outcome of ['draw', 'fled', 'monster-fled'] as const) {
       const { next, awarded } = applyBattleOutcome(s, input({ outcome }));
-      expect(next.power).toBe(3);
+      expect(next.power).toBe(3); // パワー温存
+      expect(next.playerXp).toBe(100); // XP 変わらず
+      expect(next.jobXp.warrior).toBe(20);
+      expect(next.materials).toEqual({ herb: 2 }); // 素材変わらず
       expect(awarded).toEqual({});
     }
   });

--- a/apps/web/src/components/monster-svg.tsx
+++ b/apps/web/src/components/monster-svg.tsx
@@ -37,8 +37,11 @@ const BODIES: Record<MonsterSpecies, ReactElement> = {
     <g>
       <path d="M50 18 C74 18 84 42 84 58 C84 76 68 84 50 84 C32 84 16 76 16 58 C16 42 26 18 50 18Z" fill="#c2ccd6" stroke={OUT} strokeWidth="4" />
       <path d="M28 60 C30 74 42 80 50 80 C58 80 70 74 74 60 C70 70 60 74 50 74 C40 74 32 70 28 60Z" fill="#93a1b0" />
-      <path d="M30 34 C36 26 46 24 50 24" fill="none" stroke="#f4f9ff" strokeWidth="6" strokeLinecap="round" />
-      <path d="M64 30 l3 5 l5 2 l-5 2 l-3 5 l-3 -5 l-5 -2 l5 -2Z" fill="#ffffff" />
+      {/* 金属の明るい反射面 (ギラつき) */}
+      <path d="M24 46 C24 34 34 24 46 24 C40 30 34 40 34 50 C30 50 26 49 24 46Z" fill="#eaf1f8" opacity="0.85" />
+      <path d="M30 34 C36 26 46 24 50 24" fill="none" stroke="#ffffff" strokeWidth="6" strokeLinecap="round" />
+      <path d="M66 28 l3.2 5.4 l5.4 2.2 l-5.4 2.2 l-3.2 5.4 l-3.2 -5.4 l-5.4 -2.2 l5.4 -2.2Z" fill="#ffffff" />
+      <path d="M22 62 l2 3.4 l3.4 1.4 l-3.4 1.4 l-2 3.4 l-2 -3.4 l-3.4 -1.4 l3.4 -1.4Z" fill="#ffffff" opacity="0.9" />
       <circle cx="38" cy="54" r="5" fill={OUT} />
       <circle cx="62" cy="54" r="5" fill={OUT} />
       <path d="M42 70 Q50 64 58 70" fill="none" stroke={OUT} strokeWidth="3.5" strokeLinecap="round" />

--- a/apps/web/src/components/monster-svg.tsx
+++ b/apps/web/src/components/monster-svg.tsx
@@ -32,6 +32,18 @@ const BODIES: Record<MonsterSpecies, ReactElement> = {
       <path d="M42 68 Q50 74 58 68" fill="none" stroke={OUT} strokeWidth="3.5" strokeLinecap="round" />
     </g>
   ),
+  // はぐれスライム: 同じ形の金属色 (銀) + きらめきのハイライトでレア感を出す。
+  'metal-slime': (
+    <g>
+      <path d="M50 18 C74 18 84 42 84 58 C84 76 68 84 50 84 C32 84 16 76 16 58 C16 42 26 18 50 18Z" fill="#c2ccd6" stroke={OUT} strokeWidth="4" />
+      <path d="M28 60 C30 74 42 80 50 80 C58 80 70 74 74 60 C70 70 60 74 50 74 C40 74 32 70 28 60Z" fill="#93a1b0" />
+      <path d="M30 34 C36 26 46 24 50 24" fill="none" stroke="#f4f9ff" strokeWidth="6" strokeLinecap="round" />
+      <path d="M64 30 l3 5 l5 2 l-5 2 l-3 5 l-3 -5 l-5 -2 l5 -2Z" fill="#ffffff" />
+      <circle cx="38" cy="54" r="5" fill={OUT} />
+      <circle cx="62" cy="54" r="5" fill={OUT} />
+      <path d="M42 70 Q50 64 58 70" fill="none" stroke={OUT} strokeWidth="3.5" strokeLinecap="round" />
+    </g>
+  ),
   bat: (
     <g>
       <path d="M8 40 Q20 26 34 34 L38 44 Q28 42 24 48Z" fill="#8f7ad6" stroke={OUT} strokeWidth="3.5" strokeLinejoin="round" />

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -613,6 +613,8 @@ export function World() {
         const t = b.resultPos ? townAt(b.resultPos.x, b.resultPos.y) : null;
         resultLines.push(t ? `たおれてしまった… 気がつくと「${t.name}」で 手当てされていた。` : 'たおれてしまった… 気がつくと 街で 手当てされていた。');
       }
+      // 敵に逃げられた: 悔しさを一言で残す (無言でマップへ戻さない)。
+      if (next.outcome === 'monster-fled') resultLines.push('あいてに にげられてしまった…');
       if (resultLines.length === 0) {
         battleRef.current = null;
         setBattle(null);

--- a/packages/core/src/__tests__/battle.test.ts
+++ b/packages/core/src/__tests__/battle.test.ts
@@ -146,10 +146,35 @@ describe('summonMonster', () => {
     expect(a.def.id).toBe(b.def.id);
     expect(a.def.tier).toBe(1);
   });
-  it('全 tier にモンスターが 3 体ずついる', () => {
+  it('各 tier に最低 3 体いる + はぐれスライムは tier1 のレア逃走敵', () => {
     for (const tier of [1, 2, 3] as const) {
-      expect(MONSTERS.filter((m) => m.tier === tier)).toHaveLength(3);
+      expect(MONSTERS.filter((m) => m.tier === tier).length).toBeGreaterThanOrEqual(3);
     }
+    // はぐれメタル型: tier1・レア出現 (spawnWeight<1)・逃走 (fleer)・HP 明示・高 XP
+    const stray = MONSTERS_BY_ID['stray-slime'];
+    expect(stray?.tier).toBe(1);
+    expect(stray?.ability).toBe('fleer');
+    expect(stray?.spawnWeight).toBeLessThan(1);
+    expect(stray?.hp).toBeDefined();
+  });
+
+  it('はぐれスライム: HP 明示で低い + fleer は逃走して monster-fled で決着 (勝敗なし)', () => {
+    // レア出現なので stray-slime を引く seed を探す
+    let battle: import('../battle.js').BattleState | null = null;
+    for (let seed = 0; seed < 4000; seed++) {
+      const b = startBattle('warrior', 1, 1, 'テスト', 1, seed, 0);
+      if (b.monsterId === 'stray-slime') { battle = b; break; }
+    }
+    expect(battle).not.toBeNull();
+    // HP 明示 (12) × tier1 係数 → 通常 tier1 (~70) より大幅に低い
+    expect(battle!.monster.maxHp).toBeLessThan(25);
+    // 逃走する turnSeed があり、そのとき outcome は monster-fled (win/lose ではない)
+    let fled = false;
+    for (let ts = 0; ts < 500; ts++) {
+      const next = resolveTurn(battle!, 'guard', ts); // guard で自分から倒しに行かない
+      if (next.outcome === 'monster-fled') { fled = true; break; }
+    }
+    expect(fled).toBe(true);
   });
   it('地域相性 (affinity) は tier プール内の favor 対象を出やすくする (index 方式、死角なし)', () => {
     // tier3 pool = [raven, oni, dragon]。affinity%3==0 は raven を favor

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -506,7 +506,7 @@ export const ITEMS: Record<string, { name: string }> = {
   'sky-dew': { name: 'そらのしずく' }, // MP 回復薬。青空の朝露 (世界観準拠の命名)
   'sky-feather': { name: 'そらのはね' }, // 最後に立ち寄った街へ帰還 (フィールド専用)
   'slime-drop': { name: 'スライムのしずく' },
-  'metal-shard': { name: 'はぐれのかけら' }, // はぐれスライムの希少ドロップ (レア装備素材)
+  'metal-shard': { name: 'はぐれのかけら' }, // はぐれスライムの希少ドロップ。現状は換金専用 (将来レア装備素材に転用予定)
   'bat-wing': { name: 'コウモリの翼膜' },
   'mush-spore': { name: 'ヒカリダケの胞子' },
   'golem-core': { name: 'ゴーレムの核片' },
@@ -525,7 +525,7 @@ export const MONSTERS: readonly MonsterDef[] = [
   { id: 'glow-shroom', name: 'ヒカリダケ', species: 'mushroom', tier: 1, stats: [8, 20, 4, 18, 12], xp: 30, drops: [{ item: 'mush-spore', chance: 0.6 }, { item: 'herb', chance: 0.4 }, { item: 'sky-dew', chance: 0.25 }], intro: 'ほんのり光って動かない…?' },
   // はぐれメタル型: レア出現・低 HP・高 XP・毎ターン逃走。倒せれば旨いが逃げられると何も残らない
   // (オーナー要望 2026-07-19)。HP は明示 (導出だと def なりに増えるため)。高 agi で逃げ足も速い。
-  { id: 'stray-slime', name: 'はぐれスライム', species: 'metal-slime', tier: 1, stats: [8, 22, 38, 6, 34], hp: 12, mp: 0, xp: 45, spawnWeight: 0.06, drops: [{ item: 'metal-shard', chance: 0.5 }], ability: 'fleer', intro: 'きらりと光った。逃げ足が速そうだ!' },
+  { id: 'stray-slime', name: 'はぐれスライム', species: 'metal-slime', tier: 1, stats: [8, 22, 38, 6, 34], hp: 12, mp: 0, xp: 45, spawnWeight: 0.06, drops: [{ item: 'metal-shard', chance: 0.5 }], ability: 'fleer', intro: 'きらりと 金属の光を放っている。' },
   // tier2: 修練。xp 34〜52 (healer は削り合いが長引くぶん高め)
   { id: 'moss-golem', name: 'こけむしゴーレム', species: 'golem', tier: 2, stats: [26, 36, 6, 10, 8], xp: 34, drops: [{ item: 'golem-core', chance: 0.5 }, { item: 'herb', chance: 0.2 }], intro: '地響きを立てて起き上がった。', skillName: 'いわなだれ', ability: 'charger' },
   { id: 'will-o-wisp', name: 'あおい鬼火', species: 'wisp', tier: 2, stats: [10, 12, 24, 34, 12], xp: 52, drops: [{ item: 'wisp-ember', chance: 0.5 }, { item: 'sky-dew', chance: 0.35 }], intro: 'ゆらゆらとこちらを見ている。', ability: 'healer', healName: 'いやしのゆらめき' },
@@ -610,10 +610,14 @@ export function summonMonster(
 ): { def: MonsterDef; combatant: Combatant } {
   const pool = MONSTERS.filter((m) => m.tier === tier);
   const rng = createRng((seed ^ 0x51ed270b) >>> 0);
-  // 出現重み = spawnWeight (default 1) × affinity 補正 (favor 対象を重く)。レア敵
-  // (spawnWeight<1) は favor されても稀なまま。重み付き累積抽選 (決定的)。
+  // 出現重み = spawnWeight (default 1) × affinity 補正 (favor 対象を重く)。ただし
+  // レア敵 (spawnWeight<1) は favor 対象にしない = どの地域でもごく稀のまま
+  // (地域相性で「はぐれメタルが出やすい街」を作らない — レビュー ★★)。重み付き累積抽選 (決定的)。
   const favored = affinity === undefined ? -1 : ((affinity % pool.length) + pool.length) % pool.length;
-  const weights = pool.map((m, i) => (m.spawnWeight ?? 1) * (i === favored ? AFFINITY_WEIGHT : 1));
+  const weights = pool.map((m, i) => {
+    const w = m.spawnWeight ?? 1;
+    return w * (i === favored && w >= 1 ? AFFINITY_WEIGHT : 1);
+  });
   const total = weights.reduce((a, b) => a + b, 0);
   let pick = rng() * total;
   let idx = 0;
@@ -842,8 +846,11 @@ function monsterCommand(state: BattleState, rng: () => number): MonsterAction {
     return 'attack';
   }
   if (def?.ability === 'fleer') {
-    // 毎ターン逃走を試みる (agi が高いほど逃げやすい)。逃げられなければ通常攻撃。
-    const fleeChance = Math.min(t.monsterFleeMax, Math.max(0, t.monsterFleeBase + state.monster.agi * t.monsterFleeAgiScale));
+    // 毎ターン逃走を試みる。逃走率は**基準 agi (レベル非依存)** で決める — factor で
+    // スケールする state.monster.agi を使うと高レベルほど逃走率が cap に張り付き、HP も
+    // 上がって「成長するほど倒せない」逆進になる (レビュー ★★)。常に同じ緊張感にする。
+    const baseAgi = def.stats[2] ?? 0;
+    const fleeChance = Math.min(t.monsterFleeMax, Math.max(0, t.monsterFleeBase + baseAgi * t.monsterFleeAgiScale));
     if (r < fleeChance) return 'flee';
     return 'attack';
   }

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -108,6 +108,12 @@ export const BATTLE_TUNING = {
   fleeAgiScale: 0.012,
   fleeMin: 0.25,
   fleeMax: 0.95,
+  /** モンスターの逃走 (ability='fleer')。毎ターン flee 判定する。逃走率 =
+   *  clamp(monsterFleeBase + 自agi*monsterFleeAgiScale, 0, monsterFleeMax)。
+   *  はぐれメタル型 (高XP・低HP・すぐ逃げる) 用: 倒す前に逃げられると報酬ゼロ。 */
+  monsterFleeBase: 0.35,
+  monsterFleeAgiScale: 0.006,
+  monsterFleeMax: 0.75,
   /** 最大ターン数 (超えたら判定 = 残 HP 割合勝負) */
   maxTurns: 30,
   /** ドロップ率の luk ボーナス = luk * dropLukScale (加算) */
@@ -441,6 +447,7 @@ export function levelUpGains(
 /** SVG 描画のキー (UI 側が species ごとに絵を持つ)。 */
 export type MonsterSpecies =
   | 'slime'
+  | 'metal-slime'
   | 'bat'
   | 'mushroom'
   | 'golem'
@@ -465,6 +472,14 @@ export interface MonsterDef {
   tier: 1 | 2 | 3;
   /** [atk, def, agi, int, luk] — 合計はおおむね 100 で職と同尺度 */
   stats: StatArray;
+  /** HP/MP を明示する (プレイヤーと同じ完全ステータスブロック — オーナー要望 2026-07-19)。
+   *  省略時は従来どおり def/int から導出 (後方互換)。はぐれメタル型のように
+   *  「導出だと def なりに HP が出てしまう」敵を低 HP に手調整するのに使う。
+   *  値は tier/レベル係数で従来同様にスケールする (基準値のみ明示)。 */
+  hp?: number;
+  mp?: number;
+  /** 出現の重み (default 1)。レア敵 (はぐれメタル等) は 1 未満にして稀にする。 */
+  spawnWeight?: number;
   /** 勝利時に得る XP。tier を目安にモンスター個別に設定して幅を持たせる (tier だけで
    *  決めると はぐれメタルのような「同 tier で飛び抜けて高 XP」の敵が作れない —
    *  オーナー要望 2026-07-18)。なお本格的なはぐれメタル型 (高 xp + 高回避 + 低 HP +
@@ -478,8 +493,9 @@ export interface MonsterDef {
   /** 行動タイプ (戦略性のためのバリエーション。オーナー要望 2026-07-18)。
    *  未指定 = plain (通常攻撃 + 低 HP でたまに防御)。
    *  'charger' = 1 ターン ため → 強攻撃 (予告を防御する読み合い。全体の ~20%)。
-   *  'healer' = 低 HP でたまに自己回復 (削り切る前に倒す読み合い)。 */
-  ability?: 'charger' | 'healer';
+   *  'healer' = 低 HP でたまに自己回復 (削り切る前に倒す読み合い)。
+   *  'fleer' = 毎ターン逃走を試みる (はぐれメタル型。倒す前に逃げられると報酬ゼロ)。 */
+  ability?: 'charger' | 'healer' | 'fleer';
   /** healer の回復技名 (省略時デフォルト)。 */
   healName?: string;
 }
@@ -490,6 +506,7 @@ export const ITEMS: Record<string, { name: string }> = {
   'sky-dew': { name: 'そらのしずく' }, // MP 回復薬。青空の朝露 (世界観準拠の命名)
   'sky-feather': { name: 'そらのはね' }, // 最後に立ち寄った街へ帰還 (フィールド専用)
   'slime-drop': { name: 'スライムのしずく' },
+  'metal-shard': { name: 'はぐれのかけら' }, // はぐれスライムの希少ドロップ (レア装備素材)
   'bat-wing': { name: 'コウモリの翼膜' },
   'mush-spore': { name: 'ヒカリダケの胞子' },
   'golem-core': { name: 'ゴーレムの核片' },
@@ -506,6 +523,9 @@ export const MONSTERS: readonly MonsterDef[] = [
   { id: 'sky-slime', name: 'そらいろスライム', species: 'slime', tier: 1, stats: [14, 12, 10, 8, 16], xp: 14, drops: [{ item: 'slime-drop', chance: 0.7 }, { item: 'herb', chance: 0.35 }], intro: 'ぷるぷると跳ねている。' },
   { id: 'cave-bat', name: 'ほらあなコウモリ', species: 'bat', tier: 1, stats: [12, 8, 26, 6, 12], xp: 22, drops: [{ item: 'bat-wing', chance: 0.6 }, { item: 'herb', chance: 0.3 }, { item: 'sky-feather', chance: 0.12 }], intro: 'ばさばさと羽音を立てている。' },
   { id: 'glow-shroom', name: 'ヒカリダケ', species: 'mushroom', tier: 1, stats: [8, 20, 4, 18, 12], xp: 30, drops: [{ item: 'mush-spore', chance: 0.6 }, { item: 'herb', chance: 0.4 }, { item: 'sky-dew', chance: 0.25 }], intro: 'ほんのり光って動かない…?' },
+  // はぐれメタル型: レア出現・低 HP・高 XP・毎ターン逃走。倒せれば旨いが逃げられると何も残らない
+  // (オーナー要望 2026-07-19)。HP は明示 (導出だと def なりに増えるため)。高 agi で逃げ足も速い。
+  { id: 'stray-slime', name: 'はぐれスライム', species: 'metal-slime', tier: 1, stats: [8, 22, 38, 6, 34], hp: 12, mp: 0, xp: 45, spawnWeight: 0.06, drops: [{ item: 'metal-shard', chance: 0.5 }], ability: 'fleer', intro: 'きらりと光った。逃げ足が速そうだ!' },
   // tier2: 修練。xp 34〜52 (healer は削り合いが長引くぶん高め)
   { id: 'moss-golem', name: 'こけむしゴーレム', species: 'golem', tier: 2, stats: [26, 36, 6, 10, 8], xp: 34, drops: [{ item: 'golem-core', chance: 0.5 }, { item: 'herb', chance: 0.2 }], intro: '地響きを立てて起き上がった。', skillName: 'いわなだれ', ability: 'charger' },
   { id: 'will-o-wisp', name: 'あおい鬼火', species: 'wisp', tier: 2, stats: [10, 12, 24, 34, 12], xp: 52, drops: [{ item: 'wisp-ember', chance: 0.5 }, { item: 'sky-dew', chance: 0.35 }], intro: 'ゆらゆらとこちらを見ている。', ability: 'healer', healName: 'いやしのゆらめき' },
@@ -590,26 +610,26 @@ export function summonMonster(
 ): { def: MonsterDef; combatant: Combatant } {
   const pool = MONSTERS.filter((m) => m.tier === tier);
   const rng = createRng((seed ^ 0x51ed270b) >>> 0);
-  let def: MonsterDef;
-  if (affinity === undefined) {
-    def = pool[Math.floor(rng() * pool.length)]!;
-  } else {
-    // favor 対象を重く。重み付き累積抽選 (決定的)
-    const favored = ((affinity % pool.length) + pool.length) % pool.length;
-    const weights = pool.map((_, i) => (i === favored ? AFFINITY_WEIGHT : 1));
-    const total = weights.reduce((a, b) => a + b, 0);
-    let pick = rng() * total;
-    let idx = 0;
-    for (; idx < pool.length; idx++) {
-      pick -= weights[idx]!;
-      if (pick < 0) break;
-    }
-    def = pool[Math.min(idx, pool.length - 1)]!;
+  // 出現重み = spawnWeight (default 1) × affinity 補正 (favor 対象を重く)。レア敵
+  // (spawnWeight<1) は favor されても稀なまま。重み付き累積抽選 (決定的)。
+  const favored = affinity === undefined ? -1 : ((affinity % pool.length) + pool.length) % pool.length;
+  const weights = pool.map((m, i) => (m.spawnWeight ?? 1) * (i === favored ? AFFINITY_WEIGHT : 1));
+  const total = weights.reduce((a, b) => a + b, 0);
+  let pick = rng() * total;
+  let idx = 0;
+  for (; idx < pool.length; idx++) {
+    pick -= weights[idx]!;
+    if (pick < 0) break;
   }
+  const def = pool[Math.min(idx, pool.length - 1)]!;
   const factor = monsterLevelFactor(tier, playerLevel, jobLevel);
   const flat = BATTLE_TUNING.flatLevelGain * Math.max(0, playerLevel - 1);
   const grown = def.stats.map((v) => v + flat) as unknown as StatArray;
   const combatant = fromStats(def.name, grown, factor, Math.max(1, Math.round(playerLevel * (tier === 3 ? 1.1 : 1))));
+  // HP/MP を明示している敵はその値で上書き (プレイヤーと同じ完全ステータス — 導出に頼らない)。
+  // tier/レベル係数 (factor) で従来同様にスケールさせ、はぐれメタル型の低 HP を保つ。
+  if (def.hp !== undefined) { combatant.maxHp = Math.max(1, Math.round(def.hp * factor)); combatant.hp = combatant.maxHp; }
+  if (def.mp !== undefined) { combatant.maxMp = Math.max(0, Math.round(def.mp * factor)); combatant.mp = combatant.maxMp; }
   // 遭遇ごとに HP/MP をバラつかせる (値を覚えられないように = 予想の余地を残す)。
   // variance=0 のときは rng を引かない (乱数ストリームを従来と一致させ trial/テスト不変)。
   if (variance > 0) {
@@ -626,7 +646,7 @@ export function summonMonster(
 
 export type Command = 'attack' | 'guard' | 'skill' | 'herb' | 'tonic' | 'flee';
 
-export type BattleOutcome = 'ongoing' | 'win' | 'lose' | 'draw' | 'fled';
+export type BattleOutcome = 'ongoing' | 'win' | 'lose' | 'draw' | 'fled' | 'monster-fled';
 
 export interface TurnEvent {
   /** 誰の行動か */
@@ -800,7 +820,7 @@ function doAttack(
 
 /** モンスターの行動選択 (tier が高いほど賢い)。 */
 /** モンスターの行動。'charge' = ため宣言、'heal' = 自己回復 (プレイヤーの Command とは別)。 */
-type MonsterAction = 'attack' | 'guard' | 'charge' | 'heal';
+type MonsterAction = 'attack' | 'guard' | 'charge' | 'heal' | 'flee';
 
 /** モンスターの行動を能力 (ability) で分岐する (オーナー要望 2026-07-18: ため攻撃は
  *  一部 (~20%) に限定し、回復する敵などバリエーションで戦略性を出す)。 */
@@ -819,6 +839,12 @@ function monsterCommand(state: BattleState, rng: () => number): MonsterAction {
   if (def?.ability === 'healer') {
     if (state.monster.mp >= t.monsterHealMpCost && hpRatio < t.healerLowHpRatio && r < t.healerHealChance) return 'heal';
     if (canGuard && r < t.healerHealChance + 0.15) return 'guard';
+    return 'attack';
+  }
+  if (def?.ability === 'fleer') {
+    // 毎ターン逃走を試みる (agi が高いほど逃げやすい)。逃げられなければ通常攻撃。
+    const fleeChance = Math.min(t.monsterFleeMax, Math.max(0, t.monsterFleeBase + state.monster.agi * t.monsterFleeAgiScale));
+    if (r < fleeChance) return 'flee';
     return 'attack';
   }
   // plain: 通常攻撃 + 低 HP でたまに防御
@@ -951,6 +977,7 @@ export function resolveTurn(prev: BattleState, command: Command, turnSeed?: numb
   const playerFirst = state.player.agi + rng() * 20 >= state.monster.agi + rng() * 20;
 
   const act = (who: 'player' | 'monster') => {
+    if (state.outcome !== 'ongoing') return; // 敵が逃げる等で決着済みなら以降の行動をスキップ
     if (state.player.hp === 0 || state.monster.hp === 0) return;
     if (who === 'player') {
       if (cmd === 'attack') {
@@ -998,6 +1025,10 @@ export function resolveTurn(prev: BattleState, command: Command, turnSeed?: numb
         state.monster.hp = Math.min(state.monster.maxHp, state.monster.hp + healed);
         const name = MONSTERS_BY_ID[state.monsterId]?.healName ?? 'きずをいやす';
         events.push({ actor: 'monster', text: `${state.monster.name}は${name}! HP が ${state.monster.hp - before} 回復。` });
+      } else if (mCommand === 'flee') {
+        // はぐれメタル型: 逃走成功 → 即決着 (報酬なし)。倒せなかった悔しさを残す。
+        state.outcome = 'monster-fled';
+        events.push({ actor: 'monster', text: `${state.monster.name}は にげだした!` });
       } else if (mCommand === 'attack') {
         doAttack(state.monster, state.player, rng, events, 'monster');
       }
@@ -1013,8 +1044,9 @@ export function resolveTurn(prev: BattleState, command: Command, turnSeed?: numb
   state.monster.parrying = false;
   state.player.focus = Math.max(0, state.player.focus - 1);
 
-  // 勝敗判定
-  if (state.monster.hp === 0) state.outcome = 'win';
+  // 勝敗判定 (敵の逃走 = monster-fled で既に決着している場合は上書きしない)
+  if (state.outcome !== 'ongoing') { /* monster-fled 等: 確定済み */ }
+  else if (state.monster.hp === 0) state.outcome = 'win';
   else if (state.player.hp === 0) state.outcome = 'lose';
   else if (state.turn >= BATTLE_TUNING.maxTurns) {
     // 引き分け規定: 残 HP 割合が高い方の勝ち。同率は draw。

--- a/packages/core/src/equipment.ts
+++ b/packages/core/src/equipment.ts
@@ -222,6 +222,7 @@ export const CONSUMABLE_ITEMS: readonly string[] = ['herb', 'sky-dew', 'sky-feat
  *  (equipment→battle は循環になるため静的リスト。整合はテストで固定)。 */
 export const SELLABLE_MATERIALS: readonly string[] = [
   'slime-drop',
+  'metal-shard',
   'bat-wing',
   'mush-spore',
   'golem-core',


### PR DESCRIPTION
あおぞらワールド改善エピック **P2a (敵エンジン基盤)**。以降のロスター拡充が乗る engine 基盤。**既存 9 体の挙動は不変**。

## 変更点
- **完全ステータスブロック**: `MonsterDef` に `hp`/`mp` 明示 (省略時は従来導出)。プレイヤーと同 stat モデル。
- **`fleer` ability + `monster-fled` outcome**: 毎ターン逃走。倒す前に逃げられると報酬ゼロ。逃走率は**基準 agi (レベル非依存)** で判定 (高レベルで逆進しない)。
- **`spawnWeight`** でレア出現。`summonMonster` を重み付き抽選に統一 (equal weight は従来と同分布・同 rng)。**レア敵は affinity で favor しない** (どこでも稀)。
- **はぐれスライム**: tier1・レア(0.06)・低HP明示(12)・高XP(45)・逃走・レアドロップ `metal-shard`。新 species `metal-slime` の金属色 SVG。

## 検証
- core/edge/web typecheck ✅ / test ✅ (core 307 / edge 144 / web 338) / build ✅ / web-ci ✅
- fleer→monster-fled + 明示HP + 報酬ゼロ の unit test 追加、sim(tier1) regression なし

## Review (§1.5 3 並列: 設計 / 実装 / UX) — 全指摘 PR 内対応済 (commit `f91c4e5`)
- **★★★ (設計)**: `monster-fled` が `BattleDecision` に無く `as` キャストで握られていた (報酬確定の型安全喪失) → 型に追加 + キャスト除去で網羅を型保証。
- **★★★ (設計)**: monster-fled の報酬テスト皆無 → 無報酬・無消費・素材不変の検証を追加。
- **★★ (設計)**: affinity がレア敵を favor し得た → `spawnWeight>=1` に限定。
- **★★ (設計)**: fleer 逃走率が factor 依存で高レベル逆進 → 基準 agi (レベル非依存) に。
- **★★ (UX)**: intro が agi をネタバラシ → 情景のみに。
- **★ (UX)**: SVG きらめき強化 / 逃げられ時に「にげられてしまった…」表示。
- **★ (実装)**: metal-shard コメントを実態に修正。

実装レビューは ★★★ なし・マージ可。UX は逃走/報酬体験・出現頻度を「設計どおり成立」と評価。

## スコープ外 (後続)
P2b: スライム弱小化(xp3)、herb↓、色違いレッサー/強い版、新種、序盤を厚く、guardian/mage 序盤生存率調整。店主セリフ #385。

🤖 Generated with [Claude Code](https://claude.com/claude-code)