### PR TITLE
fix(world): リセット後は精霊ブルスコンの画面へ戻す (一般ユーザー導線を再現)

### DIFF
--- a/apps/web/src/lib/onboarding-reset.ts
+++ b/apps/web/src/lib/onboarding-reset.ts
@@ -40,9 +40,11 @@ export const WELCOME_BLESSING_PENDING_KEY = 'aq-welcome-blessing-pending';
  * **契約**: 祝福マークの**消費・掃除は world 入場時が唯一の責任者** (world.tsx の grantStarter 分岐で
  * 読み捨て、手渡しダイアログを出さない入場では else で削除)。ここは「立てる」だけを担う。
  *
- * 呼び出し後は必ず `/world` へ**フルロード遷移** (`location.assign`) すること。SPA navigate では
- * world.tsx の in-memory state (ws / serverInv / tokenRef / onboardingRef) が初期化されず、
- * まっさらな入場フローにならないため。フルロードでも localStorage/sessionStorage は保持される。
+ * 呼び出し後は**精霊ブルスコンの画面 (`/spirit`) へフルロード遷移** (`location.assign`) すること。
+ * 一般ユーザーは /spirit の「あおぞらワールドを冒険する」から入場するので、そこへ戻せば
+ * 「ブルスコン画面→冒険する→イントロ→手渡し→祝福」を新規と同じ順で辿れる (/world へ直接飛ばすと
+ * 2D 地図にいきなり出て一般導線と食い違う)。フルロードなら world.tsx の in-memory state も確実に
+ * 初期化され、localStorage/sessionStorage のフラグは保持される。
  */
 export function armOnboardingReplay(): void {
   try { localStorage.removeItem(ONBOARDING_DONE_KEY); } catch { /* private mode 等は諦める */ }

--- a/apps/web/src/lib/onboarding-reset.ts
+++ b/apps/web/src/lib/onboarding-reset.ts
@@ -37,14 +37,20 @@ export const WELCOME_BLESSING_PENDING_KEY = 'aq-welcome-blessing-pending';
  * - イントロ overlay を再表示するため onboarding-done を消す (これが無いと「いきなり地図」になる)。
  * - 祝福 (+20) 演出を再入場後に出すためのマークを立てる (実際に +20 を付与したときだけ呼ぶ)。
  *
- * **契約**: 祝福マークの**消費・掃除は world 入場時が唯一の責任者** (world.tsx の grantStarter 分岐で
- * 読み捨て、手渡しダイアログを出さない入場では else で削除)。ここは「立てる」だけを担う。
+ * **契約**: 2 つのフラグの**再セット/消費・掃除の責任者はいずれも world 入場時**。ここは「立てる」だけ。
+ * - 祝福マーク (sessionStorage): world 入場で grantStarter 分岐なら読み捨て、else 分岐でも削除 (必ず掃除)。
+ * - onboarding-done (localStorage): world 入場でイントロを見終えたときに再び `'1'` に戻る。
+ * この非対称のため、`/spirit` に着地して**ワールドに入らず離脱**すると onboarding-done が消えたまま残り、
+ * 次回どこかで /world を開くとイントロが 1 回だけ再生される (閉じれば `'1'` に戻り自己回復)。祝福マークも
+ * 同じ「離脱」窓に属するが sessionStorage なのでタブを閉じれば自然消滅する。対象は dev+管理者限定なので許容。
  *
  * 呼び出し後は**精霊ブルスコンの画面 (`/spirit`) へフルロード遷移** (`location.assign`) すること。
  * 一般ユーザーは /spirit の「あおぞらワールドを冒険する」から入場するので、そこへ戻せば
  * 「ブルスコン画面→冒険する→イントロ→手渡し→祝福」を新規と同じ順で辿れる (/world へ直接飛ばすと
- * 2D 地図にいきなり出て一般導線と食い違う)。フルロードなら world.tsx の in-memory state も確実に
- * 初期化され、localStorage/sessionStorage のフラグは保持される。
+ * 2D 地図にいきなり出て一般導線と食い違う)。フルロード遷移は着地先 /spirit を確実に再初期化するため。
+ * その後 /spirit→/world は route 切替で world.tsx が fresh mount され、mount 時に storage/サーバーから
+ * 状態を読み直すので in-memory state も初期化される (フルロードだからではなく fresh mount による)。
+ * localStorage/sessionStorage のフラグはフルロードをまたいで保持される。
  */
 export function armOnboardingReplay(): void {
   try { localStorage.removeItem(ONBOARDING_DONE_KEY); } catch { /* private mode 等は諦める */ }

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -703,8 +703,9 @@ function ServerOAuthAdmin({ agent }: { agent: Agent }) {
  * 管理者専用 (dev のみ): あおぞらワールドを「はじめから」やり直す完全ワイプ。
  * 地図メニューから**設定画面へ移設**した (地図上でリセットすると「いきなり地図」から再開し、
  * 新規のオンボードルートと食い違うため — オーナー指摘 2026-07-20)。リセット後は
- * armOnboardingReplay でイントロ再表示フラグと祝福マークを立て、/world へ**フルロード遷移**して
- * 新規と同じ「イントロ→ブルスコンの手渡し→祝福」を辿る。
+ * armOnboardingReplay でイントロ再表示フラグと祝福マークを立て、**精霊ブルスコンの画面 (/spirit)**
+ * へフルロード遷移する。一般ユーザーはそこの「あおぞらワールドを冒険する」から入場するので、
+ * 「ブルスコン画面→冒険する→イントロ→手渡し→祝福」の導線をそのまま確認できる。
  */
 function WorldResetAdmin({ agent, did }: { agent: Agent; did: string }) {
   const [busy, setBusy] = useState(false);
@@ -722,9 +723,12 @@ function WorldResetAdmin({ agent, did }: { agent: Agent; did: string }) {
         resetOnboarding(agent, did),
         new Promise<never>((_, reject) => { timeoutId = window.setTimeout(() => reject(new Error('reset timeout')), 30_000); }),
       ]);
-      // 新規と同じ導入を再生する準備 (イントロ再表示 + 祝福マーク) → /world へフルロードで入場。
+      // 新規と同じ導入を再生する準備 (イントロ再表示 + 祝福マーク) → **精霊ブルスコンの画面**へ。
+      // 一般ユーザーは /spirit の「あおぞらワールドを冒険する」から入場するので、そこへ戻して
+      // 「ブルスコン画面→冒険する→イントロ→手渡し→祝福」の導線を丸ごと辿れるようにする
+      // (/world へ直接飛ばすと 2D 地図にいきなり出て一般導線と食い違う — オーナー指摘 2026-07-20)。
       armOnboardingReplay();
-      window.location.assign('/world');
+      window.location.assign('/spirit');
     } catch (e) {
       console.warn('[settings] onboarding reset failed', e);
       const detail = e instanceof Error ? e.message : '';
@@ -739,8 +743,9 @@ function WorldResetAdmin({ agent, did }: { agent: Agent; did: string }) {
     <section style={{ marginTop: '2em' }}>
       <h3 style={{ fontSize: '0.95em' }}>管理者 (ワールド)</h3>
       <p style={{ fontSize: '0.8em', color: 'var(--color-muted)', marginBottom: '0.5em' }}>
-        ワールドを「はじめから」やり直し、新規と同じ導入 (イントロ→手渡し→祝福) を確認する。
-        所持品・装備・レベル・位置を初期化 (投稿で貯めたパワー残高は残る)。
+        ワールドを「はじめから」やり直し、精霊ブルスコンの画面から一般ユーザーと同じ導線
+        (冒険する→イントロ→手渡し→祝福) を確認する。所持品・装備・レベル・位置を初期化
+        (投稿で貯めたパワー残高は残る)。
       </p>
       <button onClick={onReset} disabled={busy}>
         {busy ? 'リセット中…' : '⟲ あおぞらワールドを はじめから'}


### PR DESCRIPTION
## 背景 (オーナー指摘 2026-07-20)

> まって、リセットだけすればいいのに 2D 地図に飛ばされてしまったよ。ブルスコンの画面から遷移する一般ユーザー目線の導線を確認したいのにこれではだめです

#401 でリセットを設定画面へ移したが、完了後 `/world` (2D 地図) へ直接遷移していた。一般ユーザーはワールドへ **`/spirit` (精霊ブルスコンの画面) の「🗺 あおぞらワールドを冒険する」** から入場するので、地図に直行すると導線が飛んでしまう。

## 変更
- リセット完了後の遷移先を `/world` → **`/spirit`** に変更 (`window.location.assign`)。
- これで「精霊ブルスコンの画面 → 冒険する → イントロ → ブルスコンの手渡し → 祝福 (+20)」を、一般ユーザーと同じ順で丸ごと確認できる。
- フラグ (イントロ再表示 + 祝福マーク) は**ワールド入場時に消費**されるので /spirit 経由でも順序どおり再生 (localStorage/sessionStorage でフルロードをまたいで保持)。関連 doc / セクション説明も /spirit 起点に更新。

## 検証
- `typecheck` / `test` (346 passed) / `build` (development env) 緑。
- dev 実機確認予定: 設定 → 「⟲ あおぞらワールドを はじめから」→ **精霊ブルスコンの画面に戻る** → 「冒険する」→ イントロ → 手渡し → 祝福。

## Review

§1.5 の 3 並列 subagent レビュー (設計 / 実装 / UX) を実施。**★★★ は 0 件。** 実装レビューは ★★ 0 件 (フラグ受け渡しが fresh mount で成立することを確認)。

**★★ (PR 内で対応済み — いずれもコメント精度、コード変更不要)**
- **契約コメントの不正確** (設計): 「フルロードなら world state が初期化される」は新経路では誤り → 着地先は /spirit で、/world の state 初期化は route 切替の fresh mount が担うと訂正。(commit 54337eb)
- **離脱窓の未記載** (設計): /spirit に着地しワールドに入らず離脱すると `ONBOARDING_DONE_KEY` が残り次回 /world でイントロが 1 回再生される (自己回復) 窓を契約に明記。祝福マークは sessionStorage で自然消滅する旨も追記。dev+管理者限定で許容。(commit 54337eb)

**★★ (別 issue 化)**
- **#403**: リセット後 /spirit 着地で「効いた」手応えが薄い。ただし管理者向け成功メッセージを足すと、観察したい**一般ユーザー導線の忠実さを損なう** (新規ユーザーはそんなメッセージを見ない)。管理者は confirm + 明滅 + フルリロードで既に手応えあり。→ 「メッセージ無し=導線に忠実」を維持するか足すかはオーナー判断待ちとして issue 化。

**★ (対応不要と判断)**
- **遷移先の自動テスト空白** (実装): `window.location.assign` は unit で mock しづらく e2e 領域。1 行の遷移先変更に対し過剰なので現状維持 (実装レビューも「対応不要」)。