### PR TITLE
fix(world): リセットは設定画面に留まる (自動遷移をやめる)

### DIFF
--- a/apps/web/src/lib/onboarding-reset.ts
+++ b/apps/web/src/lib/onboarding-reset.ts
@@ -40,17 +40,14 @@ export const WELCOME_BLESSING_PENDING_KEY = 'aq-welcome-blessing-pending';
  * **契約**: 2 つのフラグの**再セット/消費・掃除の責任者はいずれも world 入場時**。ここは「立てる」だけ。
  * - 祝福マーク (sessionStorage): world 入場で grantStarter 分岐なら読み捨て、else 分岐でも削除 (必ず掃除)。
  * - onboarding-done (localStorage): world 入場でイントロを見終えたときに再び `'1'` に戻る。
- * この非対称のため、`/spirit` に着地して**ワールドに入らず離脱**すると onboarding-done が消えたまま残り、
+ * この非対称のため、リセット後に**ワールドへ入らず離れる**と onboarding-done が消えたまま残り、
  * 次回どこかで /world を開くとイントロが 1 回だけ再生される (閉じれば `'1'` に戻り自己回復)。祝福マークも
- * 同じ「離脱」窓に属するが sessionStorage なのでタブを閉じれば自然消滅する。対象は dev+管理者限定なので許容。
+ * 同じ窓に属するが sessionStorage なのでタブを閉じれば自然消滅する。対象は dev+管理者限定なので許容。
  *
