### PR TITLE
chore(edge): dev/本番エッジを分離する [env.dev] 骨組み + runbook (docs/22)

### DIFF
--- a/apps/edge/wrangler.toml
+++ b/apps/edge/wrangler.toml
@@ -23,3 +23,31 @@ preview_id = "c1f3e394d104413192a0dac7303b6443"
 # refresh_token で更新する (REFRESH_AHEAD_SEC=900 = 15 分前から。cron 間隔 < ahead で取りこぼし防止)。
 [triggers]
 crons = ["*/10 * * * *"]
+
+# ─────────────────────────────────────────────────────────────────
+# dev 環境: 本番と**完全分離**した別 Worker。dev が本番に触れる構成は不可 (オーナー方針
+# 2026-07-19)。dev.aozoraquest.app の web が VITE_EDGE_URL でここを叩く。
+#   デプロイ: wrangler deploy --env dev   /  本番: wrangler deploy (top-level, main リリース時のみ)
+#   URL は worker 名から自動: https://aozoraquest-edge-dev.<account>.workers.dev
+#   セットアップ手順は docs/22-edge-env-separation.md。
+# サーバーアカウントは本番と同じでよいが、**KV/OAuth セッション/cron/secrets はすべて dev 専用**
+# (client_id = dev の client-metadata URL = 別 grant なので refresh が本番と干渉しない)。
+[env.dev]
+name = "aozoraquest-edge-dev"
+
+# dev 専用の OAuth トークン KV (本番と物理的に別 = 二重 refresh 事故を構造的に排除)。
+# 作成: wrangler kv namespace create OAUTH_TOKENS --env dev → 出力の id をここに貼る。
+[[env.dev.kv_namespaces]]
+binding = "OAUTH_TOKENS"
+id = "REPLACE_WITH_DEV_KV_ID"
+
+# dev 専用 cron (自分のセッションのトークンだけ refresh)。
+[env.dev.triggers]
+crons = ["*/10 * * * *"]
+
+# 非 secret の env var (edge インフラ値。personal な SERVER_DID/ADMIN_DIDS と secret は
+# wrangler secret put --env dev / CF で別途設定。docs/22 参照)。
+[env.dev.vars]
+WORKER_DID = "did:web:aozoraquest-edge-dev.kojiran.workers.dev"
+PUBLIC_ORIGIN = "https://aozoraquest-edge-dev.kojiran.workers.dev"
+ALLOWED_ORIGINS = "https://dev.aozoraquest.app"

--- a/apps/edge/wrangler.toml
+++ b/apps/edge/wrangler.toml
@@ -50,4 +50,6 @@ crons = ["*/10 * * * *"]
 [env.dev.vars]
 WORKER_DID = "did:web:aozoraquest-edge-dev.kojiran.workers.dev"
 PUBLIC_ORIGIN = "https://aozoraquest-edge-dev.kojiran.workers.dev"
-ALLOWED_ORIGINS = "https://dev.aozoraquest.app"
+# CORS 許可オリジン = ブラウザ fetch 経路のみ (OAuth callback / client-metadata は
+# サーバー間 fetch = CORS 対象外)。ローカル開発 (127.0.0.1:9999) も dev エッジを叩くので許可。
+ALLOWED_ORIGINS = "https://dev.aozoraquest.app,http://127.0.0.1:9999"

