### PR TITLE
feat(battle): スライム最弱化 + 色違い強い版(専用素材) で序盤を厚く (P2b)

### DIFF
--- a/apps/web/src/components/monster-svg.tsx
+++ b/apps/web/src/components/monster-svg.tsx
@@ -6,34 +6,84 @@ import type { MonsterSpecies } from '@aozoraquest/core';
  * 画像アセットなしのインライン SVG = 軽量・省メモリ (モバイル方針)。
  * species ごとに 1 枚、viewBox 100x100。ドット RPG 風の太い輪郭とシンプルな形。
  */
-export function MonsterSvg({ species, size = 160, hue = 0 }: { species: MonsterSpecies; size?: number; hue?: number }) {
-  // 色違い変種は hue-rotate で塗り替える (同じ形の「あかいスライム」等を安価に作る)。
-  const dropShadow = 'drop-shadow(0 4px 6px rgba(0,0,0,0.35))';
+export function MonsterSvg({ species, size = 160, tint }: { species: MonsterSpecies; size?: number; tint?: string | undefined }) {
   return (
     <svg
       width={size}
       height={size}
       viewBox="0 0 100 100"
       aria-hidden
-      style={{ display: 'block', filter: hue ? `hue-rotate(${hue}deg) ${dropShadow}` : dropShadow }}
+      style={{ display: 'block', filter: 'drop-shadow(0 4px 6px rgba(0,0,0,0.35))' }}
     >
-      {BODIES[species]}
+      {bodyFor(species, tint)}
     </svg>
   );
 }
 
 const OUT = '#1b2530'; // 輪郭色
 
-const BODIES: Record<MonsterSpecies, ReactElement> = {
-  slime: (
+// 色違い変種は tint (明示色) で主要な塗りを差し替える。CSS hue-rotate は輝度保存で
+// 「紅のつもりが青緑」になる等の事故があるため、狙った色を直接指定する (レビュー ★)。
+function bodyFor(species: MonsterSpecies, tint?: string): ReactElement {
+  switch (species) {
+    case 'slime':
+      return slimeBody(tint);
+    case 'bat':
+      return batBody(tint);
+    case 'mushroom':
+      return mushroomBody(tint);
+    default:
+      return BODIES[species];
+  }
+}
+
+function slimeBody(tint?: string): ReactElement {
+  return (
     <g>
-      <path d="M50 18 C74 18 84 42 84 58 C84 76 68 84 50 84 C32 84 16 76 16 58 C16 42 26 18 50 18Z" fill="#57b7ee" stroke={OUT} strokeWidth="4" />
-      <path d="M30 34 C36 26 46 24 50 24" fill="none" stroke="#bfe6ff" strokeWidth="5" strokeLinecap="round" />
+      <path d="M50 18 C74 18 84 42 84 58 C84 76 68 84 50 84 C32 84 16 76 16 58 C16 42 26 18 50 18Z" fill={tint ?? '#57b7ee'} stroke={OUT} strokeWidth="4" />
+      <path d="M30 34 C36 26 46 24 50 24" fill="none" stroke={tint ? 'rgba(255,255,255,0.7)' : '#bfe6ff'} strokeWidth="5" strokeLinecap="round" />
       <circle cx="38" cy="54" r="5" fill={OUT} />
       <circle cx="62" cy="54" r="5" fill={OUT} />
       <path d="M42 68 Q50 74 58 68" fill="none" stroke={OUT} strokeWidth="3.5" strokeLinecap="round" />
     </g>
-  ),
+  );
+}
+
+function batBody(tint?: string): ReactElement {
+  const wing = tint ?? '#8f7ad6';
+  const body = tint ?? '#a58ff0';
+  return (
+    <g>
+      <path d="M8 40 Q20 26 34 34 L38 44 Q28 42 24 48Z" fill={wing} stroke={OUT} strokeWidth="3.5" strokeLinejoin="round" />
+      <path d="M92 40 Q80 26 66 34 L62 44 Q72 42 76 48Z" fill={wing} stroke={OUT} strokeWidth="3.5" strokeLinejoin="round" />
+      <ellipse cx="50" cy="54" rx="20" ry="22" fill={body} stroke={OUT} strokeWidth="4" />
+      <path d="M40 34 L44 24 L48 34Z M52 34 L56 24 L60 34Z" fill={body} stroke={OUT} strokeWidth="3" strokeLinejoin="round" />
+      <circle cx="43" cy="50" r="4.5" fill={OUT} />
+      <circle cx="57" cy="50" r="4.5" fill={OUT} />
+      <path d="M44 64 L48 60 L50 64 L52 60 L56 64" fill="none" stroke={OUT} strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
+    </g>
+  );
+}
+
+function mushroomBody(tint?: string): ReactElement {
+  return (
+    <g>
+      <path d="M18 48 C18 28 34 16 50 16 C66 16 82 28 82 48 C82 54 76 56 68 56 L32 56 C24 56 18 54 18 48Z" fill={tint ?? '#e8734f'} stroke={OUT} strokeWidth="4" />
+      <circle cx="34" cy="34" r="6" fill="#ffe1b3" />
+      <circle cx="58" cy="28" r="7" fill="#ffe1b3" />
+      <circle cx="68" cy="42" r="5" fill="#ffe1b3" />
+      <path d="M36 56 C36 72 40 82 50 82 C60 82 64 72 64 56Z" fill="#fff3da" stroke={OUT} strokeWidth="4" />
+      <circle cx="44" cy="66" r="4" fill={OUT} />
+      <circle cx="56" cy="66" r="4" fill={OUT} />
+      <path d="M46 75 Q50 78 54 75" fill="none" stroke={OUT} strokeWidth="3" strokeLinecap="round" />
+    </g>
+  );
+}
+
+const BODIES: Record<MonsterSpecies, ReactElement> = {
+  slime: slimeBody(),
+  bat: batBody(),
+  mushroom: mushroomBody(),
   // はぐれスライム: 同じ形の金属色 (銀) + きらめきのハイライトでレア感を出す。
   'metal-slime': (
     <g>
@@ -47,29 +97,6 @@ const BODIES: Record<MonsterSpecies, ReactElement> = {
       <circle cx="38" cy="54" r="5" fill={OUT} />
       <circle cx="62" cy="54" r="5" fill={OUT} />
       <path d="M42 70 Q50 64 58 70" fill="none" stroke={OUT} strokeWidth="3.5" strokeLinecap="round" />
-    </g>
-  ),
-  bat: (
-    <g>
-      <path d="M8 40 Q20 26 34 34 L38 44 Q28 42 24 48Z" fill="#8f7ad6" stroke={OUT} strokeWidth="3.5" strokeLinejoin="round" />
-      <path d="M92 40 Q80 26 66 34 L62 44 Q72 42 76 48Z" fill="#8f7ad6" stroke={OUT} strokeWidth="3.5" strokeLinejoin="round" />
-      <ellipse cx="50" cy="54" rx="20" ry="22" fill="#a58ff0" stroke={OUT} strokeWidth="4" />
-      <path d="M40 34 L44 24 L48 34Z M52 34 L56 24 L60 34Z" fill="#a58ff0" stroke={OUT} strokeWidth="3" strokeLinejoin="round" />
-      <circle cx="43" cy="50" r="4.5" fill={OUT} />
-      <circle cx="57" cy="50" r="4.5" fill={OUT} />
-      <path d="M44 64 L48 60 L50 64 L52 60 L56 64" fill="none" stroke={OUT} strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
-    </g>
-  ),
-  mushroom: (
-    <g>
-      <path d="M18 48 C18 28 34 16 50 16 C66 16 82 28 82 48 C82 54 76 56 68 56 L32 56 C24 56 18 54 18 48Z" fill="#e8734f" stroke={OUT} strokeWidth="4" />
-      <circle cx="34" cy="34" r="6" fill="#ffe1b3" />
-      <circle cx="58" cy="28" r="7" fill="#ffe1b3" />
-      <circle cx="68" cy="42" r="5" fill="#ffe1b3" />
-      <path d="M36 56 C36 72 40 82 50 82 C60 82 64 72 64 56Z" fill="#fff3da" stroke={OUT} strokeWidth="4" />
-      <circle cx="44" cy="66" r="4" fill={OUT} />
-      <circle cx="56" cy="66" r="4" fill={OUT} />
-      <path d="M46 75 Q50 78 54 75" fill="none" stroke={OUT} strokeWidth="3" strokeLinecap="round" />
     </g>
   ),
   golem: (

--- a/apps/web/src/components/monster-svg.tsx
+++ b/apps/web/src/components/monster-svg.tsx
@@ -6,14 +6,16 @@ import type { MonsterSpecies } from '@aozoraquest/core';
  * 画像アセットなしのインライン SVG = 軽量・省メモリ (モバイル方針)。
  * species ごとに 1 枚、viewBox 100x100。ドット RPG 風の太い輪郭とシンプルな形。
  */
-export function MonsterSvg({ species, size = 160 }: { species: MonsterSpecies; size?: number }) {
+export function MonsterSvg({ species, size = 160, hue = 0 }: { species: MonsterSpecies; size?: number; hue?: number }) {
+  // 色違い変種は hue-rotate で塗り替える (同じ形の「あかいスライム」等を安価に作る)。
+  const dropShadow = 'drop-shadow(0 4px 6px rgba(0,0,0,0.35))';
   return (
     <svg
       width={size}
       height={size}
       viewBox="0 0 100 100"
       aria-hidden
-      style={{ display: 'block', filter: 'drop-shadow(0 4px 6px rgba(0,0,0,0.35))' }}
+      style={{ display: 'block', filter: hue ? `hue-rotate(${hue}deg) ${dropShadow}` : dropShadow }}
     >
       {BODIES[species]}
     </svg>

--- a/apps/web/src/components/world-battle-controls.tsx
+++ b/apps/web/src/components/world-battle-controls.tsx
@@ -108,7 +108,7 @@ function BattleFieldEnemy({ state, showEnemyVitals, defeated }: { state: BattleS
         style={{ display: 'inline-block', opacity: defeated ? 0.35 : 1, transform: defeated ? 'rotate(180deg)' : 'none', transition: 'opacity 300ms ease' }}
         className={!defeated && state.lastEvents.some((e) => e.actor === 'player' && e.damage) ? 'trial-hit' : ''}
       >
-        <MonsterSvg species={monsterDef?.species ?? 'slime'} size={84} />
+        <MonsterSvg species={monsterDef?.species ?? 'slime'} hue={monsterDef?.hue ?? 0} size={84} />
       </div>
       {showEnemyVitals && !defeated && (
         <>

--- a/apps/web/src/components/world-battle-controls.tsx
+++ b/apps/web/src/components/world-battle-controls.tsx
@@ -108,7 +108,7 @@ function BattleFieldEnemy({ state, showEnemyVitals, defeated }: { state: BattleS
         style={{ display: 'inline-block', opacity: defeated ? 0.35 : 1, transform: defeated ? 'rotate(180deg)' : 'none', transition: 'opacity 300ms ease' }}
         className={!defeated && state.lastEvents.some((e) => e.actor === 'player' && e.damage) ? 'trial-hit' : ''}
       >
-        <MonsterSvg species={monsterDef?.species ?? 'slime'} hue={monsterDef?.hue ?? 0} size={84} />
+        <MonsterSvg species={monsterDef?.species ?? 'slime'} tint={monsterDef?.tint} size={84} />
       </div>
       {showEnemyVitals && !defeated && (
         <>

--- a/packages/core/src/__tests__/battle.test.ts
+++ b/packages/core/src/__tests__/battle.test.ts
@@ -158,6 +158,25 @@ describe('summonMonster', () => {
     expect(stray?.hp).toBeDefined();
   });
 
+  it('色違い強い版: hue + 専用素材 + レア出現 (spawnWeight<1) で差別化されている', () => {
+    // 強い版と専用素材の対応 (変種ごとに専用素材 — オーナー決定 2026-07-19)
+    const variants: Array<[string, string]> = [
+      ['red-slime', 'red-jelly'],
+      ['dusk-bat', 'dusk-wing'],
+      ['crimson-shroom', 'crimson-spore'],
+    ];
+    for (const [id, mat] of variants) {
+      const m = MONSTERS_BY_ID[id];
+      expect(m?.tier).toBe(1);
+      expect(m?.hue).toBeGreaterThan(0); // 色違い (hue-rotate)
+      expect(m?.spawnWeight).toBeLessThan(1); // 出現は base より稀
+      expect(m?.drops.some((d) => d.item === mat)).toBe(true); // 専用素材を落とす
+      expect(ITEMS[mat]).toBeDefined();
+    }
+    // そらいろスライムは最弱の練習敵 (xp 3)
+    expect(MONSTERS_BY_ID['sky-slime']?.xp).toBe(3);
+  });
+
   it('はぐれスライム: HP 明示で低い + fleer は逃走して monster-fled で決着 (勝敗なし)', () => {
     // レア出現なので stray-slime を引く seed を探す
     let battle: import('../battle.js').BattleState | null = null;

--- a/packages/core/src/__tests__/battle.test.ts
+++ b/packages/core/src/__tests__/battle.test.ts
@@ -102,7 +102,7 @@ describe('playerCombatant', () => {
 describe('モンスターの行動バリエーション (charger/healer + MP)', () => {
   it('ため攻撃は一部 (~20%) のモンスターに限定 (charger)', () => {
     const chargers = MONSTERS.filter((m) => m.ability === 'charger');
-    // 全 9 種中 2 種 = ~22%。全モンスターが力をためる状態は解消 (オーナー要望 2026-07-18)
+    // 全 12 種中 2 種 = ~17%。全モンスターが力をためる状態は解消 (オーナー要望 2026-07-18)
     expect(chargers.length).toBe(2);
     expect(chargers.length / MONSTERS.length).toBeLessThanOrEqual(0.25);
   });
@@ -158,7 +158,7 @@ describe('summonMonster', () => {
     expect(stray?.hp).toBeDefined();
   });
 
-  it('色違い強い版: hue + 専用素材 + レア出現 (spawnWeight<1) で差別化されている', () => {
+  it('色違い強い版: tint + 専用素材 + レア出現 (spawnWeight<1) で差別化されている', () => {
     // 強い版と専用素材の対応 (変種ごとに専用素材 — オーナー決定 2026-07-19)
     const variants: Array<[string, string]> = [
       ['red-slime', 'red-jelly'],
@@ -168,7 +168,7 @@ describe('summonMonster', () => {
     for (const [id, mat] of variants) {
       const m = MONSTERS_BY_ID[id];
       expect(m?.tier).toBe(1);
-      expect(m?.hue).toBeGreaterThan(0); // 色違い (hue-rotate)
+      expect(m?.tint).toMatch(/^#[0-9a-f]{6}$/i); // 色違い (明示色)
       expect(m?.spawnWeight).toBeLessThan(1); // 出現は base より稀
       expect(m?.drops.some((d) => d.item === mat)).toBe(true); // 専用素材を落とす
       expect(ITEMS[mat]).toBeDefined();

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -480,6 +480,9 @@ export interface MonsterDef {
   mp?: number;
   /** 出現の重み (default 1)。レア敵 (はぐれメタル等) は 1 未満にして稀にする。 */
   spawnWeight?: number;
+  /** 色違い変種の色相回転 (度)。同じ species の SVG を hue-rotate で塗り替えて
+   *  「あかいスライム」等の強い版/レッサーを安価に作る (オーナー要望 2026-07-19)。 */
+  hue?: number;
   /** 勝利時に得る XP。tier を目安にモンスター個別に設定して幅を持たせる (tier だけで
    *  決めると はぐれメタルのような「同 tier で飛び抜けて高 XP」の敵が作れない —
    *  オーナー要望 2026-07-18)。なお本格的なはぐれメタル型 (高 xp + 高回避 + 低 HP +
@@ -506,7 +509,10 @@ export const ITEMS: Record<string, { name: string }> = {
   'sky-dew': { name: 'そらのしずく' }, // MP 回復薬。青空の朝露 (世界観準拠の命名)
   'sky-feather': { name: 'そらのはね' }, // 最後に立ち寄った街へ帰還 (フィールド専用)
   'slime-drop': { name: 'スライムのしずく' },
+  'red-jelly': { name: 'あかいゼリー' }, // あかいスライム (強い版) の素材
   'metal-shard': { name: 'はぐれのかけら' }, // はぐれスライムの希少ドロップ。現状は換金専用 (将来レア装備素材に転用予定)
+  'dusk-wing': { name: 'よいやみの翼膜' }, // よるのコウモリ (強い版) の素材
+  'crimson-spore': { name: 'べにの胞子' }, // べにヒカリダケ (強い版) の素材
   'bat-wing': { name: 'コウモリの翼膜' },
   'mush-spore': { name: 'ヒカリダケの胞子' },
   'golem-core': { name: 'ゴーレムの核片' },
@@ -520,9 +526,15 @@ export const ITEMS: Record<string, { name: string }> = {
 export const MONSTERS: readonly MonsterDef[] = [
   // tier1: 手習い (初心者でも勝てる)。xp 14〜30。同 tier 内も体感できる幅を持たせる
   // (レビュー: 差が小さすぎると誤差に埋もれる)。tier をまたぐ差はさらに大きい。
-  { id: 'sky-slime', name: 'そらいろスライム', species: 'slime', tier: 1, stats: [14, 12, 10, 8, 16], xp: 14, drops: [{ item: 'slime-drop', chance: 0.7 }, { item: 'herb', chance: 0.35 }], intro: 'ぷるぷると跳ねている。' },
-  { id: 'cave-bat', name: 'ほらあなコウモリ', species: 'bat', tier: 1, stats: [12, 8, 26, 6, 12], xp: 22, drops: [{ item: 'bat-wing', chance: 0.6 }, { item: 'herb', chance: 0.3 }, { item: 'sky-feather', chance: 0.12 }], intro: 'ばさばさと羽音を立てている。' },
-  { id: 'glow-shroom', name: 'ヒカリダケ', species: 'mushroom', tier: 1, stats: [8, 20, 4, 18, 12], xp: 30, drops: [{ item: 'mush-spore', chance: 0.6 }, { item: 'herb', chance: 0.4 }, { item: 'sky-dew', chance: 0.25 }], intro: 'ほんのり光って動かない…?' },
+  // そらいろスライム: 最弱の練習敵 (xp3・低ドロップ)。「初期からスライムが強すぎる」を解消
+  // し、はぐれメタルの通常版という位置づけに (オーナー要望 2026-07-19)。
+  { id: 'sky-slime', name: 'そらいろスライム', species: 'slime', tier: 1, stats: [7, 7, 8, 6, 10], xp: 3, drops: [{ item: 'slime-drop', chance: 0.3 }, { item: 'herb', chance: 0.08 }], intro: 'ぷるぷると跳ねている。' },
+  // 色違い強い版 (hue-rotate)。base より手強く XP/素材も上。専用素材 red-jelly。
+  { id: 'red-slime', name: 'あかいスライム', species: 'slime', hue: 150, spawnWeight: 0.4, tier: 1, stats: [13, 12, 10, 8, 12], xp: 10, drops: [{ item: 'red-jelly', chance: 0.5 }, { item: 'herb', chance: 0.08 }], intro: '赤くぬめって、さっきのより手強そうだ。' },
+  { id: 'cave-bat', name: 'ほらあなコウモリ', species: 'bat', tier: 1, stats: [12, 8, 26, 6, 12], xp: 16, drops: [{ item: 'bat-wing', chance: 0.6 }, { item: 'herb', chance: 0.1 }, { item: 'sky-feather', chance: 0.12 }], intro: 'ばさばさと羽音を立てている。' },
+  { id: 'dusk-bat', name: 'よるのコウモリ', species: 'bat', hue: 90, spawnWeight: 0.4, tier: 1, stats: [14, 9, 28, 7, 13], xp: 20, drops: [{ item: 'dusk-wing', chance: 0.5 }, { item: 'sky-feather', chance: 0.12 }], intro: '夜色の翼で 音もなく舞う。' },
+  { id: 'glow-shroom', name: 'ヒカリダケ', species: 'mushroom', tier: 1, stats: [8, 20, 4, 18, 12], xp: 24, drops: [{ item: 'mush-spore', chance: 0.6 }, { item: 'herb', chance: 0.12 }, { item: 'sky-dew', chance: 0.25 }], intro: 'ほんのり光って動かない…?' },
+  { id: 'crimson-shroom', name: 'べにヒカリダケ', species: 'mushroom', hue: 150, spawnWeight: 0.4, tier: 1, stats: [9, 22, 4, 20, 12], xp: 26, drops: [{ item: 'crimson-spore', chance: 0.5 }, { item: 'sky-dew', chance: 0.2 }], intro: '毒々しい紅に 明滅している。' },
   // はぐれメタル型: レア出現・低 HP・高 XP・毎ターン逃走。倒せれば旨いが逃げられると何も残らない
   // (オーナー要望 2026-07-19)。HP は明示 (導出だと def なりに増えるため)。高 agi で逃げ足も速い。
   { id: 'stray-slime', name: 'はぐれスライム', species: 'metal-slime', tier: 1, stats: [8, 22, 38, 6, 34], hp: 12, mp: 0, xp: 45, spawnWeight: 0.06, drops: [{ item: 'metal-shard', chance: 0.5 }], ability: 'fleer', intro: 'きらりと 金属の光を放っている。' },

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -480,9 +480,10 @@ export interface MonsterDef {
   mp?: number;
   /** 出現の重み (default 1)。レア敵 (はぐれメタル等) は 1 未満にして稀にする。 */
   spawnWeight?: number;
-  /** 色違い変種の色相回転 (度)。同じ species の SVG を hue-rotate で塗り替えて
-   *  「あかいスライム」等の強い版/レッサーを安価に作る (オーナー要望 2026-07-19)。 */
-  hue?: number;
+  /** 色違い変種の主要な塗り色 (CSS color)。同じ species の SVG の主体色を差し替えて
+   *  「あかいスライム」等の強い版/レッサーを安価に作る (オーナー要望 2026-07-19)。
+   *  hue-rotate は輝度保存で狙った色にならない事故があるため明示色を持たせる。 */
+  tint?: string;
   /** 勝利時に得る XP。tier を目安にモンスター個別に設定して幅を持たせる (tier だけで
    *  決めると はぐれメタルのような「同 tier で飛び抜けて高 XP」の敵が作れない —
    *  オーナー要望 2026-07-18)。なお本格的なはぐれメタル型 (高 xp + 高回避 + 低 HP +
@@ -509,10 +510,10 @@ export const ITEMS: Record<string, { name: string }> = {
   'sky-dew': { name: 'そらのしずく' }, // MP 回復薬。青空の朝露 (世界観準拠の命名)
   'sky-feather': { name: 'そらのはね' }, // 最後に立ち寄った街へ帰還 (フィールド専用)
   'slime-drop': { name: 'スライムのしずく' },
-  'red-jelly': { name: 'あかいゼリー' }, // あかいスライム (強い版) の素材
+  'red-jelly': { name: 'あかいゼリー' }, // あかいスライム(強い版)のドロップ。現状は換金専用 (P4 クラフト素材に転用予定)
   'metal-shard': { name: 'はぐれのかけら' }, // はぐれスライムの希少ドロップ。現状は換金専用 (将来レア装備素材に転用予定)
-  'dusk-wing': { name: 'よいやみの翼膜' }, // よるのコウモリ (強い版) の素材
-  'crimson-spore': { name: 'べにの胞子' }, // べにヒカリダケ (強い版) の素材
+  'dusk-wing': { name: 'よいやみの翼膜' }, // よるのコウモリ(強い版)のドロップ。現状は換金専用 (P4 クラフト素材に転用予定)
+  'crimson-spore': { name: 'べにの胞子' }, // べにヒカリダケ(強い版)のドロップ。現状は換金専用 (P4 クラフト素材に転用予定)
   'bat-wing': { name: 'コウモリの翼膜' },
   'mush-spore': { name: 'ヒカリダケの胞子' },
   'golem-core': { name: 'ゴーレムの核片' },
@@ -528,13 +529,13 @@ export const MONSTERS: readonly MonsterDef[] = [
   // (レビュー: 差が小さすぎると誤差に埋もれる)。tier をまたぐ差はさらに大きい。
   // そらいろスライム: 最弱の練習敵 (xp3・低ドロップ)。「初期からスライムが強すぎる」を解消
   // し、はぐれメタルの通常版という位置づけに (オーナー要望 2026-07-19)。
-  { id: 'sky-slime', name: 'そらいろスライム', species: 'slime', tier: 1, stats: [7, 7, 8, 6, 10], xp: 3, drops: [{ item: 'slime-drop', chance: 0.3 }, { item: 'herb', chance: 0.08 }], intro: 'ぷるぷると跳ねている。' },
-  // 色違い強い版 (hue-rotate)。base より手強く XP/素材も上。専用素材 red-jelly。
-  { id: 'red-slime', name: 'あかいスライム', species: 'slime', hue: 150, spawnWeight: 0.4, tier: 1, stats: [13, 12, 10, 8, 12], xp: 10, drops: [{ item: 'red-jelly', chance: 0.5 }, { item: 'herb', chance: 0.08 }], intro: '赤くぬめって、さっきのより手強そうだ。' },
-  { id: 'cave-bat', name: 'ほらあなコウモリ', species: 'bat', tier: 1, stats: [12, 8, 26, 6, 12], xp: 16, drops: [{ item: 'bat-wing', chance: 0.6 }, { item: 'herb', chance: 0.1 }, { item: 'sky-feather', chance: 0.12 }], intro: 'ばさばさと羽音を立てている。' },
-  { id: 'dusk-bat', name: 'よるのコウモリ', species: 'bat', hue: 90, spawnWeight: 0.4, tier: 1, stats: [14, 9, 28, 7, 13], xp: 20, drops: [{ item: 'dusk-wing', chance: 0.5 }, { item: 'sky-feather', chance: 0.12 }], intro: '夜色の翼で 音もなく舞う。' },
-  { id: 'glow-shroom', name: 'ヒカリダケ', species: 'mushroom', tier: 1, stats: [8, 20, 4, 18, 12], xp: 24, drops: [{ item: 'mush-spore', chance: 0.6 }, { item: 'herb', chance: 0.12 }, { item: 'sky-dew', chance: 0.25 }], intro: 'ほんのり光って動かない…?' },
-  { id: 'crimson-shroom', name: 'べにヒカリダケ', species: 'mushroom', hue: 150, spawnWeight: 0.4, tier: 1, stats: [9, 22, 4, 20, 12], xp: 26, drops: [{ item: 'crimson-spore', chance: 0.5 }, { item: 'sky-dew', chance: 0.2 }], intro: '毒々しい紅に 明滅している。' },
+  { id: 'sky-slime', name: 'そらいろスライム', species: 'slime', tier: 1, stats: [7, 7, 8, 6, 10], xp: 3, drops: [{ item: 'slime-drop', chance: 0.3 }, { item: 'herb', chance: 0.35 }], intro: 'ぷるぷると跳ねている。' },
+  // 色違い強い版 (tint で塗り替え)。base より手強く XP/素材も上。専用素材 red-jelly。
+  { id: 'red-slime', name: 'あかいスライム', species: 'slime', tint: '#e0574a', spawnWeight: 0.4, tier: 1, stats: [13, 12, 10, 8, 12], xp: 10, drops: [{ item: 'red-jelly', chance: 0.5 }, { item: 'herb', chance: 0.08 }], intro: '赤くぬめって 脈打っている。' },
+  { id: 'cave-bat', name: 'ほらあなコウモリ', species: 'bat', tier: 1, stats: [12, 8, 26, 6, 12], xp: 22, drops: [{ item: 'bat-wing', chance: 0.6 }, { item: 'herb', chance: 0.3 }, { item: 'sky-feather', chance: 0.12 }], intro: 'ばさばさと羽音を立てている。' },
+  { id: 'dusk-bat', name: 'よるのコウモリ', species: 'bat', tint: '#5b6bd0', spawnWeight: 0.4, tier: 1, stats: [14, 9, 28, 7, 13], xp: 20, drops: [{ item: 'dusk-wing', chance: 0.5 }, { item: 'sky-feather', chance: 0.12 }], intro: '夜色の翼で 音もなく舞う。' },
+  { id: 'glow-shroom', name: 'ヒカリダケ', species: 'mushroom', tier: 1, stats: [8, 20, 4, 18, 12], xp: 30, drops: [{ item: 'mush-spore', chance: 0.6 }, { item: 'herb', chance: 0.4 }, { item: 'sky-dew', chance: 0.25 }], intro: 'ほんのり光って動かない…?' },
+  { id: 'crimson-shroom', name: 'べにヒカリダケ', species: 'mushroom', tint: '#c23a5b', spawnWeight: 0.4, tier: 1, stats: [9, 22, 4, 20, 12], xp: 26, drops: [{ item: 'crimson-spore', chance: 0.5 }, { item: 'sky-dew', chance: 0.2 }], intro: '毒々しい紅に 明滅している。' },
   // はぐれメタル型: レア出現・低 HP・高 XP・毎ターン逃走。倒せれば旨いが逃げられると何も残らない
   // (オーナー要望 2026-07-19)。HP は明示 (導出だと def なりに増えるため)。高 agi で逃げ足も速い。
   { id: 'stray-slime', name: 'はぐれスライム', species: 'metal-slime', tier: 1, stats: [8, 22, 38, 6, 34], hp: 12, mp: 0, xp: 45, spawnWeight: 0.06, drops: [{ item: 'metal-shard', chance: 0.5 }], ability: 'fleer', intro: 'きらりと 金属の光を放っている。' },

--- a/packages/core/src/equipment.ts
+++ b/packages/core/src/equipment.ts
@@ -222,9 +222,12 @@ export const CONSUMABLE_ITEMS: readonly string[] = ['herb', 'sky-dew', 'sky-feat
  *  (equipment→battle は循環になるため静的リスト。整合はテストで固定)。 */
 export const SELLABLE_MATERIALS: readonly string[] = [
   'slime-drop',
+  'red-jelly',
   'metal-shard',
   'bat-wing',
+  'dusk-wing',
   'mush-spore',
+  'crimson-spore',
   'golem-core',
   'wisp-ember',
   'serpent-scale',


### PR DESCRIPTION
あおぞらワールド改善エピック **P2b (序盤ロスター)**。P2a の基盤 (明示ステータス / spawnWeight / tint) の上に、オーナー要望「スライム弱すぎる役に / 敵が単調 / 色違い強い版 / 変種ごとに専用素材 / 序盤を厚く」を実装。

## 変更点
- **そらいろスライム = 最弱の練習敵**: xp 14→**3**、stats 弱体化、slime-drop 0.7→0.3。はぐれメタルの通常版。
- **色違い強い版 3 体** (明示 tint + 専用素材、`spawnWeight 0.4` = たまに出る):
  - あかいスライム(`#e0574a`)→`red-jelly` / よるのコウモリ(`#5b6bd0`)→`dusk-wing` / べにヒカリダケ(`#c23a5b`)→`crimson-spore`
  - base より少し手強く XP/素材が上。「変種ごとに専用素材」(オーナー決定) でクラフト(P4)に厚みが出る。
- `MonsterDef.tint` + `MonsterSvg` を明示色対応にリファクタ (hue-rotate は輝度保存で色がズレるため不採用)。
- 新素材 3 種を ITEMS + SELLABLE_MATERIALS に追加 (現状換金専用・P4 クラフト素材に転用予定)。

## バランス (sim tier1, jobLv1)
最弱スライム (xp3・弱) が練習台になり、**弱ジョブの序盤生存率がむしろ改善** = 「序盤を厚く」に沿う。
| | 前 | 後 |
|---|---|---|
| ninja | 99% | 99.7% |
| mage | 25% | **36%** |
| guardian | 11% | **28%** |

## 検証
- core/edge/web typecheck ✅ / test ✅ (core 308 / edge 144 / web 338) / build ✅

## Review (§1.5 3 並列) — 全 ★★ 対応済 (commit `8739c42`)
- **★★ (設計)**: herb ドロップを 1/4 に削ったが**なんでも屋に消耗品購入 UI が無い** (供給導線未実装) → 序盤の回復が枯れる恐れ。**herb 減を延期**し「ドロップ↓ + なんでも屋供給」をセットで **#389** に切り出し。P2b は herb ドロップ原状復帰。
- **★★ (UX/設計)**: `hue-rotate` が「紅→青緑」等の色ズレ → **明示 tint 色**に置換。
- **★★ (UX)**: red-slime intro が連戦前提/強さネタバレ → 情景のみに。
- **★★ (設計)**: 新素材コメントを metal-shard と同書式に。
- **★**: charger 比率テストのコメント更新 (9→12種)。

実装レビューは ★★★/★★ なし・マージ可。

## スコープ外 (後続 issue)
- **#389**: やくそう溜まりすぎ (ドロップ↓ + なんでも屋供給、セット・P4 と一緒)。
- **#387**: guardian/mage の底上げ (今回改善したが根本は job balance)。
- **#385**: 店主セリフ。レッサー版(弱変種) は強い版の感触見てから。

🤖 Generated with [Claude Code](https://claude.com/claude-code)