- * 呼び出し後は**精霊ブルスコンの画面 (`/spirit`) へフルロード遷移** (`location.assign`) すること。
- * 一般ユーザーは /spirit の「あおぞらワールドを冒険する」から入場するので、そこへ戻せば
- * 「ブルスコン画面→冒険する→イントロ→手渡し→祝福」を新規と同じ順で辿れる (/world へ直接飛ばすと
- * 2D 地図にいきなり出て一般導線と食い違う)。フルロード遷移は着地先 /spirit を確実に再初期化するため。
- * その後 /spirit→/world は route 切替で world.tsx が fresh mount され、mount 時に storage/サーバーから
- * 状態を読み直すので in-memory state も初期化される (フルロードだからではなく fresh mount による)。
- * localStorage/sessionStorage のフラグはフルロードをまたいで保持される。
+ * **呼び出し側は遷移しない** (リセットするだけ — オーナー指摘 2026-07-20)。フラグを storage に立てるだけで、
+ * 管理者が自分で通常どおり精霊ブルスコン→「冒険する」→ワールドと進めば、world.tsx が入場時に
+ * storage/サーバーから状態を読み直し、イントロ→手渡し→祝福を新規と同じ順で再生する。フラグは
+ * localStorage/sessionStorage なのでその後の SPA 遷移をまたいで保持される。
  */
 export function armOnboardingReplay(): void {
   try { localStorage.removeItem(ONBOARDING_DONE_KEY); } catch { /* private mode 等は諦める */ }

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -702,13 +702,16 @@ function ServerOAuthAdmin({ agent }: { agent: Agent }) {
 /**
  * 管理者専用 (dev のみ): あおぞらワールドを「はじめから」やり直す完全ワイプ。
  * 地図メニューから**設定画面へ移設**した (地図上でリセットすると「いきなり地図」から再開し、
- * 新規のオンボードルートと食い違うため — オーナー指摘 2026-07-20)。リセット後は
- * armOnboardingReplay でイントロ再表示フラグと祝福マークを立て、**精霊ブルスコンの画面 (/spirit)**
- * へフルロード遷移する。一般ユーザーはそこの「あおぞらワールドを冒険する」から入場するので、
- * 「ブルスコン画面→冒険する→イントロ→手渡し→祝福」の導線をそのまま確認できる。
+ * 新規のオンボードルートと食い違うため — オーナー指摘 2026-07-20)。
+ *
+ * **リセットするだけ**で遷移はしない (この設定画面に留まる — オーナー指摘 2026-07-20)。
+ * armOnboardingReplay でイントロ再表示フラグと祝福マークを storage に立てておくので、管理者が
+ * 自分で通常どおり精霊ブルスコン→「冒険する」→ワールドと進めば、新規ユーザーと同じ
+ * 「ブルスコン画面→冒険する→イントロ→手渡し→祝福」を頭から辿れる。
  */
 function WorldResetAdmin({ agent, did }: { agent: Agent; did: string }) {
   const [busy, setBusy] = useState(false);
+  const [done, setDone] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
   const onReset = async () => {
@@ -716,6 +719,7 @@ function WorldResetAdmin({ agent, did }: { agent: Agent; did: string }) {
     if (!window.confirm('あおぞらワールドを「はじめから」やり直します。\n所持品・装備・レベル・位置がすべて初期化され、元に戻せません (投稿で貯めたパワー残高は残ります)。よろしいですか?')) return;
     setBusy(true);
     setErr(null);
+    setDone(false);
     let timeoutId: number | undefined;
     try {
       // 30s の全体タイムアウト (PDS 無応答でも「リセット中…」で固着しない fail-safe)。
@@ -723,18 +727,16 @@ function WorldResetAdmin({ agent, did }: { agent: Agent; did: string }) {
         resetOnboarding(agent, did),
         new Promise<never>((_, reject) => { timeoutId = window.setTimeout(() => reject(new Error('reset timeout')), 30_000); }),
       ]);
-      // 新規と同じ導入を再生する準備 (イントロ再表示 + 祝福マーク) → **精霊ブルスコンの画面**へ。
-      // 一般ユーザーは /spirit の「あおぞらワールドを冒険する」から入場するので、そこへ戻して
-      // 「ブルスコン画面→冒険する→イントロ→手渡し→祝福」の導線を丸ごと辿れるようにする
-      // (/world へ直接飛ばすと 2D 地図にいきなり出て一般導線と食い違う — オーナー指摘 2026-07-20)。
+      // 次に管理者が自分でワールドへ入ったとき新規と同じ導入を再生するための準備 (イントロ再表示 +
+      // 祝福マーク)。ここでは遷移しない — この設定画面に留まる (オーナー指摘 2026-07-20)。
       armOnboardingReplay();
-      window.location.assign('/spirit');
+      setDone(true);
     } catch (e) {
       console.warn('[settings] onboarding reset failed', e);
       const detail = e instanceof Error ? e.message : '';
       setErr(`リセットに失敗しました (${detail || '通信エラー'})。もう一度どうぞ。`);
-      setBusy(false);
     } finally {
+      setBusy(false);
       if (timeoutId !== undefined) window.clearTimeout(timeoutId);
     }
   };
@@ -743,9 +745,8 @@ function WorldResetAdmin({ agent, did }: { agent: Agent; did: string }) {
     <section style={{ marginTop: '2em' }}>
       <h3 style={{ fontSize: '0.95em' }}>管理者 (ワールド)</h3>
       <p style={{ fontSize: '0.8em', color: 'var(--color-muted)', marginBottom: '0.5em' }}>
-        ワールドを「はじめから」やり直し、精霊ブルスコンの画面から一般ユーザーと同じ導線
-        (冒険する→イントロ→手渡し→祝福) を確認する。所持品・装備・レベル・位置を初期化
-        (投稿で貯めたパワー残高は残る)。
+        ワールドを「はじめから」やり直す。所持品・装備・レベル・位置を初期化 (投稿で貯めたパワー
+        残高は残る)。リセット後、精霊ブルスコンの画面から冒険すると新規と同じ導入を辿れる。
       </p>
       <button onClick={onReset} disabled={busy}>
         {busy ? 'リセット中…' : '⟲ あおぞらワールドを はじめから'}
@@ -756,6 +757,11 @@ function WorldResetAdmin({ agent, did }: { agent: Agent; did: string }) {
         <p aria-live="polite" style={{ fontSize: '0.8em', color: 'var(--color-muted)', marginTop: '0.4em' }}>
           <style>{'@keyframes reset-pulse{0%,100%{opacity:0.4}50%{opacity:1}}'}</style>
           <span style={{ animation: 'reset-pulse 1.4s ease-in-out infinite' }}>はじめの地へ もどしています…</span>
+        </p>
+      )}
+      {done && !busy && (
+        <p aria-live="polite" style={{ fontSize: '0.8em', color: 'var(--color-accent)', marginTop: '0.4em' }}>
+          リセットしました ✅ 精霊ブルスコンの画面から冒険できます。
         </p>
       )}
       {err && <p style={{ fontSize: '0.8em', color: 'var(--color-danger, crimson)', marginTop: '0.4em' }}>{err}</p>}

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -714,12 +714,20 @@ function WorldResetAdmin({ agent, did }: { agent: Agent; did: string }) {
   const [done, setDone] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
+  // 成功表示は数秒で自然に消す (この設定画面に留まって他操作を続けても居座らせない — レビュー ★★)。
+  useEffect(() => {
+    if (!done) return;
+    const t = window.setTimeout(() => setDone(false), 6000);
+    return () => window.clearTimeout(t);
+  }, [done]);
+
   const onReset = async () => {
     if (busy) return;
-    if (!window.confirm('あおぞらワールドを「はじめから」やり直します。\n所持品・装備・レベル・位置がすべて初期化され、元に戻せません (投稿で貯めたパワー残高は残ります)。よろしいですか?')) return;
-    setBusy(true);
+    // 前回の成功/失敗メッセージはボタンを押した時点で消す (confirm でキャンセルしても残像を残さない)。
     setErr(null);
     setDone(false);
+    if (!window.confirm('あおぞらワールドを「はじめから」やり直します。\n所持品・装備・レベル・位置がすべて初期化され、元に戻せません (投稿で貯めたパワー残高は残ります)。よろしいですか?')) return;
+    setBusy(true);
     let timeoutId: number | undefined;
     try {
       // 30s の全体タイムアウト (PDS 無応答でも「リセット中…」で固着しない fail-safe)。
@@ -761,7 +769,7 @@ function WorldResetAdmin({ agent, did }: { agent: Agent; did: string }) {
       )}
       {done && !busy && (
         <p aria-live="polite" style={{ fontSize: '0.8em', color: 'var(--color-accent)', marginTop: '0.4em' }}>
-          リセットしました ✅ 精霊ブルスコンの画面から冒険できます。
+          はじめの地へ もどりました。精霊ブルスコンから 冒険できます。
         </p>
       )}
       {err && <p style={{ fontSize: '0.8em', color: 'var(--color-danger, crimson)', marginTop: '0.4em' }}>{err}</p>}


### PR DESCRIPTION
## 背景 (オーナー指摘 2026-07-20)

> え？設定画面のままでいいんだよ？
> リセットするだけでいいんだよ

リセット後に自動遷移していた (#402 で /spirit へ) が、要望は「リセットするだけ」= **設定画面に留まる**こと。管理者は自分で通常どおり 精霊ブルスコン→冒険する→ワールド と進んで一般ユーザー導線を確認する。

## 変更
- `WorldResetAdmin` から `window.location.assign` を撤去。**遷移しない**。
- `armOnboardingReplay()` は維持 (イントロ再表示フラグ + 祝福マークを storage に立てる)。管理者が後から通常どおりワールドへ入れば、新規と同じ「イントロ→手渡し→祝福」が再生される。
- 成功時は設定画面に「**はじめの地へ もどりました。精霊ブルスコンから 冒険できます。**」を表示 (`done` state、6s で自然消去)。`busy` は `finally` で確実に解除。
- `armOnboardingReplay` / セクション説明文の doc を「遷移しない」前提に更新。
- 着地先 /spirit の手応え問題だった #403 は前提ごと解消のためクローズ。

## 検証
- `typecheck` / `test` (346 passed) / `build` (development env) 緑。
- dev 実機確認予定: 設定 → 「⟲ あおぞらワールドを はじめから」→ **設定画面のまま完了表示** → 自分で精霊ブルスコン→冒険する→イントロ→手渡し→祝福。

## Review

§1.5 の 3 並列 subagent レビュー (設計 / 実装 / UX) を実施。**★★★ 0 件 / ★★ (未対応) 0 件。**

**★★ (PR 内で対応済み)**
- **成功表示が次回リセットまで居座る** (設計・UX): 設定画面に留まる設計上、他操作中も残る → 6s で自然消去する `useEffect` を追加 (unmount で clear)。(commit f262f10)

**★ (PR 内で対応済み)**
- **成功表示の残像** (実装): `setDone(false)`/`setErr(null)` を confirm の前へ移動。成功表示中に再度押してキャンセルしても前回メッセージが残らない。(commit f262f10)
- **成功文のトーン割れ** (UX): 「リセットしました ✅ …」→「はじめの地へ もどりました。精霊ブルスコンから 冒険できます。」明滅文「はじめの地へ もどしています…」と対になり ✅ の実務トーン割れを解消。(commit f262f10)

**★ (対応不要と判断・記録)**
- **説明文と成功文の「冒険」重複** (UX): 事前案内 (説明文) と事後の次の一手 (成功文) で役割が異なり、成功文だけ見て完結する自己完結として許容。
- **docs/19 に reset 導線の記述なし** (設計): reset の完全ワイプ/オンボード再生フローは source docstring が事実上の設計書として self-contained に維持されており、docstring を正とする運用で現状維持。