--- a/docs/22-edge-env-separation.md
+++ b/docs/22-edge-env-separation.md
@@ -63,12 +63,26 @@ POST https://aozoraquest-edge-dev.kojiran.workers.dev/api/oauth/start   (ADMIN_D
 ```
 
 ### 5. dev web を dev エッジに向ける
-- `apps/web/.env.development`: `VITE_EDGE_URL` / `VITE_EDGE_DID` を dev エッジに。
-- CF Workers Build `aozoraquest-dev` の Variables も同様に (dev web ビルドが拾う値)。
+**重要**: 現状 `apps/web/.env.development` には `VITE_EDGE_*` 行が**無い** → Vite は
+`.env` の値 (= 本番エッジ `aozoraquest-edge.kojiran.workers.dev`) を継承する。
+**これが「dev web が共有/本番エッジを叩いていた」現状の原因**。dev エッジに向けるには
+`.env.development` に以下 2 行を**追記**して `.env` の本番値を上書きする:
 ```
 VITE_EDGE_URL=https://aozoraquest-edge-dev.kojiran.workers.dev
 VITE_EDGE_DID=did:web:aozoraquest-edge-dev.kojiran.workers.dev
 ```
+- CF Workers Build `aozoraquest-dev` の Variables にも同じ 2 値を設定 (dev web の本番ビルドが拾う値)。
+- 本番 web (`aozoraquest` / `.env.production`) は本番エッジのままにする (変更しない)。
+
+## 補足
+
+- **ALLOWED_ORIGINS** はブラウザ fetch 経路 (dev web / localhost) の CORS 許可のみ。
+  `/oauth/callback` と `/client-metadata.json` はサーバー間 fetch なので CORS 対象外
+  (ALLOWED_ORIGINS に callback URL を足す必要はない)。
+- **WORLD_TOKEN_SECRET** を本番と別鍵にするので、dev の既存位置トークン/セッションは
+  無効化される (初回セットアップなので実害なし)。
+- wrangler.toml の `REPLACE_WITH_DEV_KV_ID` を実 id に差し替えるまで `wrangler deploy --env dev`
+  は失敗する (step 1 → step 3 の順で回す)。
 
 ### 6. 確認
 - dev.aozoraquest.app でワールド移動/戦闘/リセットが dev エッジ経由で動く。

--- a/docs/22-edge-env-separation.md
+++ b/docs/22-edge-env-separation.md
@@ -1,0 +1,81 @@
+# エッジ Worker の dev/本番 分離 (docs/22)
+
+## 背景・原則
+
+エッジ Worker (`aozoraquest-edge`) は #363 で **1 デプロイで dev/本番を捌く**構成にした。
+環境の区別はリクエスト Origin → データ名前空間 (`dev.aozoraquest.app`→`app.aozoraquest.dev`) だけ。
+これは **データは分離するがコードは共有**する構成で、エッジをデプロイすると dev/本番が同時に変わる。
+
+**この構成は不可** (オーナー方針 2026-07-19):「dev が本番に影響のある構成を良しとするのはありえない」。
+dev は本番に**一切**触れられないのが原則。Web アプリが `aozoraquest-dev` / `aozoraquest` の 2 デプロイに
+分かれているのと同様、**エッジも dev 用と本番用の別 Worker に分ける**。
+
+## 設計
+
+- **本番エッジ**: `aozoraquest-edge` (top-level wrangler config)。`wrangler deploy` (main リリース時)。
+- **dev エッジ**: `aozoraquest-edge-dev` (`[env.dev]`)。`wrangler deploy --env dev`。
+  URL は worker 名から自動: `https://aozoraquest-edge-dev.kojiran.workers.dev`。
+- **サーバーアカウントは同じでよい**。dev エッジは別 client_id (= dev の `/client-metadata.json` URL) で
+  同じアカウントを認可するので、**独立した OAuth grant / 独立した refresh チェーン**になり本番と干渉しない。
+  分けるのは「別 KV (別トークン保管) / 別 cron / 別 secrets」であって「別アカウント」ではない。
+- **KV / cron / secrets はすべて dev 専用**。dev の cron は自分のセッションのトークンだけ refresh する。
+
+## セットアップ手順 (runbook)
+
+前提: `wrangler whoami` が kojiran@gmail.com (account b9cec3916d500760a7c7b9c31c720d80)。
+`cd apps/edge` で実行。secret 値はチャット/リポジトリに残さない (§4)。
+
+### 1. dev 専用 KV を作る
+```
+wrangler kv namespace create OAUTH_TOKENS --env dev
+wrangler kv namespace create OAUTH_TOKENS --env dev --preview
+```
+→ 出力の `id` / `preview_id` を `wrangler.toml` の `[[env.dev.kv_namespaces]]` の `REPLACE_WITH_DEV_KV_ID` に貼る。
+
+### 2. dev 専用の鍵/secret を生成して set
+本番と別の鍵にする (完全独立)。
+- `OAUTH_CLIENT_PRIVATE_JWK`: 新規 P-256 鍵 (confidential client の client assertion 用)。
+- `OAUTH_DPOP_PRIVATE_JWK`: 新規 P-256 鍵 (DPoP 用)。
+- `WORLD_TOKEN_SECRET`: 新規ランダム (位置トークン署名用)。
+```
+wrangler secret put OAUTH_CLIENT_PRIVATE_JWK --env dev
+wrangler secret put OAUTH_DPOP_PRIVATE_JWK --env dev
+wrangler secret put WORLD_TOKEN_SECRET --env dev
+# personal な値 (本番と同じでよい) も dev 用に set:
+wrangler secret put SERVER_DID --env dev        # サーバーアカウントの DID (本番と同じ)
+wrangler secret put ADMIN_DIDS --env dev         # 管理者 DID (本番と同じ)
+wrangler secret put OAUTH_SCOPE --env dev         # 本番と同じ (例 "atproto transition:generic")
+```
+(`WORKER_DID` / `PUBLIC_ORIGIN` / `ALLOWED_ORIGINS` は wrangler.toml の `[env.dev.vars]` に記載済み = secret 不要。)
+
+### 3. dev エッジをデプロイ
+```
+wrangler deploy --env dev
+```
+→ `https://aozoraquest-edge-dev.kojiran.workers.dev` が立つ。**本番エッジには一切触れない**。
+
+### 4. dev エッジで OAuth を bootstrap (サーバーアカウントを認可)
+管理者が dev エッジの OAuth 開始フローを踏み、dev KV にトークンを入れる (本番とは別セッション):
+```
+POST https://aozoraquest-edge-dev.kojiran.workers.dev/api/oauth/start   (ADMIN_DIDS の service auth JWT)
+→ 返った authorizeUrl をブラウザで開いてサーバーアカウントで承認
+→ /oauth/callback が dev KV にトークン保存
+```
+
+### 5. dev web を dev エッジに向ける
+- `apps/web/.env.development`: `VITE_EDGE_URL` / `VITE_EDGE_DID` を dev エッジに。
+- CF Workers Build `aozoraquest-dev` の Variables も同様に (dev web ビルドが拾う値)。
+```
+VITE_EDGE_URL=https://aozoraquest-edge-dev.kojiran.workers.dev
+VITE_EDGE_DID=did:web:aozoraquest-edge-dev.kojiran.workers.dev
+```
+
+### 6. 確認
+- dev.aozoraquest.app でワールド移動/戦闘/リセットが dev エッジ経由で動く。
+- 本番 (aozoraquest.app) は無傷 (本番エッジ・本番 KV 不変)。
+
+## 再発防止
+
+- dev エッジは dev push で自動デプロイする仕組み (GitHub Actions or CF Workers Build) を検討 (#TODO)。
+  それまでは dev エッジのコード変更は `wrangler deploy --env dev` を手動で回す (docs に明記)。
+- 本番エッジは main リリース時のみ `wrangler deploy` (top-level)。誤って本番へ出さない運用を徹底。


### PR DESCRIPTION
## 背景・原則
エッジが **1 デプロイで dev/本番を捌く** #363 構成は「dev が本番に影響しうる」= **不可**(オーナー方針)。エッジも別 Worker に分ける。

## この PR (骨組み + 手順書)
- `wrangler.toml` `[env.dev]` → `aozoraquest-edge-dev` (dev 専用 KV/cron/vars)。`wrangler deploy --env dev` は **dev のみ**、本番 (top-level) 不可侵。
- `docs/22-edge-env-separation.md` に runbook。
- サーバーアカウントは同じでよい (別 client_id = 独立 OAuth grant)。分けるのは KV/セッション/cron/secrets。

## 検証
- prod (top-level) `wrangler deploy --dry-run` **不変** (KV `fa7215…`)。dev env は別 Worker/KV を正しく解決。secret 非コミット。

## Review (§1.5 設計/インフラ) — 全 ★★ 対応済 (commit `f4bfbe3`)
- **★★★ なし**。wrangler env 分離・client_id 別 grant・did:web audience 文字列比較の核心設計は正しく、本番 top-level 設定は無傷と確認。
- **★★**: `.env.development` に VITE_EDGE_* が無く `.env` の**本番エッジ値を継承** = 現状「dev web が共有エッジを叩いていた」原因 → runbook step5 に「2 行追記で上書き」を明記。
- **★★**: ALLOWED_ORIGINS はブラウザ fetch 経路のみ (OAuth callback/metadata は CORS 対象外) を明記 + localhost:9999 を許可に追加。
- **★**: WORLD_TOKEN_SECRET 鍵変更の無効化・KV id 順序依存を明記。dev エッジ自動デプロイは **#394**。

## この後 (runbook, 別途実行)
KV 作成 → dev secret set → `wrangler deploy --env dev` → OAuth bootstrap (管理者ブラウザ) → dev web を dev エッジへ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)