### PR TITLE
feat(oauth): 連携後に web アプリの設定画面へ戻す (workers.dev に留まらない)

### DIFF
--- a/apps/edge/src/oauth-routes.ts
+++ b/apps/edge/src/oauth-routes.ts
@@ -19,6 +19,23 @@ export const LXM_OAUTH_STATUS = 'app.aozoraquest.oauth.status';
 /** router.ts の Env のうち OAuth ルートが使う部分 + KV。 */
 export interface OAuthRoutesEnv extends OAuthEnv {
   OAUTH_TOKENS?: KVNamespace;
+  /** 連携完了後の戻り先 origin の許可リスト (open-redirect 防止)。 */
+  ALLOWED_ORIGINS?: string;
+}
+
+/** 連携完了後の戻り先 URL を検証する。origin が ALLOWED_ORIGINS に含まれる http(s) URL のみ許可
+ *  (open-redirect 防止)。不正/未指定は undefined。export はテスト用。 */
+export function validateReturnTo(raw: unknown, allowed?: string): string | undefined {
+  if (typeof raw !== 'string' || !raw) return undefined;
+  let u: URL;
+  try {
+    u = new URL(raw);
+  } catch {
+    return undefined;
+  }
+  if (u.protocol !== 'https:' && u.protocol !== 'http:') return undefined;
+  const list = (allowed ?? '').split(',').map((s) => s.trim()).filter(Boolean);
+  return list.includes(u.origin) ? u.toString() : undefined;
 }
 
 interface Deps {
@@ -66,12 +83,16 @@ export async function handleOAuthStart(req: Request, env: OAuthRoutesEnv, deps: 
   }
   if (!isEdgeAdmin(env, iss)) return json({ error: 'forbidden' }, 403);
 
+  // 連携完了後の戻り先 (web アプリの設定画面等)。origin を ALLOWED_ORIGINS で検証 (open-redirect 防止)。
+  const reqBody = (await req.json().catch(() => ({}))) as { returnTo?: unknown };
+  const returnTo = validateReturnTo(reqBody.returnTo, env.ALLOWED_ORIGINS);
+
   // discovery / PAR は失敗しうる (認可サーバーが client-metadata を弾く等)。**catch して JSON で返す**
   // — 未処理例外だと 500 が CORS ヘッダ無しで返り、ブラウザ側が「Load failed」になり原因が見えない。
   try {
     const { pdsUrl, authServer } = await discoverForDid(cfg.serverDid, deps.fetchImpl);
     const { url, state, verifier } = await buildAuthorizeUrl({ ...cfg, now: deps.now, fetchImpl: deps.fetchImpl }, authServer, { loginHint: cfg.serverDid });
-    await putPendingAuth(env.OAUTH_TOKENS, state, { verifier, authServer, pdsUrl, createdAt: deps.now });
+    await putPendingAuth(env.OAUTH_TOKENS, state, { verifier, authServer, pdsUrl, createdAt: deps.now, ...(returnTo ? { returnTo } : {}) });
     return json({ authorizeUrl: url });
   } catch (e) {
     return json({ error: 'oauth_start_failed', message: e instanceof Error ? e.message : String(e) }, 502);
@@ -121,5 +142,12 @@ export async function handleOAuthCallback(req: Request, env: OAuthRoutesEnv, dep
   }
   const tokens = await exchangeCode({ ...cfg, now: deps.now, fetchImpl: deps.fetchImpl }, pending.authServer, code, pending.verifier, pending.pdsUrl, cfg.serverDid);
   await writeServerTokens(env.OAUTH_TOKENS, tokens);
+  // 戻り先が指定されていれば web アプリの元画面 (設定等) へ 302 で返す (workers.dev に留まらない)。
+  // returnTo は start 時に origin 検証済み。付与時は連携成功が確定した後なのでトークンは既に保存済み。
+  if (pending.returnTo) {
+    const to = new URL(pending.returnTo);
+    to.searchParams.set('serverOAuth', 'linked'); // 戻り先で「連携できました」を表示するヒント
+    return new Response(null, { status: 302, headers: { location: to.toString() } });
+  }
   return html(`<h1>連携できました ✅</h1><p>サーバーアカウント (${tokens.did}) の書き込み認証を保存しました。このタブは閉じて構いません。</p>`);
 }

--- a/apps/edge/src/oauth-routes.ts
+++ b/apps/edge/src/oauth-routes.ts
@@ -34,6 +34,9 @@ export function validateReturnTo(raw: unknown, allowed?: string): string | undef
     return undefined;
   }
   if (u.protocol !== 'https:' && u.protocol !== 'http:') return undefined;
+  // userinfo (user:pass@) 付きは拒否。origin 比較は userinfo を無視するので許可されうるが、
+  // toString() が保持し 302 location に認証情報が載る非対称を塞ぐ。
+  if (u.username || u.password) return undefined;
   const list = (allowed ?? '').split(',').map((s) => s.trim()).filter(Boolean);
   return list.includes(u.origin) ? u.toString() : undefined;
 }

