### PR TITLE
chore(edge): dev エッジをデプロイ + ローカル web を dev エッジに向ける

### DIFF
--- a/apps/web/.env.development
+++ b/apps/web/.env.development
@@ -9,3 +9,8 @@ VITE_APP_URL=http://127.0.0.1:9999
 # ローカル PDS 書き込みは prod とも dev branch deploy とも分離
 VITE_NSID_ROOT=app.aozoraquest
 VITE_NSID_ENV=local
+
+# ローカル dev は dev エッジ (aozoraquest-edge-dev) を叩く。**本番エッジには触れない**。
+# dev.aozoraquest.app デプロイ用は CF Workers Builds の env vars で別途指定 (docs/22 step5)。
+VITE_EDGE_URL=https://aozoraquest-edge-dev.kojiran.workers.dev
+VITE_EDGE_DID=did:web:aozoraquest-edge-dev.kojiran.workers.dev

--- a/apps/web/src/lib/world-server.test.ts
+++ b/apps/web/src/lib/world-server.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test, afterEach, vi } from 'vitest';
+
+/**
+ * エッジ URL の環境別解決の回帰防止。核心は「**dev ビルドは本番エッジを叩かない**」
+ * (#396: .env.production を本番/dev 両ビルドが読むため VITE_EDGE_URL が本番エッジを
+ * 指しても、VITE_NSID_ENV=dev なら dev エッジを強制する)。
+ * モジュールトップレベルで import.meta.env を評価するので stubEnv + 動的 import。
+ */
+describe('world-server: エッジ URL の環境別解決', () => {
+  afterEach(() => { vi.unstubAllEnvs(); vi.resetModules(); });
+
+  test('VITE_NSID_ENV=dev は VITE_EDGE_URL が本番エッジでも dev エッジを強制する', async () => {
+    vi.stubEnv('VITE_NSID_ENV', 'dev');
+    vi.stubEnv('VITE_EDGE_URL', 'https://aozoraquest-edge.kojiran.workers.dev'); // 本番エッジ
+    vi.stubEnv('VITE_EDGE_DID', 'did:web:aozoraquest-edge.kojiran.workers.dev');
+    const { __edgeForTest } = await import('./world-server');
+    expect(__edgeForTest.url).toBe('https://aozoraquest-edge-dev.kojiran.workers.dev');
+    expect(__edgeForTest.did).toBe('did:web:aozoraquest-edge-dev.kojiran.workers.dev');
+    expect(__edgeForTest.url).not.toContain('edge.kojiran'); // 本番エッジに解決しない (edge-dev のみ)
+  });
+
+  test('本番 (VITE_NSID_ENV 未設定) は VITE_EDGE_URL (本番エッジ) を使う', async () => {
+    vi.stubEnv('VITE_NSID_ENV', '');
+    vi.stubEnv('VITE_EDGE_URL', 'https://aozoraquest-edge.kojiran.workers.dev');
+    vi.stubEnv('VITE_EDGE_DID', 'did:web:aozoraquest-edge.kojiran.workers.dev');
+    const { __edgeForTest } = await import('./world-server');
+    expect(__edgeForTest.url).toBe('https://aozoraquest-edge.kojiran.workers.dev');
+  });
+
+  test('ローカル (VITE_NSID_ENV=local) は VITE_EDGE_URL (=.env.development の dev エッジ) を使う', async () => {
+    vi.stubEnv('VITE_NSID_ENV', 'local');
+    vi.stubEnv('VITE_EDGE_URL', 'https://aozoraquest-edge-dev.kojiran.workers.dev');
+    vi.stubEnv('VITE_EDGE_DID', 'did:web:aozoraquest-edge-dev.kojiran.workers.dev');
+    const { __edgeForTest } = await import('./world-server');
+    expect(__edgeForTest.url).toBe('https://aozoraquest-edge-dev.kojiran.workers.dev');
+  });
+});

--- a/apps/web/src/lib/world-server.ts
+++ b/apps/web/src/lib/world-server.ts
@@ -18,6 +18,9 @@ const DEV_EDGE_DID = 'did:web:aozoraquest-edge-dev.kojiran.workers.dev';
 const EDGE_URL = NSID_ENV === 'dev' ? DEV_EDGE_URL : (import.meta.env.VITE_EDGE_URL as string | undefined)?.trim();
 const EDGE_DID = NSID_ENV === 'dev' ? DEV_EDGE_DID : (import.meta.env.VITE_EDGE_DID as string | undefined)?.trim();
 
