### PR TITLE
feat(settings): サーバーアカウント連携の状態を設定画面に表示 + 連携先を dev エッジに統一

### DIFF
--- a/apps/edge/src/oauth-routes.ts
+++ b/apps/edge/src/oauth-routes.ts
@@ -11,9 +11,10 @@ import { verifyServiceAuth, resolveDidDocument, type DidDocument } from './servi
 import { loadOAuthConfig, buildClientMetadata, isEdgeAdmin, OAuthConfigError, type OAuthEnv } from './oauth-config';
 import { discoverForDid } from './oauth-metadata';
 import { buildAuthorizeUrl, exchangeCode } from './oauth-client';
-import { putPendingAuth, takePendingAuth, writeServerTokens } from './oauth-store';
+import { putPendingAuth, takePendingAuth, writeServerTokens, readServerTokens } from './oauth-store';
 
 export const LXM_OAUTH_START = 'app.aozoraquest.oauth.start';
+export const LXM_OAUTH_STATUS = 'app.aozoraquest.oauth.status';
 
 /** router.ts の Env のうち OAuth ルートが使う部分 + KV。 */
 export interface OAuthRoutesEnv extends OAuthEnv {
@@ -75,6 +76,27 @@ export async function handleOAuthStart(req: Request, env: OAuthRoutesEnv, deps: 
   } catch (e) {
     return json({ error: 'oauth_start_failed', message: e instanceof Error ? e.message : String(e) }, 502);
   }
+}
+
+/** GET /api/oauth/status — 管理者のみ。サーバーアカウント連携の状態を返す (トークン本体は返さない)。 */
+export async function handleOAuthStatus(req: Request, env: OAuthRoutesEnv, deps: Deps): Promise<Response> {
+  if (!env.OAUTH_TOKENS) return json({ error: 'oauth_not_configured', message: 'KV 未 binding' }, 503);
+  const audience = env.WORKER_DID;
+  if (!audience) return json({ error: 'oauth_not_configured', message: 'WORKER_DID 未設定' }, 503);
+  const token = bearer(req);
+  if (!token) return json({ error: 'missing_token' }, 401);
+  const verify = deps.verify ?? verifyServiceAuth;
+  let iss: string;
+  try {
+    ({ iss } = await verify(token, { audience, lxm: LXM_OAUTH_STATUS, now: deps.now, resolveDid: (d) => resolveDidDocument(d, deps.fetchImpl) }));
+  } catch {
+    return json({ error: 'invalid_token' }, 401);
+  }
+  if (!isEdgeAdmin(env, iss)) return json({ error: 'forbidden' }, 403);
+  // トークン**本体は返さない** — 連携有無・アカウント DID・失効時刻・更新時刻のみ (監査/UI 表示用)。
+  const tokens = await readServerTokens(env.OAUTH_TOKENS);
+  if (!tokens) return json({ linked: false });
+  return json({ linked: true, did: tokens.did, pdsUrl: tokens.pdsUrl, expiresAt: tokens.expiresAt, updatedAt: tokens.updatedAt });
 }
 
 /** GET /oauth/callback — 認可サーバーからのリダイレクト。code→token 交換し KV 格納。 */

--- a/apps/edge/src/router.ts
+++ b/apps/edge/src/router.ts
@@ -12,7 +12,7 @@
 import { verifyServiceAuth, ServiceAuthError } from './service-auth';
 import { PdsError } from './pds';
 import { readState } from './game-state';
-import { handleClientMetadata, handleOAuthStart, handleOAuthCallback, type OAuthRoutesEnv } from './oauth-routes';
+import { handleClientMetadata, handleOAuthStart, handleOAuthStatus, handleOAuthCallback, type OAuthRoutesEnv } from './oauth-routes';
 import { handleMove, handleTurn, handleTeleport, handleItem, handleGear, handleSearch, handleReset, migrateInitState, ResolverError } from './battle-resolver';
 import { signPosition } from './world-token';
 import { ServerWriteError } from './server-pds';
