### PR TITLE
feat(battle): 序盤バランス再設計 — 敵の強さと XP を連動 + tier1 の HP を明示して弱く

### DIFF
--- a/packages/core/src/__tests__/battle.test.ts
+++ b/packages/core/src/__tests__/battle.test.ts
@@ -234,11 +234,27 @@ describe('summonMonster', () => {
       // tier1 内: 硬い ヒカリダケ > 最弱 そらいろスライム (HP 連動)
       expect(battleXpFor('glow-shroom')).toBeGreaterThan(battleXpFor('sky-slime'));
       expect(new Set(MONSTERS.map((m) => battleXpFor(m.id))).size).toBeGreaterThan(1);
-      // レアなジャックポット (はぐれメタル型 spawnWeight<0.1) を除けば tier が上ほど上限が高い
+      // レアなジャックポット (はぐれメタル型) を除けば tier が上ほど上限が高い。閾値未満の
+      // spawnWeight = 「tier 単調性の対象外にするレア敵」の境界 (stray=0.06 を除外)。
+      const RARE_JACKPOT_MAX_SPAWN = 0.1;
       const maxOf = (t: 1 | 2 | 3) =>
-        Math.max(...MONSTERS.filter((m) => m.tier === t && (m.spawnWeight ?? 1) >= 0.1).map((m) => battleXpFor(m.id)));
+        Math.max(
+          ...MONSTERS.filter((m) => m.tier === t && (m.spawnWeight ?? 1) >= RARE_JACKPOT_MAX_SPAWN).map((m) => battleXpFor(m.id)),
+        );
       expect(maxOf(2)).toBeGreaterThan(maxOf(1));
       expect(maxOf(3)).toBeGreaterThan(maxOf(2));
+    });
+
+    it('tier2/3 は xp を明示している (式は tier1 校正なので省略すると過小になる — 回帰防止)', () => {
+      // baselineXp は tier1 帯校正。tier2/3 で xp を省くと式が ~1/3〜1/8 に崩落するため、
+      // 上位 tier は必ず明示 xp を持たせる契約 (レビュー ★★)。
+      for (const m of MONSTERS) {
+        if (m.tier >= 2) {
+          expect(m.xp, `${m.id} (tier${m.tier}) は xp を明示すべき`).toBeGreaterThan(0);
+          // 式より十分高い (明示の意味がある) ことも確認
+          expect(m.xp!).toBeGreaterThan(baselineXp(m));
+        }
+      }
     });
 
     it('式 baselineXp: 基準 HP + atk/agi から算出 (xp 省略時のデフォルト)', () => {

--- a/packages/core/src/__tests__/battle.test.ts
+++ b/packages/core/src/__tests__/battle.test.ts
@@ -8,6 +8,7 @@ import {
   playerCombatant,
   summonMonster,
   battleXpFor,
+  baselineXp,
   favoredMonsterFor,
   pickTrialTier,
   startBattle,
@@ -173,8 +174,8 @@ describe('summonMonster', () => {
       expect(m?.drops.some((d) => d.item === mat)).toBe(true); // 専用素材を落とす
       expect(ITEMS[mat]).toBeDefined();
     }
-    // そらいろスライムは最弱の練習敵 (xp 3)
-    expect(MONSTERS_BY_ID['sky-slime']?.xp).toBe(3);
+    // そらいろスライムは最弱の練習敵 (式で最低クラスの XP)。強い版 (red-slime) より低い。
+    expect(battleXpFor('sky-slime')).toBeLessThan(battleXpFor('red-slime'));
   });
 
   it('はぐれスライム: HP 明示で低い + fleer は逃走して monster-fled で決着 (勝敗なし)', () => {
@@ -224,21 +225,34 @@ describe('summonMonster', () => {
     }
   });
 
-  describe('勝利 XP はモンスター個別 (battleXpFor)', () => {
-    it('全モンスターに xp>0 が定義されている', () => {
-      for (const m of MONSTERS) expect(m.xp).toBeGreaterThan(0);
+  describe('勝利 XP は式＋個別調整 (battleXpFor / baselineXp)', () => {
+    it('全モンスターの勝利 XP は 0 より大きい (式 or 個別上書き)', () => {
+      for (const m of MONSTERS) expect(battleXpFor(m.id)).toBeGreaterThan(0);
     });
 
-    it('XP は一律でなく幅がある / 強い tier ほど上限が高い', () => {
-      expect(new Set(MONSTERS.map((m) => m.xp)).size).toBeGreaterThan(1);
-      const maxOf = (t: 1 | 2 | 3) => Math.max(...MONSTERS.filter((m) => m.tier === t).map((m) => m.xp));
+    it('XP は敵の強さと連動する: 硬い敵ほど高い / 上位 tier ほど上限が高い (レア除く)', () => {
+      // tier1 内: 硬い ヒカリダケ > 最弱 そらいろスライム (HP 連動)
+      expect(battleXpFor('glow-shroom')).toBeGreaterThan(battleXpFor('sky-slime'));
+      expect(new Set(MONSTERS.map((m) => battleXpFor(m.id))).size).toBeGreaterThan(1);
+      // レアなジャックポット (はぐれメタル型 spawnWeight<0.1) を除けば tier が上ほど上限が高い
+      const maxOf = (t: 1 | 2 | 3) =>
+        Math.max(...MONSTERS.filter((m) => m.tier === t && (m.spawnWeight ?? 1) >= 0.1).map((m) => battleXpFor(m.id)));
       expect(maxOf(2)).toBeGreaterThan(maxOf(1));
       expect(maxOf(3)).toBeGreaterThan(maxOf(2));
     });
 
-    it('battleXpFor は個別 xp を返し、未知 id は xpWin フォールバック', () => {
-      expect(battleXpFor('sky-slime')).toBe(MONSTERS_BY_ID['sky-slime']!.xp);
-      expect(battleXpFor('sky-dragon')).toBe(MONSTERS_BY_ID['sky-dragon']!.xp);
+    it('式 baselineXp: 基準 HP + atk/agi から算出 (xp 省略時のデフォルト)', () => {
+      // sky-slime は xp 未指定 → 式で算出。低 HP なので低 XP。
+      expect(MONSTERS_BY_ID['sky-slime']!.xp).toBeUndefined();
+      expect(battleXpFor('sky-slime')).toBe(baselineXp(MONSTERS_BY_ID['sky-slime']!));
+      expect(battleXpFor('sky-slime')).toBeLessThanOrEqual(3);
+    });
+
+    it('個別上書き: はぐれスライムは低 HP でも xp=100 (ジャックポット)、未知 id は xpWin', () => {
+      expect(MONSTERS_BY_ID['stray-slime']!.xp).toBe(100);
+      expect(battleXpFor('stray-slime')).toBe(100);
+      // 低 HP なので式なら低 XP になる = 上書きが効いている証拠
+      expect(baselineXp(MONSTERS_BY_ID['stray-slime']!)).toBeLessThan(100);
       expect(battleXpFor('no-such-monster')).toBe(BATTLE_TUNING.xpWin);
     });
   });

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -484,11 +484,10 @@ export interface MonsterDef {
    *  「あかいスライム」等の強い版/レッサーを安価に作る (オーナー要望 2026-07-19)。
    *  hue-rotate は輝度保存で狙った色にならない事故があるため明示色を持たせる。 */
   tint?: string;
-  /** 勝利時に得る XP。tier を目安にモンスター個別に設定して幅を持たせる (tier だけで
-   *  決めると はぐれメタルのような「同 tier で飛び抜けて高 XP」の敵が作れない —
-   *  オーナー要望 2026-07-18)。なお本格的なはぐれメタル型 (高 xp + 高回避 + 低 HP +
-   *  高逃走) には別途モンスター側の逃走挙動が要る (未実装。#341)。 */
-  xp: number;
+  /** 勝利時に得る XP の**個別上書き**。省略時は `baselineXp(def)` が実効的な強さ (基準 HP +
+   *  atk/agi) から算出する (式＋個別調整 — オーナー要望 2026-07-20)。低 HP なのに高 XP の
+   *  はぐれメタル型ジャックポットや、式が合わない上位 tier はここで明示する。 */
+  xp?: number;
   drops: readonly DropDef[];
   /** ひとこと (召喚時の口上に使う) */
   intro: string;
@@ -525,20 +524,21 @@ export const ITEMS: Record<string, { name: string }> = {
 };
 
 export const MONSTERS: readonly MonsterDef[] = [
-  // tier1: 手習い (初心者でも勝てる)。xp 14〜30。同 tier 内も体感できる幅を持たせる
-  // (レビュー: 差が小さすぎると誤差に埋もれる)。tier をまたぐ差はさらに大きい。
-  // そらいろスライム: 最弱の練習敵 (xp3・低ドロップ)。「初期からスライムが強すぎる」を解消
-  // し、はぐれメタルの通常版という位置づけに (オーナー要望 2026-07-19)。
-  { id: 'sky-slime', name: 'そらいろスライム', species: 'slime', tier: 1, stats: [7, 7, 8, 6, 10], xp: 3, drops: [{ item: 'slime-drop', chance: 0.3 }, { item: 'herb', chance: 0.35 }], intro: 'ぷるぷると跳ねている。' },
-  // 色違い強い版 (tint で塗り替え)。base より手強く XP/素材も上。専用素材 red-jelly。
-  { id: 'red-slime', name: 'あかいスライム', species: 'slime', tint: '#e0574a', spawnWeight: 0.4, tier: 1, stats: [13, 12, 10, 8, 12], xp: 10, drops: [{ item: 'red-jelly', chance: 0.5 }, { item: 'herb', chance: 0.08 }], intro: '赤くぬめって 脈打っている。' },
-  { id: 'cave-bat', name: 'ほらあなコウモリ', species: 'bat', tier: 1, stats: [12, 8, 26, 6, 12], xp: 22, drops: [{ item: 'bat-wing', chance: 0.6 }, { item: 'herb', chance: 0.3 }, { item: 'sky-feather', chance: 0.12 }], intro: 'ばさばさと羽音を立てている。' },
-  { id: 'dusk-bat', name: 'よるのコウモリ', species: 'bat', tint: '#5b6bd0', spawnWeight: 0.4, tier: 1, stats: [14, 9, 28, 7, 13], xp: 20, drops: [{ item: 'dusk-wing', chance: 0.5 }, { item: 'sky-feather', chance: 0.12 }], intro: '夜色の翼で 音もなく舞う。' },
-  { id: 'glow-shroom', name: 'ヒカリダケ', species: 'mushroom', tier: 1, stats: [8, 20, 4, 18, 12], xp: 30, drops: [{ item: 'mush-spore', chance: 0.6 }, { item: 'herb', chance: 0.4 }, { item: 'sky-dew', chance: 0.25 }], intro: 'ほんのり光って動かない…?' },
-  { id: 'crimson-shroom', name: 'べにヒカリダケ', species: 'mushroom', tint: '#c23a5b', spawnWeight: 0.4, tier: 1, stats: [9, 22, 4, 20, 12], xp: 26, drops: [{ item: 'crimson-spore', chance: 0.5 }, { item: 'sky-dew', chance: 0.2 }], intro: '毒々しい紅に 明滅している。' },
-  // はぐれメタル型: レア出現・低 HP・高 XP・毎ターン逃走。倒せれば旨いが逃げられると何も残らない
-  // (オーナー要望 2026-07-19)。HP は明示 (導出だと def なりに増えるため)。高 agi で逃げ足も速い。
-  { id: 'stray-slime', name: 'はぐれスライム', species: 'metal-slime', tier: 1, stats: [8, 22, 38, 6, 34], hp: 12, mp: 0, xp: 45, spawnWeight: 0.06, drops: [{ item: 'metal-shard', chance: 0.5 }], ability: 'fleer', intro: 'きらりと 金属の光を放っている。' },
+  // tier1: 手習い (初心者でも勝てる)。**HP を明示して弱い敵は本当に弱く**した (以前は hpBase=66 が
+  // 支配的で全 tier1 が HP~70 横並び → 序盤が重い真因。オーナー指摘 2026-07-20)。XP は xp を省いて
+  // baselineXp (基準 HP + atk/agi) で自動算出 = 敵の強さと XP が構造的に連動する (スライム 2・
+  // ヒカリダケ 8 程度)。個別に効かせたい敵だけ xp を明示する。
+  // そらいろスライム: 最弱の練習敵 (低 HP・低 XP・低ドロップ)。序盤の的。
+  { id: 'sky-slime', name: 'そらいろスライム', species: 'slime', tier: 1, stats: [7, 7, 8, 6, 10], hp: 20, drops: [{ item: 'slime-drop', chance: 0.3 }, { item: 'herb', chance: 0.35 }], intro: 'ぷるぷると跳ねている。' },
+  // 色違い強い版 (tint で塗り替え)。base より少し硬く XP/素材も上。専用素材 red-jelly。
+  { id: 'red-slime', name: 'あかいスライム', species: 'slime', tint: '#e0574a', spawnWeight: 0.4, tier: 1, stats: [13, 12, 10, 8, 12], hp: 30, drops: [{ item: 'red-jelly', chance: 0.5 }, { item: 'herb', chance: 0.08 }], intro: '赤くぬめって 脈打っている。' },
+  { id: 'cave-bat', name: 'ほらあなコウモリ', species: 'bat', tier: 1, stats: [12, 8, 26, 6, 12], hp: 44, drops: [{ item: 'bat-wing', chance: 0.6 }, { item: 'herb', chance: 0.3 }, { item: 'sky-feather', chance: 0.12 }], intro: 'ばさばさと羽音を立てている。' },
+  { id: 'dusk-bat', name: 'よるのコウモリ', species: 'bat', tint: '#5b6bd0', spawnWeight: 0.4, tier: 1, stats: [14, 9, 28, 7, 13], hp: 40, drops: [{ item: 'dusk-wing', chance: 0.5 }, { item: 'sky-feather', chance: 0.12 }], intro: '夜色の翼で 音もなく舞う。' },
+  { id: 'glow-shroom', name: 'ヒカリダケ', species: 'mushroom', tier: 1, stats: [8, 20, 4, 18, 12], hp: 62, drops: [{ item: 'mush-spore', chance: 0.6 }, { item: 'herb', chance: 0.4 }, { item: 'sky-dew', chance: 0.25 }], intro: 'ほんのり光って動かない…?' },
+  { id: 'crimson-shroom', name: 'べにヒカリダケ', species: 'mushroom', tint: '#c23a5b', spawnWeight: 0.4, tier: 1, stats: [9, 22, 4, 20, 12], hp: 56, drops: [{ item: 'crimson-spore', chance: 0.5 }, { item: 'sky-dew', chance: 0.2 }], intro: '毒々しい紅に 明滅している。' },
+  // はぐれメタル型: レア出現・低 HP・**高 XP (100)**・毎ターン逃走。倒せれば旨いが逃げられると何も
+  // 残らない (オーナー要望 2026-07-20)。低 HP なので式では低 XP になる → ジャックポットとして xp を明示。
+  { id: 'stray-slime', name: 'はぐれスライム', species: 'metal-slime', tier: 1, stats: [8, 22, 38, 6, 34], hp: 12, mp: 0, xp: 100, spawnWeight: 0.06, drops: [{ item: 'metal-shard', chance: 0.5 }], ability: 'fleer', intro: 'きらりと 金属の光を放っている。' },
   // tier2: 修練。xp 34〜52 (healer は削り合いが長引くぶん高め)
   { id: 'moss-golem', name: 'こけむしゴーレム', species: 'golem', tier: 2, stats: [26, 36, 6, 10, 8], xp: 34, drops: [{ item: 'golem-core', chance: 0.5 }, { item: 'herb', chance: 0.2 }], intro: '地響きを立てて起き上がった。', skillName: 'いわなだれ', ability: 'charger' },
   { id: 'will-o-wisp', name: 'あおい鬼火', species: 'wisp', tier: 2, stats: [10, 12, 24, 34, 12], xp: 52, drops: [{ item: 'wisp-ember', chance: 0.5 }, { item: 'sky-dew', chance: 0.35 }], intro: 'ゆらゆらとこちらを見ている。', ability: 'healer', healName: 'いやしのゆらめき' },
@@ -553,10 +553,27 @@ export const MONSTERS_BY_ID: Record<string, MonsterDef> = Object.fromEntries(
   MONSTERS.map((m) => [m.id, m]),
 );
 
-/** 勝利時に得る XP (モンスター個別)。未知 id は BATTLE_TUNING.xpWin にフォールバック。
- *  world / 試練の両方でこれを使う (勝利 XP を一律固定にしない)。 */
+/** XP 算出式の係数 (式＋個別調整の「式」側)。倒す手間 (基準 HP) と脅威 (atk+agi) から出す。
+ *  tier1 帯 (基準 HP 12〜62) でおおむね 2〜9 になるよう校正 (オーナー要望 2026-07-20)。 */
+const XP_HP_FLOOR = 10; // これ以下の基準 HP は XP に寄与しない (最弱の下限を作る)
+const XP_HP_SCALE = 0.15; // 基準 HP 1 あたりの XP
+const XP_OFFENSE_SCALE = 0.04; // (atk+agi) 1 あたりの XP (素早い/強い敵を少し厚く)
+
+/** モンスターの XP 既定値を「実効的な強さ」から算出する。基準 HP は def.hp があればそれ、
+ *  無ければ従来の導出 (hpBase + def*hpDefScale)。敵の強さと XP を構造的に連動させる
+ *  (スライム=低 HP=低 XP、硬い敵=高 HP=高 XP。オーナー要望 2026-07-20)。 */
+export function baselineXp(def: MonsterDef): number {
+  const baseHp = def.hp ?? BATTLE_TUNING.hpBase + def.stats[1] * BATTLE_TUNING.hpDefScale;
+  const [atk, , agi] = def.stats;
+  return Math.max(1, Math.round(Math.max(0, baseHp - XP_HP_FLOOR) * XP_HP_SCALE + (atk + agi) * XP_OFFENSE_SCALE));
+}
+
+/** 勝利時に得る XP。def.xp があればそれ (個別上書き)、無ければ baselineXp。
+ *  未知 id は BATTLE_TUNING.xpWin にフォールバック。world / 試練の両方でこれを使う。 */
 export function battleXpFor(monsterId: string): number {
-  return MONSTERS_BY_ID[monsterId]?.xp ?? BATTLE_TUNING.xpWin;
+  const def = MONSTERS_BY_ID[monsterId];
+  if (!def) return BATTLE_TUNING.xpWin;
+  return def.xp ?? baselineXp(def);
 }
 
 /**

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -559,9 +559,16 @@ const XP_HP_FLOOR = 10; // これ以下の基準 HP は XP に寄与しない (�
 const XP_HP_SCALE = 0.15; // 基準 HP 1 あたりの XP
 const XP_OFFENSE_SCALE = 0.04; // (atk+agi) 1 あたりの XP (素早い/強い敵を少し厚く)
 
-/** モンスターの XP 既定値を「実効的な強さ」から算出する。基準 HP は def.hp があればそれ、
- *  無ければ従来の導出 (hpBase + def*hpDefScale)。敵の強さと XP を構造的に連動させる
- *  (スライム=低 HP=低 XP、硬い敵=高 HP=高 XP。オーナー要望 2026-07-20)。 */
+/** モンスターの XP 既定値を「実効的な強さ」から算出する (式＋個別調整の式側)。基準 HP は
+ *  def.hp があればそれ、無ければ従来の導出 (hpBase + def*hpDefScale)。敵の強さと XP を
+ *  構造的に連動させる (スライム=低 HP=低 XP、硬い敵=高 HP=高 XP。オーナー要望 2026-07-20)。
+ *
+ *  **校正は tier1 帯のみ** (基準 HP 12〜62 でおおむね 2〜9)。tier2/3 に生で使うと過小になる
+ *  (例: sky-dragon 式 ~12 vs 現行 96) ので、**tier2/3 は必ず def.xp を明示する** (回帰テスト
+ *  「tier2/3 は xp を明示」で固定)。tier をまたいで式化したくなったら tier 係数が要る。
+ *
+ *  **基準 HP はレベル 1 相当の名目値**。実 HP は factor でレベルに応じ伸びるが、XP は
+ *  レベル非依存に固定する (サーバーが monsterId だけから決定的に再導出できるため — docs/21)。 */
 export function baselineXp(def: MonsterDef): number {
   const baseHp = def.hp ?? BATTLE_TUNING.hpBase + def.stats[1] * BATTLE_TUNING.hpDefScale;
   const [atk, , agi] = def.stats;

--- a/scripts/analyze-tier1-encounter.ts
+++ b/scripts/analyze-tier1-encounter.ts
@@ -1,0 +1,65 @@
+/**
+ * tier1 (序盤) の遭遇率・討伐率・実効 XP を算出する分析スクリプト。
+ *
+ * 目的: はぐれメタル型 (低 HP・高 XP・毎ターン逃走) の XP を高く設定しても、
+ * 「遭遇率 × 討伐率」で薄まるので序盤 XP を壊さないことを数値で確認する
+ * (オーナー要望 2026-07-20: 実際の遭遇率と討伐率を算出して影響を見る)。
+ *
+ * 実行: pnpm exec tsx scripts/analyze-tier1-encounter.ts
+ */
+import { MONSTERS, summonMonster, startBattle, resolveTurn, battleXpFor } from '../packages/core/src/index.js';
+
+const VARIANCE = 0.15; // world の monsterVitalsVariance
+
+// 1) 遭遇分布 (empirical, tier1, Lv1)
+const N = 200_000;
+const counts: Record<string, number> = {};
+for (let s = 0; s < N; s++) {
+  const id = summonMonster(1, 1, s, 1, undefined, VARIANCE).def.id;
+  counts[id] = (counts[id] ?? 0) + 1;
+}
+const tier1 = MONSTERS.filter((m) => m.tier === 1);
+console.log(`=== tier1 遭遇分布 (Lv1, ${N} 回) ===`);
+for (const m of tier1) {
+  const c = counts[m.id] ?? 0;
+  console.log(m.name.padEnd(12), `${((c / N) * 100).toFixed(2).padStart(6)}%`, `xp=${battleXpFor(m.id)}`);
+}
+
+// 2) はぐれスライム 討伐率 (毎ターン全力攻撃 = 倒しに行く。複数ジョブで平均)
+const jobs = ['warrior', 'mage', 'guardian', 'ninja', 'fighter'] as const;
+let killed = 0;
+let fled = 0;
+let trials = 0;
+for (const job of jobs) {
+  let found = 0;
+  for (let seed = 0; seed < 200_000 && found < 600; seed++) {
+    const b0 = startBattle(job, 1, 1, 't', 1, seed, VARIANCE);
+    if (b0.monsterId !== 'stray-slime') continue;
+    found++;
+    trials++;
+    let b = b0;
+    for (let ts = 0; ts < 40; ts++) {
+      b = resolveTurn(b, 'attack', ts);
+      if (b.outcome === 'win') { killed++; break; }
+      if (b.outcome === 'monster-fled') { fled++; break; }
+      if (b.outcome === 'lose' || b.outcome === 'draw' || b.outcome === 'fled') break;
+    }
+  }
+}
+const killRate = killed / trials;
+console.log(`\n=== はぐれスライム 討伐率 (全力攻撃, ${trials} 戦) ===`);
+console.log(`倒せた: ${(killRate * 100).toFixed(1)}% / 逃げられた: ${((fled / trials) * 100).toFixed(1)}%`);
+
+// 3) 実効 XP 寄与 = 遭遇率 × 討伐率 × XP
+const encRate = (counts['stray-slime'] ?? 0) / N;
+const slimeEnc = (counts['sky-slime'] ?? 0) / N;
+console.log('\n=== 実効 XP 寄与 (1 遭遇あたり平均) ===');
+console.log(`はぐれ  : 遭遇 ${(encRate * 100).toFixed(2)}% × 討伐 ${(killRate * 100).toFixed(0)}% × 100xp = ${(encRate * killRate * 100).toFixed(2)} xp/遭遇`);
+console.log(`そらいろ: 遭遇 ${(slimeEnc * 100).toFixed(2)}% × 討伐 ~100% × 2xp = ${(slimeEnc * 2).toFixed(2)} xp/遭遇`);
+let avgXp = 0;
+for (const m of tier1) {
+  const p = (counts[m.id] ?? 0) / N;
+  const kr = m.id === 'stray-slime' ? killRate : 1;
+  avgXp += p * kr * battleXpFor(m.id);
+}
+console.log(`\ntier1 平均 XP/遭遇 (討伐込み) ≈ ${avgXp.toFixed(2)} → JobLV2(30xp) まで約 ${Math.ceil(30 / avgXp)} 戦`);

--- a/scripts/analyze-tier1-encounter.ts
+++ b/scripts/analyze-tier1-encounter.ts
@@ -33,7 +33,8 @@ let trials = 0;
 for (const job of jobs) {
   let found = 0;
   for (let seed = 0; seed < 200_000 && found < 600; seed++) {
-    const b0 = startBattle(job, 1, 1, 't', 1, seed, VARIANCE);
+    // variance は extras.vitalsVariance で渡す (第7引数は herbs)。world と同じ分散モデルで討伐率を測る。
+    const b0 = startBattle(job, 1, 1, 't', 1, seed, 0, undefined, { vitalsVariance: VARIANCE });
     if (b0.monsterId !== 'stray-slime') continue;
     found++;
     trials++;


### PR DESCRIPTION
## 背景 (オーナー指摘 2026-07-20)

> あと敵の強さと経験値が全然連動してないです。スライムが3なのにヒカリダケは30とか差がありすぎです。序盤なのに経験値が高すぎる。スライムは経験値3なのだからHPももっと低くてもいいはずです。序盤の戦闘バランスに苦労してたのはそもそも序盤の敵が強すぎるからです。

**真因:** `hpBase=66` が支配的で全 tier1 が HP ~70 横並び (弱いスライムが実質弱くない) + 手置き XP の幅過大 (ヒカリダケ1匹で JobLV2 即到達)。

## 変更
1. **XP は式＋個別調整**: `MonsterDef.xp` を optional 化 → 省略時は `baselineXp(基準HP+atk/agi)` で自動算出 (強さと XP を連動)。個別に効かせたい敵は `xp` 明示上書き。
2. **tier1 に HP 明示**して弱い敵を本当に弱く (そらいろ20 … ヒカリ62、Lv1 実効 ×0.72)。XP は式で 2〜8。
3. **はぐれスライム xp 45→100** (ご指定)。低 HP のジャックポットとして上書き。

## 検証
- **遭遇率×討伐率 (`scripts/analyze-tier1-encounter.ts`)**: はぐれ = 遭遇1.42% × 討伐20%(逃走80%) × 100xp = **実効 0.28 xp/遭遇** (普通のスライム 0.47 未満) → xp100 でも序盤 XP を壊さない。tier1 平均 5.87 xp/遭遇 → JobLV2 まで ~6 戦 (以前は1匹)。
- **生存 sim (tier1/Lv1/全ジョブ/5連戦)**: guardian 29%→99% / mage 36%→100% / seer 59%→100%。弱ジョブは残 HP ~48% で決着。
- `core test 310` / `web test 346` / `build` 緑。

**トレードオフ記録**: tier1 の生存率↑ (序盤の壁を撤去) と引き換えに leveling を緩めた (JobLV2 まで ~6 戦)。序盤は数をこなして伸ばすテンポへ意図的に振った。

## Review

§1.5 3 並列 subagent レビュー (設計 / 実装 / バランスUX) を実施。**★★★ 0 件。** 本番コードにブロッカーなし。サーバー権威 (docs/21) の XP 決定性も確認済み (battleXpFor は monsterId から純関数)。

**★★ (PR 内で対応済み)**
- **baselineXp の適用範囲** (設計): tier1 校正で tier2/3 に生使用すると過小 (xp optional 化の副作用) → JSDoc 明記 (tier1 校正・tier2/3 は xp 明示必須・基準 HP はレベル非依存) + 回帰テスト「tier2/3 は xp を明示」追加。(commit 00a4b63)
- **分析スクリプトの分散バグ** (実装): `startBattle` の variance を herbs 引数に渡していた → `extras.vitalsVariance` に修正 (討伐率は 20% で不変 = 逃走支配のため)。(commit 00a4b63)

**★ (PR 内で対応済み)**
- tier 単調性テストのレア除外閾値を `RARE_JACKPOT_MAX_SPAWN` 定数に命名。(commit 00a4b63)

**★★ (別 issue 化 — バランス判断・PR スコープ外)**
- **#407**: tier1→tier2 の難易度の崖 (tier1 が無傷すぎて戦闘システムを学ぶ前に tier2 の壁)。tier2/3 は本 PR 未変更。
- **#408**: はぐれメタル討伐率 20% の「追う楽しさ」導線 (先制/拘束/猶予)。

**★ (記録のみ)**: tier1 の XP 差 2〜8 は学習信号としてやや控えめ (係数を上げれば強調できるが平均 XP が上がるトレードオフ)。オーナー判断に委ねる。