### PR TITLE
fix(world): リセット失敗を解消 (並列 deleteRecord + 原因可視化)

### DIFF
--- a/apps/web/src/lib/onboarding-reset.test.ts
+++ b/apps/web/src/lib/onboarding-reset.test.ts
@@ -1,41 +1,46 @@
 import { describe, expect, test, vi } from 'vitest';
 import { deleteAllRecords } from './onboarding-reset';
 
-/** listRecords が n 件 (100 件/ページ) 返すモック agent。applyWrites/deleteRecord を記録。 */
+/** listRecords が total 件 (100 件/ページ) 返すモック agent。deleteRecord を記録。 */
 function makeAgent(total: number) {
-  const applyWrites = vi.fn(async (_args: { repo: string; writes: unknown[] }) => ({ data: {} }));
-  const deleteRecord = vi.fn(async (_args: unknown) => ({ data: {} }));
+  const deleteRecord = vi.fn(async (_args: { repo: string; collection: string; rkey: string }) => ({ data: {} }));
   const listRecords = vi.fn(async ({ cursor }: { cursor?: string }) => {
     const start = cursor ? Number(cursor) : 0;
     const end = Math.min(start + 100, total);
     const records = Array.from({ length: end - start }, (_, i) => ({ uri: `at://did:test/col/rk${start + i}` }));
     return { data: { records, ...(end < total ? { cursor: String(end) } : {}) } };
   });
-  return { agent: { com: { atproto: { repo: { listRecords, applyWrites, deleteRecord } } } } as any, applyWrites, deleteRecord, listRecords };
+  return { agent: { com: { atproto: { repo: { listRecords, deleteRecord } } } } as any, deleteRecord, listRecords };
 }
 
