### PR TITLE
feat(world): 会話ウィンドウをマップ枠内にオーバーレイ表示 (DQ 風)

### DIFF
--- a/apps/web/src/components/dialogue-window.tsx
+++ b/apps/web/src/components/dialogue-window.tsx
@@ -24,6 +24,13 @@ import {
 
 const CHAR_MS = 45;
 
+/** 会話レイヤーの z。送り面 (透明背景) は footer 等の背後 UI より上に全画面で敷き、窓本体は
+ *  さらにその上。地図内の HUD/戦闘 (world-hud の HUD_Z=2 / OVERLAY_Z=3) や地図枠より十分上、
+ *  祝福の全画面演出 (welcome-blessing z=1100) よりは下。祖先に transform/filter が無いので
+ *  position:fixed は viewport に貼れる (footer まで覆える) — anchor='map' でも同じ。 */
+const DIALOGUE_BACKDROP_Z = 900;
+const DIALOGUE_WINDOW_Z = 901;
+
 /** visually-hidden (スクリーンリーダーにだけ全文を渡す) */
 const SR_ONLY: React.CSSProperties = {
   position: 'absolute',
@@ -106,40 +113,39 @@ export function DialogueWindow({
   const complete = lineComplete(lines, st);
 
   return (
-    // 全面オーバーレイ: どこをタップしても会話が進む (DQ の会話送り)。
-    // 背後の UI (スティック・ボタン) への誤タップもこれで防ぐ
-    <div
-      ref={overlayRef}
-      role="dialog"
-      aria-modal="true"
-      aria-label={line.speaker ? `${line.speaker}のセリフ` : 'セリフ'}
-      onClick={advance}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          advance();
-        }
-      }}
-      tabIndex={0}
-      style={{
-        // 'map' は地図枠内 (absolute) に敷く。z は地図内の HUD/戦闘 (HUD_Z=2/OVERLAY_Z=3)
-        // より上。'viewport' は従来どおり画面全体に固定。
-        position: onMap ? 'absolute' : 'fixed',
-        inset: 0,
-        zIndex: onMap ? 12 : 900,
-        cursor: 'pointer',
-        background: 'transparent',
-      }}
-    >
+    <>
+      {/* 送り面: **常に画面全体を覆う** 透明レイヤー。どこをタップしても会話が進み、footer や
+          スティック等の背後 UI への誤タップ・誤遷移を防ぐ。anchor='map' で窓を地図に貼っても
+          この送り面は viewport 全面のままなので、画面下端 (footer 際) を送ろうとしても効く
+          (地図枠だけを覆うと footer 遷移で会話が中断する回帰があった — レビュー ★★)。 */}
       <div
+        ref={overlayRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={line.speaker ? `${line.speaker}のセリフ` : 'セリフ'}
+        onClick={advance}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            advance();
+          }
+        }}
+        tabIndex={0}
+        style={{ position: 'fixed', inset: 0, zIndex: DIALOGUE_BACKDROP_Z, cursor: 'pointer', background: 'transparent' }}
+      />
+      {/* 窓本体: 'viewport' は footer 際に固定、'map' は直近の position:relative 祖先
+          (ワールドの地図枠) の下端に貼る (DQ 風。オーナー指摘 2026-07-20)。送り面より上 (z)。 */}
+      <div
+        onClick={advance}
         style={{
-          position: 'absolute',
+          position: onMap ? 'absolute' : 'fixed',
           left: '50%',
           // 'map': 地図枠の下端に貼る (DQ 風)。'viewport': footer 実測高 (app-shell) に追従
           bottom: onMap ? '0.5em' : 'calc(var(--footer-height, 4.5em) + 0.5em)',
           transform: 'translateX(-50%)',
           width: onMap ? 'calc(100% - 0.8em)' : 'min(94vw, 520px)',
           maxWidth: 520,
+          zIndex: DIALOGUE_WINDOW_Z,
         }}
       >
         {line.speaker && (
@@ -164,7 +170,10 @@ export function DialogueWindow({
         )}
         <div
           className="dq-window"
-          style={{ padding: '0.7em 0.9em 0.8em', minHeight: '5.8em', fontSize: '0.92em', lineHeight: 1.7 }}
+          // maxHeight/overflowY: 将来の長い NPC セリフでも窓がアバターに被らないよう上限を設ける
+          //   (DQ も 1 窓は数行で固定 — レビュー ★★)。marginBottom:0: dq-window 既定の 0.9em を
+          //   打ち消し、地図枠の下端 (bottom:0.5em) にぴったり寄せる (レビュー ★)。
+          style={{ padding: '0.7em 0.9em 0.8em', minHeight: '5.8em', maxHeight: '34vh', overflowY: 'auto', marginBottom: 0, fontSize: '0.92em', lineHeight: 1.7 }}
         >
           {/* 部分文字列の逐次読み上げは SR に不向きなので、全文を visually-hidden で
               先に置き、タイプ表示は aria-hidden にする (汎用要素の aria-label は
@@ -183,6 +192,6 @@ export function DialogueWindow({
 @media (prefers-reduced-motion: reduce) { .aq-dialogue-next { animation: none; } }
 `}</style>
       </div>
-    </div>
+    </>
   );
 }

--- a/apps/web/src/components/dialogue-window.tsx
+++ b/apps/web/src/components/dialogue-window.tsx
@@ -41,13 +41,19 @@ export function DialogueWindow({
   lines,
   plateIcon,
   onDone,
+  anchor = 'viewport',
 }: {
   lines: readonly DialogueLine[];
   /** 話者名プレートに添えるアイコン (例: ブルスコンは SpiritIcon — 他画面の
    *  吹き出しと同じ顔で認識できるように)。NPC ごとの出し分けは呼び出し側の責務 */
   plateIcon?: React.ReactNode;
   onDone: () => void;
+  /** 出す位置。'viewport' = 画面下端 (footer 際) に固定 (既定)。'map' = 直近の
+   *  position:relative 祖先 (ワールドの地図枠) の下部にオーバーレイし、DQ 風に
+   *  「マップ上」へ会話窓を出す (オーナー指摘 2026-07-20)。 */
+  anchor?: 'viewport' | 'map';
 }) {
+  const onMap = anchor === 'map';
   const [st, setSt] = useState(startDialogue);
   const reduced = useMemo(
     () => typeof matchMedia !== 'undefined' && matchMedia('(prefers-reduced-motion: reduce)').matches,
@@ -115,15 +121,25 @@ export function DialogueWindow({
         }
       }}
       tabIndex={0}
-      style={{ position: 'fixed', inset: 0, zIndex: 900, cursor: 'pointer', background: 'transparent' }}
+      style={{
+        // 'map' は地図枠内 (absolute) に敷く。z は地図内の HUD/戦闘 (HUD_Z=2/OVERLAY_Z=3)
+        // より上。'viewport' は従来どおり画面全体に固定。
+        position: onMap ? 'absolute' : 'fixed',
+        inset: 0,
+        zIndex: onMap ? 12 : 900,
+        cursor: 'pointer',
+        background: 'transparent',
+      }}
     >
       <div
         style={{
           position: 'absolute',
           left: '50%',
-          bottom: 'calc(var(--footer-height, 4.5em) + 0.5em)', // footer 実測高 (app-shell が書き出す) に追従
+          // 'map': 地図枠の下端に貼る (DQ 風)。'viewport': footer 実測高 (app-shell) に追従
+          bottom: onMap ? '0.5em' : 'calc(var(--footer-height, 4.5em) + 0.5em)',
           transform: 'translateX(-50%)',
-          width: 'min(94vw, 520px)',
+          width: onMap ? 'calc(100% - 0.8em)' : 'min(94vw, 520px)',
+          maxWidth: 520,
         }}
       >
         {line.speaker && (

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -1172,28 +1172,44 @@ export function World() {
               )}
             </div>
           )}
+          {/* 会話ウィンドウは**地図枠内**にオーバーレイする (DQ 風。以前は画面下端の footer 際に
+              出て「マップ上」に見えなかった — オーナー指摘 2026-07-20)。anchor="map" で、この
+              position:relative の地図枠の下部に貼る。一度に出るのは 1 つ (相互にガード)。 */}
+          {onboarding && (
+            <DialogueWindow
+              anchor="map"
+              lines={ONBOARDING_LINES}
+              plateIcon={<SpiritIcon size={20} />}
+              onDone={() => {
+                setOnboarding(false);
+                onboardingRef.current = false;
+                try { localStorage.setItem(ONBOARDING_DONE_KEY, '1'); } catch { /* private mode */ }
+              }}
+            />
+          )}
+          {showStarter && !onboarding && (
+            // ブルスコンが やくそう と そらのはね を手渡す。リセット (実 +20 付与) 経由のときだけ
+            // 祝福のセリフを足し、読み終えた瞬間に祝福演出を出す (以前は地図でいきなり出てフローが
+            // 分からなかった — オーナー指摘 2026-07-20)。starterBlessed は入場時にマークから確定済み。
+            // 声はブルスコンのトーンに合わせ ひらがな主体で統一 (UX レビュー ★)。
+            <DialogueWindow
+              anchor="map"
+              lines={[
+                { speaker: 'ブルスコン', text: 'たびの はじめに、やくそう と そらのはね を もたせよう。' },
+                { speaker: 'ブルスコン', text: 'やくそうは きずを いやす。そらのはねは いったことの ある街へ もどれる。こまったら どうぐ から つかうといい。' },
+                starterBlessed
+                  ? { speaker: 'ブルスコン', text: 'それと、はじまりの しゅくふくを。あおぞらパワーを 20 さずけるよ。よい たびを。' }
+                  : { speaker: 'ブルスコン', text: 'よい たびを。' },
+              ]}
+              plateIcon={<SpiritIcon size={20} />}
+              onDone={() => { setShowStarter(false); if (starterBlessed) notifyWelcome({ power: WELCOME_POWER }); }}
+            />
+          )}
+          {searchMsg !== null && (
+            <DialogueWindow anchor="map" lines={[{ text: searchMsg }]} onDone={() => setSearchMsg(null)} />
+          )}
         </div>
       </div>
-      {searchMsg !== null && (
-        <DialogueWindow lines={[{ text: searchMsg }]} onDone={() => setSearchMsg(null)} />
-      )}
-      {showStarter && !onboarding && (
-        // ブルスコンが やくそう と そらのはね を手渡す。リセット (実 +20 付与) 経由のときだけ
-        // 祝福のセリフを足し、読み終えた瞬間に祝福演出を出す (以前は地図でいきなり出てフローが
-        // 分からなかった — オーナー指摘 2026-07-20)。starterBlessed は入場時にマークから確定済み。
-        // 声はブルスコンのトーンに合わせ ひらがな主体で統一 (UX レビュー ★)。
-        <DialogueWindow
-          lines={[
-            { speaker: 'ブルスコン', text: 'たびの はじめに、やくそう と そらのはね を もたせよう。' },
-            { speaker: 'ブルスコン', text: 'やくそうは きずを いやす。そらのはねは いったことの ある街へ もどれる。こまったら どうぐ から つかうといい。' },
-            starterBlessed
-              ? { speaker: 'ブルスコン', text: 'それと、はじまりの しゅくふくを。あおぞらパワーを 20 さずけるよ。よい たびを。' }
-              : { speaker: 'ブルスコン', text: 'よい たびを。' },
-          ]}
-          plateIcon={<SpiritIcon size={20} />}
-          onDone={() => { setShowStarter(false); if (starterBlessed) notifyWelcome({ power: WELCOME_POWER }); }}
-        />
-      )}
 
       {/* マップ下: 戦闘/リザルトはマップ枠内で完結するので何も出さない (縦スクロール
           をなくす — オーナー要望 2026-07-18)。通常時のみ操作ヒント。 */}
@@ -1263,17 +1279,6 @@ export function World() {
           mp={curMp}
           gearPieces={resolvedGear?.pieces ?? {}}
           onClose={() => setStatusOpen(false)}
-        />
-      )}
-      {onboarding && (
-        <DialogueWindow
-          lines={ONBOARDING_LINES}
-          plateIcon={<SpiritIcon size={20} />}
-          onDone={() => {
-            setOnboarding(false);
-            onboardingRef.current = false;
-            try { localStorage.setItem(ONBOARDING_DONE_KEY, '1'); } catch { /* private mode */ }
-          }}
         />
       )}
       {gearOpen && (

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -1174,8 +1174,10 @@ export function World() {
           )}
           {/* 会話ウィンドウは**地図枠内**にオーバーレイする (DQ 風。以前は画面下端の footer 際に
               出て「マップ上」に見えなかった — オーナー指摘 2026-07-20)。anchor="map" で、この
-              position:relative の地図枠の下部に貼る。一度に出るのは 1 つ (相互にガード)。 */}
-          {onboarding && (
+              position:relative の地図枠の下部に貼る。一度に出るのは 1 つ (相互にガード)。
+              会話は z が戦闘オーバーレイ (OVERLAY_Z) より上なので、状態機械のガードに加えて
+              !battle でも囲い、万一の同時表示で戦闘操作が塞がれる事故を防ぐ (レビュー ★★)。 */}
+          {!battle && onboarding && (
             <DialogueWindow
               anchor="map"
               lines={ONBOARDING_LINES}
@@ -1187,7 +1189,7 @@ export function World() {
               }}
             />
           )}
-          {showStarter && !onboarding && (
+          {!battle && showStarter && !onboarding && (
             // ブルスコンが やくそう と そらのはね を手渡す。リセット (実 +20 付与) 経由のときだけ
             // 祝福のセリフを足し、読み終えた瞬間に祝福演出を出す (以前は地図でいきなり出てフローが
             // 分からなかった — オーナー指摘 2026-07-20)。starterBlessed は入場時にマークから確定済み。
@@ -1205,7 +1207,7 @@ export function World() {
               onDone={() => { setShowStarter(false); if (starterBlessed) notifyWelcome({ power: WELCOME_POWER }); }}
             />
           )}
-          {searchMsg !== null && (
+          {!battle && searchMsg !== null && (
             <DialogueWindow anchor="map" lines={[{ text: searchMsg }]} onDone={() => setSearchMsg(null)} />
           )}
         </div>


### PR DESCRIPTION
## 背景 (オーナー指摘 2026-07-20)

> ブルスコンのセリフはマップ上にオーバーレイ表示してください。

会話ウィンドウ (`DialogueWindow`) は画面下端 (footer 際) に `position:fixed` で固定され、マップ枠から離れた画面下に出ていた。DQ のように地図枠の下部へ会話窓を重ねる。

## 変更
- `DialogueWindow` に `anchor?: 'viewport' | 'map'` を追加 (既定 `viewport`)。
  - **送り面** (タップで会話送りする透明レイヤー) は**常に全画面 `position:fixed`** で維持 → footer 等の背後 UI を覆い、どこをタップしても会話が進む。
  - **窓本体**だけを anchor で出し分け: `map` は直近の `position:relative` 祖先 (地図枠) の下端に `position:absolute` で貼る / `viewport` は従来どおり footer 際。
- `world.tsx` の in-world 会話 3 種 (オンボード導入 / ブルスコンの手渡し / しらべる結果) を地図枠の内側へ移し `anchor="map"`。

## 検証
- `typecheck` / `test` (346 passed) / `build` (development env) 緑。
- 祖先 (`.dq-window` / 地図枠) に `transform`/`filter`/`will-change` が無く、地図枠内でも `position:fixed` が viewport に貼れる (footer まで覆える) ことをソースで確認。
- dev 実機確認予定: リセット→ブルスコン画面→冒険する→**マップ上に**導入・手渡しセリフが重なる。画面下端をタップしても会話が進み footer に飛ばない。

## Review

§1.5 3 並列 subagent レビュー (設計 / 実装 / UX) を実施。**★★★ 0 件。** 実装レビューは ★★ 0 件。

**★★ (PR 内で対応済み)**
- **footer 誤タップで会話中断の回帰** (設計・UX): map anchor で送り面が地図枠内だけになっていた → 送り面を**全画面 fixed に維持**し、窓本体だけを anchor で出し分ける構成へ。footer を覆うので会話中に誤遷移しない。(commit 5d62c37)
- **会話 z が戦闘オーバーレイより上** (設計): 万一の同時表示で戦闘操作が塞がれうる → 3 会話を `!battle` でも囲い JSX の安全弁を追加。(commit 5d62c37)
- **長文でアバターに被る恐れ** (UX): 窓本体に `maxHeight:34vh` + `overflowY` を設定 (DQ も 1 窓は数行固定)。(commit 5d62c37)

**★ (PR 内で対応済み)**
- **z のマジックナンバー** (設計・実装): `12` を `DIALOGUE_BACKDROP_Z`/`DIALOGUE_WINDOW_Z` 定数に整理。(commit 5d62c37)
- **窓下端のズレ** (UX): 本文の `dq-window` 既定 `margin-bottom:0.9em` を打ち消し、地図枠下端にぴったり寄せた。(commit 5d62c37)

**確認済み・指摘に至らず**: DOM 移設の残骸なし・二重描画なし (旧 onboarding ブロック削除)。anchor 既定 `viewport` で後方互換維持。clipping なし (祖先に overflow:hidden なし)。