### PR TITLE
feat(world): オンボード用リセットを地図メニューから設定画面へ移設

### DIFF
--- a/apps/web/src/lib/onboarding-reset.test.ts
+++ b/apps/web/src/lib/onboarding-reset.test.ts
@@ -1,5 +1,16 @@
-import { describe, expect, test, vi } from 'vitest';
-import { deleteAllRecords } from './onboarding-reset';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { armOnboardingReplay, deleteAllRecords, ONBOARDING_DONE_KEY, WELCOME_BLESSING_PENDING_KEY } from './onboarding-reset';
+
+/** Map ベースの最小 Storage モック (node 環境には localStorage/sessionStorage が無い)。 */
+function mockStorage() {
+  const m = new Map<string, string>();
+  return {
+    getItem: (k: string) => m.get(k) ?? null,
+    setItem: vi.fn((k: string, v: string) => { m.set(k, v); }),
+    removeItem: vi.fn((k: string) => { m.delete(k); }),
+    _map: m,
+  };
+}
 
 /** listRecords が total 件 (100 件/ページ) 返すモック agent。deleteRecord を記録。 */
 function makeAgent(total: number) {
@@ -42,5 +53,30 @@ describe('deleteAllRecords (並列バッチ削除)', () => {
     const throwing = { com: { atproto: { repo: { listRecords: vi.fn(async () => { throw new Error('nope'); }), deleteRecord: vi.fn() } } } } as any;
     await expect(deleteAllRecords(throwing, 'did:test', 'x')).resolves.toBeUndefined();
     expect(throwing.com.atproto.repo.deleteRecord).not.toHaveBeenCalled();
+  });
+});
+
+describe('armOnboardingReplay (オンボード再生の準備)', () => {
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  test('onboarding-done を消し、祝福マークを 1 にする', () => {
+    const local = mockStorage();
+    const session = mockStorage();
+    local._map.set(ONBOARDING_DONE_KEY, '1'); // 既に見終えた状態から
+    vi.stubGlobal('localStorage', local);
+    vi.stubGlobal('sessionStorage', session);
+
+    armOnboardingReplay();
+
+    expect(local.removeItem).toHaveBeenCalledWith(ONBOARDING_DONE_KEY); // イントロを再表示
+    expect(local._map.has(ONBOARDING_DONE_KEY)).toBe(false);
+    expect(session.setItem).toHaveBeenCalledWith(WELCOME_BLESSING_PENDING_KEY, '1'); // 祝福演出のマーク
+    expect(session._map.get(WELCOME_BLESSING_PENDING_KEY)).toBe('1');
+  });
+
+  test('storage が throw しても例外を投げない (private mode 等)', () => {
+    vi.stubGlobal('localStorage', { removeItem: () => { throw new Error('denied'); } });
+    vi.stubGlobal('sessionStorage', { setItem: () => { throw new Error('denied'); } });
+    expect(() => armOnboardingReplay()).not.toThrow();
   });
 });

--- a/apps/web/src/lib/onboarding-reset.ts
+++ b/apps/web/src/lib/onboarding-reset.ts
@@ -24,6 +24,24 @@ import { serverReset } from './world-server';
 /** 歓迎付与するあおぞらパワー (演出とともに加算)。 */
 export const WELCOME_POWER = 20;
 
