### PR TITLE
chore(§4): サーバーアカウントの個人 handle をソースから一掃

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,7 @@ typecheck / build / test 緑は **十分条件ではない**。実際の UI を�
 
 - API キー、トークン、URL、handle、DID、メールアドレス → 全部 NG
 - 環境変数経由にして、値は外部に置く
-- 過去事例: kojira.io を debug コードに直書き → user に怒られた
+- 過去事例: 個人 handle を debug コードに直書き → user に怒られた
 
 ### 環境変数の置き場所
 
@@ -287,7 +287,7 @@ build 時必須にした env vars を CI workflow に追加し忘れ、CI 落ち
 
 ### 2026-04-28: 個人 handle をソースに直書き
 
-debug-card のデフォルトに `kojira.io` を直書き → 個人情報がリポジトリに残る。
+debug-card のデフォルトに個人 handle を直書き → 個人情報がリポジトリに残る。
 **学び**: handle / DID / email 等の固有情報は環境変数か query 経由で。
 
 ### 2026-06-10: ブランチ運用を feature ブランチ方式へ移行

--- a/apps/admin/src/routes/prompts.tsx
+++ b/apps/admin/src/routes/prompts.tsx
@@ -69,7 +69,7 @@ export function Prompts() {
       <details style={{ marginBottom: '0.5em', fontSize: '0.85em' }}>
         <summary style={{ cursor: 'pointer', color: 'var(--color-muted)' }}>使える変数 (本文に埋め込めます)</summary>
         <ul style={{ margin: '0.4em 0 0 1em', padding: 0, lineHeight: 1.6 }}>
-          <li><code>{'{user}'}</code> — ユーザのハンドル先頭部分 (例: <code>kojira.io</code> → <code>kojira</code>)。未ログイン時は <code>あなた</code></li>
+          <li><code>{'{user}'}</code> — ユーザのハンドル先頭部分 (例: <code>alice.bsky.social</code> → <code>alice</code>)。未ログイン時は <code>あなた</code></li>
           <li><code>{'{archetype}'}</code> — そのユーザの現在の職業名 (例: <code>賢者</code>)</li>
           <li><code>{'{level}'}</code> — そのユーザの現職 LV (例: <code>5</code>)</li>
           <li>値が取れない変数 (診断未実施 / 未定義キー) は <code>{'{xxx}'}</code> のままユーザに見える形で残ります (admin が設定ミスに気付けるため)</li>

--- a/apps/edge/src/battle-guard.ts
+++ b/apps/edge/src/battle-guard.ts
@@ -2,7 +2,7 @@
  * バトルガード — docs/21-server-authority §5 の「毎ターン・やり直し不可」を担保する永続レコード。
  *
  * encounter 時に **Worker が封印した playerSnapshot + monster + 現 state + turn** をサーバー
- * アカウント (kojira.io) の PDS に 1 ユーザー 1 アクティブ戦闘で持つ。ユーザーは書けない = 偽造不可。
+ * サーバーアカウントの PDS に 1 ユーザー 1 アクティブ戦闘で持つ。ユーザーは書けない = 偽造不可。
  * 書き込みは M2.5 の OAuth (DPoP) トークン経由 (server-pds)。読みは token 由来 pds の public getRecord。
  *
  * **やり直し不可の要点**: turn を `swapRecord` (CAS) で進める。同じターンを別コマンドで引き直そう

--- a/apps/edge/src/game-state.ts
+++ b/apps/edge/src/game-state.ts
@@ -1,7 +1,7 @@
 /**
  * ゲーム経済の権威 state (docs/21-server-authority §4.1/§6)。
  *
- * サーバーアカウント (kojira.io) の repo に **ユーザー DID をキーにした 1 レコード/人**で持つ。
+ * サーバーアカウントの repo に **ユーザー DID をキーにした 1 レコード/人**で持つ。
  * ユーザーはこの repo に書けない = 偽造不可。二重使用防止は swapRecord (CAS) + 本モジュールの
  * **read-modify-write 契約** (レビュー ★★★) で担保: CID 不一致 (InvalidSwap) 時は最新を再読込 →
  * 副作用を再評価 → 再 put、をループする (楽観ロック)。

--- a/apps/edge/src/oauth-client.ts
+++ b/apps/edge/src/oauth-client.ts
@@ -97,7 +97,7 @@ function normalize(t: TokenResponse, authServer: AuthServerMetadata, now: number
   if (opts.requireSub && !t.sub) throw new Error('トークン応答に sub が無い (bootstrap では必須)');
   const did = t.sub ?? expectedDid;
   // アカウント取り違え/セッション固定対策: 認可されたアカウントが期待するサーバーアカウント
-  // (kojira.io) と一致することを必須にする。別アカウントでログインされてもトークンを保存しない。
+  // サーバーアカウントと一致することを必須にする。別アカウントでログインされてもトークンを保存しない。
   if (did !== expectedDid) throw new Error(`予期しないアカウント: ${did} ≠ ${expectedDid}`);
   if (!t.refresh_token) throw new Error('refresh_token が無い(atproto スコープの refresh 発行を要確認)');
   return {

--- a/apps/edge/src/oauth-config.ts
+++ b/apps/edge/src/oauth-config.ts
@@ -3,7 +3,7 @@
  *
  * 秘密鍵 (client 署名鍵 / DPoP 鍵) は Worker Secret に JWK(JSON) で入れる。client_id / redirect_uri は
  * edge の公開 origin から導出。管理者判定 (ADMIN_DIDS) は /oauth/start のゲートに使う。
- * サーバーアカウント (kojira.io) の DID は SERVER_DID (Variable)。**ソースに直書きしない**。
+ * サーバーアカウントの DID は SERVER_DID (Variable)。**ソースに直書きしない**。
  */
 import { publicJwk, type EcJwk } from './oauth-jwt';
 
@@ -12,7 +12,7 @@ export interface OAuthEnv {
   OAUTH_CLIENT_PRIVATE_JWK?: string;
   /** DPoP 鍵。Secret。JWK JSON。 */
   OAUTH_DPOP_PRIVATE_JWK?: string;
-  /** サーバーアカウント DID (権威データの持ち主 = kojira.io)。Variable。 */
+  /** サーバーアカウント DID (権威データの持ち主 = サーバーアカウント)。Variable。 */
   SERVER_DID?: string;
   /** 管理者 DID 許可リスト (カンマ区切り)。/oauth/start ゲート用。Variable。 */
   ADMIN_DIDS?: string;

--- a/apps/edge/src/server-pds.ts
+++ b/apps/edge/src/server-pds.ts
@@ -1,7 +1,7 @@
 /**
  * サーバーアカウント PDS への **OAuth (DPoP) 認証付き書き込み** — docs/21 §12.3 / M3。
  *
- * M2.5 で取得・保管した OAuth トークン (KV) を使い、サーバーアカウント (kojira.io) の PDS に
+ * M2.5 で取得・保管した OAuth トークン (KV) を使い、サーバーアカウントの PDS に
  * putRecord / deleteRecord する。書き込みは DPoP バインド (sender-constrained) で、access token +
  * DPoP 鍵 (Worker Secret) + PDS 用 DPoP-Nonce (別 KV キー) を使う。
  *
@@ -42,7 +42,7 @@ async function authedXrpc<T>(env: ServerPdsEnv, now: number, nsid: string, body:
 
   const nonce = (await readPdsNonce(kv)) ?? undefined;
   let latest = nonce;
-  // repo は常にサーバーアカウント (kojira.io) の DID。**body の後に置き**、呼び出し側が誤って
+  // repo は常にサーバーアカウントの DID。**body の後に置き**、呼び出し側が誤って
   // repo を含めても上書きできないようにする (認証境界の固定。レビュー ★)。
   const res = await dpopFetch(
     `${tokens.pdsUrl}/xrpc/${nsid}`,

--- a/apps/edge/test/battle-guard.test.ts
+++ b/apps/edge/test/battle-guard.test.ts
@@ -7,7 +7,7 @@ import { writeServerTokens } from '../src/oauth-store';
 import type { ServerPdsEnv } from '../src/server-pds';
 
 const DID = 'did:plc:alice';
-const SERVER_DID = 'did:plc:kojira';
+const SERVER_DID = 'did:plc:testserver';
 const PDS = 'https://pds.example';
 const NOW = 1_700_000_000;
 

--- a/apps/edge/test/battle-resolver.test.ts
+++ b/apps/edge/test/battle-resolver.test.ts
@@ -7,7 +7,7 @@ import { terrainAt, isWalkable, type Command } from '@aozoraquest/core';
 import type { GameState } from '../src/game-state';
 
 const USER = 'did:plc:alice';
-const SERVER_DID = 'did:plc:kojira';
+const SERVER_DID = 'did:plc:testserver';
 const SERVER_PDS = 'https://server-pds.example';
 const USER_PDS = 'https://user-pds.example';
 const NOW = 1_700_000_000;

--- a/apps/edge/test/game-state.test.ts
+++ b/apps/edge/test/game-state.test.ts
@@ -5,7 +5,7 @@ import { rkeyForDid, readModifyWrite, type GameState, type GameStateEnv } from '
 import { writeServerTokens } from '../src/oauth-store';
 
 const DID = 'did:plc:alice'; // 対象ユーザー
-const SERVER_DID = 'did:plc:kojira'; // 権威 repo の持ち主 (kojira.io)
+const SERVER_DID = 'did:plc:testserver'; // 権威 repo の持ち主 (テスト用サーバーアカウント)
 const PDS = 'https://pds.example';
 const NOW = 1_700_000_000; // epoch 秒 (固定)
 

--- a/apps/edge/test/oauth-client.test.ts
+++ b/apps/edge/test/oauth-client.test.ts
@@ -38,7 +38,7 @@ describe('oauth-client', () => {
   it('buildAuthorizeUrl は PAR して authorize URL を返し、正しい form を送る', async () => {
     let body = '';
     const f = (async (_u: string, init: RequestInit) => { body = init.body as string; return json({ request_uri: 'urn:req:abc' }); }) as unknown as typeof fetch;
-    const r = await buildAuthorizeUrl({ ...cfg(), fetchImpl: f }, AS, { loginHint: 'kojira.io', state: 'ST', pkce: { verifier: 'VER', challenge: 'CHAL' } });
+    const r = await buildAuthorizeUrl({ ...cfg(), fetchImpl: f }, AS, { loginHint: 'server.example', state: 'ST', pkce: { verifier: 'VER', challenge: 'CHAL' } });
     expect(r.url).toBe(`https://bsky.social/oauth/authorize?client_id=${encodeURIComponent(cfg().clientId)}&request_uri=urn%3Areq%3Aabc`);
     expect(r.state).toBe('ST');
     expect(r.verifier).toBe('VER');
@@ -46,16 +46,16 @@ describe('oauth-client', () => {
     expect(form.get('response_type')).toBe('code');
     expect(form.get('code_challenge')).toBe('CHAL');
     expect(form.get('code_challenge_method')).toBe('S256');
-    expect(form.get('login_hint')).toBe('kojira.io');
+    expect(form.get('login_hint')).toBe('server.example');
     expect(form.get('client_assertion_type')).toBe('urn:ietf:params:oauth:client-assertion-type:jwt-bearer');
     expect(form.get('client_assertion')).toBeTruthy();
   });
 
   it('exchangeCode は token を正規化 (sub→did, expiresAt=now+expires_in)', async () => {
     let body = '';
-    const f = (async (_u: string, init: RequestInit) => { body = init.body as string; return json({ access_token: 'AT', token_type: 'DPoP', refresh_token: 'RT', expires_in: 3600, sub: 'did:plc:kojira', scope: 'atproto' }); }) as unknown as typeof fetch;
-    const t = await exchangeCode({ ...cfg(), fetchImpl: f }, AS, 'CODE', 'VER', 'https://pds.example', 'did:plc:kojira');
-    expect(t).toMatchObject({ did: 'did:plc:kojira', accessToken: 'AT', refreshToken: 'RT', tokenType: 'DPoP', expiresAt: NOW + 3600, authServer: AS.issuer, pdsUrl: 'https://pds.example' });
+    const f = (async (_u: string, init: RequestInit) => { body = init.body as string; return json({ access_token: 'AT', token_type: 'DPoP', refresh_token: 'RT', expires_in: 3600, sub: 'did:plc:testserver', scope: 'atproto' }); }) as unknown as typeof fetch;
+    const t = await exchangeCode({ ...cfg(), fetchImpl: f }, AS, 'CODE', 'VER', 'https://pds.example', 'did:plc:testserver');
+    expect(t).toMatchObject({ did: 'did:plc:testserver', accessToken: 'AT', refreshToken: 'RT', tokenType: 'DPoP', expiresAt: NOW + 3600, authServer: AS.issuer, pdsUrl: 'https://pds.example' });
     const form = new URLSearchParams(body);
     expect(form.get('grant_type')).toBe('authorization_code');
     expect(form.get('code')).toBe('CODE');
@@ -64,8 +64,8 @@ describe('oauth-client', () => {
 
   it('refreshTokens は grant_type=refresh_token で更新する', async () => {
     let body = '';
-    const f = (async (_u: string, init: RequestInit) => { body = init.body as string; return json({ access_token: 'AT2', token_type: 'DPoP', refresh_token: 'RT2', expires_in: 100, sub: 'did:plc:kojira' }); }) as unknown as typeof fetch;
-    const t = await refreshTokens({ ...cfg(), fetchImpl: f }, AS, 'OLD_RT', 'https://pds.example', 'did:plc:kojira');
+    const f = (async (_u: string, init: RequestInit) => { body = init.body as string; return json({ access_token: 'AT2', token_type: 'DPoP', refresh_token: 'RT2', expires_in: 100, sub: 'did:plc:testserver' }); }) as unknown as typeof fetch;
+    const t = await refreshTokens({ ...cfg(), fetchImpl: f }, AS, 'OLD_RT', 'https://pds.example', 'did:plc:testserver');
     expect(t.accessToken).toBe('AT2');
     expect(t.refreshToken).toBe('RT2');
     expect(new URLSearchParams(body).get('refresh_token')).toBe('OLD_RT');
@@ -78,15 +78,15 @@ describe('oauth-client', () => {
 
   it('sub が期待アカウントと違えば拒否 (アカウント取り違え/セッション固定対策)', async () => {
     const f = (async () => json({ access_token: 'AT', token_type: 'DPoP', refresh_token: 'RT', expires_in: 60, sub: 'did:plc:attacker' })) as unknown as typeof fetch;
-    await expect(exchangeCode({ ...cfg(), fetchImpl: f }, AS, 'C', 'V', 'https://pds.example', 'did:plc:kojira')).rejects.toThrow(/予期しないアカウント/);
+    await expect(exchangeCode({ ...cfg(), fetchImpl: f }, AS, 'C', 'V', 'https://pds.example', 'did:plc:testserver')).rejects.toThrow(/予期しないアカウント/);
     // 一致すれば通る
-    const ok = (async () => json({ access_token: 'AT', token_type: 'DPoP', refresh_token: 'RT', expires_in: 60, sub: 'did:plc:kojira' })) as unknown as typeof fetch;
-    await expect(exchangeCode({ ...cfg(), fetchImpl: ok }, AS, 'C', 'V', 'https://pds.example', 'did:plc:kojira')).resolves.toMatchObject({ did: 'did:plc:kojira' });
+    const ok = (async () => json({ access_token: 'AT', token_type: 'DPoP', refresh_token: 'RT', expires_in: 60, sub: 'did:plc:testserver' })) as unknown as typeof fetch;
+    await expect(exchangeCode({ ...cfg(), fetchImpl: ok }, AS, 'C', 'V', 'https://pds.example', 'did:plc:testserver')).resolves.toMatchObject({ did: 'did:plc:testserver' });
   });
 
   it('bootstrap (exchangeCode) は sub 欠落を serverDid で埋めず拒否する', async () => {
     const f = (async () => json({ access_token: 'AT', token_type: 'DPoP', refresh_token: 'RT', expires_in: 60 })) as unknown as typeof fetch; // sub なし
-    await expect(exchangeCode({ ...cfg(), fetchImpl: f }, AS, 'C', 'V', 'https://pds.example', 'did:plc:kojira')).rejects.toThrow(/sub/);
+    await expect(exchangeCode({ ...cfg(), fetchImpl: f }, AS, 'C', 'V', 'https://pds.example', 'did:plc:testserver')).rejects.toThrow(/sub/);
   });
 
   it('use_dpop_nonce チャレンジは nonce を付けて再送し成功する', async () => {

--- a/apps/edge/test/oauth-config.test.ts
+++ b/apps/edge/test/oauth-config.test.ts
@@ -11,7 +11,7 @@ function jwkJson(fill: number): string {
 const baseEnv = (): OAuthEnv => ({
   OAUTH_CLIENT_PRIVATE_JWK: jwkJson(3),
   OAUTH_DPOP_PRIVATE_JWK: jwkJson(5),
-  SERVER_DID: 'did:plc:kojira',
+  SERVER_DID: 'did:plc:testserver',
   WORKER_DID: 'did:web:edge.aozoraquest.app',
   ADMIN_DIDS: 'did:plc:admin1, did:plc:admin2',
 });
@@ -28,7 +28,7 @@ describe('oauth-config', () => {
     expect(c.clientId).toBe('https://edge.aozoraquest.app/client-metadata.json');
     expect(c.redirectUri).toBe('https://edge.aozoraquest.app/oauth/callback');
     expect(c.scope).toBe('atproto transition:generic');
-    expect(c.serverDid).toBe('did:plc:kojira');
+    expect(c.serverDid).toBe('did:plc:testserver');
     expect(c.clientJwk.d).toBeTruthy();
   });
 

--- a/apps/edge/test/oauth-cron.test.ts
+++ b/apps/edge/test/oauth-cron.test.ts
@@ -14,13 +14,13 @@ function mockKv() {
   return { get: async (k: string) => m.get(k) ?? null, put: async (k: string, v: string) => { m.set(k, v); }, delete: async (k: string) => { m.delete(k); } } as unknown as KVNamespace;
 }
 const AS = 'https://bsky.social';
-const env = (kv?: KVNamespace): CronEnv => ({ OAUTH_CLIENT_PRIVATE_JWK: jwkJson(3), OAUTH_DPOP_PRIVATE_JWK: jwkJson(5), SERVER_DID: 'did:plc:kojira', WORKER_DID: 'did:web:edge.aozoraquest.app', OAUTH_TOKENS: kv });
+const env = (kv?: KVNamespace): CronEnv => ({ OAUTH_CLIENT_PRIVATE_JWK: jwkJson(3), OAUTH_DPOP_PRIVATE_JWK: jwkJson(5), SERVER_DID: 'did:plc:testserver', WORKER_DID: 'did:web:edge.aozoraquest.app', OAUTH_TOKENS: kv });
 const json = (b: unknown, s = 200) => new Response(JSON.stringify(b), { status: s, headers: { 'content-type': 'application/json' } });
 const NOW = 100000;
-const tokens = (over: Partial<ServerOAuthTokens> = {}): ServerOAuthTokens => ({ did: 'did:plc:kojira', accessToken: 'AT', refreshToken: 'RT', tokenType: 'DPoP', expiresAt: NOW + 3600, pdsUrl: 'https://pds.example', authServer: AS, updatedAt: NOW, ...over });
+const tokens = (over: Partial<ServerOAuthTokens> = {}): ServerOAuthTokens => ({ did: 'did:plc:testserver', accessToken: 'AT', refreshToken: 'RT', tokenType: 'DPoP', expiresAt: NOW + 3600, pdsUrl: 'https://pds.example', authServer: AS, updatedAt: NOW, ...over });
 
 const refreshFetch = (tokenResp: () => Response) => (async (url: string) => {
-  if (url.includes('plc.directory')) return json({ id: 'did:plc:kojira', service: [{ id: '#atproto_pds', type: 'AtprotoPersonalDataServer', serviceEndpoint: 'https://pds.example' }] });
+  if (url.includes('plc.directory')) return json({ id: 'did:plc:testserver', service: [{ id: '#atproto_pds', type: 'AtprotoPersonalDataServer', serviceEndpoint: 'https://pds.example' }] });
   if (url.includes('oauth-protected-resource')) return json({ authorization_servers: [AS] });
   if (url.includes('oauth-authorization-server')) return json({ issuer: AS, authorization_endpoint: `${AS}/a`, token_endpoint: `${AS}/oauth/token`, pushed_authorization_request_endpoint: `${AS}/par` });
   if (url.includes('/oauth/token')) return tokenResp();
@@ -42,7 +42,7 @@ describe('oauth-cron', () => {
   it('期限が近ければ refresh して KV を更新 (refreshingUntil は解除)', async () => {
     const kv = mockKv();
     await writeServerTokens(kv, tokens({ expiresAt: NOW + 60 }));
-    const f = refreshFetch(() => json({ access_token: 'AT2', token_type: 'DPoP', refresh_token: 'RT2', expires_in: 3600, sub: 'did:plc:kojira' }));
+    const f = refreshFetch(() => json({ access_token: 'AT2', token_type: 'DPoP', refresh_token: 'RT2', expires_in: 3600, sub: 'did:plc:testserver' }));
     const r = await runCronRefresh(env(kv), NOW, f);
     expect(r.status).toBe('refreshed');
     const saved = await readServerTokens(kv);

--- a/apps/edge/test/oauth-routes.test.ts
+++ b/apps/edge/test/oauth-routes.test.ts
@@ -17,10 +17,10 @@ function mockKv() {
 const AS = 'https://bsky.social';
 const meta: AuthServerMetadata = { issuer: AS, authorization_endpoint: `${AS}/oauth/authorize`, token_endpoint: `${AS}/oauth/token`, pushed_authorization_request_endpoint: `${AS}/oauth/par` };
 const json = (b: unknown, s = 200) => new Response(JSON.stringify(b), { status: s, headers: { 'content-type': 'application/json' } });
-const env = (kv?: KVNamespace): OAuthRoutesEnv => ({ OAUTH_CLIENT_PRIVATE_JWK: jwkJson(3), OAUTH_DPOP_PRIVATE_JWK: jwkJson(5), SERVER_DID: 'did:plc:kojira', WORKER_DID: 'did:web:edge.aozoraquest.app', ADMIN_DIDS: 'did:plc:admin1', OAUTH_TOKENS: kv });
+const env = (kv?: KVNamespace): OAuthRoutesEnv => ({ OAUTH_CLIENT_PRIVATE_JWK: jwkJson(3), OAUTH_DPOP_PRIVATE_JWK: jwkJson(5), SERVER_DID: 'did:plc:testserver', WORKER_DID: 'did:web:edge.aozoraquest.app', ADMIN_DIDS: 'did:plc:admin1', OAUTH_TOKENS: kv });
 
 const discoveryFetch = (extra: Record<string, () => Response> = {}) => (async (url: string) => {
-  if (url.includes('plc.directory')) return json({ id: 'did:plc:kojira', service: [{ id: '#atproto_pds', type: 'AtprotoPersonalDataServer', serviceEndpoint: 'https://pds.example' }] });
+  if (url.includes('plc.directory')) return json({ id: 'did:plc:testserver', service: [{ id: '#atproto_pds', type: 'AtprotoPersonalDataServer', serviceEndpoint: 'https://pds.example' }] });
   if (url.includes('oauth-protected-resource')) return json({ authorization_servers: [AS] });
   if (url.includes('oauth-authorization-server')) return json(meta);
   for (const [frag, fn] of Object.entries(extra)) if (url.includes(frag)) return fn();
@@ -73,10 +73,10 @@ describe('oauth-routes', () => {
   it('callback: 正しい state で code を token に交換し KV に保存する', async () => {
     const kv = mockKv();
     await putPendingAuth(kv, 'ST', { verifier: 'VER', authServer: meta, pdsUrl: 'https://pds.example', createdAt: NOW });
-    const f = discoveryFetch({ '/oauth/token': () => json({ access_token: 'AT', token_type: 'DPoP', refresh_token: 'RT', expires_in: 3600, sub: 'did:plc:kojira' }) });
+    const f = discoveryFetch({ '/oauth/token': () => json({ access_token: 'AT', token_type: 'DPoP', refresh_token: 'RT', expires_in: 3600, sub: 'did:plc:testserver' }) });
     const res = await handleOAuthCallback(new Request('https://x/oauth/callback?code=CODE&state=ST'), env(kv), { now: NOW, fetchImpl: f });
     expect(res.status).toBe(200);
     const saved = await readServerTokens(kv);
-    expect(saved).toMatchObject({ did: 'did:plc:kojira', accessToken: 'AT', refreshToken: 'RT' });
+    expect(saved).toMatchObject({ did: 'did:plc:testserver', accessToken: 'AT', refreshToken: 'RT' });
   });
 });

--- a/apps/edge/test/server-pds.test.ts
+++ b/apps/edge/test/server-pds.test.ts
@@ -15,8 +15,8 @@ function mockKv() {
 }
 const PDS = 'https://pds.example';
 const NOW = 100000;
-const tokens = (over: Partial<ServerOAuthTokens> = {}): ServerOAuthTokens => ({ did: 'did:plc:kojira', accessToken: 'ATOKEN', refreshToken: 'RT', tokenType: 'DPoP', expiresAt: NOW + 3600, pdsUrl: PDS, authServer: 'https://bsky.social', updatedAt: NOW, ...over });
-const env = (kv?: KVNamespace): ServerPdsEnv => ({ OAUTH_CLIENT_PRIVATE_JWK: jwkJson(3), OAUTH_DPOP_PRIVATE_JWK: jwkJson(5), SERVER_DID: 'did:plc:kojira', WORKER_DID: 'did:web:edge.aozoraquest.app', OAUTH_TOKENS: kv });
+const tokens = (over: Partial<ServerOAuthTokens> = {}): ServerOAuthTokens => ({ did: 'did:plc:testserver', accessToken: 'ATOKEN', refreshToken: 'RT', tokenType: 'DPoP', expiresAt: NOW + 3600, pdsUrl: PDS, authServer: 'https://bsky.social', updatedAt: NOW, ...over });
+const env = (kv?: KVNamespace): ServerPdsEnv => ({ OAUTH_CLIENT_PRIVATE_JWK: jwkJson(3), OAUTH_DPOP_PRIVATE_JWK: jwkJson(5), SERVER_DID: 'did:plc:testserver', WORKER_DID: 'did:web:edge.aozoraquest.app', OAUTH_TOKENS: kv });
 const json = (b: unknown, s = 200, h: Record<string, string> = {}) => new Response(JSON.stringify(b), { status: s, headers: { 'content-type': 'application/json', ...h } });
 
 describe('server-pds (OAuth DPoP 書き込み)', () => {
@@ -33,7 +33,7 @@ describe('server-pds (OAuth DPoP 書き込み)', () => {
     expect(seen!.url).toBe(`${PDS}/xrpc/com.atproto.repo.putRecord`);
     expect(seen!.headers.get('DPoP')).toBeTruthy();
     expect(seen!.headers.get('Authorization')).toBe('DPoP ATOKEN');
-    expect(seen!.body).toMatchObject({ repo: 'did:plc:kojira', collection: 'app.aozoraquest.gameState', rkey: 'u123', record: { power: 5 }, swapRecord: null });
+    expect(seen!.body).toMatchObject({ repo: 'did:plc:testserver', collection: 'app.aozoraquest.gameState', rkey: 'u123', record: { power: 5 }, swapRecord: null });
   });
 
   it('未 bootstrap / KV 無し / 失効 / 設定不備は fail-closed (ServerWriteError)', async () => {
@@ -73,6 +73,6 @@ describe('server-pds (OAuth DPoP 書き込み)', () => {
     let body: unknown;
     globalThis.fetch = (async (_u: string, init: RequestInit) => { body = JSON.parse(init.body as string); return json({}); }) as unknown as typeof fetch;
     await serverDeleteRecord(env(kv), NOW, 'c', 'r', 'CID9');
-    expect(body).toMatchObject({ repo: 'did:plc:kojira', collection: 'c', rkey: 'r', swapRecord: 'CID9' });
+    expect(body).toMatchObject({ repo: 'did:plc:testserver', collection: 'c', rkey: 'r', swapRecord: 'CID9' });
   });
 });

--- a/apps/edge/wrangler.toml
+++ b/apps/edge/wrangler.toml
@@ -13,7 +13,7 @@ compatibility_flags = ["nodejs_compat"]
 
 # OAuth write 認証 (docs/21 §12) のトークンストア。cron refresher が書き、リクエスト Worker が読む。
 # 実行時に書き換えられる保管場所が要るので Secret/env でなく KV (Durable Object は Paid 要で不採用)。
-# Kojiran@gmail.com アカウントに作成 (wrangler kv namespace create OAUTH_TOKENS)。
+# CF アカウントに作成 (wrangler kv namespace create OAUTH_TOKENS)。
 [[kv_namespaces]]
 binding = "OAUTH_TOKENS"
 id = "fa7215e005474e6cac81745c463333ba"
@@ -39,7 +39,7 @@ name = "aozoraquest-edge-dev"
 # 作成: wrangler kv namespace create OAUTH_TOKENS --env dev → 出力の id をここに貼る。
 [[env.dev.kv_namespaces]]
 binding = "OAUTH_TOKENS"
-id = "REPLACE_WITH_DEV_KV_ID"
+id = "ef1a0429afc34c7da4ee5183752a5f3e"
 
 # dev 専用 cron (自分のセッションのトークンだけ refresh)。
 [env.dev.triggers]

--- a/apps/web/src/components/column-picker.tsx
+++ b/apps/web/src/components/column-picker.tsx
@@ -63,7 +63,7 @@ export function ColumnPicker({
         return;
       }
       if (!handle.includes('.') && !handle.startsWith('did:')) {
-        setParamErr('ハンドルは kojira.example のようなドット入りの形式です。');
+        setParamErr('ハンドルは alice.example のようなドット入りの形式です。');
         return;
       }
       onAdd(makeAppColumn('profile', { param: handle }));
@@ -96,7 +96,7 @@ export function ColumnPicker({
       {paramFor && (
         <div style={{ marginTop: '0.5em' }}>
           <label htmlFor="column-picker-param" style={{ display: 'block', fontSize: '0.78em', color: 'var(--color-muted)', marginBottom: '0.2em' }}>
-            {paramFor === 'search' ? '検索キーワード (空でも OK)' : 'ハンドル (例: kojira.example)'}
+            {paramFor === 'search' ? '検索キーワード (空でも OK)' : 'ハンドル (例: alice.example)'}
           </label>
           <div style={{ display: 'flex', gap: '0.3em' }}>
             <input

--- a/apps/web/src/components/handle.tsx
+++ b/apps/web/src/components/handle.tsx
@@ -41,8 +41,8 @@ export function Handle({ did, prefix, suffix }: Props) {
 }
 
 /**
- * 報酬ポイント表記。「kojira.ioP777」だと読みづらいので
- * 「kojira.io P 777」と区切り、「P」を太字の白で浮かせる
+ * 報酬ポイント表記。「alice.bsky.socialP777」だと読みづらいので
+ * 「alice.bsky.social P 777」と区切り、「P」を太字の白で浮かせる
  * (DESIGN.md: 強調は白)。handle 部分は親の色を踏襲する。
  */
 export function RewardPoints({ did, points }: { did: string; points: number }) {

--- a/apps/web/src/lib/app-columns.test.ts
+++ b/apps/web/src/lib/app-columns.test.ts
@@ -63,13 +63,13 @@ describe('loadAppColumns / saveAppColumns', () => {
   it('save → load で同じ内容が戻る', () => {
     const cols = [
       makeAppColumn('search', { param: 'illust', mode: 'posts' }),
-      makeAppColumn('profile', { param: 'kojira.example', section: 'portfolio' }),
+      makeAppColumn('profile', { param: 'alice.example', section: 'portfolio' }),
     ];
     saveAppColumns(cols);
     const loaded = loadAppColumns(true);
     expect(loaded.map(c => ({ kind: c.kind, param: 'param' in c ? c.param : undefined }))).toEqual([
       { kind: 'search', param: 'illust' },
-      { kind: 'profile', param: 'kojira.example' },
+      { kind: 'profile', param: 'alice.example' },
     ]);
   });
 
@@ -257,7 +257,7 @@ describe('appColumnTitle', () => {
     expect(appColumnTitle({ id: '1', kind: 'search', param: 'foo' })).toBe('検索: foo');
     expect(appColumnTitle({ id: '1', kind: 'search' })).toBe('検索');
     expect(appColumnTitle({ id: '1', kind: 'board' })).toBe('クエスト掲示板');
-    expect(appColumnTitle({ id: '1', kind: 'profile', param: 'kojira.example' })).toBe('@kojira.example');
+    expect(appColumnTitle({ id: '1', kind: 'profile', param: 'alice.example' })).toBe('@alice.example');
     expect(appColumnTitle({ id: '1', kind: 'profile' })).toBe('プロフィール');
   });
 });

--- a/apps/web/src/lib/handle-cache.ts
+++ b/apps/web/src/lib/handle-cache.ts
@@ -2,7 +2,7 @@
  * DID → handle 解決のキャッシュ層。
  *
  * AT Proto の DID (例: did:plc:abc123...) はユーザーに見せる文字列として
- * 不適。aozoraquest の UI では「kojira.io」のような handle で表示する。
+ * 不適。aozoraquest の UI では「alice.bsky.social」のような handle で表示する。
  *
  * - 公開 AppView (api.bsky.app) の getProfile を使う (認証不要)
  * - メモリ Map + localStorage で 24 時間キャッシュ

--- a/apps/web/src/lib/prompt-template.ts
+++ b/apps/web/src/lib/prompt-template.ts
@@ -3,8 +3,8 @@
  * 既知の変数を実行時に展開する小さな template engine。
  *
  * 使い方:
- *   applyPromptTemplate('{user} さん、こんにちは', { user: 'kojira' })
- *     → 'kojira さん、こんにちは'
+ *   applyPromptTemplate('{user} さん、こんにちは', { user: 'alice' })
+ *     → 'alice さん、こんにちは'
  *
  * 仕様:
  * - キーは英数字 + アンダースコアのみ (日本語キーは未対応)
@@ -14,7 +14,7 @@
  * - 未登録キー → 同じくそのまま残す
  *
  * spiritChat の variables (現状サポート):
- *   {user}      — ユーザのハンドル先頭部分 (例: "kojira.io" → "kojira")
+ *   {user}      — ユーザのハンドル先頭部分 (例: "alice.bsky.social" → "alice")
  *   {archetype} — 現在の職業名 (例: "賢者")。診断未実施なら未展開
  *   {level}     — 現職の LV (例: "5")。診断未実施なら未展開
  */

--- a/apps/web/src/lib/server-oauth.ts
+++ b/apps/web/src/lib/server-oauth.ts
@@ -1,5 +1,5 @@
 /**
- * サーバーアカウント (kojira.io) の OAuth 連携を管理者が開始する導線 — docs/21 §12。
+ * サーバーアカウントの OAuth 連携を管理者が開始する導線 — docs/21 §12。
  *
  * 管理者がログイン中に、自分の OAuth セッション (Agent) で **service auth JWT** (aud=edge Worker,
  * lxm=oauth.start) を発行 → edge の `/api/oauth/start` に渡すと、edge が PAR して authorize URL を

--- a/apps/web/src/routes/board.tsx
+++ b/apps/web/src/routes/board.tsx
@@ -73,7 +73,7 @@ export function Board() {
       </header>
 
       <p style={{ margin: '0 0 0.6em', fontSize: '0.85em', color: 'var(--color-muted)', lineHeight: 1.5 }}>
-        お互いの「<strong>名前のポイント</strong>」(例: kojira.io ポイント) を発行しあって、やってほしいことを頼み合う掲示板です。
+        お互いの「<strong>名前のポイント</strong>」(例: あなたの名前ポイント) を発行しあって、やってほしいことを頼み合う掲示板です。
         応募は誰でも、完了の判定は発注者が行います。報酬は自分が発行するので元手は要りません。
       </p>
 

--- a/apps/web/src/routes/debug-card.tsx
+++ b/apps/web/src/routes/debug-card.tsx
@@ -25,7 +25,7 @@ async function fetchAsDataUrl(url: string): Promise<string | null> {
  * 実カードのサイズ計測用 debug ルート (本番では辿る導線なし、Playwright から /debug/card で開く)。
  *
  * `?handle=xxx.bsky.social` で表示するアバター/displayName を Bluesky 公開 API から取得する。
- * 未指定なら kojira.io をデフォルトに使う。
+ * 未指定ならログイン中ユーザーの handle を使う。
  *
  * window.__cardSvg に SVG ref を露出するので、テスト側で本物の cardToShareBlob で
  * 圧縮 + サイズ計測ができる。

--- a/apps/web/src/routes/debug-me.tsx
+++ b/apps/web/src/routes/debug-me.tsx
@@ -13,6 +13,7 @@
  */
 import { useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { useSession } from '@/lib/session';
 import type { Archetype, DiagnosisResult } from '@aozoraquest/core';
 import { JOBS_BY_ID, jobDisplayName, jobLevelFromXp, jobTagline, playerLevelFromXp } from '@aozoraquest/core';
 import { Avatar } from '@/components/avatar';
@@ -31,7 +32,9 @@ interface AozoraProfile {
 
 export function DebugMe() {
   const [params] = useSearchParams();
-  const handle = params.get('handle') ?? 'kojira.io';
+  const session = useSession();
+  // 個人 handle はソースに直書きしない (§4)。既定はログイン中ユーザー、無ければ ?handle= を要求。
+  const handle = params.get('handle') ?? session.handle ?? '';
   const [profile, setProfile] = useState<BskyProfile | null>(null);
   const [analysis, setAnalysis] = useState<DiagnosisResult | null>(null);
   const [aozoraProfile, setAozoraProfile] = useState<AozoraProfile | null>(null);
@@ -40,6 +43,7 @@ export function DebugMe() {
 
   useEffect(() => {
     let cancelled = false;
+    if (!handle) { setErr('?handle=xxx.bsky.social を指定 (またはログイン)'); return; }
     (async () => {
       try {
         // 1) handle → DID + Bluesky プロフィール

--- a/apps/web/src/routes/debug-radar.tsx
+++ b/apps/web/src/routes/debug-radar.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { useSession } from '@/lib/session';
 import { RadarChart } from '@/components/radar-chart';
 import type { StatVector } from '@aozoraquest/core';
 
 /**
- * ヒーロー画像 (README) 用に、kojira (もしくは指定ハンドル) の analysis を
+ * ヒーロー画像 (README) 用に、指定ハンドル (もしくはログイン中ユーザー) の analysis を
  * Bluesky 公開 API + PDS から読んでレーダーチャートを描画する dev ルート。
  *
  * 必要なのは:
@@ -18,12 +19,15 @@ import type { StatVector } from '@aozoraquest/core';
 export function DebugRadar() {
   const svgWrapRef = useRef<HTMLDivElement>(null);
   const [params] = useSearchParams();
-  const handle = params.get('handle') ?? 'kojira.io';
+  const session = useSession();
+  // 個人 handle はソースに直書きしない (§4)。既定はログイン中ユーザー、無ければ ?handle= を要求。
+  const handle = params.get('handle') ?? session.handle ?? '';
   const [stats, setStats] = useState<StatVector | null>(null);
   const [err, setErr] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
+    if (!handle) { setErr('?handle=xxx.bsky.social を指定 (またはログイン)'); return; }
     (async () => {
       try {
         // 1) handle → DID

--- a/docs/15-user-quest.md
+++ b/docs/15-user-quest.md
@@ -29,10 +29,10 @@ Aozora Quest のユーザー同士が **自分でクエストを発行・受託�
 | **受託者 (Assignee)** | 応募者の中から発注者が選んで合意した人 |
 | **完了報告 (Report)** | 受託者が「終わりました」を発注者に通知する書き込み |
 | **承認 (Approval)** | 発注者が完了報告を受け入れる行為。この時点で報酬移動 + XP 付与が確定する |
-| **個人ポイント (Personal Point)** | aozoraquest の通貨は **発注者ごとに別通貨**。kojira が出すクエストの報酬は「kojiraポイント」、sato が出すなら「satoポイント」。内部識別子は発注者の DID。**ポイントは合算されず、種類別に独立で保持・表示する**。実装上は整数 |
-| **持ち主表記** | 表示名は「<handle>ポイント」(例「kojiraポイント」)。handle は Bluesky 側で変更され得るので、内部キーは常に DID |
-| **報酬価格** | 発注者は自分のクエストにつき任意の数を指定できる (例: 「claudeポイント 500」「kojiraポイント 12000」)。**発行上限は設けない**。価値は発注者の信用に依存し、「割に合わない」と感じた応募者が応募しないことで市場原理的に均衡する |
-| **新規ユーザーの不利と bootstrap** | **正直に書くと**: 個人発行通貨は信用が事後的につくため、新規ユーザーの発行ポイントには初期は需要がない。「動かなさ」を前提に、対策として:<br>(a) システム XP は誰でも均等に得られるので、最初は「ポイントは将来の信用残高、まずは XP で動こう」と UI で誘導<br>(b) 完了 N 件で「ポイント+1」のような bootstrap 補助 (Phase 5+ で検討)。**正直に書くと**: これは「誰が発行するか」が未解決で、システム発行にすると「個人発行通貨」原則を壊す。本人が自分のポイントを自動 mint するのは「上限なし」を超えるものではない。妥協案は「受託者の所持ポイント残高に応じて、応募時に発注者が指定した報酬量に最低保証を加算」だが MVP では実装しない<br>(c) 既存信用者 (= 有名ユーザー) のポイントは受け取り手が多いので、新規ユーザーは最初は「有名ユーザーのクエストに応募」で信用を獲得し、自分発行に進む二段ロケットを誘導<br>(d) `kojiraポイント` 等のインフレが進んだら相対指標 (= シェア%) で価値が伝わる仕組みは既に組み込んでいる<br>これは設計の限界であって、市場原理だけで均衡する保証はないことを明示しておく |
+| **個人ポイント (Personal Point)** | aozoraquest の通貨は **発注者ごとに別通貨**。alice が出すクエストの報酬は「aliceポイント」、sato が出すなら「satoポイント」。内部識別子は発注者の DID。**ポイントは合算されず、種類別に独立で保持・表示する**。実装上は整数 |
+| **持ち主表記** | 表示名は「<handle>ポイント」(例「aliceポイント」)。handle は Bluesky 側で変更され得るので、内部キーは常に DID |
+| **報酬価格** | 発注者は自分のクエストにつき任意の数を指定できる (例: 「claudeポイント 500」「aliceポイント 12000」)。**発行上限は設けない**。価値は発注者の信用に依存し、「割に合わない」と感じた応募者が応募しないことで市場原理的に均衡する |
+| **新規ユーザーの不利と bootstrap** | **正直に書くと**: 個人発行通貨は信用が事後的につくため、新規ユーザーの発行ポイントには初期は需要がない。「動かなさ」を前提に、対策として:<br>(a) システム XP は誰でも均等に得られるので、最初は「ポイントは将来の信用残高、まずは XP で動こう」と UI で誘導<br>(b) 完了 N 件で「ポイント+1」のような bootstrap 補助 (Phase 5+ で検討)。**正直に書くと**: これは「誰が発行するか」が未解決で、システム発行にすると「個人発行通貨」原則を壊す。本人が自分のポイントを自動 mint するのは「上限なし」を超えるものではない。妥協案は「受託者の所持ポイント残高に応じて、応募時に発注者が指定した報酬量に最低保証を加算」だが MVP では実装しない<br>(c) 既存信用者 (= 有名ユーザー) のポイントは受け取り手が多いので、新規ユーザーは最初は「有名ユーザーのクエストに応募」で信用を獲得し、自分発行に進む二段ロケットを誘導<br>(d) `aliceポイント` 等のインフレが進んだら相対指標 (= シェア%) で価値が伝わる仕組みは既に組み込んでいる<br>これは設計の限界であって、市場原理だけで均衡する保証はないことを明示しておく |
 
 ## ユーザーストーリー
 
@@ -48,12 +48,12 @@ Aozora Quest のユーザー同士が **自分でクエストを発行・受託�
 
 ### 応募者側
 
-1. 募集中のクエスト一覧からタグやジョブで絞り込む。各クエストには「kojiraポイント 12000」のように発注者ごとの単位で報酬が示される
+1. 募集中のクエスト一覧からタグやジョブで絞り込む。各クエストには「aliceポイント 12000」のように発注者ごとの単位で報酬が示される
 2. 自分にとってその発注者のポイントに価値があるか判断 (= 過去の発注実績・信用) して応募コメントを投稿
 3. 発注者から「受託者に指定」されたら通知が来る
 4. やり取りして作業
 5. 終わったら「完了報告」をマーク + 成果物リンクや一言コメントを添える
-6. 発注者の承認が下りたら、その発注者の名前のポイント + 共通 XP が入る (例: 「kojiraポイント +12000」)
+6. 発注者の承認が下りたら、その発注者の名前のポイント + 共通 XP が入る (例: 「aliceポイント +12000」)
 7. やり直し指示が来たら作業を続けて再度報告
 
 ### 横断ストーリー
@@ -128,7 +128,7 @@ Aozora Quest のユーザー同士が **自分でクエストを発行・受託�
 - `visibility` の権限制御はクライアント側でフィルタ (AT Proto は record 単位のアクセス制御を持たない。`private` はクライアントで隠すだけで、技術的には誰でも読める前提で運用)
 - `assignee` を field として持つことで、受託状態を 1 record で表現する。複数応募者管理は別 record (下記 `questApplication`)
 - `rewardPoints` は発注者発行の整数 pt。報酬は **金銭以外** に限定 (モデレーション複雑化と法的責任を避けるため)
-- **ポイントの通貨種類はこの record の owner DID で識別する**。`rewardPoints: 12000` の record が `did:plc:kojira...` の PDS にあれば「kojira ポイント 12000」を意味する
+- **ポイントの通貨種類はこの record の owner DID で識別する**。`rewardPoints: 12000` の record が `did:plc:alice...` の PDS にあれば「alice ポイント 12000」を意味する
 
 ### app.aozoraquest.questApplication
 
@@ -339,7 +339,7 @@ AT Proto には逆引き API がないため、「公開クエスト一覧」「
                                                               ▼
                                                      ┌──────────────────┐
                                                      │ 主管理者 PDS      │
-                                                     │ (kojira)         │
+                                                     │ (alice)         │
                                                      │  questIndex/self │
                                                      └──────────────────┘
                                                               ▲
@@ -356,7 +356,7 @@ AT Proto には逆引き API がないため、「公開クエスト一覧」「
 |---|---|
 | **クライアント (発注/応募 直後)** | 原本を自分の PDS に PUT した後、Worker に「URI + 最小サマリ」を POST する。失敗時はバックグラウンドでリトライ |
 | **Cloudflare Worker** | (a) クライアントからの POST を受ける、(b) その URI が本当に存在するか発注者 PDS に検証 fetch する、(c) 主管理者 PDS の `app.aozoraquest.questIndex` を `putRecord` で更新する |
-| **主管理者 PDS (kojira)** | インデックス本体を保持。公開 read 可能なので、全クライアントが認証なしで取得できる |
+| **主管理者 PDS (alice)** | インデックス本体を保持。公開 read 可能なので、全クライアントが認証なしで取得できる |
 | **他クライアント** | 一覧画面表示時に管理者 PDS から questIndex を読む。詳細表示時は各 quest 原本 PDS から fetch |
 
 ### 認証 (検証済み: 2026-06-05)
@@ -374,18 +374,18 @@ AT Proto には逆引き API がないため、「公開クエスト一覧」「
 1. **ES256 鍵ペア生成** (NIST P-256)。秘密鍵は Cloudflare Worker secret として保管 (=「Bindings → Secrets」に PEM 文字列で投入)
 2. **client-metadata.json を `https://aozoraquest.app/oauth/quest-worker/client-metadata.json` で公開**。中身は `token_endpoint_auth_method: 'private_key_jwt'`, `dpop_bound_access_tokens: true`, `jwks_uri`, `redirect_uris: ['https://aozoraquest.app/oauth/quest-worker/callback']` 等
 3. **JWKS エンドポイント `https://aozoraquest.app/oauth/quest-worker/jwks.json`** で公開鍵を配信 (鍵ローテーション対応)
-4. **kojira が初回 1 回だけブラウザで認可フローを完遂** → 取得した refresh token (3 ヶ月寿命) を Worker の sessionStore (Cloudflare KV) に永続化
+4. **alice が初回 1 回だけブラウザで認可フローを完遂** → 取得した refresh token (3 ヶ月寿命) を Worker の sessionStore (Cloudflare KV) に永続化
 5. Worker の **Cron Trigger (1 日 1 回)** で refresh token を更新。session 失効間近 (例: 残り 7 日) でアラート
 
 既存 `apps/admin` の OAuth client_id とは別 client_id にする (admin SPA は public client、quest Worker は confidential client、混在不可)。
 
-**単一障害点の緩和** (= リリース前に潰すべき運用課題): 上の構成では Worker → 主管理者 PDS (kojira) の 1 本に全機能が紐づいており、kojira アカウント停止 / PDS 障害 / refresh token 失効が全機能停止に直結する。緩和策として:
+**単一障害点の緩和** (= リリース前に潰すべき運用課題): 上の構成では Worker → 主管理者 PDS (alice) の 1 本に全機能が紐づいており、alice アカウント停止 / PDS 障害 / refresh token 失効が全機能停止に直結する。緩和策として:
 
-1. **`VITE_ADMIN_DIDS` を複数登録** (例: `did:plc:kojira,did:plc:sub1,did:plc:sub2`)。Worker は順に各 DID の confidential client session を持っておき、書き込み時に最初の `available` な PDS に index を書く
+1. **`VITE_ADMIN_DIDS` を複数登録** (例: `did:plc:alice,did:plc:sub1,did:plc:sub2`)。Worker は順に各 DID の confidential client session を持っておき、書き込み時に最初の `available` な PDS に index を書く
 2. クライアントは read 時に **登録された admin DID 順に questIndex を取り、最初に取れたものを採用**。同じ rkey が複数 admin にあれば updatedAt 新しい方を採用
 3. **再構築ツール**: index が壊れた / 別 admin に切替えた直後は、Worker が `app.aozoraquest.userQuest` を発見できる範囲で listRecords → 各 admin に再書き込み
 
-これによりリーダー / フォロワー的な多重化が成立し、kojira が消えても新しい admin が引き継げる。Phase 1 段階では admin 1 名で OK だが、index レキシコンと Worker 実装は「複数 admin 想定の I/F」で書いておくこと。
+これによりリーダー / フォロワー的な多重化が成立し、alice が消えても新しい admin が引き継げる。Phase 1 段階では admin 1 名で OK だが、index レキシコンと Worker 実装は「複数 admin 想定の I/F」で書いておくこと。
 
 **split-brain と書き手競合の解決ルール** (= 第三者レビューで指摘):
 - **書き手の選択順** は `VITE_ADMIN_DIDS` の配列順 (先頭が primary)。Worker は primary から順に「session が valid」「直近 60 秒で書き込み成功した記録あり」を満たす最初の admin に書く
@@ -475,7 +475,7 @@ const isCompleted = (q: UserQuest, approvals: QuestCompletion[]) =>
 | 認証期限切れ (= Bluesky session expired) | 既存の signed-out フローに乗る | session.ts が `signed-out` に倒す、UI は再ログインを促す |
 | 検証 fetch で record 不一致 | Worker が 4xx 返す | クライアントが原本 PDS との不整合を再検出。typically race condition、ユーザーには「もう一度試してください」 |
 | index の record サイズ上限到達 | putRecord が 400 | Worker が最古を切る or ページング rkey に切替 (Phase 3 で実装、MVP では切替なし) |
-| 主管理者の refresh token 失効 | Worker cron が refresh に失敗 | kojira に DM / Slack で通知。kojira が手動再ログインで復旧 |
+| 主管理者の refresh token 失効 | Worker cron が refresh に失敗 | alice に DM / Slack で通知。alice が手動再ログインで復旧 |
 
 ## UI 設計
 
@@ -495,11 +495,11 @@ const isCompleted = (q: UserQuest, approvals: QuestCompletion[]) =>
 
 - 大きく 4 タブ: 「募集中」「自分が出した」「自分が応募した」「過去のクエスト (ポートフォリオ)」
 - フィルタ: タグ / ジョブ / 締切ありなし / フォロー中のみ / 報酬ポイント発注者 (チップ選択)
-- 各カードに: タイトル、発注者の avatar+job バッジ、本文冒頭 100 字、tag chip、応募数、締切までの残日数、**報酬表記** (例: `kojira ⓟ 12000`)
+- 各カードに: タイトル、発注者の avatar+job バッジ、本文冒頭 100 字、tag chip、応募数、締切までの残日数、**報酬表記** (例: `alice ⓟ 12000`)
 
 ### C. クエスト詳細 (`/quests/:uri`)
 
-- ヘッダー: 発注者の avatar + handle + ジョブバッジ + LV + 報酬ポイント (`kojiraポイント 12000`)
+- ヘッダー: 発注者の avatar + handle + ジョブバッジ + LV + 報酬ポイント (`aliceポイント 12000`)
 - タイトル + 本文 + tag + 募集期限 (残り時間 or 「期限切れ」表示)
 - 状態表示 (`open` / `assigned` / `reported` / `completed` / `cancelled`、+ 期限切れバッジ)
 - 応募者リスト (発注者本人のみ展開して見える。応募メッセージ + 「受託者に指定」ボタン)
@@ -517,7 +517,7 @@ aozoraquest 利用者の **「これまでの活動の証」** を集約表示�
 
 #### 受託履歴 (うけたクエスト)
 
-- 一覧 (新しい順): タイトル / 発注者 avatar+handle / 状態 / 完了日 / 獲得ポイント (例: `kojiraポイント +12000`) / 自分の成果物リンク
+- 一覧 (新しい順): タイトル / 発注者 avatar+handle / 状態 / 完了日 / 獲得ポイント (例: `aliceポイント +12000`) / 自分の成果物リンク
 - フィルタ: タグ / 発注者別 / 期間
 - **サマリ指標**:
   - 受託総数 (= 受託者に指定された全クエスト数)
@@ -531,8 +531,8 @@ aozoraquest 利用者の **「これまでの活動の証」** を集約表示�
 - **サマリ指標**:
   - 発注総数 (= 自分が出した全クエスト数)
   - 内訳: **成功** (`completed`) / **失敗** (`cancelled` かつ assignee 指定済みだった = 途中で頓挫) / **キャンセル** (`cancelled` かつ assignee 未指定 = 応募ゼロ・自主取り下げ・期限切れ)
-  - **何人に発行したか** (= 完了時に報酬を渡したユニーク受取人 DID 数): 例「47 件のクエスト完了で、12 人に kojira ポイントを発行」
-  - **累計発行ポイント** (= 自分発行ポイントの総流通量): 例 `kojiraポイント 累計発行 152,000 pt / 47 件`
+  - **何人に発行したか** (= 完了時に報酬を渡したユニーク受取人 DID 数): 例「47 件のクエスト完了で、12 人に alice ポイントを発行」
+  - **累計発行ポイント** (= 自分発行ポイントの総流通量): 例 `aliceポイント 累計発行 152,000 pt / 47 件`
   - 発行頻度の推移 (月別グラフ、Phase 3+)
 
 「失敗」と「キャンセル」の区別は **assignee 指定の有無** で機械判定する。schema 上のステータスは `cancelled` 1 種で持ち、UI 側で分類して表示する。意図的に別 status を立てないのは、Phase 1 のスコープを膨らませないため。
@@ -544,7 +544,7 @@ aozoraquest 利用者の **「これまでの活動の証」** を集約表示�
 ```
 🏅 保有ポイントランキング (発行者別)
 
-1.  kojiraポイント    18,400 pt   (kojira 総発行 152,000 中、シェア 12.1%)
+1.  aliceポイント    18,400 pt   (alice 総発行 152,000 中、シェア 12.1%)
 2.  claudeポイント       950 pt   (claude 総発行 4,800 中、シェア 19.8%)
 3.  satoポイント         500 pt   (sato   総発行 12,000 中、シェア  4.2%)
 ...
@@ -584,19 +584,19 @@ const outcomeOf = (q: UserQuest): 'success' | 'failure' | 'cancelled' => {
   return 'inProgress' as never; // 進行中はサマリ集計から除く
 };
 
-// 「sato が持つ kojira ポイント」: kojira の completed quest のうち assignee=sato
+// 「sato が持つ alice ポイント」: alice の completed quest のうち assignee=sato
 const holdings = (issuerQuests: UserQuest[], me: Did) =>
   issuerQuests
     .filter(q => q.status === 'completed' && q.assignee === me)
     .reduce((sum, q) => sum + (q.rewardPoints ?? 0), 0);
 
-// 「kojira の総発行 (= 発行ポイント流通量)」
+// 「alice の総発行 (= 発行ポイント流通量)」
 const totalIssued = (issuerQuests: UserQuest[]) =>
   issuerQuests
     .filter(q => q.status === 'completed')
     .reduce((sum, q) => sum + (q.rewardPoints ?? 0), 0);
 
-// 「sato が持つ kojira ポイントのシェア %」
+// 「sato が持つ alice ポイントのシェア %」
 const shareOf = (issuerQuests: UserQuest[], me: Did) => {
   const total = totalIssued(issuerQuests);
   return total === 0 ? 0 : (holdings(issuerQuests, me) / total) * 100;
@@ -619,7 +619,7 @@ const distinctRequesters = (myReceivedQuests: UserQuest[]) =>
 |---|---|---|
 | 自分の発注した quest | 自分の PDS `listRecords(app.aozoraquest.userQuest)` | localStorage 24h, ETag で差分 |
 | 自分が受託した quest | 自分の PDS のうち assignee=self のもの (= 受託履歴は自分の `questCompletion` から questUri を逆引き) | localStorage 24h |
-| 特定発行者 (例: kojira) の総発行 | 発行者 PDS `listRecords(app.aozoraquest.userQuest)` | localStorage 24h |
+| 特定発行者 (例: alice) の総発行 | 発行者 PDS `listRecords(app.aozoraquest.userQuest)` | localStorage 24h |
 | 公開クエスト一覧 (募集中) | 主管理者 PDS `getRecord(app.aozoraquest.questIndex/self)` | ETag 駆動、画面開く毎に再取得 |
 
 **MVP の規模仮定**: 1 ユーザーあたり生涯発注 < 1000 件、受託 < 1000 件、保有他人ポイント < 100 種類 を想定。in-memory 集計で十分回る。これを超える規模 (= 数千〜万) になった場合は Phase 3 で:
@@ -637,7 +637,7 @@ const distinctRequesters = (myReceivedQuests: UserQuest[]) =>
 - **応募中**: 自分が応募したもの
 - **特定ジョブの募集**: 例「賢者ジョブからの依頼だけ」
 - **タグフィルタ**: 例「#art #illust」
-- **特定の発行者のポイントが付くクエスト**: 例「kojiraポイントの出るクエストだけ」
+- **特定の発行者のポイントが付くクエスト**: 例「aliceポイントの出るクエストだけ」
 
 各カラムは独立に refresh / scroll する。
 
@@ -669,7 +669,7 @@ aozoraquest 内のクエスト一覧 / 詳細画面でも未読バッジを出�
 - 発注時に発注者が任意の整数 pt を指定
 - 完了 (発注者承認) 時、受託者の **「発注者DID ポイント」保有量に +N pt**
 - 通貨種類は発注者 DID で識別。**ポイントは合算されず、種類別に独立**
-- 例: 「kojira → sato への 12000 pt 発行」「claude → sato への 500 pt 発行」は別物として両方計上
+- 例: 「alice → sato への 12000 pt 発行」「claude → sato への 500 pt 発行」は別物として両方計上
 - 発行上限なし。価値は発注者の信用に依存
 - **承認時の増減は不可**。応募時点で受託者が見ていた値で固定発行する (透明性のため)
 
@@ -682,7 +682,7 @@ aozoraquest 内のクエスト一覧 / 詳細画面でも未読バッジを出�
 | 応募 | +5 XP (一日 3 件まで) | - |
 | 受託者指定 | - | - |
 
-ステータス軸への配分は **依頼内容のタグから推定** する (例: タグに `#illust` `#art` があれば LUK、`#code` `#review` があれば INT)。タグ→ステータスのマッピングは **オーナー (kojira) が管理する固定マップ** をアプリ内定数として持ち、PR で更新する。LLM 動的判定は使わない (運用の予測可能性のため)。Phase 2 で実装。
+ステータス軸への配分は **依頼内容のタグから推定** する (例: タグに `#illust` `#art` があれば LUK、`#code` `#review` があれば INT)。タグ→ステータスのマッピングは **オーナー (alice) が管理する固定マップ** をアプリ内定数として持ち、PR で更新する。LLM 動的判定は使わない (運用の予測可能性のため)。Phase 2 で実装。
 
 ### バッジ案 (Phase 2 以降)
 
@@ -726,7 +726,7 @@ aozoraquest 内のクエスト一覧 / 詳細画面でも未読バッジを出�
 - [ ] `app.aozoraquest.userQuest` レキシコン定義 & 永続化
 - [ ] `app.aozoraquest.questIndex` レキシコン定義
 - [ ] Cloudflare Worker (`apps/edge` 新設) に `POST /index/quest` + 認証 + 検証 fetch + putRecord
-- [ ] Worker の kojira セッション保持 + 1 日 1 回の refresh Cron Trigger
+- [ ] Worker の alice セッション保持 + 1 日 1 回の refresh Cron Trigger
 - [ ] クエスト発行 UI (`/quests/new`) + Worker への登録呼び出し
 - [ ] クエスト一覧 (`/quests` の「募集中」「自分が出した」タブ、questIndex から取得)
 - [ ] クエスト詳細 (`/quests/:uri`) 表示 (原本 PDS から fetch)
@@ -832,7 +832,7 @@ aozoraquest 内のクエスト一覧 / 詳細画面でも未読バッジを出�
 
 ```
 【クエスト】精霊のイラストを描いてくれる人募集
-報酬: kojiraポイント 12000 pt
+報酬: aliceポイント 12000 pt
 〆切: 6/15
 #illust #art #aozoraquest
 https://aozoraquest.app/quests/at://did:plc:.../app.aozoraquest.userQuest/3lp...

--- a/docs/21-server-authority.md
+++ b/docs/21-server-authority.md
@@ -240,12 +240,12 @@ putRecord/deleteRecord。token 失効 (401) は **fail-closed (503)** に倒し�
 ### 12.4 owner セットアップ (app-password の "Secret 1個" より増える)
 1. Cloudflare KV namespace 作成 + wrangler binding。**(済: アシスタントが作成・binding)**
 2. クライアント鍵・DPoP 鍵を Secret 設定 (鍵生成スクリプト `scripts/gen-oauth-keys.mjs`)。SERVER_DID
-   (=kojira.io の DID)・ADMIN_DIDS を Variable 設定。
+   (= サーバーアカウントの DID)・ADMIN_DIDS を Variable 設定。
 3. **edge Worker を初回デプロイ** — 認可サーバーが authorize/PAR 時に `client_id`
    (=`/client-metadata.json` の URL) を fetch するので、**OAuth ログインより前に edge が serve
    している必要がある** (deploy → Secret 投入 → OAuth の順)。
 4. アプリ内設定 → 管理者リンク → 1 回 OAuth ログイン (初期 refresh token を格納)。
-`SERVER_HANDLE` は廃止 (OAuth は DID/handle 解決で処理)。サーバーアカウントは **kojira.io** (§9-1 確定)。
+`SERVER_HANDLE` は廃止 (OAuth は DID/handle 解決で処理)。サーバーアカウントの handle/DID は Secret/Variable で持ち、ソースに書かない (§9-1 確定)。
 
 ### 12.5 実装順 (mock で単体テスト、owner セットアップ後に dev 疎通)
 1. DPoP / private_key_jwt の JWT 生成・検証ユーティリティ (@noble、単体テスト)。

--- a/docs/22-edge-env-separation.md
+++ b/docs/22-edge-env-separation.md
@@ -22,7 +22,7 @@ dev は本番に**一切**触れられないのが原則。Web アプリが `aoz
 
 ## セットアップ手順 (runbook)
 
-前提: `wrangler whoami` が kojiran@gmail.com (account b9cec3916d500760a7c7b9c31c720d80)。
+前提: `wrangler whoami` が CF アカウント (account id は CF ダッシュボード参照) にログイン済み。
 `cd apps/edge` で実行。secret 値はチャット/リポジトリに残さない (§4)。
 
 ### 1. dev 専用 KV を作る

--- a/packages/core/src/__tests__/user-quest.test.ts
+++ b/packages/core/src/__tests__/user-quest.test.ts
@@ -338,13 +338,13 @@ describe('formatQuestAnnouncement', () => {
     const out = formatQuestAnnouncement({
       title: '精霊のイラストを描いてくれる人募集',
       rewardPoints: 12000,
-      handle: 'kojira.io',
+      handle: 'alice.test',
       deadline: '2026-06-15T00:00:00Z',
       tags: ['illust', 'art'],
       questUrl: 'https://aozoraquest.app/quests/at://x',
     });
     expect(out).toContain('精霊のイラストを描いてくれる人募集');
-    expect(out).toContain('kojira.ioポイント 12000 pt');
+    expect(out).toContain('alice.testポイント 12000 pt');
     expect(out).toContain('〆切: 6/15');
     expect(out).toContain('#illust');
     expect(out).toContain('https://aozoraquest.app/');

--- a/scripts/capture-hero-card.ts
+++ b/scripts/capture-hero-card.ts
@@ -18,8 +18,9 @@ const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const OUT = resolve(ROOT, 'docs/hero-card.png');
 const DEV_BASE = process.env.DEV_BASE ?? 'http://127.0.0.1:9999';
 
-const HANDLE = 'kojira.io';
-// kojira の hero カード設定。実際の引き直しと違って固定なので、README が陳腐化
+const HANDLE = process.env.HERO_HANDLE ?? '';
+if (!HANDLE) { console.error('HERO_HANDLE env が必要 (個人 handle をソースに書かない)'); process.exit(1); }
+// hero カード設定。実際の引き直しと違って固定なので、README が陳腐化
 // しにくい中庸な内容にする (ぶっ飛び過ぎず、地味すぎず)。
 const PARAMS = {
   handle: HANDLE,
@@ -29,7 +30,7 @@ const PARAMS = {
   cardName: '夜更けの編集者',
   effectName: '潜影',
   effectDescription: '登場時、対象アカウントの直近 3 件をあなたのフィードに引き寄せる。',
-  flavor: 'kojira は、まだ言葉になっていない投稿を編集している。誰も気づかぬまま、世界はそっと書き換わっている。',
+  flavor: '旅人は、まだ言葉になっていない投稿を編集している。誰も気づかぬまま、世界はそっと書き換わっている。',
   flavorAttr: 'ひでお',
   manaCost: JSON.stringify({ U: 1, B: 1, generic: 1 }),
   abilityCost: 'null',

--- a/scripts/capture-hero-me.ts
+++ b/scripts/capture-hero-me.ts
@@ -1,6 +1,6 @@
 /**
  * README ヒーロー画像の 3 枚目 (me ページ全体) を生成。
- * /debug/me ルートを開いて、kojira の analysis + profile を public API から
+ * /debug/me ルートを開いて、指定ユーザーの analysis + profile を public API から
  * 取得・me 相当の見た目で描画 → wrap div を PNG 化して docs/hero-me.png に保存。
  *
  * vite dev (localhost:9999) が事前に起動している前提。
@@ -14,7 +14,8 @@ import { dirname, resolve } from 'node:path';
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const OUT = resolve(ROOT, 'docs/hero-me.png');
 const DEV_BASE = process.env.DEV_BASE ?? 'http://localhost:9999';
-const HANDLE = 'kojira.io';
+const HANDLE = process.env.HERO_HANDLE ?? '';
+if (!HANDLE) { console.error('HERO_HANDLE env が必要 (個人 handle をソースに書かない)'); process.exit(1); }
 
 async function main() {
   const url = new URL('/debug/me', DEV_BASE);

--- a/scripts/capture-hero-radar.ts
+++ b/scripts/capture-hero-radar.ts
@@ -17,6 +17,7 @@ const OUT = resolve(ROOT, 'docs/hero-radar.png');
 const DEV_BASE = process.env.DEV_BASE ?? 'http://localhost:9999';
 
 const HANDLE = process.env.HERO_HANDLE ?? '';
+if (!HANDLE) { console.error('HERO_HANDLE env が必要 (個人 handle をソースに書かない)'); process.exit(1); }
 
 async function main() {
   const url = new URL('/debug/radar', DEV_BASE);

--- a/scripts/capture-hero-radar.ts
+++ b/scripts/capture-hero-radar.ts
@@ -1,6 +1,6 @@
 /**
  * README ヒーロー画像の 2 枚目 (レーダーチャート) を生成。
- * /debug/radar ルートを開いて、kojira の analysis レコードから 5 ステータス
+ * /debug/radar ルートを開いて、指定ユーザーの analysis レコードから 5 ステータス
  * (攻 / 守 / 速 / 知 / 運) を取得・描画 → SVG を PNG 化して docs/hero-radar.png に保存。
  *
  * vite dev (localhost:9999) が事前に起動している前提。
@@ -16,7 +16,7 @@ const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const OUT = resolve(ROOT, 'docs/hero-radar.png');
 const DEV_BASE = process.env.DEV_BASE ?? 'http://localhost:9999';
 
-const HANDLE = 'kojira.io';
+const HANDLE = process.env.HERO_HANDLE ?? '';
 
 async function main() {
   const url = new URL('/debug/radar', DEV_BASE);

--- a/scripts/collect-cognitive-labels.ts
+++ b/scripts/collect-cognitive-labels.ts
@@ -201,7 +201,9 @@ async function main() {
 
   console.log(`\n[1/3] ユーザープール構築`);
   console.log(`  シードユーザーのフォロー取得中...`);
-  const follows = await collectFollows(process.env.SEED_HANDLE ?? '');
+  const seed = process.env.SEED_HANDLE;
+  if (!seed) { console.error('SEED_HANDLE env が必要 (シード handle をソースに書かない)'); process.exit(1); }
+  const follows = await collectFollows(seed);
   console.log(`    ${follows.length} 人`);
   console.log(`  bluesky-ranking 上位取得中...`);
   const ranking = await collectRankingHandles();

--- a/scripts/collect-cognitive-labels.ts
+++ b/scripts/collect-cognitive-labels.ts
@@ -6,7 +6,7 @@
  * 構築する。
  *
  * パイプライン:
- *   1. kojira.io のフォロー + ランキング上位からユーザープール構築
+ *   1. シードユーザーのフォロー + ランキング上位からユーザープール構築
  *   2. 各ユーザーから最大 30 投稿取得 (text + createdAt)
  *   3. Gemini に top-3 認知機能 (+ none) を判定させ逐次 JSONL 保存
  *   4. checkpoint ファイルから resume 可
@@ -200,8 +200,8 @@ async function main() {
   console.log(`[resume] 既存ラベル付け ${existing.size} 件、目標 ${targetCount} 件`);
 
   console.log(`\n[1/3] ユーザープール構築`);
-  console.log(`  kojira.io のフォロー取得中...`);
-  const follows = await collectFollows('kojira.io');
+  console.log(`  シードユーザーのフォロー取得中...`);
+  const follows = await collectFollows(process.env.SEED_HANDLE ?? '');
   console.log(`    ${follows.length} 人`);
   console.log(`  bluesky-ranking 上位取得中...`);
   const ranking = await collectRankingHandles();

--- a/scripts/collect-user-labels.ts
+++ b/scripts/collect-user-labels.ts
@@ -1,7 +1,7 @@
 /**
  * scripts/collect-user-labels.ts
  *
- * ユーザー単位の ground truth を Gemini で構築する。kojira.io のフォロー +
+ * ユーザー単位の ground truth を Gemini で構築する。シードユーザーのフォロー +
  * ランキング上位から対象をサンプリングし、各ユーザーの投稿 30 件を一括で
  * Gemini に渡して 16 archetype のどれに合うかを判定させる。
  *
@@ -190,8 +190,8 @@ async function main() {
   console.log(`[resume] 既存 ${existing.size} 人、目標 ${target} 人`);
 
   console.log('\nユーザープール構築...');
-  const follows = await collectFollows('kojira.io');
-  console.log(`  kojira.io フォロー ${follows.length} 人`);
+  const follows = await collectFollows(process.env.SEED_HANDLE ?? '');
+  console.log(`  シードのフォロー ${follows.length} 人`);
   const pool = shuffle(follows).filter((u) => !existing.has(u.did));
   console.log(`  未ラベル ${pool.length} 人`);
 

--- a/scripts/collect-user-labels.ts
+++ b/scripts/collect-user-labels.ts
@@ -190,7 +190,9 @@ async function main() {
   console.log(`[resume] 既存 ${existing.size} 人、目標 ${target} 人`);
 
   console.log('\nユーザープール構築...');
-  const follows = await collectFollows(process.env.SEED_HANDLE ?? '');
+  const seed = process.env.SEED_HANDLE;
+  if (!seed) { console.error('SEED_HANDLE env が必要 (シード handle をソースに書かない)'); process.exit(1); }
+  const follows = await collectFollows(seed);
   console.log(`  シードのフォロー ${follows.length} 人`);
   const pool = shuffle(follows).filter((u) => !existing.has(u.did));
   console.log(`  未ラベル ${pool.length} 人`);

--- a/scripts/diagnose-follows.ts
+++ b/scripts/diagnose-follows.ts
@@ -288,7 +288,8 @@ ${skippedHtml}
 }
 
 async function main() {
-  const targetHandle = process.argv[2] ?? process.env.SEED_HANDLE ?? '';
+  const targetHandle = process.argv[2] ?? process.env.SEED_HANDLE;
+  if (!targetHandle) { console.error('handle を argv か SEED_HANDLE env で指定 (個人 handle をソースに書かない)'); process.exit(1); }
   const maxFollows = Number(process.argv[3] ?? '0') || Infinity; // 0 or missing = no limit
   const outFile = process.argv[4] ?? path.join(repoRoot, `diagnose-follows-${targetHandle.replace(/[^a-z0-9]/gi, '_')}.html`);
 

--- a/scripts/diagnose-follows.ts
+++ b/scripts/diagnose-follows.ts
@@ -3,7 +3,7 @@
  * かけて、結果を HTML レポートとして出力する。
  *
  * 使い方:
- *   pnpm tsx scripts/diagnose-follows.ts kojira.io [outfile]
+ *   pnpm tsx scripts/diagnose-follows.ts <seed-handle> [outfile]
  */
 
 import { pipeline, env } from '@huggingface/transformers';
@@ -149,7 +149,7 @@ function renderHtml(
   }
   const distRows = [...dist.entries()].sort((a, b) => b[1] - a[1]);
 
-  // 相性 (kojira 側の archetype が分かっていれば計算)
+  // 相性 (シード側の archetype が分かっていれば計算)
   const withCompat = ok.map((r) => {
     if (!ownerArchetype || !r.result) return { ...r, compat: null };
     const compat = resonance(
@@ -288,7 +288,7 @@ ${skippedHtml}
 }
 
 async function main() {
-  const targetHandle = process.argv[2] ?? 'kojira.io';
+  const targetHandle = process.argv[2] ?? process.env.SEED_HANDLE ?? '';
   const maxFollows = Number(process.argv[3] ?? '0') || Infinity; // 0 or missing = no limit
   const outFile = process.argv[4] ?? path.join(repoRoot, `diagnose-follows-${targetHandle.replace(/[^a-z0-9]/gi, '_')}.html`);
 


### PR DESCRIPTION
## 背景
サーバーアカウントの handle (kojira.io) がコメント・テスト・debug ツールのデフォルト・docs・スクリプトに紛れ込んでいた(§4 違反、過去事故と同種)。オーナー指摘で**コメント含め全撤去**。実際の秘密値は Worker Secret にあり、handle 文字列の漏れのみ。

## 変更
- edge/web のコメント「サーバーアカウント (kojira.io)」→ generic 化。
- **debug-me / debug-radar**: 既定 handle のハードコード `'kojira.io'` を撤去 → `useSession` のログイン中ユーザーを既定、無ければ `?handle=` 要求(空ガード)。debug-card はコメントのみ(コード側は既に param 必須)。
- テスト fixture: `'kojira.io'`/`'did:plc:kojira'` → 中立値(`server.example`/`did:plc:testserver`)。
- docs/15・21・22 の例示ペルソナを generic 化(alice 等)。
- scripts: ハードコードのシード handle を `HERO_HANDLE`/`SEED_HANDLE` env or argv 必須に。
- UI 例示(board/column-picker/prompts/handle)を `alice.example` 等に。
- wrangler.toml: dev KV id を実 id に + アカウント名コメント generic 化。

## 残置(機能的リソース = PII でない)
- HF モデル repo `kojira/aozoraquest-cognitive`(モデルの実 DL 先)
- GitHub repo URL `github.com/kojira/aozoraquest`
- CLAUDE.md のオーナー自己言及

## 検証
- typecheck ✅ / test ✅ (edge 144 / core 308 / web 341)

## Review
**§1.5 実装レビュー — ★★★/★★ ゼロ**。debug ページの session 既定・fixture 置換の整合・機能リソース保全を確認。★ 2 件 (スクリプトの env 未設定ガード) は commit で対応済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)