### PR TITLE
feat(admin): あおぞらワールド 管理ダッシュボードの土台 (設定→/admin + ゲート + ナビ)

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -18,6 +18,7 @@ const Quests = lazy(() => import('@/routes/quests').then(m => ({ default: m.Ques
 const Search = lazy(() => import('@/routes/search').then(m => ({ default: m.Search })));
 const Settings = lazy(() => import('@/routes/settings').then(m => ({ default: m.Settings })));
 const Spirit = lazy(() => import('@/routes/spirit').then(m => ({ default: m.Spirit })));
+const AdminDashboard = lazy(() => import('@/routes/admin-dashboard').then(m => ({ default: m.AdminDashboard })));
 const World = lazy(() => import('@/routes/world').then(m => ({ default: m.World })));
 const Onboarding = lazy(() => import('@/routes/onboarding').then(m => ({ default: m.Onboarding })));
 const OAuthCallback = lazy(() => import('@/routes/oauth-callback').then(m => ({ default: m.OAuthCallback })));
@@ -72,6 +73,7 @@ const router = createBrowserRouter([
       { path: 'search', element: <Search /> },
       { path: 'settings', element: <Settings /> },
       { path: 'spirit', element: <Spirit /> },
+      { path: 'admin', element: <AdminDashboard /> },
       { path: 'world', element: <World /> },
       { path: 'onboarding', element: <Onboarding /> },
       { path: 'oauth/callback', element: <OAuthCallback /> },

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -73,6 +73,9 @@ const router = createBrowserRouter([
       { path: 'search', element: <Search /> },
       { path: 'settings', element: <Settings /> },
       { path: 'spirit', element: <Spirit /> },
+      // /admin は /world と同じく無条件登録 + コンポーネント内ゲート (WORLD_PREVIEW_ENABLED &&
+      // isAdminDid)。dev 限定なのでこの段階は表示ゲートで足りる。#418 で実データ CRUD (edge 権限
+      // 検証) を入れる際、/debug/* のような本番除外の条件登録へ寄せるか再検討する。
       { path: 'admin', element: <AdminDashboard /> },
       { path: 'world', element: <World /> },
       { path: 'onboarding', element: <Onboarding /> },

--- a/apps/web/src/routes/admin-dashboard.tsx
+++ b/apps/web/src/routes/admin-dashboard.tsx
@@ -1,0 +1,92 @@
+import { Link } from 'react-router-dom';
+import { useSession } from '@/lib/session';
+import { isAdminDid } from '@/lib/runtime-config';
+import { WORLD_PREVIEW_ENABLED } from '@/lib/world-preview';
+
+/**
+ * あおぞらワールド 管理ダッシュボードの土台 (issue #417 / エピック #416)。
+ *
+ * 設定ページから遷移してくる管理者専用のハブ。各コンテンツ CRUD (モンスター/アイテム/
+ * マップ/店/クエスト…) の入口を並べる骨組み。中身の CRUD は #418 (データ化) の後に各サブ
+ * issue で実装するので、ここではセクションの枠 + 状態 (準備中/既存ツールへのリンク) だけ。
+ * 露出は dev + 管理者のみ。
+ */
+
+interface Section {
+  key: string;
+  title: string;
+  desc: string;
+  /** 既存機能への遷移先 (無ければ準備中)。 */
+  to?: string;
+  /** 準備中セクションの追跡 issue 番号。 */
+  issue?: number;
+}
+
+const CONTENT_SECTIONS: Section[] = [
+  { key: 'monsters', title: 'モンスター', desc: 'ステータス・ドロップ・画像を CRUD', issue: 419 },
+  { key: 'items', title: 'アイテム', desc: '装備 / 消費 / 素材を CRUD', issue: 420 },
+  { key: 'map', title: 'マップ / タイル', desc: '地形・エリア・出現配置・パーツ編集', issue: 421 },
+  { key: 'shops', title: 'お店', desc: 'ラインナップ・合成素材・店主セリフ', issue: 422 },
+  { key: 'quests', title: 'クエスト', desc: 'ゲーム内クエストの作成・編集', issue: 423 },
+  { key: 'npc', title: 'NPC (将来)', desc: 'NPC の CRUD と配置', issue: 425 },
+  { key: 'flags', title: 'フラグ (将来)', desc: '進行フラグでゲート', issue: 426 },
+];
+
+/** 既に別画面にある管理ツール (ダッシュボードから辿れるように集約)。 */
+const EXISTING_TOOLS: Section[] = [
+  { key: 'sim', title: '模擬戦シミュレータ', desc: 'バランス検証 (敵/ジョブ/装備を選んでバッチ・1戦)', to: '/spirit' },
+  { key: 'server', title: 'サーバー連携 / ワールドリセット', desc: '設定ページの管理者セクション', to: '/settings' },
+];
+
+function Card({ s }: { s: Section }) {
+  const body = (
+    <div className="dq-window" style={{ padding: '0.7em 0.9em', height: '100%' }}>
+      <div style={{ fontWeight: 700 }}>{s.title}</div>
+      <div style={{ fontSize: '0.8em', color: 'var(--color-muted)', marginTop: '0.2em' }}>{s.desc}</div>
+      <div style={{ fontSize: '0.75em', marginTop: '0.4em', color: s.to ? 'var(--color-accent)' : 'var(--color-muted)' }}>
+        {s.to ? '開く →' : `準備中${s.issue ? ` (#${s.issue})` : ''}`}
+      </div>
+    </div>
+  );
+  return s.to ? (
+    <Link to={s.to} style={{ textDecoration: 'none', color: 'inherit' }}>{body}</Link>
+  ) : (
+    body
+  );
+}
+
+export function AdminDashboard() {
+  const session = useSession();
+  const isAdmin = WORLD_PREVIEW_ENABLED && isAdminDid(session.did);
+
+  if (!isAdmin) {
+    return (
+      <div style={{ maxWidth: 560, margin: '0 auto', padding: '1em' }}>
+        <h2>管理ダッシュボード</h2>
+        <p style={{ fontSize: '0.9em', color: 'var(--color-muted)' }}>この画面は管理者専用です。</p>
+        <Link to="/settings"><button>設定へ戻る</button></Link>
+      </div>
+    );
+  }
+
+  const grid: React.CSSProperties = { display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(150px, 1fr))', gap: '0.6em', marginTop: '0.5em' };
+
+  return (
+    <div style={{ maxWidth: 720, margin: '0 auto', padding: '1em' }}>
+      <h2>あおぞらワールド 管理</h2>
+      <p style={{ fontSize: '0.82em', color: 'var(--color-muted)', margin: '0.2em 0 0' }}>
+        ゲーム内容の編集ハブ (エピック #416)。CRUD の中身は データ化 (#418) 後に各セクションへ実装。
+      </p>
+
+      <h3 style={{ fontSize: '0.95em', marginTop: '1.2em' }}>コンテンツ</h3>
+      <div style={grid}>
+        {CONTENT_SECTIONS.map((s) => (<Card key={s.key} s={s} />))}
+      </div>
+
+      <h3 style={{ fontSize: '0.95em', marginTop: '1.4em' }}>既存の管理ツール</h3>
+      <div style={grid}>
+        {EXISTING_TOOLS.map((s) => (<Card key={s.key} s={s} />))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/routes/admin-dashboard.tsx
+++ b/apps/web/src/routes/admin-dashboard.tsx
@@ -9,7 +9,11 @@ import { WORLD_PREVIEW_ENABLED } from '@/lib/world-preview';
  * 設定ページから遷移してくる管理者専用のハブ。各コンテンツ CRUD (モンスター/アイテム/
  * マップ/店/クエスト…) の入口を並べる骨組み。中身の CRUD は #418 (データ化) の後に各サブ
  * issue で実装するので、ここではセクションの枠 + 状態 (準備中/既存ツールへのリンク) だけ。
- * 露出は dev + 管理者のみ。
+ *
+ * **重要**: `WORLD_PREVIEW_ENABLED && isAdminDid` は**表示ゲートであって認可 (セキュリティ境界)
+ * ではない**。isAdminDid はクライアント公開 env との文字列一致で詐称可能。実データ CRUD を
+ * 実装する #418 以降では、**書き込みは必ず edge/サーバー側で権限検証**すること (この UI ゲートを
+ * 認可と誤認しない)。露出は dev + 管理者のみ。
  */
 
 interface Section {
@@ -32,19 +36,27 @@ const CONTENT_SECTIONS: Section[] = [
   { key: 'flags', title: 'フラグ (将来)', desc: '進行フラグでゲート', issue: 426 },
 ];
 
-/** 既に別画面にある管理ツール (ダッシュボードから辿れるように集約)。 */
+/** 既に別画面にある管理ツール (当面はリンクで集約。将来 /admin へ移設するかは #416 で判断)。
+ *  リンク先はページ下部の該当セクションなので、着地点を desc で明示する (アンカー未対応)。 */
 const EXISTING_TOOLS: Section[] = [
-  { key: 'sim', title: '模擬戦シミュレータ', desc: 'バランス検証 (敵/ジョブ/装備を選んでバッチ・1戦)', to: '/spirit' },
-  { key: 'server', title: 'サーバー連携 / ワールドリセット', desc: '設定ページの管理者セクション', to: '/settings' },
+  { key: 'sim', title: '模擬戦シミュレータ', desc: 'バランス検証 → 精霊ページ下部', to: '/spirit' },
+  { key: 'server', title: 'サーバー連携', desc: 'サーバーアカウント連携 → 設定ページ下部', to: '/settings' },
+  { key: 'reset', title: 'ワールドリセット', desc: 'はじめからやり直す → 設定ページ下部', to: '/settings' },
 ];
 
 function Card({ s }: { s: Section }) {
+  const pending = !s.to;
   const body = (
-    <div className="dq-window" style={{ padding: '0.7em 0.9em', height: '100%' }}>
+    // 準備中カードは opacity/cursor で非活性を明示 (押しても無反応と分かるように)。
+    // marginBottom:0 で dq-window 既定の 0.9em を打ち消し、grid の gap と二重に効かせない。
+    <div
+      className="dq-window"
+      style={{ padding: '0.7em 0.9em', height: '100%', marginBottom: 0, opacity: pending ? 0.6 : 1, cursor: pending ? 'default' : 'pointer' }}
+    >
       <div style={{ fontWeight: 700 }}>{s.title}</div>
       <div style={{ fontSize: '0.8em', color: 'var(--color-muted)', marginTop: '0.2em' }}>{s.desc}</div>
-      <div style={{ fontSize: '0.75em', marginTop: '0.4em', color: s.to ? 'var(--color-accent)' : 'var(--color-muted)' }}>
-        {s.to ? '開く →' : `準備中${s.issue ? ` (#${s.issue})` : ''}`}
+      <div style={{ fontSize: '0.75em', marginTop: '0.4em', color: pending ? 'var(--color-muted)' : 'var(--color-accent)' }}>
+        {pending ? `準備中${s.issue ? ` (#${s.issue})` : ''}` : '開く →'}
       </div>
     </div>
   );
@@ -57,6 +69,11 @@ function Card({ s }: { s: Section }) {
 
 export function AdminDashboard() {
   const session = useSession();
+  // セッション復元中は認可判定より前に「読み込み中」を出す (world/spirit と同様。復元中は
+  // did が undefined で isAdmin=false になり、一瞬「管理者専用」がちらつくのを防ぐ)。
+  if (session.status === 'loading') {
+    return <p style={{ padding: '1em' }}>読み込み中…</p>;
+  }
   const isAdmin = WORLD_PREVIEW_ENABLED && isAdminDid(session.did);
 
   if (!isAdmin) {

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -339,6 +339,16 @@ export function Settings() {
         <PostQuestNotificationsToggle />
       </section>
 
+      {isAdminDid(session.did) && WORLD_PREVIEW_ENABLED && (
+        <section style={{ marginTop: '2em' }}>
+          <h3 style={{ fontSize: '0.95em' }}>あおぞらワールド 管理</h3>
+          <p style={{ fontSize: '0.8em', color: 'var(--color-muted)', marginBottom: '0.5em' }}>
+            モンスター・アイテム・マップ・店・クエストの編集ハブ (管理者専用)。
+          </p>
+          <button onClick={() => navigate('/admin')}>管理ダッシュボードを開く</button>
+        </section>
+      )}
+
       {isAdminDid(session.did) && serverOAuthConfigured && session.agent && (
         <ServerOAuthAdmin agent={session.agent} />
       )}


### PR DESCRIPTION
Closes #417
Epic #416

## 背景
ゲーム内容 CRUD 化 (エピック #416) の**土台**。管理者は設定ページから遷移できる。

## 変更
- **/admin ルート**を新設 (lazy)。`AdminDashboard` は **dev + 管理者**のみ中身を表示。
- コンテンツ CRUD の入口カード骨組み (モンスター #419 / アイテム #420 / マップ #421 / 店 #422 / クエスト #423 / NPC #425 / フラグ #426、準備中)。
- 既存管理ツール (模擬戦=/spirit、連携 / リセット=/settings) へのリンクを集約。
- 設定ページに「管理ダッシュボードを開く」導線。

## 検証
- `web typecheck` / `test 346` / `build` 緑。

## Review

§1.5 3 並列レビュー (設計/実装/UX)。**★★★ 0 件。**

**★★ (PR 内で対応済み)**
- **復元中のちらつき** (実装): `status==='loading'` で「読み込み中」を先に返す (world/spirit と同枠組み)。(cbd54df)
- **認可注記** (設計): 表示ゲートが認可ではない旨を docstring に明記 (#418 以降の CRUD は edge 権限検証必須)。/admin 無条件登録の選択理由も main.tsx にコメント。(cbd54df)
- **既存ツール導線が曖昧** (UX): 着地点 (精霊/設定ページ下部) を desc で明示、連携・リセットを 2 カードに分割。(cbd54df)

**★ (PR 内で対応済み)**
- カード margin と grid gap の二重回避 / 準備中カードを opacity・cursor で非活性表示。(cbd54df)

**★ (記録・任意)**: 導線ボタンを navigate→Link に統一 / /admin の smoke テスト — 後続で任意。

## 関連
- Epic #416 / #418 データ化 (**PDS レコード + blob に決定** — issue にスキーマ設計の次タスクを記録)