--- a/apps/edge/src/oauth-store.ts
+++ b/apps/edge/src/oauth-store.ts
@@ -77,6 +77,8 @@ export interface PendingAuth {
   /** 書き込み先 PDS URL (authorize 時に discovery。callback でトークンレコードに載せる)。 */
   pdsUrl: string;
   createdAt: number;
+  /** 認可完了後にブラウザを戻す web アプリの URL (start 時に origin 検証済み)。省略時は完了 HTML。 */
+  returnTo?: string;
 }
 
 const PENDING_PREFIX = 'oauth-pending:';

--- a/apps/edge/test/oauth-routes.test.ts
+++ b/apps/edge/test/oauth-routes.test.ts
@@ -125,6 +125,12 @@ describe('oauth-routes', () => {
     expect(validateReturnTo('https://evil.example/steal', allowed)).toBeUndefined();
     expect(validateReturnTo('javascript:alert(1)', allowed)).toBeUndefined();
     expect(validateReturnTo('/relative/path', allowed)).toBeUndefined();
+    // open-redirect バイパス系はすべて弾く
+    expect(validateReturnTo('https://dev.aozoraquest.app@evil.example/x', allowed)).toBeUndefined(); // userinfo トリック (origin=evil)
+    expect(validateReturnTo('https://dev.aozoraquest.app.evil.example/x', allowed)).toBeUndefined(); // サブドメイン suffix
+    expect(validateReturnTo('https://dev.aozoraquest.app:8443/x', allowed)).toBeUndefined(); // ポート違い
+    expect(validateReturnTo('https://user:pass@dev.aozoraquest.app/settings', allowed)).toBeUndefined(); // 許可 origin でも userinfo は拒否
+    expect(validateReturnTo('data:text/html,x', allowed)).toBeUndefined();
     expect(validateReturnTo('', allowed)).toBeUndefined();
     expect(validateReturnTo(undefined, allowed)).toBeUndefined();
     expect(validateReturnTo(123, allowed)).toBeUndefined();

--- a/apps/edge/test/oauth-routes.test.ts
+++ b/apps/edge/test/oauth-routes.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { p256 } from '@noble/curves/p256';
 import { base64urlnopad } from '@scure/base';
-import { handleClientMetadata, handleOAuthStart, handleOAuthStatus, handleOAuthCallback, type OAuthRoutesEnv } from '../src/oauth-routes';
+import { handleClientMetadata, handleOAuthStart, handleOAuthStatus, handleOAuthCallback, validateReturnTo, type OAuthRoutesEnv } from '../src/oauth-routes';
 import { putPendingAuth, readServerTokens, writeServerTokens } from '../src/oauth-store';
 import type { AuthServerMetadata } from '../src/oauth-metadata';
 
@@ -102,5 +102,32 @@ describe('oauth-routes', () => {
     expect(res.status).toBe(200);
     const saved = await readServerTokens(kv);
     expect(saved).toMatchObject({ did: 'did:plc:testserver', accessToken: 'AT', refreshToken: 'RT' });
+  });
+
+  it('callback: returnTo 付き pending は web アプリへ 302 で戻す (serverOAuth=linked)', async () => {
+    const kv = mockKv();
+    await putPendingAuth(kv, 'ST', { verifier: 'VER', authServer: meta, pdsUrl: 'https://pds.example', createdAt: NOW, returnTo: 'https://dev.aozoraquest.app/settings' });
+    const f = discoveryFetch({ '/oauth/token': () => json({ access_token: 'AT', token_type: 'DPoP', refresh_token: 'RT', expires_in: 3600, sub: 'did:plc:testserver' }) });
+    const res = await handleOAuthCallback(new Request('https://x/oauth/callback?code=CODE&state=ST'), env(kv), { now: NOW, fetchImpl: f });
+    expect(res.status).toBe(302);
+    const loc = res.headers.get('location') ?? '';
+    expect(loc).toContain('https://dev.aozoraquest.app/settings');
+    expect(loc).toContain('serverOAuth=linked');
+    expect(await readServerTokens(kv)).toMatchObject({ did: 'did:plc:testserver' }); // 戻す前に保存済み
+  });
+
+  it('validateReturnTo: ALLOWED_ORIGINS の origin の http(s) URL のみ許可 (open-redirect 防止)', () => {
+    const allowed = 'https://dev.aozoraquest.app,http://127.0.0.1:9999';
+    // 許可 origin
+    expect(validateReturnTo('https://dev.aozoraquest.app/settings', allowed)).toBe('https://dev.aozoraquest.app/settings');
+    expect(validateReturnTo('http://127.0.0.1:9999/settings?x=1', allowed)).toBe('http://127.0.0.1:9999/settings?x=1');
+    // 不許可 origin / スキーム / 不正値 → undefined
+    expect(validateReturnTo('https://evil.example/steal', allowed)).toBeUndefined();
+    expect(validateReturnTo('javascript:alert(1)', allowed)).toBeUndefined();
+    expect(validateReturnTo('/relative/path', allowed)).toBeUndefined();
+    expect(validateReturnTo('', allowed)).toBeUndefined();
+    expect(validateReturnTo(undefined, allowed)).toBeUndefined();
+    expect(validateReturnTo(123, allowed)).toBeUndefined();
+    expect(validateReturnTo('https://dev.aozoraquest.app/settings', undefined)).toBeUndefined(); // 許可リスト無し
   });
 });