-describe('deleteAllRecords (バッチ削除)', () => {
-  test('250 件を 200 件/リクエストの applyWrites で一括削除 (逐次 deleteRecord を使わない)', async () => {
-    const { agent, applyWrites, deleteRecord } = makeAgent(250);
+describe('deleteAllRecords (並列バッチ削除)', () => {
+  test('全レコードを deleteRecord で消す (ページングして 250 件すべて)', async () => {
+    const { agent, deleteRecord, listRecords } = makeAgent(250);
     await deleteAllRecords(agent, 'did:test', 'app.aozoraquest.craft');
-    // 逐次 deleteRecord は使わない (これが実機ハングの原因だった)
-    expect(deleteRecord).not.toHaveBeenCalled();
-    // 250 件 → ceil(250/200) = 2 リクエスト
-    expect(applyWrites).toHaveBeenCalledTimes(2);
-    const first = applyWrites.mock.calls[0]![0] as any;
-    expect(first.writes).toHaveLength(200);
-    expect(first.writes[0]).toMatchObject({ $type: 'com.atproto.repo.applyWrites#delete', collection: 'app.aozoraquest.craft', rkey: 'rk0' });
-    const second = applyWrites.mock.calls[1]![0] as any;
-    expect(second.writes).toHaveLength(50);
+    // 250 件すべて削除 (逐次でなく並列バッチだが、呼び出し回数は 1 件 1 回)
+    expect(deleteRecord).toHaveBeenCalledTimes(250);
+    const rkeys = deleteRecord.mock.calls.map((c) => (c[0] as { rkey: string }).rkey).sort();
+    expect(rkeys).toContain('rk0');
+    expect(rkeys).toContain('rk249');
+    expect(new Set(rkeys).size).toBe(250); // 重複なし
+    // listRecords は 3 ページ (100+100+50) 舐める
+    expect(listRecords).toHaveBeenCalledTimes(3);
   });
 
-  test('0 件なら applyWrites を呼ばない / 未作成 (listRecords throw) は無害', async () => {
-    const { agent, applyWrites } = makeAgent(0);
-    await deleteAllRecords(agent, 'did:test', 'app.aozoraquest.craft');
-    expect(applyWrites).not.toHaveBeenCalled();
+  test('個々の deleteRecord 失敗は握りつぶして続行 (存在しない rkey 等)', async () => {
+    const { agent, deleteRecord } = makeAgent(30);
+    deleteRecord.mockImplementation(async () => { throw new Error('RecordNotFound'); });
+    await expect(deleteAllRecords(agent, 'did:test', 'x')).resolves.toBeUndefined();
+    expect(deleteRecord).toHaveBeenCalledTimes(30); // 失敗しても全件試す
+  });
 
-    const throwing = { com: { atproto: { repo: { listRecords: vi.fn(async () => { throw new Error('nope'); }), applyWrites: vi.fn() } } } } as any;
+  test('0 件なら deleteRecord を呼ばない / 未作成 (listRecords throw) は無害', async () => {
+    const { agent, deleteRecord } = makeAgent(0);
+    await deleteAllRecords(agent, 'did:test', 'x');
+    expect(deleteRecord).not.toHaveBeenCalled();
+
+    const throwing = { com: { atproto: { repo: { listRecords: vi.fn(async () => { throw new Error('nope'); }), deleteRecord: vi.fn() } } } } as any;
     await expect(deleteAllRecords(throwing, 'did:test', 'x')).resolves.toBeUndefined();
-    expect(throwing.com.atproto.repo.applyWrites).not.toHaveBeenCalled();
+    expect(throwing.com.atproto.repo.deleteRecord).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/onboarding-reset.ts
+++ b/apps/web/src/lib/onboarding-reset.ts
@@ -24,12 +24,13 @@ import { serverReset } from './world-server';
 /** 歓迎付与するあおぞらパワー (演出とともに加算)。 */
 export const WELCOME_POWER = 20;
 
-/** あるコレクションの全レコードを削除。**applyWrites でバッチ削除**する — 1 件ずつ
- *  逐次 deleteRecord すると、レコードが多いアカウントで数十〜数百往復かかり実質ハングする
- *  (アクティブなアカウントでリセットが固まる不具合。所持記録が多いほど顕著)。
- *  records が尽きるまでページングして rkey を集め、200 件ずつ applyWrites で一括削除する。
+/** あるコレクションの全レコードを削除。**並列バッチの deleteRecord** で消す —
+ *  1 件ずつ逐次 await するとレコードが多いアカウントで数十〜数百往復かかり実質ハングする
+ *  (リセットが固まる不具合)。records を集めてから 25 件ずつ並列に削除する。
+ *  applyWrites の一括削除はバッチ全体が落ちる/入力検証で同期 throw する事故があり、
+ *  独立した deleteRecord を並列に投げる方が堅牢 (存在しない rkey は個別に無視)。
  *  未作成コレクションは何もしない。安全上限 10000 件 (暴走防止)。
- *  @internal export はテスト用 (バッチ削除の回帰防止)。 */
+ *  @internal export はテスト用 (並列削除の回帰防止)。 */
 export async function deleteAllRecords(agent: Agent, did: string, collection: string): Promise<void> {
   const rkeys: string[] = [];
   let cursor: string | undefined;
@@ -48,14 +49,13 @@ export async function deleteAllRecords(agent: Agent, did: string, collection: st
     if (!next || next === cursor || res.data.records.length === 0) break;
     cursor = next;
   }
-  // 200 件/リクエストの applyWrites で一括削除 (逐次 deleteRecord の N 往復 → ceil(N/200) 往復)。
-  for (let i = 0; i < rkeys.length; i += 200) {
-    const writes = rkeys.slice(i, i + 200).map((rkey) => ({
-      $type: 'com.atproto.repo.applyWrites#delete' as const,
-      collection,
-      rkey,
-    }));
-    await agent.com.atproto.repo.applyWrites({ repo: did, writes }).catch(() => {});
+  const BATCH = 25;
+  for (let i = 0; i < rkeys.length; i += BATCH) {
+    await Promise.all(
+      rkeys.slice(i, i + BATCH).map((rkey) =>
+        agent.com.atproto.repo.deleteRecord({ repo: did, collection, rkey }).catch(() => {}),
+      ),
+    );
   }
 }
 
@@ -87,11 +87,20 @@ async function zeroAnalysisXp(agent: Agent, did: string): Promise<void> {
  * 5. サーバー権威 gameState + 戦闘ガードを削除 → 次のワールド入場で初期状態を生成 (最後に実行)。
  */
 export async function resetOnboarding(agent: Agent, did: string): Promise<void> {
-  await deleteAllRecords(agent, did, COL.craft);
-  await deleteAllRecords(agent, did, COL.battle);
-  await deleteSelf(agent, did, COL.gear);
-  await deleteSelf(agent, did, COL.world);
-  await zeroAnalysisXp(agent, did);
-  await resetWorldPower(agent, did, WELCOME_POWER);
-  await serverReset(agent);
+  // 各ステップを label 付きで実行 — どのステップで失敗したかをエラーに載せて UI で分かるようにする
+  // (「リセットに失敗」だけだと原因が特定できない不具合対応)。
+  const step = async (label: string, fn: () => Promise<unknown>): Promise<void> => {
+    try {
+      await fn();
+    } catch (e) {
+      throw new Error(`${label}: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  };
+  await step('craft', () => deleteAllRecords(agent, did, COL.craft));
+  await step('battle', () => deleteAllRecords(agent, did, COL.battle));
+  await step('gear', () => deleteSelf(agent, did, COL.gear));
+  await step('world', () => deleteSelf(agent, did, COL.world));
+  await step('analysisXp', () => zeroAnalysisXp(agent, did));
+  await step('power', () => resetWorldPower(agent, did, WELCOME_POWER));
+  await step('serverReset', () => serverReset(agent));
 }

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -819,7 +819,9 @@ export function World() {
       window.setTimeout(() => window.location.reload(), WELCOME_TOTAL_MS + 900);
     } catch (e) {
       console.warn('[world] onboarding reset failed', e);
-      setNotice('リセットに失敗した (通信エラー)。もう一度どうぞ。');
+      // 失敗したステップ/理由を出す (原因特定のため。resetOnboarding は `step: message` 形式で throw)。
+      const detail = e instanceof WorldServerError ? `${e.status || ''} ${e.message}`.trim() : e instanceof Error ? e.message : '';
+      setNotice(`リセットに失敗した (${detail || '通信エラー'})。もう一度どうぞ。`);
       setResetting(false);
     } finally {
       if (timeoutId !== undefined) window.clearTimeout(timeoutId);

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -819,8 +819,9 @@ export function World() {
       window.setTimeout(() => window.location.reload(), WELCOME_TOTAL_MS + 900);
     } catch (e) {
       console.warn('[world] onboarding reset failed', e);
-      // 失敗したステップ/理由を出す (原因特定のため。resetOnboarding は `step: message` 形式で throw)。
-      const detail = e instanceof WorldServerError ? `${e.status || ''} ${e.message}`.trim() : e instanceof Error ? e.message : '';
+      // 失敗したステップ/理由を出す。resetOnboarding は `step: message` 形式 (WorldServerError も
+      // その message にラップ済み) で throw するので、message をそのまま出せば原因が分かる。
+      const detail = e instanceof Error ? e.message : '';
       setNotice(`リセットに失敗した (${detail || '通信エラー'})。もう一度どうぞ。`);
       setResetting(false);
     } finally {


### PR DESCRIPTION
## 不具合
実機で「⟲ はじめから」が「リセットに失敗した (通信エラー)」で失敗 (オーナー報告 IMG_5547)。#390 でハングは解消したが今度は throw して失敗。

## 修正
- `deleteAllRecords` を **並列バッチの `deleteRecord`** に (25 件並列)。`applyWrites` はバッチ全体が落ちる/入力検証で同期 throw して `.catch` で拾えないリスクがあり廃止。各削除が独立で堅牢。
- `resetOnboarding` の各ステップに **label** を付与し失敗時 `step: message` で throw → `doReset` が notice に詳細表示。**どのステップ (analysisXp/power/serverReset) で落ちたか実機で特定できる**。

これで applyWrites 由来なら解消、別ステップなら原因が可視化される。

## 検証
- web typecheck ✅ / test ✅ (341) / build ✅ / web-ci ✅

## Review (§1.5 実装レビュー) — 対応済 (commit `4fa1ce8`)
- **★★**: `step()` が WorldServerError を plain Error に包むため doReset の `instanceof WorldServerError` 分岐がデッドコード化 (status 表示が落ちる) → 分岐を外し `e.message` をそのまま表示 (message に label+理由が載る)。主目的の原因可視化は機能。
- **★** (429 時のログ欠落): best-effort + 冪等リトライ収束で実害小、対応不要。
- 冪等性・テスト・step 順序は健全と確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)