+/** 通常オンボードのイントロ (ONBOARDING_LINES overlay) を「見終えた」フラグの localStorage キー。
+ *  これが '1' だとイントロは再生されない。リセット時に消すと新規と同じ導入から始まる。 */
+export const ONBOARDING_DONE_KEY = 'aq-world-onboarding-done';
+/** リセットで +20 を付与した直後だけ、再入場後のブルスコン手渡しの最後に祝福演出を出すためのマーク
+ *  (sessionStorage はリロードをまたいで残り、タブを閉じれば消える。使い捨て)。 */
+export const WELCOME_BLESSING_PENDING_KEY = 'aq-welcome-blessing-pending';
+
+/**
+ * リセット完了後、**通常の新規オンボードルートを丸ごと再生**させる準備。
+ * - イントロ overlay を再表示するため onboarding-done を消す (これが無いと「いきなり地図」になる)。
+ * - 祝福 (+20) 演出を再入場後に出すためのマークを立てる (実際に +20 を付与したときだけ呼ぶ)。
+ * 呼び出し後に /world へフルロード遷移すると、新規ユーザーと同じ「イントロ→手渡し→祝福」を辿る。
+ */
+export function armOnboardingReplay(): void {
+  try { localStorage.removeItem(ONBOARDING_DONE_KEY); } catch { /* private mode 等は諦める */ }
+  try { sessionStorage.setItem(WELCOME_BLESSING_PENDING_KEY, '1'); } catch { /* private mode 等は諦める */ }
+}
+
 /** あるコレクションの全レコードを削除。**並列バッチの deleteRecord** で消す —
  *  1 件ずつ逐次 await するとレコードが多いアカウントで数十〜数百往復かかり実質ハングする
  *  (リセットが固まる不具合)。records を集めてから 25 件ずつ並列に削除する。

--- a/apps/web/src/lib/onboarding-reset.ts
+++ b/apps/web/src/lib/onboarding-reset.ts
@@ -11,7 +11,8 @@
  * analysis(XP)/world(位置)/power(残高) を読んで初期状態を作るので、それらを先に掃除してから
  * gameState を消す。こうすると途中失敗しても「gameState は残る=旧状態のまま」で止まり、
  * 半端に古い Lv/位置で復帰しない。各ステップは冪等 (削除は no-op 安全、power は絶対値書き込み)
- * なので、失敗時は同じ操作を再実行すれば収束する (doReset がエラーを拾ってリトライ導線にする)。
+ * なので、失敗時は同じ操作を再実行すれば収束する (呼び出し側 UI = WorldResetAdmin (設定画面) が
+ * エラーを拾ってリトライ導線にする)。
  *
  * dev + 管理者のみが UI から呼べる。自分の repo と自分の gameState しか触らない。
  */
@@ -35,7 +36,13 @@ export const WELCOME_BLESSING_PENDING_KEY = 'aq-welcome-blessing-pending';
  * リセット完了後、**通常の新規オンボードルートを丸ごと再生**させる準備。
  * - イントロ overlay を再表示するため onboarding-done を消す (これが無いと「いきなり地図」になる)。
  * - 祝福 (+20) 演出を再入場後に出すためのマークを立てる (実際に +20 を付与したときだけ呼ぶ)。