--- a/apps/web/src/lib/server-oauth.ts
+++ b/apps/web/src/lib/server-oauth.ts
@@ -46,7 +46,9 @@ export async function startServerOAuth(agent: Agent): Promise<void> {
   const { data } = await agent.com.atproto.server.getServiceAuth({ aud: EDGE_DID, lxm: LXM_OAUTH_START });
   const res = await fetch(`${EDGE_URL}/api/oauth/start`, {
     method: 'POST',
-    headers: { authorization: `Bearer ${data.token}` },
+    headers: { authorization: `Bearer ${data.token}`, 'content-type': 'application/json' },
+    // 認可完了後にこの設定画面へ戻すための戻り先 (edge が origin を検証してから使う)。
+    body: JSON.stringify({ returnTo: window.location.href }),
   });
   if (!res.ok) {
     const body = (await res.json().catch(() => ({}))) as { error?: string; message?: string };

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -619,6 +619,18 @@ function ServerOAuthAdmin({ agent }: { agent: Agent }) {
   const [err, setErr] = useState<string | null>(null);
   const [status, setStatus] = useState<ServerOAuthStatus | null>(null);
   const [statusErr, setStatusErr] = useState<string | null>(null);
+  const [justLinked, setJustLinked] = useState(false);
+
+  // 認可 callback から ?serverOAuth=linked で戻ってきたら「連携できました」を出し、param を掃除する。
+  useEffect(() => {
+    const p = new URLSearchParams(window.location.search);
+    if (p.get('serverOAuth') === 'linked') {
+      setJustLinked(true);
+      p.delete('serverOAuth');
+      const q = p.toString();
+      window.history.replaceState(null, '', window.location.pathname + (q ? `?${q}` : ''));
+    }
+  }, []);
 
   // 連携状態を確認して表示する (以前は状態が画面に出ず「連携できたか分からない」だった)。
   useEffect(() => {
@@ -651,6 +663,9 @@ function ServerOAuthAdmin({ agent }: { agent: Agent }) {
       <p style={{ fontSize: '0.8em', color: 'var(--color-muted)', marginBottom: '0.5em' }}>
         ゲームの権威データを書き込むサーバーアカウントの連携。
       </p>
+      {justLinked && (
+        <p style={{ fontSize: '0.8em', color: 'var(--color-accent)', marginBottom: '0.5em' }}>連携できました ✅</p>
+      )}
       {/* 連携状態 */}
       <div style={{ fontSize: '0.8em', marginBottom: '0.6em' }}>
         {statusErr ? (


### PR DESCRIPTION
## 背景 (オーナー指摘)
OAuth 連携後、認可サーバーは `redirect_uri`(= エッジの `/oauth/callback` = workers.dev)へ戻すため、完了 HTML が **workers.dev で止まり** dev.aozoraquest.app/settings に戻れなかった。

## 修正 (戻り先を OAuth の往復に載せる標準手法)
- **client** (`server-oauth.ts`): `/api/oauth/start` の body に `returnTo`= 現在の設定画面 URL を渡す。
- **edge** (`oauth-routes.ts`):
  - `start` が `returnTo` を **origin 検証** (`validateReturnTo` × `ALLOWED_ORIGINS`) してから pending に保存(**open-redirect 防止**)。
  - `callback` はトークン保存後、`returnTo` があればそこへ **302**(`?serverOAuth=linked` 付き)。無ければ従来の完了 HTML。
- **settings.tsx**: `?serverOAuth=linked` で戻ったら「連携できました ✅」を出し param を掃除。

## 検証
- edge test ✅ (147: `validateReturnTo` の許可/不許可/不正スキーム + callback の 302 redirect + トークンは戻す前に保存済み)。web/edge typecheck 緑。dev エッジにデプロイ済み。

## Review
**§1.5 実装/セキュリティレビュー — ★★★ ゼロ**。open-redirect 対策 (origin 完全一致 + http(s) 限定 + server-side state キー) は古典的バイパス (userinfo/サブドメイン suffix/ポート違い) を実測で全弾き。★★ (userinfo が 302 location に残る) は commit で拒否 + テスト追加。★★ (本番 ALLOWED_ORIGINS): returnTo は ALLOWED_ORIGINS に app origin が要る = CORS と同条件、本番は既存 CORS 設定で有効。csrf state フロー維持・回帰 (returnTo 無し=200 HTML) 確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)