### PR TITLE
fix(world): リセットが「もどしています…」で固まる不具合を修正

### DIFF
--- a/apps/web/src/lib/onboarding-reset.test.ts
+++ b/apps/web/src/lib/onboarding-reset.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test, vi } from 'vitest';
+import { deleteAllRecords } from './onboarding-reset';
+
+/** listRecords が n 件 (100 件/ページ) 返すモック agent。applyWrites/deleteRecord を記録。 */
+function makeAgent(total: number) {
+  const applyWrites = vi.fn(async () => ({ data: {} }));
+  const deleteRecord = vi.fn(async () => ({ data: {} }));
+  const listRecords = vi.fn(async ({ cursor }: { cursor?: string }) => {
+    const start = cursor ? Number(cursor) : 0;
+    const end = Math.min(start + 100, total);
+    const records = Array.from({ length: end - start }, (_, i) => ({ uri: `at://did:test/col/rk${start + i}` }));
+    return { data: { records, ...(end < total ? { cursor: String(end) } : {}) } };
+  });
+  return { agent: { com: { atproto: { repo: { listRecords, applyWrites, deleteRecord } } } } as any, applyWrites, deleteRecord, listRecords };
+}
+
+describe('deleteAllRecords (バッチ削除)', () => {
+  test('250 件を 200 件/リクエストの applyWrites で一括削除 (逐次 deleteRecord を使わない)', async () => {
+    const { agent, applyWrites, deleteRecord } = makeAgent(250);
+    await deleteAllRecords(agent, 'did:test', 'app.aozoraquest.craft');
+    // 逐次 deleteRecord は使わない (これが実機ハングの原因だった)
+    expect(deleteRecord).not.toHaveBeenCalled();
+    // 250 件 → ceil(250/200) = 2 リクエスト
+    expect(applyWrites).toHaveBeenCalledTimes(2);
+    const first = applyWrites.mock.calls[0]![0] as any;
+    expect(first.writes).toHaveLength(200);
+    expect(first.writes[0]).toMatchObject({ $type: 'com.atproto.repo.applyWrites#delete', collection: 'app.aozoraquest.craft', rkey: 'rk0' });
+    const second = applyWrites.mock.calls[1]![0] as any;
+    expect(second.writes).toHaveLength(50);
+  });
+
+  test('0 件なら applyWrites を呼ばない / 未作成 (listRecords throw) は無害', async () => {
+    const { agent, applyWrites } = makeAgent(0);
+    await deleteAllRecords(agent, 'did:test', 'app.aozoraquest.craft');
+    expect(applyWrites).not.toHaveBeenCalled();
+
+    const throwing = { com: { atproto: { repo: { listRecords: vi.fn(async () => { throw new Error('nope'); }), applyWrites: vi.fn() } } } } as any;
+    await expect(deleteAllRecords(throwing, 'did:test', 'x')).resolves.toBeUndefined();
+    expect(throwing.com.atproto.repo.applyWrites).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/onboarding-reset.test.ts
+++ b/apps/web/src/lib/onboarding-reset.test.ts
@@ -3,8 +3,8 @@ import { deleteAllRecords } from './onboarding-reset';
 
 /** listRecords が n 件 (100 件/ページ) 返すモック agent。applyWrites/deleteRecord を記録。 */
 function makeAgent(total: number) {
-  const applyWrites = vi.fn(async () => ({ data: {} }));
-  const deleteRecord = vi.fn(async () => ({ data: {} }));
+  const applyWrites = vi.fn(async (_args: { repo: string; writes: unknown[] }) => ({ data: {} }));
+  const deleteRecord = vi.fn(async (_args: unknown) => ({ data: {} }));
   const listRecords = vi.fn(async ({ cursor }: { cursor?: string }) => {
     const start = cursor ? Number(cursor) : 0;
     const end = Math.min(start + 100, total);

--- a/apps/web/src/lib/onboarding-reset.ts
+++ b/apps/web/src/lib/onboarding-reset.ts
@@ -24,10 +24,14 @@ import { serverReset } from './world-server';
 /** 歓迎付与するあおぞらパワー (演出とともに加算)。 */
 export const WELCOME_POWER = 20;
 
-/** あるコレクションの全レコードを削除。records が尽きるまでページングする
- *  (途中で打ち切ると「完全ワイプ」にならず、直後の power 再集計に残留分が混ざる)。
- *  未作成コレクションは何もしない。安全上限 10000 件 (暴走防止)。 */
-async function deleteAllRecords(agent: Agent, did: string, collection: string): Promise<void> {
+/** あるコレクションの全レコードを削除。**applyWrites でバッチ削除**する — 1 件ずつ
+ *  逐次 deleteRecord すると、レコードが多いアカウントで数十〜数百往復かかり実質ハングする
+ *  (アクティブなアカウントでリセットが固まる不具合。所持記録が多いほど顕著)。
+ *  records が尽きるまでページングして rkey を集め、200 件ずつ applyWrites で一括削除する。
+ *  未作成コレクションは何もしない。安全上限 10000 件 (暴走防止)。
+ *  @internal export はテスト用 (バッチ削除の回帰防止)。 */
+export async function deleteAllRecords(agent: Agent, did: string, collection: string): Promise<void> {
+  const rkeys: string[] = [];
   let cursor: string | undefined;
   for (let page = 0; page < 100; page++) {
     let res;
@@ -36,14 +40,22 @@ async function deleteAllRecords(agent: Agent, did: string, collection: string): 
     } catch {
       return; // 未作成
     }
-    if (res.data.records.length === 0) break;
     for (const r of res.data.records) {
       const rkey = r.uri.split('/').pop();
-      if (rkey) await agent.com.atproto.repo.deleteRecord({ repo: did, collection, rkey }).catch(() => {});
+      if (rkey) rkeys.push(rkey);
     }
     const next = res.data.cursor;
-    if (!next || next === cursor) break;
+    if (!next || next === cursor || res.data.records.length === 0) break;
     cursor = next;
+  }
+  // 200 件/リクエストの applyWrites で一括削除 (逐次 deleteRecord の N 往復 → ceil(N/200) 往復)。
+  for (let i = 0; i < rkeys.length; i += 200) {
+    const writes = rkeys.slice(i, i + 200).map((rkey) => ({
+      $type: 'com.atproto.repo.applyWrites#delete' as const,
+      collection,
+      rkey,
+    }));
+    await agent.com.atproto.repo.applyWrites({ repo: did, writes }).catch(() => {});
   }
 }
 

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -803,10 +803,16 @@ export function World() {
   const doReset = useCallback(async () => {
     if (!agent || !did || resetting) return;
     if (!window.confirm('あおぞらワールドを「はじめから」やり直します。\n所持品・装備・レベル・位置がすべて初期化されます (投稿で貯めたパワー残高は残ります)。よろしいですか?')) return;
-    setResetting(true); // 重い直列 I/O の間、進行オーバーレイを出す (無反応に見せない)
+    setResetting(true); // I/O の間、進行オーバーレイを出す (無反応に見せない)
     setMenuOpen(false);
     try {
-      await resetOnboarding(agent, did);
+      // 全体タイムアウト (30s)。PDS 応答が返らない等でも進行オーバーレイが永久に
+      // 固着しないよう fail-safe で throw する (実機で「もどしています…」から進めなく
+      // なる不具合の再発防止)。
+      await Promise.race([
+        resetOnboarding(agent, did),
+        new Promise<never>((_, reject) => window.setTimeout(() => reject(new Error('reset timeout')), 30_000)),
+      ]);
       notifyWelcome({ power: WELCOME_POWER });
       // 演出 (フェード込み ≈ 3.3s) を見せ切って余韻を残してから初期状態で再入場
       window.setTimeout(() => window.location.reload(), WELCOME_TOTAL_MS + 900);

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -805,13 +805,14 @@ export function World() {
     if (!window.confirm('あおぞらワールドを「はじめから」やり直します。\n所持品・装備・レベル・位置がすべて初期化されます (投稿で貯めたパワー残高は残ります)。よろしいですか?')) return;
     setResetting(true); // I/O の間、進行オーバーレイを出す (無反応に見せない)
     setMenuOpen(false);
+    let timeoutId: number | undefined;
     try {
       // 全体タイムアウト (30s)。PDS 応答が返らない等でも進行オーバーレイが永久に
       // 固着しないよう fail-safe で throw する (実機で「もどしています…」から進めなく
-      // なる不具合の再発防止)。
+      // なる不具合の再発防止)。勝った側で必ず timer を片付ける (finally)。
       await Promise.race([
         resetOnboarding(agent, did),
-        new Promise<never>((_, reject) => window.setTimeout(() => reject(new Error('reset timeout')), 30_000)),
+        new Promise<never>((_, reject) => { timeoutId = window.setTimeout(() => reject(new Error('reset timeout')), 30_000); }),
       ]);
       notifyWelcome({ power: WELCOME_POWER });
       // 演出 (フェード込み ≈ 3.3s) を見せ切って余韻を残してから初期状態で再入場
@@ -820,6 +821,8 @@ export function World() {
       console.warn('[world] onboarding reset failed', e);
       setNotice('リセットに失敗した (通信エラー)。もう一度どうぞ。');
       setResetting(false);
+    } finally {
+      if (timeoutId !== undefined) window.clearTimeout(timeoutId);
     }
   }, [agent, did, resetting]);
 
@@ -1318,7 +1321,9 @@ export function World() {
             fontSize: '0.95em', letterSpacing: '0.04em',
           }}
         >
-          はじめの地へ もどしています…
+          {/* 明滅させて「処理中」を伝える (静止だと固まって見える = 今回直したい症状そのもの)。 */}
+          <style>{'@keyframes reset-pulse{0%,100%{opacity:0.45}50%{opacity:1}}'}</style>
+          <span style={{ animation: 'reset-pulse 1.4s ease-in-out infinite' }}>はじめの地へ もどしています…</span>
         </div>
       )}
       <WelcomeBlessingOverlay />


### PR DESCRIPTION
## 不具合
実機で「⟲ はじめから」を選ぶと進行オーバーレイ「はじめの地へ もどしています…」から**進めなくなる** (オーナー報告 IMG_5546, dev)。

## 原因
`resetOnboarding` が制作/戦闘レコード (`COL.craft` / `COL.battle`) を**1 件ずつ逐次 `deleteRecord`** していた。投稿・戦闘が多いアクティブなアカウント (例: パワー 106) では数十〜数百往復かかり、進行オーバーレイ (`pointerEvents` 非設定で全操作をブロック) が実質固着していた。

## 修正
- `deleteAllRecords` を **`applyWrites` の一括削除** に (200 件/リクエスト → N 往復が ceil(N/200) 往復に激減)。逐次 `deleteRecord` を廃止。
- `doReset` に**全体タイムアウト 30s** (Promise.race) を追加。PDS 無応答等でも進行オーバーレイが永久固着しない fail-safe。エラー表示 + 解除し、リセットは冪等なのでリトライで収束。勝利時は timer を clear。
- 進行オーバーレイを**明滅アニメ**に (静止だと固まって見える)。

## 検証
- web typecheck ✅ / test ✅ (340, `applyWrites` バッチ削除の回帰テスト追加) / build ✅

## Review (§1.5 3 並列) — 全 ★★★/★★ 対応済 (commit `af257aa`)
- **★★★ (実装)**: テスト mock の引数型欠落で typecheck 赤 → 型付与で修正。
- **★★ (UX)**: 静止オーバーレイが「固まって見える」→ 明滅アニメ追加。
- **★ (実装)**: Promise.race 勝利時の timer 未 clear → finally で clearTimeout。
- **設計 ★★** (atproto per-request timeout 非対称 / timeout 時のジョブ非中断→二重実行) は冪等性に守られ非致命のため **#391** に切り出し (管理者専用・dev)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)