- * 呼び出し後に /world へフルロード遷移すると、新規ユーザーと同じ「イントロ→手渡し→祝福」を辿る。
+ *
+ * **契約**: 祝福マークの**消費・掃除は world 入場時が唯一の責任者** (world.tsx の grantStarter 分岐で
+ * 読み捨て、手渡しダイアログを出さない入場では else で削除)。ここは「立てる」だけを担う。
+ *
+ * 呼び出し後は必ず `/world` へ**フルロード遷移** (`location.assign`) すること。SPA navigate では
+ * world.tsx の in-memory state (ws / serverInv / tokenRef / onboardingRef) が初期化されず、
+ * まっさらな入場フローにならないため。フルロードでも localStorage/sessionStorage は保持される。
  */
 export function armOnboardingReplay(): void {
   try { localStorage.removeItem(ONBOARDING_DONE_KEY); } catch { /* private mode 等は諦める */ }

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -665,7 +665,7 @@ function ServerOAuthAdmin({ agent }: { agent: Agent }) {
 
   return (
     <section style={{ marginTop: '2em' }}>
-      <h3 style={{ fontSize: '0.95em' }}>管理者</h3>
+      <h3 style={{ fontSize: '0.95em' }}>管理者 (サーバー連携)</h3>
       <p style={{ fontSize: '0.8em', color: 'var(--color-muted)', marginBottom: '0.5em' }}>
         ゲームの権威データを書き込むサーバーアカウントの連携。
       </p>
@@ -712,7 +712,7 @@ function WorldResetAdmin({ agent, did }: { agent: Agent; did: string }) {
 
   const onReset = async () => {
     if (busy) return;
-    if (!window.confirm('あおぞらワールドを「はじめから」やり直します。\n所持品・装備・レベル・位置がすべて初期化されます (投稿で貯めたパワー残高は残ります)。よろしいですか?')) return;
+    if (!window.confirm('あおぞらワールドを「はじめから」やり直します。\n所持品・装備・レベル・位置がすべて初期化され、元に戻せません (投稿で貯めたパワー残高は残ります)。よろしいですか?')) return;
     setBusy(true);
     setErr(null);
     let timeoutId: number | undefined;
@@ -737,7 +737,7 @@ function WorldResetAdmin({ agent, did }: { agent: Agent; did: string }) {
 
   return (
     <section style={{ marginTop: '2em' }}>
-      <h3 style={{ fontSize: '0.95em' }}>あおぞらワールド (管理)</h3>
+      <h3 style={{ fontSize: '0.95em' }}>管理者 (ワールド)</h3>
       <p style={{ fontSize: '0.8em', color: 'var(--color-muted)', marginBottom: '0.5em' }}>
         ワールドを「はじめから」やり直し、新規と同じ導入 (イントロ→手渡し→祝福) を確認する。
         所持品・装備・レベル・位置を初期化 (投稿で貯めたパワー残高は残る)。
@@ -745,6 +745,14 @@ function WorldResetAdmin({ agent, did }: { agent: Agent; did: string }) {
       <button onClick={onReset} disabled={busy}>
         {busy ? 'リセット中…' : '⟲ あおぞらワールドを はじめから'}
       </button>
+      {/* 重い I/O (最大 30s) 中は「固まった?」に見えないよう明滅で処理継続を示す
+          (旧地図の全画面オーバーレイの脈動を最小構成で踏襲 — レビュー ★★)。 */}
+      {busy && (
+        <p aria-live="polite" style={{ fontSize: '0.8em', color: 'var(--color-muted)', marginTop: '0.4em' }}>
+          <style>{'@keyframes reset-pulse{0%,100%{opacity:0.4}50%{opacity:1}}'}</style>
+          <span style={{ animation: 'reset-pulse 1.4s ease-in-out infinite' }}>はじめの地へ もどしています…</span>
+        </p>
+      )}
       {err && <p style={{ fontSize: '0.8em', color: 'var(--color-danger, crimson)', marginTop: '0.4em' }}>{err}</p>}
     </section>
   );

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -6,6 +6,8 @@ import { ARCHETYPES, JOBS_BY_ID, jobDisplayName, jobTagline, statArrayToVector }
 import { useSession } from '@/lib/session';
 import { isAdminDid } from '@/lib/runtime-config';
 import { startServerOAuth, serverOAuthConfigured, getServerOAuthStatus, type ServerOAuthStatus } from '@/lib/server-oauth';
+import { resetOnboarding, armOnboardingReplay } from '@/lib/onboarding-reset';
+import { WORLD_PREVIEW_ENABLED } from '@/lib/world-preview';
 import { signOut } from '@/lib/oauth';
 import { createTaggedPost, getRecord, putRecord } from '@/lib/atproto';
 import { COL } from '@/lib/collections';
@@ -339,6 +341,10 @@ export function Settings() {
 
       {isAdminDid(session.did) && serverOAuthConfigured && session.agent && (
         <ServerOAuthAdmin agent={session.agent} />
+      )}
+
+      {isAdminDid(session.did) && WORLD_PREVIEW_ENABLED && session.agent && session.did && (
+        <WorldResetAdmin agent={session.agent} did={session.did} />
       )}
 
       <section style={{ marginTop: '2em' }}>
@@ -687,6 +693,57 @@ function ServerOAuthAdmin({ agent }: { agent: Agent }) {
       </div>
       <button onClick={onLink} disabled={busy}>
         {busy ? '連携中…' : status?.linked ? '再連携する' : 'サーバーアカウントと連携'}
+      </button>
+      {err && <p style={{ fontSize: '0.8em', color: 'var(--color-danger, crimson)', marginTop: '0.4em' }}>{err}</p>}
+    </section>
+  );
+}
+
+/**
+ * 管理者専用 (dev のみ): あおぞらワールドを「はじめから」やり直す完全ワイプ。
+ * 地図メニューから**設定画面へ移設**した (地図上でリセットすると「いきなり地図」から再開し、
+ * 新規のオンボードルートと食い違うため — オーナー指摘 2026-07-20)。リセット後は
+ * armOnboardingReplay でイントロ再表示フラグと祝福マークを立て、/world へ**フルロード遷移**して
+ * 新規と同じ「イントロ→ブルスコンの手渡し→祝福」を辿る。
+ */
+function WorldResetAdmin({ agent, did }: { agent: Agent; did: string }) {
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const onReset = async () => {
+    if (busy) return;
+    if (!window.confirm('あおぞらワールドを「はじめから」やり直します。\n所持品・装備・レベル・位置がすべて初期化されます (投稿で貯めたパワー残高は残ります)。よろしいですか?')) return;
+    setBusy(true);
+    setErr(null);
+    let timeoutId: number | undefined;
+    try {
+      // 30s の全体タイムアウト (PDS 無応答でも「リセット中…」で固着しない fail-safe)。
+      await Promise.race([
+        resetOnboarding(agent, did),
+        new Promise<never>((_, reject) => { timeoutId = window.setTimeout(() => reject(new Error('reset timeout')), 30_000); }),
+      ]);
+      // 新規と同じ導入を再生する準備 (イントロ再表示 + 祝福マーク) → /world へフルロードで入場。
+      armOnboardingReplay();
+      window.location.assign('/world');
+    } catch (e) {
+      console.warn('[settings] onboarding reset failed', e);
+      const detail = e instanceof Error ? e.message : '';
+      setErr(`リセットに失敗しました (${detail || '通信エラー'})。もう一度どうぞ。`);
+      setBusy(false);
+    } finally {
+      if (timeoutId !== undefined) window.clearTimeout(timeoutId);
+    }
+  };
+
+  return (
+    <section style={{ marginTop: '2em' }}>
+      <h3 style={{ fontSize: '0.95em' }}>あおぞらワールド (管理)</h3>
+      <p style={{ fontSize: '0.8em', color: 'var(--color-muted)', marginBottom: '0.5em' }}>
+        ワールドを「はじめから」やり直し、新規と同じ導入 (イントロ→手渡し→祝福) を確認する。
+        所持品・装備・レベル・位置を初期化 (投稿で貯めたパワー残高は残る)。
+      </p>
+      <button onClick={onReset} disabled={busy}>
+        {busy ? 'リセット中…' : '⟲ あおぞらワールドを はじめから'}
       </button>
       {err && <p style={{ fontSize: '0.8em', color: 'var(--color-danger, crimson)', marginTop: '0.4em' }}>{err}</p>}
     </section>

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -52,8 +52,7 @@ import { WorldMenu, type WorldMenuCommand } from '@/components/world-menu';
 import { ItemsModal, InventoryModal } from '@/components/world-item-modals';
 import { FeatherModal } from '@/components/feather-modal';
 import { WelcomeBlessingOverlay, notifyWelcome } from '@/components/welcome-blessing';
-import { resetOnboarding, WELCOME_POWER } from '@/lib/onboarding-reset';
-import { isAdminDid } from '@/lib/runtime-config';
+import { WELCOME_POWER, ONBOARDING_DONE_KEY, WELCOME_BLESSING_PENDING_KEY } from '@/lib/onboarding-reset';
 import type { DialogueLine } from '@/lib/dialogue';
 
 /**
@@ -99,11 +98,6 @@ interface Vitals {
   gotStarterFeather: boolean;
 }
 
-/** 初回オンボーディングを見終えたかの localStorage キー (スティックのヒントと同じ方式) */
-const ONBOARDING_DONE_KEY = 'aq-world-onboarding-done';
-/** リセットで +20 を付与した直後だけ、再入場後のブルスコン手渡しの最後に祝福演出を出すためのマーク
- *  (sessionStorage はリロードをまたいで残り、タブを閉じれば消える。使い捨て)。 */
-const WELCOME_BLESSING_PENDING_KEY = 'aq-welcome-blessing-pending';
 /** 「自分タップでコマンド」コーチマークを出したか。操作 UI が不可視 (スティックも
  *  コマンドもタップ起動) なので、オンボーディングを読み飛ばしても実際にマップへ
  *  立ったとき 1 回だけ操作を思い出させる。一度メニューを開くと消える。 */
@@ -137,7 +131,6 @@ export function World() {
   statusOpenRef.current = statusOpen;
   const [menuOpen, setMenuOpen] = useState(false);
   const menuOpenRef = useRef(false);
-  const [resetting, setResetting] = useState(false); // オンボード用リセット中 (dev+管理者)
   menuOpenRef.current = menuOpen;
   const [menuHint, setMenuHint] = useState(() => {
     try {
@@ -817,42 +810,9 @@ export function World() {
     }
   }, [agent, did]);
 
-  // オンボード用リセット (dev + 管理者のみ)。完全ワイプ → 初期状態 + はじまりの祝福 (+20 パワー)。
-  // 演出を見せてから再読込して確実に初期状態を反映する。
-  const doReset = useCallback(async () => {
-    if (!agent || !did || resetting) return;
-    if (!window.confirm('あおぞらワールドを「はじめから」やり直します。\n所持品・装備・レベル・位置がすべて初期化されます (投稿で貯めたパワー残高は残ります)。よろしいですか?')) return;
-    setResetting(true); // I/O の間、進行オーバーレイを出す (無反応に見せない)
-    setMenuOpen(false);
-    let timeoutId: number | undefined;
-    try {
-      // 全体タイムアウト (30s)。PDS 応答が返らない等でも進行オーバーレイが永久に
-      // 固着しないよう fail-safe で throw する (実機で「もどしています…」から進めなく
-      // なる不具合の再発防止)。勝った側で必ず timer を片付ける (finally)。
-      await Promise.race([
-        resetOnboarding(agent, did),
-        new Promise<never>((_, reject) => { timeoutId = window.setTimeout(() => reject(new Error('reset timeout')), 30_000); }),
-      ]);
-      // 初期状態で再入場 → 再入場後に**ブルスコンが やくそう/そらのはね を手渡し + 祝福を演出**する
-      // (以前は地図でいきなり +20 が出てフローが分からなかった — オーナー指摘 2026-07-20)。
-      // 祝福 (+20) の演出はリロードをまたいで出すため sessionStorage にマークを置く。
-      // resetOnboarding が実際に +20 を付与したときだけ立てる → 演出と実際の付与が必ず一致する
-      // (通常の新規入場では +20 は付かないので演出も出さない)。マークは再入場時に必ず消費/掃除される。
-      try { sessionStorage.setItem(WELCOME_BLESSING_PENDING_KEY, '1'); } catch { /* private mode 等は演出だけ諦める */ }
-      // resetting オーバーレイをひと呼吸見せてから初期状態で再入場する。sessionStorage の set は
-      // 同期なので反映待ちは不要 — この 300ms は体感 (急に画面が飛ばない) のためだけ。
-      window.setTimeout(() => window.location.reload(), 300);
-    } catch (e) {
-      console.warn('[world] onboarding reset failed', e);
-      // 失敗したステップ/理由を出す。resetOnboarding は `step: message` 形式 (WorldServerError も
-      // その message にラップ済み) で throw するので、message をそのまま出せば原因が分かる。
-      const detail = e instanceof Error ? e.message : '';
-      setNotice(`リセットに失敗した (${detail || '通信エラー'})。もう一度どうぞ。`);
-      setResetting(false);
-    } finally {
-      if (timeoutId !== undefined) window.clearTimeout(timeoutId);
-    }
-  }, [agent, did, resetting]);
+  // オンボード用リセットは**設定画面**へ移設した (地図メニューから消し、新規と同じ
+  // 「イントロ→手渡し→祝福」導入を辿れるようにするため — オーナー指摘 2026-07-20)。
+  // world 側は再入場時にマーク/フラグを読むだけ (WELCOME_BLESSING_PENDING_KEY / ONBOARDING_DONE_KEY)。
 
   // なんでも屋で作ってもらう (docs/20 W6b)。支払い: パワー (craftPowerSpent 累積) +
   // 素材 (craft レコードの集計で差し引き)。品質は rkey + luk から決定的
@@ -1065,12 +1025,7 @@ export function World() {
     ...(inTown
       ? [{ key: 'shop', label: 'なんでも屋', onSelect: () => { setLastShopAction(null); setMaterialsView({ ...materialsRef.current }); setShopOpen(true); } } as WorldMenuCommand]
       : []),
-    // 管理者用: オンボードを体験するための「はじめから」。破壊的なので confirm 付き。
-    // world ルート自体が WORLD_PREVIEW_ENABLED (dev/local 限定) で早期 return されるので、
-    // ここは追加で管理者 (isAdminDid) に絞るだけ = 実質 dev + 管理者。
-    ...(did && isAdminDid(did)
-      ? [{ key: 'reset', label: resetting ? 'リセット中…' : '⟲ はじめから (管理)', onSelect: () => void doReset() } as WorldMenuCommand]
-      : []),
+    // 「はじめから (管理)」は設定画面へ移設 (新規と同じ導入を辿らせるため)。ここには出さない。
   ];
 
   // ビューポートのタイル列 (プレイヤー中央固定)。平地は見た目バリアントを散らす。
@@ -1353,21 +1308,6 @@ export function World() {
         />
       )}
       {wipeOverlay}
-      {/* リセット中の進行表示 (重い直列 I/O の間、無反応に見せない)。祝福演出 (z1100) の下に敷く。 */}
-      {resetting && (
-        <div
-          aria-live="polite"
-          style={{
-            position: 'fixed', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center',
-            background: 'rgba(6, 12, 24, 0.82)', color: 'var(--color-fg)', zIndex: 1050,
-            fontSize: '0.95em', letterSpacing: '0.04em',
-          }}
-        >
-          {/* 明滅させて「処理中」を伝える (静止だと固まって見える = 今回直したい症状そのもの)。 */}
-          <style>{'@keyframes reset-pulse{0%,100%{opacity:0.45}50%{opacity:1}}'}</style>
-          <span style={{ animation: 'reset-pulse 1.4s ease-in-out infinite' }}>はじめの地へ もどしています…</span>
-        </div>
-      )}
       <WelcomeBlessingOverlay />
     </div>
   );


### PR DESCRIPTION
## 背景 (オーナー指摘 2026-07-20)

> 地図画面からリセットがあるのが良くないな。設定画面からリセットできるように変えて欲しい。そうでないといきなり地図の画面から始まっているので通常のオンボードルートとは異なってしまう。

**根因**: 地図メニューの「はじめから (管理)」は `resetOnboarding` 後に `window.location.reload()` で**その場 (地図) に再入場**していた。`resetOnboarding` は `ONBOARDING_DONE_KEY` (localStorage) を消さないため、イントロ overlay (`ONBOARDING_LINES`) が再生されず、新規ユーザーの導入ルートと食い違って「いきなり地図から始まる」状態だった。

## 変更

1. **リセット導線を設定画面の管理者セクションへ移設** (`WorldResetAdmin`、dev + 管理者のみ)。地図メニューからは撤去。
2. リセット後は `armOnboardingReplay()` で `ONBOARDING_DONE_KEY` を消して**イントロを再表示**し、祝福 (+20) マークを立て、`/world` へ**フルロード遷移**。→ 新規と同じ「イントロ→ブルスコンの手渡し→祝福」を丸ごと辿る。
3. `world.tsx` から `doReset` / `resetting` state / 進行オーバーレイ / 地図メニューの reset コマンドを撤去。共有キーと replay ヘルパを `onboarding-reset.ts` に集約 (world=読み手 / settings=書き手)。

## 検証
- `typecheck` / `test` (346 passed、`armOnboardingReplay` 単体テスト +2) / `build` (development env) 緑。
- dev 実機確認予定: 設定 → 「⟲ あおぞらワールドを はじめから」→ /world でイントロから始まり、手渡し→祝福まで新規と同じ導入を辿ること。地図メニューに reset が無いこと。

## Review

§1.5 の 3 並列 subagent レビュー (設計 / 実装 / UX) を実施。**★★★ は 0 件。**

**★★ (PR 内で対応済み)**
- **リセット中フィードバックの後退** (設計・UX): 全画面オーバーレイ撤去でボタン文言のみになり、最大 30s の I/O 中「固まった?」に見えるリスク → ボタン下に明滅する「はじめの地へ もどしています…」を復活 (旧オーバーレイの脈動を最小構成で踏襲)。(commit ab51f9f)
- **管理セクションの命名非対称** (UX): 「管理者」と「あおぞらワールド (管理)」が並んで階層が揃わない → 「管理者 (サーバー連携)」「管理者 (ワールド)」に統一。(commit ab51f9f)

**★ (PR 内で対応済み)**
- **破壊操作の警告不足** (UX): confirm 文言に「元に戻せません」を追加。(commit ab51f9f)
- **stale コメント / doc 契約** (実装・設計): `resetOnboarding` の doc が撤去済み `doReset` を参照 → `WorldResetAdmin` に修正。`armOnboardingReplay` に「祝福マークの消費・掃除は world 入場が唯一の責任者」「フルロード遷移必須 (SPA では world state が初期化されない)」の契約を明記。(commit ab51f9f)
- **テスト網羅** (実装): `armOnboardingReplay` の単体テストを追加 (done キー削除 / 祝福マークセット / storage throw 時に無例外)。(commit ab51f9f)

**確認済み・指摘に至らず**: 撤去残骸なし (isAdminDid/resetOnboarding import 除去、dangling 参照なし)。二重クリック防止・timeout clear・エラー時 busy 復帰・成功時は遷移前提で setState しない (unmount 後 setState 警告なし)。露出範囲は地図時代と同一 (dev + 管理者、本番では `WORLD_PREVIEW_ENABLED=false` で非表示)。循環 import なし。docs に stale な「地図メニューでリセット」記述なし。