### PR TITLE
fix(world): オンボーディングの祝福 +20 をブルスコンの手渡しフロー内で演出

### DIFF
--- a/apps/web/src/components/welcome-blessing.tsx
+++ b/apps/web/src/components/welcome-blessing.tsx
@@ -93,8 +93,9 @@ export function WelcomeBlessingOverlay() {
         >
           はじまりの祝福
         </div>
+        {/* アイテムの受け渡しは手前のブルスコンのセリフで済んでいるので、この演出は
+            あおぞらパワー授与の儀式に純化する (重複を避ける — UX レビュー ★★)。 */}
         <div style={{ marginTop: '0.6em', fontSize: '0.95em', color: '#ffffff', lineHeight: 1.7 }}>
-          <div>やくそう と そらのはね を手にした</div>
           <div style={{ marginTop: '0.2em' }}>
             あおぞらパワー{' '}
             <span style={{ fontFamily: 'ui-monospace, monospace', color: 'var(--color-accent)', fontWeight: 700 }}>

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -156,9 +156,12 @@ export function World() {
   const searchMsgRef = useRef(false);
   searchMsgRef.current = searchMsg !== null;
   const [featherOpen, setFeatherOpen] = useState(false);
-  const [starterMsg, setStarterMsg] = useState<string | null>(null);
+  const [showStarter, setShowStarter] = useState(false);
+  // リセット (= 実際に +20 を付与した経路) からの入場か。祝福セリフ/演出の有無を実付与と
+  // 一致させるための旗。入場時に sessionStorage マークから確定する。
+  const [starterBlessed, setStarterBlessed] = useState(false);
   const starterMsgRef = useRef(false);
-  starterMsgRef.current = starterMsg !== null;
+  starterMsgRef.current = showStarter;
   const itemsOpenRef = useRef(false);
   itemsOpenRef.current = itemsOpen;
   const invOpenRef = useRef(false);
@@ -322,13 +325,25 @@ export function World() {
         };
         setWs(initialWs);
         if (grantStarter) {
-          // 専用の DQ ウィンドウで見せる (notice だとオンボーディングに覆われ、
-          // relocated 通知に上書きされて「もらった瞬間」が消える — レビュー ★★★)。
-          // 中身は下の render の固定セリフ (ブルスコンの手渡し + 祝福)。ここは表示トリガのみ。
-          setStarterMsg('start');
+          // 専用の DQ ウィンドウでブルスコンの手渡しを見せる (notice だとオンボーディングに
+          // 覆われ、relocated 通知に上書きされて「もらった瞬間」が消える — レビュー ★★★)。
+          // リセット (実 +20 付与) 経由かをマークで判定 → 祝福セリフ/演出の有無を実付与に一致させる。
+          // マークは**ここで読み捨てる**。set 側 (doReset) との間にリロードを挟んでも、入場時に
+          // 必ず消費/掃除されるので残留・誤発火しない (レビュー ★★)。
+          let blessed = false;
+          try {
+            blessed = sessionStorage.getItem(WELCOME_BLESSING_PENDING_KEY) === '1';
+            if (blessed) sessionStorage.removeItem(WELCOME_BLESSING_PENDING_KEY);
+          } catch { /* private mode 等は演出だけ諦める (+20 付与自体は済んでいる) */ }
+          setStarterBlessed(blessed);
+          setShowStarter(true);
           // gotStarterFeather=true は即時保存 (デバウンス中リロードで二重配布しない —
           // かけら/初訪問と同じ流儀。レビュー ★★)
           void saveWorldState(agent, initialWs);
+        } else {
+          // 手渡しダイアログを出さない入場では祝福マークを掃除する (set したのに演出へ
+          // 到達しなかった残留マークによる誤発火を防ぐ — レビュー ★★)。
+          try { sessionStorage.removeItem(WELCOME_BLESSING_PENDING_KEY); } catch { /* ignore */ }
         }
         try {
           if (typeof localStorage !== 'undefined' && localStorage.getItem(ONBOARDING_DONE_KEY) !== '1') {
@@ -822,8 +837,10 @@ export function World() {
       // (以前は地図でいきなり +20 が出てフローが分からなかった — オーナー指摘 2026-07-20)。
       // 祝福 (+20) の演出はリロードをまたいで出すため sessionStorage にマークを置く。
       // resetOnboarding が実際に +20 を付与したときだけ立てる → 演出と実際の付与が必ず一致する
-      // (通常の新規入場では +20 は付かないので演出も出さない)。
+      // (通常の新規入場では +20 は付かないので演出も出さない)。マークは再入場時に必ず消費/掃除される。
       try { sessionStorage.setItem(WELCOME_BLESSING_PENDING_KEY, '1'); } catch { /* private mode 等は演出だけ諦める */ }
+      // resetting オーバーレイをひと呼吸見せてから初期状態で再入場する。sessionStorage の set は
+      // 同期なので反映待ちは不要 — この 300ms は体感 (急に画面が飛ばない) のためだけ。
       window.setTimeout(() => window.location.reload(), 300);
     } catch (e) {
       console.warn('[world] onboarding reset failed', e);
@@ -1205,25 +1222,21 @@ export function World() {
       {searchMsg !== null && (
         <DialogueWindow lines={[{ text: searchMsg }]} onDone={() => setSearchMsg(null)} />
       )}
-      {starterMsg !== null && !onboarding && (
-        // ブルスコンが やくそう と そらのはね を手渡し、最後に はじまりの祝福 (+20 パワー) を授ける。
-        // 祝福の演出は**ダイアログを読み終えた瞬間**に出す (以前は地図画面でいきなり出て
-        // フローが分からなかった — オーナー指摘 2026-07-20)。
+      {showStarter && !onboarding && (
+        // ブルスコンが やくそう と そらのはね を手渡す。リセット (実 +20 付与) 経由のときだけ
+        // 祝福のセリフを足し、読み終えた瞬間に祝福演出を出す (以前は地図でいきなり出てフローが
+        // 分からなかった — オーナー指摘 2026-07-20)。starterBlessed は入場時にマークから確定済み。
+        // 声はブルスコンのトーンに合わせ ひらがな主体で統一 (UX レビュー ★)。
         <DialogueWindow
           lines={[
-            { speaker: 'ブルスコン', text: 'たびの はじめに、やくそう と そらのはね を 持たせよう。' },
-            { speaker: 'ブルスコン', text: 'やくそうは 傷を癒す。そらのはねは 行ったことのある街へ もどれる。こまったら どうぐ から つかうといい。' },
-            { speaker: 'ブルスコン', text: 'それと、はじまりの祝福を。あおぞらパワーを 20 授けるよ。よい旅を。' },
+            { speaker: 'ブルスコン', text: 'たびの はじめに、やくそう と そらのはね を もたせよう。' },
+            { speaker: 'ブルスコン', text: 'やくそうは きずを いやす。そらのはねは いったことの ある街へ もどれる。こまったら どうぐ から つかうといい。' },
+            starterBlessed
+              ? { speaker: 'ブルスコン', text: 'それと、はじまりの しゅくふくを。あおぞらパワーを 20 さずけるよ。よい たびを。' }
+              : { speaker: 'ブルスコン', text: 'よい たびを。' },
           ]}
           plateIcon={<SpiritIcon size={20} />}
-          onDone={() => {
-            setStarterMsg(null);
-            // 祝福 (+20) の演出は、リセットで実際に +20 を付与したときだけ (マーク有り)。
-            // 使い捨て (removeItem) で二重演出を防ぐ。
-            let blessed = false;
-            try { blessed = sessionStorage.getItem(WELCOME_BLESSING_PENDING_KEY) === '1'; if (blessed) sessionStorage.removeItem(WELCOME_BLESSING_PENDING_KEY); } catch { /* ignore */ }
-            if (blessed) notifyWelcome({ power: WELCOME_POWER });
-          }}
+          onDone={() => { setShowStarter(false); if (starterBlessed) notifyWelcome({ power: WELCOME_POWER }); }}
         />
       )}
 

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -51,7 +51,7 @@ import { WorldHud, HUD_Z, OVERLAY_Z } from '@/components/world-hud';
 import { WorldMenu, type WorldMenuCommand } from '@/components/world-menu';
 import { ItemsModal, InventoryModal } from '@/components/world-item-modals';
 import { FeatherModal } from '@/components/feather-modal';
-import { WelcomeBlessingOverlay, notifyWelcome, WELCOME_TOTAL_MS } from '@/components/welcome-blessing';
+import { WelcomeBlessingOverlay, notifyWelcome } from '@/components/welcome-blessing';
 import { resetOnboarding, WELCOME_POWER } from '@/lib/onboarding-reset';
 import { isAdminDid } from '@/lib/runtime-config';
 import type { DialogueLine } from '@/lib/dialogue';
@@ -101,6 +101,9 @@ interface Vitals {
 
 /** 初回オンボーディングを見終えたかの localStorage キー (スティックのヒントと同じ方式) */
 const ONBOARDING_DONE_KEY = 'aq-world-onboarding-done';
+/** リセットで +20 を付与した直後だけ、再入場後のブルスコン手渡しの最後に祝福演出を出すためのマーク
+ *  (sessionStorage はリロードをまたいで残り、タブを閉じれば消える。使い捨て)。 */
+const WELCOME_BLESSING_PENDING_KEY = 'aq-welcome-blessing-pending';
 /** 「自分タップでコマンド」コーチマークを出したか。操作 UI が不可視 (スティックも
  *  コマンドもタップ起動) なので、オンボーディングを読み飛ばしても実際にマップへ
  *  立ったとき 1 回だけ操作を思い出させる。一度メニューを開くと消える。 */
@@ -320,8 +323,9 @@ export function World() {
         setWs(initialWs);
         if (grantStarter) {
           // 専用の DQ ウィンドウで見せる (notice だとオンボーディングに覆われ、
-          // relocated 通知に上書きされて「もらった瞬間」が消える — レビュー ★★★)
-          setStarterMsg('たびの はじめに「そらのはね」を 1 つ もらった! こまったら どうぐ から つかって、行ったことのある街へ もどれるよ。');
+          // relocated 通知に上書きされて「もらった瞬間」が消える — レビュー ★★★)。
+          // 中身は下の render の固定セリフ (ブルスコンの手渡し + 祝福)。ここは表示トリガのみ。
+          setStarterMsg('start');
           // gotStarterFeather=true は即時保存 (デバウンス中リロードで二重配布しない —
           // かけら/初訪問と同じ流儀。レビュー ★★)
           void saveWorldState(agent, initialWs);
@@ -814,9 +818,13 @@ export function World() {
         resetOnboarding(agent, did),
         new Promise<never>((_, reject) => { timeoutId = window.setTimeout(() => reject(new Error('reset timeout')), 30_000); }),
       ]);
-      notifyWelcome({ power: WELCOME_POWER });
-      // 演出 (フェード込み ≈ 3.3s) を見せ切って余韻を残してから初期状態で再入場
-      window.setTimeout(() => window.location.reload(), WELCOME_TOTAL_MS + 900);
+      // 初期状態で再入場 → 再入場後に**ブルスコンが やくそう/そらのはね を手渡し + 祝福を演出**する
+      // (以前は地図でいきなり +20 が出てフローが分からなかった — オーナー指摘 2026-07-20)。
+      // 祝福 (+20) の演出はリロードをまたいで出すため sessionStorage にマークを置く。
+      // resetOnboarding が実際に +20 を付与したときだけ立てる → 演出と実際の付与が必ず一致する
+      // (通常の新規入場では +20 は付かないので演出も出さない)。
+      try { sessionStorage.setItem(WELCOME_BLESSING_PENDING_KEY, '1'); } catch { /* private mode 等は演出だけ諦める */ }
+      window.setTimeout(() => window.location.reload(), 300);
     } catch (e) {
       console.warn('[world] onboarding reset failed', e);
       // 失敗したステップ/理由を出す。resetOnboarding は `step: message` 形式 (WorldServerError も
@@ -1198,7 +1206,25 @@ export function World() {
         <DialogueWindow lines={[{ text: searchMsg }]} onDone={() => setSearchMsg(null)} />
       )}
       {starterMsg !== null && !onboarding && (
-        <DialogueWindow lines={[{ speaker: 'ブルスコン', text: starterMsg }]} plateIcon={<SpiritIcon size={20} />} onDone={() => setStarterMsg(null)} />
+        // ブルスコンが やくそう と そらのはね を手渡し、最後に はじまりの祝福 (+20 パワー) を授ける。
+        // 祝福の演出は**ダイアログを読み終えた瞬間**に出す (以前は地図画面でいきなり出て
+        // フローが分からなかった — オーナー指摘 2026-07-20)。
+        <DialogueWindow
+          lines={[
+            { speaker: 'ブルスコン', text: 'たびの はじめに、やくそう と そらのはね を 持たせよう。' },
+            { speaker: 'ブルスコン', text: 'やくそうは 傷を癒す。そらのはねは 行ったことのある街へ もどれる。こまったら どうぐ から つかうといい。' },
+            { speaker: 'ブルスコン', text: 'それと、はじまりの祝福を。あおぞらパワーを 20 授けるよ。よい旅を。' },
+          ]}
+          plateIcon={<SpiritIcon size={20} />}
+          onDone={() => {
+            setStarterMsg(null);
+            // 祝福 (+20) の演出は、リセットで実際に +20 を付与したときだけ (マーク有り)。
+            // 使い捨て (removeItem) で二重演出を防ぐ。
+            let blessed = false;
+            try { blessed = sessionStorage.getItem(WELCOME_BLESSING_PENDING_KEY) === '1'; if (blessed) sessionStorage.removeItem(WELCOME_BLESSING_PENDING_KEY); } catch { /* ignore */ }
+            if (blessed) notifyWelcome({ power: WELCOME_POWER });
+          }}
+        />
       )}
 
       {/* マップ下: 戦闘/リザルトはマップ枠内で完結するので何も出さない (縦スクロール


### PR DESCRIPTION
## 背景 (オーナー指摘 2026-07-20)

> やっと位置も初期化されました。しかしすぐに祝福の20あおぞらパワーが**地図画面のまま**授与されてしまいます。実際のフローが確認できません。そしてセリフをブルスコンから**やくそうとそらのはねを渡される**ようにして欲しいです。

## 変更

1. **祝福 (+20) の演出を再入場後のフロー内へ**
   - 以前: `doReset` が `resetOnboarding` 完了直後、**地図上で** `notifyWelcome` → 再入場前に一瞬 +20 演出が出て終わり。
   - 今回: リセットは +20 を付与して即再入場。再入場後、ブルスコンの手渡しダイアログを**読み終えた瞬間**に +20 演出を出す。

2. **ブルスコンが やくそう と そらのはね を手渡すセリフに**
   - 3 行の DQ ダイアログ (ひらがな主体) — ① やくそう と そらのはね を手渡す → ② 使い方 → ③ (リセット経由のみ)「あおぞらパワーを 20 さずける」で演出。

3. **演出・セリフ・実付与の一致 (sessionStorage マーク)**
   - `grantStarter` (= `!gotStarterFeather`) は通常の新規入場でも真だが、+20 は `resetOnboarding` でしか付与されない。リセット時だけマークを立て、**再入場時に読み捨て**て祝福セリフ/演出を出す。通常入場では祝福セリフも演出も出ない。

## 検証
- `typecheck` / `test` (344 passed) / `build` (development env) 緑。
- `DialogueWindow` は複数行を DQ 式に進め onDone を 1 回だけ呼ぶことをソースで確認 (`dialogue.ts` の `doneRef`)。
- dev で実機確認予定: 管理者リセット → 再入場 → ブルスコンが 2 アイテム手渡し → 最後に +20 演出。通常入場では祝福セリフ/演出が出ないこと。

## Review

§1.5 の 3 並列 subagent レビュー (設計 / 実装 / UX) を実施。★★★ は 0 件。

**★★ (PR 内で対応済み)**
- **祝福マークの残留・誤発火** (実装・設計): sessionStorage マークの set (リロード前) と消費 (旧: ダイアログ onDone) が分離し、ダイアログ経路に乗らないと残留し得た → マークの読み取り+消費を**入場時 (grantStarter 判定)** に移し、ダイアログを出さない入場では `else` で掃除。set とリロードを挟んでも入場時に必ず消費/掃除され残留しない。(commit 0af792b)
- **演出とセリフの情報重複** (UX): 祝福オーバーレイの「やくそう と そらのはね を手にした」がブルスコンのセリフと重複 → オーバーレイはパワー授与の儀式に純化 (アイテム行を削除)。(commit 0af792b)

**★ (PR 内で対応済み)**
- **セリフと実付与の不一致** (実装・設計): 「20 授ける」を新規入場でも常に喋っていた → `starterBlessed` でセリフ 3 行目を出し分け、演出発火も同じ旗で行い一致させた。(commit 0af792b)
- **表記ゆれ** (UX): ブルスコンのセリフを ひらがな主体に統一 (きずを いやす / さずける / よい たびを)。(commit 0af792b)
- **マジック文字列** (設計): `starterMsg: string` の `'start'` センチネル → `showStarter: boolean`。(commit 0af792b)

**別 issue 化**
- **#400**: +20 付与元が `resetOnboarding` 以外に増えたら (= 新規プレイヤーにも +20) マークの責務を付与点へ寄せる。現状 (dev + 管理者 reset のみ) では本 PR の方式で整合しているため急がない。
- **テスト網羅性** (実装 ★): マークのライフサイクルは reload をまたぐ UI glue で node テスト化しづらい。純関数化の余地はあるが本 PR では見送り (★・柔軟)。