+/** @internal テスト用: 環境別に解決したエッジ設定 (dev が本番エッジを叩かない回帰防止)。 */
+export const __edgeForTest = { url: EDGE_URL, did: EDGE_DID };
+
 const LXM_MOVE = 'app.aozoraquest.world.move';
 const LXM_TELEPORT = 'app.aozoraquest.world.teleport';
 const LXM_ITEM = 'app.aozoraquest.world.item';

--- a/apps/web/src/lib/world-server.ts
+++ b/apps/web/src/lib/world-server.ts
@@ -8,8 +8,15 @@
  */
 import type { Agent } from '@atproto/api';
 
-const EDGE_URL = (import.meta.env.VITE_EDGE_URL as string | undefined)?.trim();
-const EDGE_DID = (import.meta.env.VITE_EDGE_DID as string | undefined)?.trim();
+// エッジ URL の環境別解決。dev branch デプロイ (VITE_NSID_ENV=dev) は **dev エッジを強制**する。
+// .env.production は本番/dev 両ビルドが読むため VITE_EDGE_URL が共有エッジを指してしまい、
+// dev が本番エッジを叩く事故が起きる (#396)。dev は必ず dev エッジ、と**コードで構造的に保証**する。
+// エッジ URL は secret でなくインフラ値 (既に .env に commit 済) なのでコードに置いてよい。
+const NSID_ENV = (import.meta.env.VITE_NSID_ENV as string | undefined)?.trim();
+const DEV_EDGE_URL = 'https://aozoraquest-edge-dev.kojiran.workers.dev';
+const DEV_EDGE_DID = 'did:web:aozoraquest-edge-dev.kojiran.workers.dev';
+const EDGE_URL = NSID_ENV === 'dev' ? DEV_EDGE_URL : (import.meta.env.VITE_EDGE_URL as string | undefined)?.trim();
+const EDGE_DID = NSID_ENV === 'dev' ? DEV_EDGE_DID : (import.meta.env.VITE_EDGE_DID as string | undefined)?.trim();
 
 const LXM_MOVE = 'app.aozoraquest.world.move';
 const LXM_TELEPORT = 'app.aozoraquest.world.teleport';

--- a/docs/22-edge-env-separation.md
+++ b/docs/22-edge-env-separation.md
@@ -27,9 +27,8 @@ dev は本番に**一切**触れられないのが原則。Web アプリが `aoz
 - ✅ step3 `wrangler deploy --env dev` → `https://aozoraquest-edge-dev.kojiran.workers.dev` 稼働
       (`/api/world/reset` が 401 = ルート存在。共有エッジは 404 だった)
 - ✅ step5 ローカル: `.env.development` に VITE_EDGE_URL/DID を dev エッジで追記
