### PR TITLE
feat(spirit): 管理者デバッグ模擬戦シミュレータ (バッチ + 決定論1戦)

### DIFF
--- a/apps/web/src/components/debug-battle-sim.tsx
+++ b/apps/web/src/components/debug-battle-sim.tsx
@@ -1,0 +1,219 @@
+import { useMemo, useState } from 'react';
+import {
+  ARCHETYPES,
+  EQUIPMENT,
+  JOB_XP_CURVE,
+  MONSTERS,
+  MONSTERS_BY_ID,
+  autoBattleCommand,
+  battleXpFor,
+  jobDisplayName,
+  resolveTurn,
+  runAutoBattle,
+  startBattle,
+  type Archetype,
+  type BattleState,
+  type Command,
+  type GearSelection,
+} from '@aozoraquest/core';
+
+/**
+ * 管理者デバッグ模擬戦シミュレータ (issue #414)。/spirit の管理者セクションから使う。
+ *
+ * 敵をリスト選択、プレイヤー側もジョブ/装備/レベルを選択し、
+ *  - バッチ: N 戦を自動プレイ → 勝率・平均 XP・平均ターン・生存時残 HP・次 Lv まで何戦
+ *  - 決定論 1 戦: variance 0 + 固定 seed で自分でコマンドを選び挙動確認
+ * を行う。固定強度化 (#409) の上でエリア/順路/XP カーブ (#412/#413) の数値を詰める道具。
+ */
+
+const WORLD_HERB_MAX = 3;
+const WORLD_TONIC_MAX = 3;
+
+/** その職の JobLv L→L+1 に必要な XP 差 (JOB_XP_CURVE の閾値差)。 */
+function jobLevelGap(level: number): number {
+  const cur = JOB_XP_CURVE.find((e) => e[0] === level)?.[1] ?? 0;
+  const next = JOB_XP_CURVE.find((e) => e[0] === level + 1)?.[1];
+  return next === undefined ? 0 : next - cur;
+}
+
+const bySlot = (slot: 'weapon' | 'armor' | 'charm') => EQUIPMENT.filter((e) => e.slot === slot);
+
+interface BatchResult {
+  trials: number;
+  winRate: number;
+  avgXpPerWin: number;
+  avgXpPerFight: number;
+  avgTurns: number;
+  avgHpPctOnWin: number;
+  fightsToNextJobLv: number | null;
+}
+
+export function DebugBattleSim() {
+  const [enemyId, setEnemyId] = useState(MONSTERS[0]!.id);
+  const [job, setJob] = useState<Archetype>('warrior');
+  const [playerLv, setPlayerLv] = useState(1);
+  const [jobLv, setJobLv] = useState(1);
+  const [weapon, setWeapon] = useState('');
+  const [armor, setArmor] = useState('');
+  const [charm, setCharm] = useState('');
+  const [herbs, setHerbs] = useState(WORLD_HERB_MAX);
+  const [tonics, setTonics] = useState(WORLD_TONIC_MAX);
+  const [trials, setTrials] = useState(300);
+  const [batch, setBatch] = useState<BatchResult | null>(null);
+  const [duel, setDuel] = useState<BattleState | null>(null);
+
+  const enemy = MONSTERS_BY_ID[enemyId]!;
+  const gear = useMemo<GearSelection>(
+    () => ({ ...(weapon ? { weapon } : {}), ...(armor ? { armor } : {}), ...(charm ? { charm } : {}) }),
+    [weapon, armor, charm],
+  );
+
+  /** 1 戦を開始 (variance を指定)。tier は敵に付随 (monsterId 固定なので抽選はされない)。 */
+  const start = (seed: number, variance: number): BattleState =>
+    startBattle(job, jobLv, playerLv, 'sim', enemy.tier, seed, herbs, undefined, {
+      monsterId: enemyId,
+      gear,
+      tonics,
+      vitalsVariance: variance,
+    });
+
+  const runBatch = () => {
+    setDuel(null);
+    const n = Math.max(1, Math.min(2000, Math.floor(trials)));
+    let wins = 0;
+    let xpSum = 0;
+    let turnSum = 0;
+    let hpPctSum = 0;
+    for (let seed = 0; seed < n; seed++) {
+      const end = runAutoBattle(start(seed, 0.15)); // world と同じ ±15% 分散
+      turnSum += end.turn;
+      if (end.outcome === 'win') {
+        wins++;
+        xpSum += battleXpFor(end.monsterId);
+        hpPctSum += end.player.hp / end.player.maxHp;
+      }
+    }
+    const avgXpPerFight = xpSum / n;
+    const gap = jobLevelGap(jobLv);
+    setBatch({
+      trials: n,
+      winRate: wins / n,
+      avgXpPerWin: wins ? xpSum / wins : 0,
+      avgXpPerFight,
+      avgTurns: turnSum / n,
+      avgHpPctOnWin: wins ? hpPctSum / wins : 0,
+      fightsToNextJobLv: gap > 0 && avgXpPerFight > 0 ? Math.ceil(gap / avgXpPerFight) : null,
+    });
+  };
+
+  const startDuel = () => {
+    setBatch(null);
+    setDuel(start(1, 0)); // 決定論: variance 0 + 固定 seed
+  };
+  const duelCmd = (cmd: Command) => setDuel((s) => (s && s.outcome === 'ongoing' ? resolveTurn(s, cmd) : s));
+  const duelAuto = () => setDuel((s) => (s && s.outcome === 'ongoing' ? resolveTurn(s, autoBattleCommand(s)) : s));
+
+  const pct = (x: number) => `${Math.round(x * 100)}%`;
+
+  return (
+    <section style={{ marginTop: '2em' }}>
+      <h3 style={{ fontSize: '0.95em' }}>管理者 (模擬戦)</h3>
+      <p style={{ fontSize: '0.78em', color: 'var(--color-muted)', marginBottom: '0.5em' }}>
+        物理ランダムなしの模擬戦。敵・ジョブ・装備・レベルを選んで、バランスを数値で確認する。
+      </p>
+
+      {/* 入力フォーム */}
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.4em 0.6em', fontSize: '0.82em' }}>
+        <label>敵
+          <select value={enemyId} onChange={(e) => setEnemyId(e.target.value)} style={{ width: '100%' }}>
+            {MONSTERS.map((m) => (
+              <option key={m.id} value={m.id}>{`T${m.tier} ${m.name}`}</option>
+            ))}
+          </select>
+        </label>
+        <label>ジョブ
+          <select value={job} onChange={(e) => setJob(e.target.value as Archetype)} style={{ width: '100%' }}>
+            {ARCHETYPES.map((a) => (
+              <option key={a} value={a}>{jobDisplayName(a)}</option>
+            ))}
+          </select>
+        </label>
+        <label>プレイヤーLv
+          <input type="number" min={1} max={99} value={playerLv} onChange={(e) => setPlayerLv(Number(e.target.value))} style={{ width: '100%' }} />
+        </label>
+        <label>ジョブLv
+          <input type="number" min={1} max={50} value={jobLv} onChange={(e) => setJobLv(Number(e.target.value))} style={{ width: '100%' }} />
+        </label>
+        <label>武器
+          <select value={weapon} onChange={(e) => setWeapon(e.target.value)} style={{ width: '100%' }}>
+            <option value="">(なし)</option>
+            {bySlot('weapon').map((e) => (<option key={e.id} value={e.id}>{e.name}</option>))}
+          </select>
+        </label>
+        <label>防具
+          <select value={armor} onChange={(e) => setArmor(e.target.value)} style={{ width: '100%' }}>
+            <option value="">(なし)</option>
+            {bySlot('armor').map((e) => (<option key={e.id} value={e.id}>{e.name}</option>))}
+          </select>
+        </label>
+        <label>お守り
+          <select value={charm} onChange={(e) => setCharm(e.target.value)} style={{ width: '100%' }}>
+            <option value="">(なし)</option>
+            {bySlot('charm').map((e) => (<option key={e.id} value={e.id}>{e.name}</option>))}
+          </select>
+        </label>
+        <label>やくそう / しずく
+          <span style={{ display: 'inline-flex', gap: '0.3em' }}>
+            <input type="number" min={0} max={WORLD_HERB_MAX} value={herbs} onChange={(e) => setHerbs(Number(e.target.value))} style={{ width: '3em' }} />
+            <input type="number" min={0} max={WORLD_TONIC_MAX} value={tonics} onChange={(e) => setTonics(Number(e.target.value))} style={{ width: '3em' }} />
+          </span>
+        </label>
+      </div>
+
+      <div style={{ display: 'flex', gap: '0.5em', alignItems: 'center', marginTop: '0.6em', flexWrap: 'wrap' }}>
+        <button onClick={runBatch}>バッチ</button>
+        <label style={{ fontSize: '0.8em' }}>N
+          <input type="number" min={1} max={2000} value={trials} onChange={(e) => setTrials(Number(e.target.value))} style={{ width: '4em', marginLeft: '0.3em' }} />
+        </label>
+        <button onClick={startDuel}>決定論1戦</button>
+      </div>
+
+      {/* バッチ結果 */}
+      {batch && (
+        <div className="dq-window" style={{ marginTop: '0.6em', fontSize: '0.82em', padding: '0.6em 0.8em' }}>
+          <div style={{ fontWeight: 700, marginBottom: '0.3em' }}>{`${jobDisplayName(job)} (plLv${playerLv}/jobLv${jobLv}) vs ${enemy.name} — ${batch.trials} 戦`}</div>
+          <div>勝率 <b>{pct(batch.winRate)}</b> / 平均 {batch.avgTurns.toFixed(1)} ターン</div>
+          <div>勝利時 残 HP <b>{pct(batch.avgHpPctOnWin)}</b></div>
+          <div>XP: 勝利 {batch.avgXpPerWin.toFixed(1)} / 1 戦平均 {batch.avgXpPerFight.toFixed(2)}</div>
+          <div>
+            次 JobLv{jobLv + 1} まで{' '}
+            <b>{batch.fightsToNextJobLv === null ? '—' : `約 ${batch.fightsToNextJobLv} 戦`}</b>
+            <span style={{ color: 'var(--color-muted)' }}>{' '}(戦闘 XP が JobLv に入ると仮定)</span>
+          </div>
+        </div>
+      )}
+
+      {/* 決定論 1 戦 */}
+      {duel && (
+        <div className="dq-window" style={{ marginTop: '0.6em', fontSize: '0.82em', padding: '0.6em 0.8em' }}>
+          <div style={{ fontWeight: 700 }}>{`${duel.player.name ?? jobDisplayName(job)} vs ${duel.monster.name}`}</div>
+          <div>じぶん HP {duel.player.hp}/{duel.player.maxHp} · MP {duel.player.mp}/{duel.player.maxMp} · やくそう{duel.herbs} しずく{duel.tonics}</div>
+          <div>てき HP {duel.monster.hp}/{duel.monster.maxHp}{duel.monster.charging ? ' · ⚡ため中' : ''}</div>
+          <div style={{ margin: '0.3em 0', minHeight: '2.4em', color: 'var(--color-muted)' }}>
+            {duel.lastEvents.map((ev, i) => (<div key={i}>{ev.text}</div>))}
+          </div>
+          {duel.outcome === 'ongoing' ? (
+            <div style={{ display: 'flex', gap: '0.3em', flexWrap: 'wrap' }}>
+              {(['attack', 'guard', 'skill', 'herb', 'tonic', 'flee'] as const).map((c) => (
+                <button key={c} onClick={() => duelCmd(c)} style={{ fontSize: '0.85em', padding: '0.2em 0.5em' }}>{c}</button>
+              ))}
+              <button onClick={duelAuto} style={{ fontSize: '0.85em', padding: '0.2em 0.5em' }}>auto1</button>
+            </div>
+          ) : (
+            <div style={{ fontWeight: 700, color: 'var(--color-accent)' }}>決着: {duel.outcome} ({duel.turn} ターン)</div>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/debug-battle-sim.tsx
+++ b/apps/web/src/components/debug-battle-sim.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import {
   ARCHETYPES,
+  BATTLE_TUNING,
   EQUIPMENT,
   JOB_XP_CURVE,
   MONSTERS,
@@ -29,6 +30,15 @@ import {
 const WORLD_HERB_MAX = 3;
 const WORLD_TONIC_MAX = 3;
 
+/** number 入力の NaN/範囲外を潰す (空欄 = NaN が startBattle に渡ると勝率 0% のゴミ結果になる)。 */
+const clampInt = (v: number, def: number, min: number, max: number) =>
+  Number.isFinite(v) ? Math.min(max, Math.max(min, Math.floor(v))) : def;
+
+/** 決定論1戦のコマンド表示名 (world 戦闘と同じ日本語で手触りを揃える)。 */
+const CMD_LABEL: Record<Command, string> = {
+  attack: 'たたかう', guard: 'ぼうぎょ', skill: 'とくぎ', herb: 'やくそう', tonic: 'しずく', flee: 'にげる',
+};
+
 /** その職の JobLv L→L+1 に必要な XP 差 (JOB_XP_CURVE の閾値差)。 */
 function jobLevelGap(level: number): number {
   const cur = JOB_XP_CURVE.find((e) => e[0] === level)?.[1] ?? 0;
@@ -40,6 +50,8 @@ const bySlot = (slot: 'weapon' | 'armor' | 'charm') => EQUIPMENT.filter((e) => e
 
 interface BatchResult {
   trials: number;
+  plLv: number;
+  jobLv: number;
   winRate: number;
   avgXpPerWin: number;
   avgXpPerFight: number;
@@ -68,14 +80,20 @@ export function DebugBattleSim() {
     [weapon, armor, charm],
   );
 
-  /** 1 戦を開始 (variance を指定)。tier は敵に付随 (monsterId 固定なので抽選はされない)。 */
+  /** 1 戦を開始 (variance を指定)。tier は敵に付随 (monsterId 固定なので抽選はされない)。
+   *  入力は clampInt で NaN/範囲外を潰してから渡す。 */
   const start = (seed: number, variance: number): BattleState =>
-    startBattle(job, jobLv, playerLv, 'sim', enemy.tier, seed, herbs, undefined, {
-      monsterId: enemyId,
-      gear,
-      tonics,
-      vitalsVariance: variance,
-    });
+    startBattle(
+      job,
+      clampInt(jobLv, 1, 1, 50),
+      clampInt(playerLv, 1, 1, 99),
+      'sim',
+      enemy.tier,
+      seed,
+      clampInt(herbs, 0, 0, WORLD_HERB_MAX),
+      undefined,
+      { monsterId: enemyId, gear, tonics: clampInt(tonics, 0, 0, WORLD_TONIC_MAX), vitalsVariance: variance },
+    );
 
   const runBatch = () => {
     setDuel(null);
@@ -85,7 +103,7 @@ export function DebugBattleSim() {
     let turnSum = 0;
     let hpPctSum = 0;
     for (let seed = 0; seed < n; seed++) {
-      const end = runAutoBattle(start(seed, 0.15)); // world と同じ ±15% 分散
+      const end = runAutoBattle(start(seed, BATTLE_TUNING.monsterVitalsVariance)); // world と同じ分散
       turnSum += end.turn;
       if (end.outcome === 'win') {
         wins++;
@@ -94,9 +112,12 @@ export function DebugBattleSim() {
       }
     }
     const avgXpPerFight = xpSum / n;
-    const gap = jobLevelGap(jobLv);
+    const jl = clampInt(jobLv, 1, 1, 50);
+    const gap = jobLevelGap(jl);
     setBatch({
       trials: n,
+      plLv: clampInt(playerLv, 1, 1, 99),
+      jobLv: jl,
       winRate: wins / n,
       avgXpPerWin: wins ? xpSum / wins : 0,
       avgXpPerFight,
@@ -117,7 +138,7 @@ export function DebugBattleSim() {
 
   return (
     <section style={{ marginTop: '2em' }}>
-      <h3 style={{ fontSize: '0.95em' }}>管理者 (模擬戦)</h3>
+      <h3 style={{ fontSize: '0.95em' }}>管理者 · 模擬戦</h3>
       <p style={{ fontSize: '0.78em', color: 'var(--color-muted)', marginBottom: '0.5em' }}>
         物理ランダムなしの模擬戦。敵・ジョブ・装備・レベルを選んで、バランスを数値で確認する。
       </p>
@@ -181,14 +202,14 @@ export function DebugBattleSim() {
       {/* バッチ結果 */}
       {batch && (
         <div className="dq-window" style={{ marginTop: '0.6em', fontSize: '0.82em', padding: '0.6em 0.8em' }}>
-          <div style={{ fontWeight: 700, marginBottom: '0.3em' }}>{`${jobDisplayName(job)} (plLv${playerLv}/jobLv${jobLv}) vs ${enemy.name} — ${batch.trials} 戦`}</div>
+          <div style={{ fontWeight: 700, marginBottom: '0.3em' }}>{`${jobDisplayName(job)} (plLv${batch.plLv}/jobLv${batch.jobLv}) vs ${enemy.name} — ${batch.trials} 戦`}</div>
           <div>勝率 <b>{pct(batch.winRate)}</b> / 平均 {batch.avgTurns.toFixed(1)} ターン</div>
           <div>勝利時 残 HP <b>{pct(batch.avgHpPctOnWin)}</b></div>
           <div>XP: 勝利 {batch.avgXpPerWin.toFixed(1)} / 1 戦平均 {batch.avgXpPerFight.toFixed(2)}</div>
           <div>
-            次 JobLv{jobLv + 1} まで{' '}
+            次 JobLv{batch.jobLv + 1} まで{' '}
             <b>{batch.fightsToNextJobLv === null ? '—' : `約 ${batch.fightsToNextJobLv} 戦`}</b>
-            <span style={{ color: 'var(--color-muted)' }}>{' '}(戦闘 XP が JobLv に入ると仮定)</span>
+            <span style={{ color: 'var(--color-muted)' }}>{' '}(勝利 XP は JobLv/PlayerLv に加算。敗北の xpLose は不算入の楽観値)</span>
           </div>
         </div>
       )}
@@ -196,7 +217,7 @@ export function DebugBattleSim() {
       {/* 決定論 1 戦 */}
       {duel && (
         <div className="dq-window" style={{ marginTop: '0.6em', fontSize: '0.82em', padding: '0.6em 0.8em' }}>
-          <div style={{ fontWeight: 700 }}>{`${duel.player.name ?? jobDisplayName(job)} vs ${duel.monster.name}`}</div>
+          <div style={{ fontWeight: 700 }}>{`${jobDisplayName(job)} vs ${duel.monster.name}`}</div>
           <div>じぶん HP {duel.player.hp}/{duel.player.maxHp} · MP {duel.player.mp}/{duel.player.maxMp} · やくそう{duel.herbs} しずく{duel.tonics}</div>
           <div>てき HP {duel.monster.hp}/{duel.monster.maxHp}{duel.monster.charging ? ' · ⚡ため中' : ''}</div>
           <div style={{ margin: '0.3em 0', minHeight: '2.4em', color: 'var(--color-muted)' }}>
@@ -205,9 +226,9 @@ export function DebugBattleSim() {
           {duel.outcome === 'ongoing' ? (
             <div style={{ display: 'flex', gap: '0.3em', flexWrap: 'wrap' }}>
               {(['attack', 'guard', 'skill', 'herb', 'tonic', 'flee'] as const).map((c) => (
-                <button key={c} onClick={() => duelCmd(c)} style={{ fontSize: '0.85em', padding: '0.2em 0.5em' }}>{c}</button>
+                <button key={c} onClick={() => duelCmd(c)} style={{ fontSize: '0.85em', padding: '0.2em 0.5em' }}>{CMD_LABEL[c]}</button>
               ))}
-              <button onClick={duelAuto} style={{ fontSize: '0.85em', padding: '0.2em 0.5em' }}>auto1</button>
+              <button onClick={duelAuto} style={{ fontSize: '0.85em', padding: '0.2em 0.5em' }}>自動1手</button>
             </div>
           ) : (
             <div style={{ fontWeight: 700, color: 'var(--color-accent)' }}>決着: {duel.outcome} ({duel.turn} ターン)</div>

--- a/apps/web/src/routes/spirit.tsx
+++ b/apps/web/src/routes/spirit.tsx
@@ -297,7 +297,7 @@ export function Spirit() {
                   color: 'var(--color-muted)',
                 }}
               >
-                <span>{grantingPower ? '管理者用 · 付与中…' : `管理者用 · あおぞらパワー ${points.balance}`}</span>
+                <span>{grantingPower ? '管理者 · 付与中…' : `管理者 · パワー ${points.balance}`}</span>
                 {[100, 1000].map((n) => (
                   <button
                     key={n}

--- a/apps/web/src/routes/spirit.tsx
+++ b/apps/web/src/routes/spirit.tsx
@@ -21,6 +21,7 @@ import { useRuntimeConfig } from '@/components/config-provider';
 import { applyPromptTemplate } from '@/lib/prompt-template';
 import { bumpPower, loadPointsState, SUMMON_THRESHOLD, type PointsState } from '@/lib/points';
 import { WORLD_PREVIEW_ENABLED } from '@/lib/world-preview';
+import { DebugBattleSim } from '@/components/debug-battle-sim';
 import { isAdminDid } from '@/lib/runtime-config';
 
 /**
@@ -322,6 +323,9 @@ export function Spirit() {
               </div>
             </section>
           )}
+
+          {/* 管理者デバッグ模擬戦 (issue #414)。dev + 管理者のみ。 */}
+          {WORLD_PREVIEW_ENABLED && did && isAdminDid(did) && <DebugBattleSim />}
         </>
       )}
 

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -655,22 +655,24 @@ export function summonMonster(
   // 呼び出し文脈として残すが強度計算には使わない (将来のエンドコンテンツ追従の受け皿)。
   void playerLevel;
   void jobLevel;
-  const factor = monsterLevelFactor(tier);
-  const combatant = fromStats(def.name, def.stats, factor, 1);
+  return { def, combatant: monsterCombatant(def, variance, rng) };
+}
+
+/** モンスター def から戦闘値 (Combatant) を作る。tier 固定強度 (factor) + 明示 HP/MP 上書き +
+ *  遭遇ごとの分散ジッター。variance=0 のときは rng を引かない (乱数ストリームを従来と一致させ
+ *  テスト/決定論を保つ)。summonMonster (tier 抽選) と、模擬戦の敵指定の双方から使う。 */
+export function monsterCombatant(def: MonsterDef, variance: number, rng: () => number): Combatant {
+  const factor = monsterLevelFactor(def.tier);
+  const c = fromStats(def.name, def.stats, factor, 1);
   // HP/MP を明示している敵はその値で上書き (プレイヤーと同じ完全ステータス — 導出に頼らない)。
-  // tier/レベル係数 (factor) で従来同様にスケールさせ、はぐれメタル型の低 HP を保つ。
-  if (def.hp !== undefined) { combatant.maxHp = Math.max(1, Math.round(def.hp * factor)); combatant.hp = combatant.maxHp; }
-  if (def.mp !== undefined) { combatant.maxMp = Math.max(0, Math.round(def.mp * factor)); combatant.mp = combatant.maxMp; }
-  // 遭遇ごとに HP/MP をバラつかせる (値を覚えられないように = 予想の余地を残す)。
-  // variance=0 のときは rng を引かない (乱数ストリームを従来と一致させ trial/テスト不変)。
+  if (def.hp !== undefined) { c.maxHp = Math.max(1, Math.round(def.hp * factor)); c.hp = c.maxHp; }
+  if (def.mp !== undefined) { c.maxMp = Math.max(0, Math.round(def.mp * factor)); c.mp = c.maxMp; }
   if (variance > 0) {
     const jitter = () => 1 + (rng() * 2 - 1) * variance;
-    combatant.maxHp = Math.max(1, Math.round(combatant.maxHp * jitter()));
-    combatant.hp = combatant.maxHp;
-    combatant.maxMp = Math.max(0, Math.round(combatant.maxMp * jitter()));
-    combatant.mp = combatant.maxMp;
+    c.maxHp = Math.max(1, Math.round(c.maxHp * jitter())); c.hp = c.maxHp;
+    c.maxMp = Math.max(0, Math.round(c.maxMp * jitter())); c.mp = c.maxMp;
   }
-  return { def, combatant };
+  return c;
 }
 
 // ─── バトル状態と解決 ───────────────────────────────────────
@@ -740,6 +742,9 @@ export function startBattle(
     affinity?: number;
     /** 敵 HP/MP の分散 (±割合)。world 遭遇のみ指定、trial は未指定 = 0 (固定)。 */
     vitalsVariance?: number;
+    /** 出現を tier 抽選せず**この id のモンスターに固定**する (模擬戦シミュレータ用)。
+     *  未知 id は無視して従来どおり tier 抽選。 */
+    monsterId?: string;
   },
 ): BattleState {
   const player = playerCombatant(archetype, jobLevel, playerLevel, displayName, extras?.baseStats, extras?.equipIds, extras?.gear);
@@ -749,7 +754,11 @@ export function startBattle(
   if (carry?.mp !== undefined) {
     player.mp = Math.max(0, Math.min(player.maxMp, Math.floor(carry.mp)));
   }
-  const { def, combatant } = summonMonster(tier, playerLevel, seed, jobLevel, extras?.affinity, extras?.vitalsVariance ?? 0);
+  const variance = extras?.vitalsVariance ?? 0;
+  const forced = extras?.monsterId ? MONSTERS_BY_ID[extras.monsterId] : undefined;
+  const { def, combatant } = forced
+    ? { def: forced, combatant: monsterCombatant(forced, variance, createRng((seed ^ 0x2a9f) >>> 0)) }
+    : summonMonster(tier, playerLevel, seed, jobLevel, extras?.affinity, variance);
   const gains = mpGainsFor(archetype);
   return {
     seed,
@@ -1112,6 +1121,28 @@ export function resolveTurn(prev: BattleState, command: Command, turnSeed?: numb
  *   記録単体からの再現・検証はできない (materialsLost は他の戦闘結果と同じく
  *   クライアント申告値。検証可能化は W3 のサーバー権威で扱う)。
  */
+/** 模擬戦の自動プレイ方針 (現実的な「上手い操作」の代表)。1 ターン分のコマンドを返す。
+ *  ため予告 → (見切り職は特技/それ以外は防御) / HP<45% かつ薬草 → 薬草 /
+ *  MP 不足かつしずく → しずく / MP 足りれば特技 / それ以外 たたかう。
+ *  scripts/sim-battle-balance.ts と /spirit 模擬戦シミュレータで共有する。 */
+export function autoBattleCommand(s: BattleState): Command {
+  const t = BATTLE_TUNING;
+  const isParry = s.playerSkill.kind === 'parry';
+  const p = s.player;
+  if (s.monster.charging) return isParry && p.mp >= t.skillMpCost ? 'skill' : 'guard';
+  if (s.herbs > 0 && p.hp < p.maxHp * 0.45) return 'herb';
+  if (s.tonics > 0 && p.mp < t.skillMpCost && p.maxMp >= t.skillMpCost * 2) return 'tonic';
+  if (!isParry && p.mp >= t.skillMpCost) return 'skill';
+  return 'attack';
+}
+
+/** 自動プレイで決着まで進める (最大 maxTurns)。turnSeed は渡さず state 由来で決定的。 */
+export function runAutoBattle(state: BattleState, maxTurns = 80): BattleState {
+  let s = state;
+  for (let i = 0; i < maxTurns && s.outcome === 'ongoing'; i++) s = resolveTurn(s, autoBattleCommand(s));
+  return s;
+}
+
 export function rollDefeatLoss(materials: Record<string, number>, luk: number, seed: number): string[] {
   const t = BATTLE_TUNING;
   const rng = createRng((seed ^ 0x7b0c9d21) >>> 0);

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -1131,7 +1131,8 @@ export function autoBattleCommand(s: BattleState): Command {
   const p = s.player;
   if (s.monster.charging) return isParry && p.mp >= t.skillMpCost ? 'skill' : 'guard';
   if (s.herbs > 0 && p.hp < p.maxHp * 0.45) return 'herb';
-  if (s.tonics > 0 && p.mp < t.skillMpCost && p.maxMp >= t.skillMpCost * 2) return 'tonic';
+  // 見切り (parry) 職は特技を撃たない → MP 回復しても無駄なので しずくを飲まない。
+  if (!isParry && s.tonics > 0 && p.mp < t.skillMpCost && p.maxMp >= t.skillMpCost * 2) return 'tonic';
   if (!isParry && p.mp >= t.skillMpCost) return 'skill';
   return 'attack';
 }

--- a/scripts/sim-battle-balance.ts
+++ b/scripts/sim-battle-balance.ts
@@ -18,7 +18,7 @@ import {
   BATTLE_TUNING,
   JOBS_BY_ID,
   createRng,
-  resolveTurn,
+  runAutoBattle,
   rollDrops,
   startBattle,
   type Archetype,
@@ -45,29 +45,9 @@ if (baseIdx >= 0 && args[baseIdx + 1]) {
   baseStats = [nums[0]!, nums[1]!, nums[2]!, nums[3]!, nums[4]!];
 }
 
-function playPolicy(s: BattleState): BattleState {
-  const t = BATTLE_TUNING;
-  const isParry = s.playerSkill.kind === 'parry';
-  for (let i = 0; i < 80 && s.outcome === 'ongoing'; i++) {
-    const p = s.player;
-    // parry (見切り) は「攻撃が来るターンに構える」のが正しい使い方。毎ターン
-    // 空打ちすると火力ゼロで作戦負けする (人間はそう使わない) ので、
-    // ため予告のターンだけ構え、それ以外は殴る。
-    const cmd = s.monster.charging
-      ? isParry && p.mp >= t.skillMpCost
-        ? 'skill'
-        : 'guard'
-      : s.herbs > 0 && p.hp < p.maxHp * 0.45
-        ? 'herb'
-        : s.tonics > 0 && p.mp < t.skillMpCost && p.maxMp >= t.skillMpCost * 2
-          ? 'tonic'
-          : !isParry && p.mp >= t.skillMpCost
-            ? 'skill'
-            : 'attack';
-    s = resolveTurn(s, cmd);
-  }
-  return s;
-}
+// 自動プレイ方針は core の autoBattleCommand/runAutoBattle を共有する (sim と /spirit 模擬戦で
+// 数値を一致させるため。方針を 2 箇所に持たない — レビュー ★★)。
+const playPolicy = (s: BattleState): BattleState => runAutoBattle(s);
 
 interface JobResult {
   job: Archetype;


### PR DESCRIPTION
Closes #414

## 背景 (オーナー要望 2026-07-20)
物理ランダムなしの模擬戦闘を管理者のみが /spirit で行えるようにする。敵はリスト選択、プレイヤー側もジョブと装備を選択。目的は「何戦してレベルいくつになれば次の地域が楽になるか」を経験値配分でシミュレーションできるようにすること。

## 変更
**core**: `monsterCombatant` を `summonMonster` から抽出 / `startBattle.extras.monsterId` で敵固定 / `autoBattleCommand`・`runAutoBattle` を core 化 (sim スクリプトと共有)。
**UI (`DebugBattleSim`, dev + 管理者)**: 敵・ジョブ・装備・レベル・やくそう/しずくを選択 → バッチ (勝率/平均ターン/勝利時残HP/平均XP/次JobLvまで何戦) と 決定論1戦 (日本語コマンドボタン + 自動1手)。

## 検証
- `core 311` / `web 346` / `build` 緑。sim スクリプトも core の runAutoBattle に置換後も動作。

## Review

§1.5 3 並列レビュー (設計/実装/UX)。**★★★ 0 件。** core リファクタは決定性・等価性を厳密に保持 (実測確認)。

**判明した事実**: world 戦闘は勝利時に `battleXpFor` を **jobXp/playerXp に実加算** している (`battle-reward.ts:67-72`)。→ 「次 JobLv まで何戦」は仮定でなく事実ベース。オーナーの「100回戦ってもレベルが上がらない」アンチファームは実在の課題。

**★★ (PR 内で対応済み)**
- **方針ロジック重複** (設計): `sim-battle-balance.ts` の playPolicy を core の `runAutoBattle` に置換 (方針を 2 箇所に持たない)。(commit b7834d1)
- **分散リテラル直書き** (設計): `0.15` → `BATTLE_TUNING.monsterVitalsVariance`。(commit b7834d1)
- **XP 注記の事実誤認** (設計・UX): 「仮定」→「勝利 XP は JobLv/PlayerLv に加算。敗北 xpLose は不算入の楽観値」。(commit b7834d1)
- **英語コマンドラベル** (UX): たたかう/ぼうぎょ/とくぎ/やくそう/しずく/にげる に日本語化。(commit b7834d1)

**★ (PR 内で対応済み)**
- NaN 入力ガード (clampInt) / autoBattleCommand の parry しずく空打ち防止 (!isParry) / duel name deadcode 整理 / 管理者見出しを「管理者 · ◯◯」に統一。(commit b7834d1)

**★ (記録・任意)**: duel の seed 入力 (複数シード掃引) / jobLevelGap の core 化 / やくそう・しずくの 2 セル分割 — デバッグツールの利便向上で任意。

## 関連
- #409 固定強度化 / #412 エリア敵配置 / #413 想定順路