@@ -263,6 +263,10 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
   // 管理者が OAuth 連携を開始 (service auth JWT + ADMIN_DIDS)。authorizeUrl を返す。
   if (req.method === 'POST' && url.pathname === '/api/oauth/start') {
     return cors(await handleOAuthStart(req, env, { now: nowSec() }), allowedOrigin);
+  }
+  // 管理者が連携状態を確認 (トークン本体は返さない)。設定画面の表示用。
+  if (req.method === 'GET' && url.pathname === '/api/oauth/status') {
+    return cors(await handleOAuthStatus(req, env, { now: nowSec() }), allowedOrigin);
   }
   // 認可サーバーからのリダイレクト先。ブラウザ遷移なので HTML を直接返す (CORS 不要)。
   if (req.method === 'GET' && url.pathname === '/oauth/callback') {

--- a/apps/edge/test/oauth-routes.test.ts
+++ b/apps/edge/test/oauth-routes.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { p256 } from '@noble/curves/p256';
 import { base64urlnopad } from '@scure/base';
-import { handleClientMetadata, handleOAuthStart, handleOAuthCallback, type OAuthRoutesEnv } from '../src/oauth-routes';
-import { putPendingAuth, readServerTokens } from '../src/oauth-store';
+import { handleClientMetadata, handleOAuthStart, handleOAuthStatus, handleOAuthCallback, type OAuthRoutesEnv } from '../src/oauth-routes';
+import { putPendingAuth, readServerTokens, writeServerTokens } from '../src/oauth-store';
 import type { AuthServerMetadata } from '../src/oauth-metadata';
 
 function jwkJson(fill: number): string {
@@ -58,6 +58,30 @@ describe('oauth-routes', () => {
     const body = (await res.json()) as { authorizeUrl: string };
     expect(body.authorizeUrl).toContain(`${AS}/oauth/authorize`);
     expect(body.authorizeUrl).toContain('request_uri=urn%3Areq%3A1');
+  });
+
+  it('status: 認証ゲート (401/403) + トークン本体を絶対に返さない', async () => {
+    const url = 'https://x/api/oauth/status';
+    // トークン無し → 401
+    expect((await handleOAuthStatus(new Request(url), env(mockKv()), { now: NOW })).status).toBe(401);
+    const req = new Request(url, { headers: { authorization: 'Bearer T' } });
+    // 非管理者 → 403
+    expect((await handleOAuthStatus(req, env(mockKv()), { now: NOW, verify: async () => ({ iss: 'did:plc:someone' }) })).status).toBe(403);
+    // 未連携 (KV にトークン無し) → linked:false
+    const unlinked = await handleOAuthStatus(req, env(mockKv()), { now: NOW, verify: okVerify });
+    expect(await unlinked.json()).toEqual({ linked: false });
+    // 連携済み → did/pdsUrl/失効/更新のみ、**トークン本体 (accessToken/refreshToken/authServer) は返さない**
+    const kv = mockKv();
+    await writeServerTokens(kv, { did: 'did:plc:testserver', accessToken: 'SECRET_AT', refreshToken: 'SECRET_RT', tokenType: 'DPoP', expiresAt: NOW + 3600, pdsUrl: 'https://pds.example', authServer: AS, updatedAt: NOW });
+    const linked = await handleOAuthStatus(req, env(kv), { now: NOW, verify: okVerify });
+    const body = (await linked.json()) as Record<string, unknown>;
+    expect(body).toMatchObject({ linked: true, did: 'did:plc:testserver', pdsUrl: 'https://pds.example', expiresAt: NOW + 3600, updatedAt: NOW });
+    const s = JSON.stringify(body);
+    expect(s).not.toContain('SECRET_AT');
+    expect(s).not.toContain('SECRET_RT');
+    expect(body).not.toHaveProperty('accessToken');
+    expect(body).not.toHaveProperty('refreshToken');
+    expect(body).not.toHaveProperty('authServer');
   });
 
   it('callback: error パラメータは失敗ページ / code|state 欠落は 400', async () => {

--- a/apps/web/src/lib/edge-config.test.ts
+++ b/apps/web/src/lib/edge-config.test.ts
@@ -3,35 +3,36 @@ import { describe, expect, test, afterEach, vi } from 'vitest';
 /**
  * エッジ URL の環境別解決の回帰防止。核心は「**dev ビルドは本番エッジを叩かない**」
  * (#396: .env.production を本番/dev 両ビルドが読むため VITE_EDGE_URL が本番エッジを
- * 指しても、VITE_NSID_ENV=dev なら dev エッジを強制する)。
+ * 指しても、VITE_NSID_ENV=dev なら dev エッジを強制する)。world-server / server-oauth が
+ * ここを import して同じエッジを使う (連携先とワールド呼び出し先がズレない)。
  * モジュールトップレベルで import.meta.env を評価するので stubEnv + 動的 import。
  */
-describe('world-server: エッジ URL の環境別解決', () => {
+describe('edge-config: エッジ URL の環境別解決', () => {
   afterEach(() => { vi.unstubAllEnvs(); vi.resetModules(); });
 
   test('VITE_NSID_ENV=dev は VITE_EDGE_URL が本番エッジでも dev エッジを強制する', async () => {
     vi.stubEnv('VITE_NSID_ENV', 'dev');
     vi.stubEnv('VITE_EDGE_URL', 'https://aozoraquest-edge.kojiran.workers.dev'); // 本番エッジ
     vi.stubEnv('VITE_EDGE_DID', 'did:web:aozoraquest-edge.kojiran.workers.dev');
-    const { __edgeForTest } = await import('./world-server');
-    expect(__edgeForTest.url).toBe('https://aozoraquest-edge-dev.kojiran.workers.dev');
-    expect(__edgeForTest.did).toBe('did:web:aozoraquest-edge-dev.kojiran.workers.dev');
-    expect(__edgeForTest.url).not.toContain('edge.kojiran'); // 本番エッジに解決しない (edge-dev のみ)
+    const { EDGE_URL, EDGE_DID } = await import('./edge-config');
+    expect(EDGE_URL).toBe('https://aozoraquest-edge-dev.kojiran.workers.dev');
+    expect(EDGE_DID).toBe('did:web:aozoraquest-edge-dev.kojiran.workers.dev');
+    expect(EDGE_URL).toContain('edge-dev'); // 本番エッジ (edge.kojiran) には解決しない
   });
 
   test('本番 (VITE_NSID_ENV 未設定) は VITE_EDGE_URL (本番エッジ) を使う', async () => {
     vi.stubEnv('VITE_NSID_ENV', '');
     vi.stubEnv('VITE_EDGE_URL', 'https://aozoraquest-edge.kojiran.workers.dev');
     vi.stubEnv('VITE_EDGE_DID', 'did:web:aozoraquest-edge.kojiran.workers.dev');
-    const { __edgeForTest } = await import('./world-server');
-    expect(__edgeForTest.url).toBe('https://aozoraquest-edge.kojiran.workers.dev');
+    const { EDGE_URL } = await import('./edge-config');
+    expect(EDGE_URL).toBe('https://aozoraquest-edge.kojiran.workers.dev');
   });
 
   test('ローカル (VITE_NSID_ENV=local) は VITE_EDGE_URL (=.env.development の dev エッジ) を使う', async () => {
     vi.stubEnv('VITE_NSID_ENV', 'local');
     vi.stubEnv('VITE_EDGE_URL', 'https://aozoraquest-edge-dev.kojiran.workers.dev');
     vi.stubEnv('VITE_EDGE_DID', 'did:web:aozoraquest-edge-dev.kojiran.workers.dev');
-    const { __edgeForTest } = await import('./world-server');
-    expect(__edgeForTest.url).toBe('https://aozoraquest-edge-dev.kojiran.workers.dev');
+    const { EDGE_URL } = await import('./edge-config');
+    expect(EDGE_URL).toBe('https://aozoraquest-edge-dev.kojiran.workers.dev');
   });
 });

--- a/apps/web/src/lib/edge-config.ts
+++ b/apps/web/src/lib/edge-config.ts
@@ -1,0 +1,17 @@
+/**
+ * エッジ Worker の URL / DID の**環境別解決** (単一の出所)。
+ *
+ * dev branch デプロイ (`VITE_NSID_ENV=dev`) は **dev エッジを強制**する。`.env.production` は
+ * 本番/dev 両ビルドが読むため `VITE_EDGE_URL` が共有エッジを指してしまい、dev が本番エッジを
+ * 叩く事故が起きる (#396)。エッジを叩く全モジュール (world-server / server-oauth) がここを
+ * import して**同じエッジ**を使う ← 連携先とワールド呼び出し先がズレる不具合を防ぐ。
+ *
+ * エッジ URL は secret でなく公開インフラ値 (既に .env に commit 済) なのでコードに置いてよい。
+ * dev エッジをリネーム/再デプロイした時はこの定数と .env.development を直す (docs/22)。
+ */
+const NSID_ENV = (import.meta.env.VITE_NSID_ENV as string | undefined)?.trim();
+const DEV_EDGE_URL = 'https://aozoraquest-edge-dev.kojiran.workers.dev';
+const DEV_EDGE_DID = 'did:web:aozoraquest-edge-dev.kojiran.workers.dev';
+
+export const EDGE_URL = NSID_ENV === 'dev' ? DEV_EDGE_URL : (import.meta.env.VITE_EDGE_URL as string | undefined)?.trim();
+export const EDGE_DID = NSID_ENV === 'dev' ? DEV_EDGE_DID : (import.meta.env.VITE_EDGE_DID as string | undefined)?.trim();

--- a/apps/web/src/lib/server-oauth.ts
+++ b/apps/web/src/lib/server-oauth.ts
@@ -6,13 +6,38 @@
  * 返す。そこへリダイレクトし、サーバーアカウントで 1 回ログインすると edge がトークンを保管する。
  */
 import type { Agent } from '@atproto/api';
+// world-server と**同じエッジ**を叩く (連携先とワールド呼び出し先がズレる不具合を防ぐ。#396)。
+import { EDGE_URL, EDGE_DID } from './edge-config';
 
-const EDGE_URL = (import.meta.env.VITE_EDGE_URL as string | undefined)?.trim();
-const EDGE_DID = (import.meta.env.VITE_EDGE_DID as string | undefined)?.trim();
 const LXM_OAUTH_START = 'app.aozoraquest.oauth.start';
+const LXM_OAUTH_STATUS = 'app.aozoraquest.oauth.status';
 
 /** edge URL / DID が設定されていれば連携導線を出せる。 */
 export const serverOAuthConfigured = Boolean(EDGE_URL && EDGE_DID);
+
+/** サーバーアカウント連携の状態 (トークン本体は含まない)。 */
+export interface ServerOAuthStatus {
+  linked: boolean;
+  did?: string;
+  pdsUrl?: string;
+  /** access token 失効時刻 (epoch 秒)。 */
+  expiresAt?: number;
+  /** 最終更新 (epoch 秒。cron refresh でも更新)。 */
+  updatedAt?: number;
+}
+
+/** サーバーアカウント連携の状態を取得 (設定画面の表示用)。管理者のみ (edge が ADMIN_DIDS 検証)。 */
+export async function getServerOAuthStatus(agent: Agent): Promise<ServerOAuthStatus> {
+  if (!EDGE_URL || !EDGE_DID) throw new Error('VITE_EDGE_URL / VITE_EDGE_DID が未設定です');
+  const { data } = await agent.com.atproto.server.getServiceAuth({ aud: EDGE_DID, lxm: LXM_OAUTH_STATUS });
+  const res = await fetch(`${EDGE_URL}/api/oauth/status`, { headers: { authorization: `Bearer ${data.token}` } });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string; message?: string };
+    const detail = [body.error, body.message].filter(Boolean).join(' ').trim();
+    throw new Error(`状態取得に失敗しました (${res.status})${detail ? `: ${detail}` : ''}`);
+  }
+  return (await res.json()) as ServerOAuthStatus;
+}
 
 /** サーバーアカウント OAuth 連携を開始し、認可 URL へ遷移する。失敗時は Error を throw。 */
 export async function startServerOAuth(agent: Agent): Promise<void> {

--- a/apps/web/src/lib/world-server.ts
+++ b/apps/web/src/lib/world-server.ts
@@ -8,18 +8,8 @@
  */
 import type { Agent } from '@atproto/api';
 
-// エッジ URL の環境別解決。dev branch デプロイ (VITE_NSID_ENV=dev) は **dev エッジを強制**する。
-// .env.production は本番/dev 両ビルドが読むため VITE_EDGE_URL が共有エッジを指してしまい、
-// dev が本番エッジを叩く事故が起きる (#396)。dev は必ず dev エッジ、と**コードで構造的に保証**する。
-// エッジ URL は secret でなくインフラ値 (既に .env に commit 済) なのでコードに置いてよい。
-const NSID_ENV = (import.meta.env.VITE_NSID_ENV as string | undefined)?.trim();
-const DEV_EDGE_URL = 'https://aozoraquest-edge-dev.kojiran.workers.dev';
-const DEV_EDGE_DID = 'did:web:aozoraquest-edge-dev.kojiran.workers.dev';
-const EDGE_URL = NSID_ENV === 'dev' ? DEV_EDGE_URL : (import.meta.env.VITE_EDGE_URL as string | undefined)?.trim();
-const EDGE_DID = NSID_ENV === 'dev' ? DEV_EDGE_DID : (import.meta.env.VITE_EDGE_DID as string | undefined)?.trim();
-
-/** @internal テスト用: 環境別に解決したエッジ設定 (dev が本番エッジを叩かない回帰防止)。 */
-export const __edgeForTest = { url: EDGE_URL, did: EDGE_DID };
+// エッジ URL/DID の環境別解決は edge-config に一元化 (world/連携が同じエッジを使う。#396)。
+import { EDGE_URL, EDGE_DID } from './edge-config';
 
 const LXM_MOVE = 'app.aozoraquest.world.move';
 const LXM_TELEPORT = 'app.aozoraquest.world.teleport';

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -5,7 +5,7 @@ import type { Archetype, DiagnosisResult, StatVector } from '@aozoraquest/core';
 import { ARCHETYPES, JOBS_BY_ID, jobDisplayName, jobTagline, statArrayToVector } from '@aozoraquest/core';
 import { useSession } from '@/lib/session';
 import { isAdminDid } from '@/lib/runtime-config';
-import { startServerOAuth, serverOAuthConfigured } from '@/lib/server-oauth';
+import { startServerOAuth, serverOAuthConfigured, getServerOAuthStatus, type ServerOAuthStatus } from '@/lib/server-oauth';
 import { signOut } from '@/lib/oauth';
 import { createTaggedPost, getRecord, putRecord } from '@/lib/atproto';
 import { COL } from '@/lib/collections';
@@ -617,6 +617,20 @@ function AnalyzePostsToggle() {
 function ServerOAuthAdmin({ agent }: { agent: Agent }) {
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+  const [status, setStatus] = useState<ServerOAuthStatus | null>(null);
+  const [statusErr, setStatusErr] = useState<string | null>(null);
+
+  // 連携状態を確認して表示する (以前は状態が画面に出ず「連携できたか分からない」だった)。
+  useEffect(() => {
+    let cancelled = false;
+    setStatus(null);
+    setStatusErr(null);
+    getServerOAuthStatus(agent)
+      .then((s) => { if (!cancelled) setStatus(s); })
+      .catch((e) => { if (!cancelled) setStatusErr(e instanceof Error ? e.message : '状態取得に失敗しました'); });
+    return () => { cancelled = true; };
+  }, [agent]);
+
   const onLink = async () => {
     setBusy(true);
     setErr(null);
@@ -627,14 +641,37 @@ function ServerOAuthAdmin({ agent }: { agent: Agent }) {
       setBusy(false);
     }
   };
+
+  const fmt = (sec?: number) => (sec ? new Date(sec * 1000).toLocaleString('ja-JP') : '—');
+  const expired = status?.linked && status.expiresAt !== undefined && status.expiresAt * 1000 < Date.now();
+
   return (
     <section style={{ marginTop: '2em' }}>
       <h3 style={{ fontSize: '0.95em' }}>管理者</h3>
       <p style={{ fontSize: '0.8em', color: 'var(--color-muted)', marginBottom: '0.5em' }}>
         ゲームの権威データを書き込むサーバーアカウントの連携。
       </p>
+      {/* 連携状態 */}
+      <div style={{ fontSize: '0.8em', marginBottom: '0.6em' }}>
+        {statusErr ? (
+          <span style={{ color: 'var(--color-muted)' }}>状態を確認できません: {statusErr}</span>
+        ) : status === null ? (
+          <span style={{ color: 'var(--color-muted)' }}>状態を確認中…</span>
+        ) : status.linked ? (
+          <span style={{ color: expired ? 'var(--color-danger, crimson)' : 'var(--color-accent)' }}>
+            {expired ? '⚠ 連携済み (アクセストークン失効・cron 更新待ち)' : '✓ 連携済み'}
+            {status.did ? <span style={{ color: 'var(--color-muted)' }}> ({status.did})</span> : null}
+            <br />
+            <span style={{ color: 'var(--color-muted)' }}>
+              トークン失効: {fmt(status.expiresAt)} / 最終更新: {fmt(status.updatedAt)}
+            </span>
+          </span>
+        ) : (
+          <span style={{ color: 'var(--color-muted)' }}>未連携</span>
+        )}
+      </div>
       <button onClick={onLink} disabled={busy}>
-        {busy ? '連携中…' : 'サーバーアカウントと連携'}
+        {busy ? '連携中…' : status?.linked ? '再連携する' : 'サーバーアカウントと連携'}
       </button>
       {err && <p style={{ fontSize: '0.8em', color: 'var(--color-danger, crimson)', marginTop: '0.4em' }}>{err}</p>}
     </section>


### PR DESCRIPTION
## 背景
連携後に**状態が設定画面に反映されず**「連携できたか分からない」(オーナー再指摘)。加えて `server-oauth.ts` が raw `VITE_EDGE_URL` を使い、`world-server`(edge-config で dev 強制)と**別エッジを叩く**不具合 = dev で連携先とワールド呼び出し先がズレる。

## 変更
- **新 `GET /api/oauth/status`** (管理者のみ)。連携有無・アカウント DID・トークン失効/更新時刻を返す(**トークン本体は返さない**)。
- **`edge-config.ts` に エッジ解決を一元化**(VITE_NSID_ENV=dev→dev エッジ強制)。`world-server`/`server-oauth` 両方が import = **同じエッジ**。#396 の重複も解消。
- **settings.tsx**: 連携状態を表示(✓連携済み / 未連携 / 失効警告 + DID・失効時刻)。ボタンは未連携=「連携」/ 連携済み=「再連携する」。
- 回帰テストを `edge-config.test.ts` にリネーム。

## 検証
- edge/web typecheck・test 緑(web 344 / edge 144)。dev エッジに status/reset 両ルートをデプロイ済み(401=ルート存在)。

## 重要(オーナー操作)
以前の連携は**旧・共有エッジ**に入った可能性大(連携ボタンがまだ dev エッジを指していなかった)。この PR が dev 反映後、設定画面の状態が dev エッジ基準になる(おそらく「未連携」)。**もう一度「連携」**を押すと dev エッジに入り「✓連携済み」表示 → リセット/戦闘が動きます。

## Review
**§1.5 実装/セキュリティレビュー — ★★★ ゼロ**。status エンドポイントの管理者ゲートは start と同型・**トークン本体を返さない**ことを確認、edge-config 一元化で連携先=ワールド呼び出し先が一致。★★ (status の edge テスト欠如) は commit `d62d254` で対応 (401/403/未連携/トークン非漏洩を固定, edge 145)。★ (403 と障害の区別 / 失効表示 / URL 重複) は許容範囲。

🤖 Generated with [Claude Code](https://claude.com/claude-code)