-- ⬜ **step5 (dev デプロイ)** CF Workers Builds `aozoraquest-dev` の Variables に
-      `VITE_EDGE_URL=https://aozoraquest-edge-dev.kojiran.workers.dev` /
-      `VITE_EDGE_DID=did:web:aozoraquest-edge-dev.kojiran.workers.dev` を設定 → dev push で反映。**オーナー操作**。
+- ✅ **step5 (dev デプロイ)** CF 変数は**不要にした**: world-server.ts で `VITE_NSID_ENV=dev` の
+      とき dev エッジを**コードで強制** (#396)。dev push で dev.aozoraquest.app が自動的に dev エッジへ。
 - ⬜ **step4 OAuth bootstrap** dev エッジに向いた web (ローカル or dev.aozoraquest.app) で
       管理者ログイン → 設定 → 「サーバーアカウント OAuth 連携」ボタン → kojira.io を承認 →
       dev KV にトークン保存。**オーナー操作 (ブラウザ)**。
@@ -85,8 +84,9 @@ POST https://aozoraquest-edge-dev.kojiran.workers.dev/api/oauth/start   (ADMIN_D
 VITE_EDGE_URL=https://aozoraquest-edge-dev.kojiran.workers.dev
 VITE_EDGE_DID=did:web:aozoraquest-edge-dev.kojiran.workers.dev
 ```
-- CF Workers Build `aozoraquest-dev` の Variables にも同じ 2 値を設定 (dev web の本番ビルドが拾う値)。
-- 本番 web (`aozoraquest` / `.env.production`) は本番エッジのままにする (変更しない)。
+- **dev.aozoraquest.app デプロイ**: CF Variables は不要。world-server.ts が `VITE_NSID_ENV=dev`
+  (dev ビルドに既に入っている) を見て dev エッジを強制する (#396)。dev push で自動反映。
+- 本番 web (`aozoraquest` / `.env.production`) は本番エッジのまま (world-server.ts の else 枝)。
 
 ## 補足
 
@@ -101,6 +101,11 @@ VITE_EDGE_DID=did:web:aozoraquest-edge-dev.kojiran.workers.dev
 ### 6. 確認
 - dev.aozoraquest.app でワールド移動/戦闘/リセットが dev エッジ経由で動く。
 - 本番 (aozoraquest.app) は無傷 (本番エッジ・本番 KV 不変)。
+
+
+- **dev エッジをリネーム/再デプロイした時**は、`apps/web/src/lib/world-server.ts` の
+  `DEV_EDGE_URL`/`DEV_EDGE_DID` 定数と `.env.development` の VITE_EDGE_URL/DID も直す
+  (dev は VITE_NSID_ENV=dev のときコード側の定数でエッジを強制しているため)。
 
 ## 再発防止
 

--- a/docs/22-edge-env-separation.md
+++ b/docs/22-edge-env-separation.md
@@ -20,6 +20,20 @@ dev は本番に**一切**触れられないのが原則。Web アプリが `aoz
   分けるのは「別 KV (別トークン保管) / 別 cron / 別 secrets」であって「別アカウント」ではない。
 - **KV / cron / secrets はすべて dev 専用**。dev の cron は自分のセッションのトークンだけ refresh する。
 
+## 進捗 (2026-07-20)
+
+- ✅ step1 dev KV 作成 (`ef1a0429afc34c7da4ee5183752a5f3e`) → wrangler.toml 反映
+- ✅ step2 dev secret set (OAUTH_CLIENT/DPOP_JWK・WORLD_TOKEN_SECRET・SERVER_DID・ADMIN_DIDS=kojira.io の DID)
+- ✅ step3 `wrangler deploy --env dev` → `https://aozoraquest-edge-dev.kojiran.workers.dev` 稼働
+      (`/api/world/reset` が 401 = ルート存在。共有エッジは 404 だった)
+- ✅ step5 ローカル: `.env.development` に VITE_EDGE_URL/DID を dev エッジで追記
+- ⬜ **step5 (dev デプロイ)** CF Workers Builds `aozoraquest-dev` の Variables に
+      `VITE_EDGE_URL=https://aozoraquest-edge-dev.kojiran.workers.dev` /
+      `VITE_EDGE_DID=did:web:aozoraquest-edge-dev.kojiran.workers.dev` を設定 → dev push で反映。**オーナー操作**。
+- ⬜ **step4 OAuth bootstrap** dev エッジに向いた web (ローカル or dev.aozoraquest.app) で
+      管理者ログイン → 設定 → 「サーバーアカウント OAuth 連携」ボタン → kojira.io を承認 →
+      dev KV にトークン保存。**オーナー操作 (ブラウザ)**。
+
 ## セットアップ手順 (runbook)
 
 前提: `wrangler whoami` が CF アカウント (account id は CF ダッシュボード参照) にログイン済み。


### PR DESCRIPTION
dev エッジ (`aozoraquest-edge-dev`) を分離デプロイし、**dev ビルドをコードで dev エッジに強制**。本番エッジには一切触れない。

## 完了 (私が実行、本番不可侵)
- dev KV 作成 + wrangler.toml 反映 / dev 専用 secret set / `wrangler deploy --env dev` 稼働
- 検証: dev エッジの `/api/world/reset` が **401** (ルート存在)。共有エッジは 404 `not_found` だった → **リセット失敗の真因が解消**。
- **world-server.ts: `VITE_NSID_ENV=dev` のとき dev エッジを強制** → `.env.production` が本番/dev 両ビルドに共有エッジを焼き込む問題を回避。**CF Workers Builds の Variables 設定は不要**。dev push で dev.aozoraquest.app が自動的に dev エッジへ。
- 回帰テスト: dev が本番エッジに解決しないことを固定 (web 344)。

## 残り (オーナー操作・ブラウザのみ)
- **OAuth bootstrap**: dev エッジに向いた web (この PR の dev 反映後の dev.aozoraquest.app、または手元 `pnpm dev`) で kojira.io ログイン → 設定 →「サーバーアカウント OAuth 連携」→ 承認。

## Review (§1.5 実装) — ★★★/★★ ゼロ
3 環境のエッジ解決が正しく **dev が本番エッジを叩く経路なし**を確認。★ 2 件 (回帰テスト・docs 追記) は commit で対応済み。VITE_NSID_ENV=dev は既存の load-bearing invariant。

🤖 Generated with [Claude Code](https://claude.com/claude-code)