### PR TITLE
feat(admin): 管理ツールをダッシュボードに集約 (埋め込み)

### DIFF
--- a/apps/web/src/components/admin/power-grant-admin.tsx
+++ b/apps/web/src/components/admin/power-grant-admin.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react';
+import type { Agent } from '@atproto/api';
+import { bumpPower, loadPointsState, type PointsState } from '@/lib/points';
+
+/** 管理者用 (dev): テスト用にあおぞらパワーを付与する。管理ダッシュボード (#417) に集約
+ *  (以前は精霊ページ)。加算は残高に純増する salePowerEarned に乗せる (viaPosts は召喚進捗
+ *  ゲージ・toSummon も動かす別セマンティクスなので、残高だけ盛る用途では使わない)。 */
+export function PowerGrantAdmin({ agent, did }: { agent: Agent; did: string }) {
+  const [points, setPoints] = useState<PointsState | null>(null);
+  const [granting, setGranting] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    loadPointsState(agent, did)
+      .then((p) => { if (!cancelled) setPoints(p); })
+      .catch((e) => console.warn('points load failed', e));
+    return () => { cancelled = true; };
+  }, [agent, did]);
+
+  const grant = async (n: number) => {
+    setGranting(true);
+    try {
+      await bumpPower(agent, did, { salePowerEarned: n });
+      const next = await loadPointsState(agent, did);
+      setPoints(next);
+    } catch (e) {
+      console.warn('admin power grant failed', e);
+    } finally {
+      setGranting(false);
+    }
+  };
+
+  return (
+    <section style={{ marginTop: '2em' }}>
+      <h3 style={{ fontSize: '0.95em' }}>パワー付与 (テスト)</h3>
+      <div
+        style={{
+          display: 'inline-flex',
+          gap: '0.5em',
+          alignItems: 'center',
+          fontSize: '0.85em',
+          border: '1px dashed var(--color-muted)',
+          borderRadius: 6,
+          padding: '0.45em 0.7em',
+          color: 'var(--color-muted)',
+        }}
+      >
+        <span>{granting ? '付与中…' : `残高 ${points?.balance ?? '—'}`}</span>
+        {[100, 1000].map((n) => (
+          <button key={n} type="button" disabled={granting} onClick={() => void grant(n)} style={{ fontSize: '1em', padding: '0.2em 0.6em' }}>
+            +{n}
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/admin/power-grant-admin.tsx
+++ b/apps/web/src/components/admin/power-grant-admin.tsx
@@ -33,6 +33,9 @@ export function PowerGrantAdmin({ agent, did }: { agent: Agent; did: string }) {
   return (
     <section style={{ marginTop: '2em' }}>
       <h3 style={{ fontSize: '0.95em' }}>パワー付与 (テスト)</h3>
+      <p style={{ fontSize: '0.8em', color: 'var(--color-muted)', marginBottom: '0.5em' }}>
+        テスト用に残高を加算する (召喚ゲージ viaPosts は動かさない)。
+      </p>
       <div
         style={{
           display: 'inline-flex',

--- a/apps/web/src/components/admin/server-oauth-admin.tsx
+++ b/apps/web/src/components/admin/server-oauth-admin.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useState } from 'react';
+import type { Agent } from '@atproto/api';
+import { startServerOAuth, getServerOAuthStatus, type ServerOAuthStatus } from '@/lib/server-oauth';
+
+/** 管理者専用: サーバーアカウント (権威 state の持ち主) の OAuth 連携を開始する。docs/21 §12。
+ *  管理ダッシュボード (#417) に集約 (以前は設定ページ)。 */
+export function ServerOAuthAdmin({ agent }: { agent: Agent }) {
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [status, setStatus] = useState<ServerOAuthStatus | null>(null);
+  const [statusErr, setStatusErr] = useState<string | null>(null);
+  const [justLinked, setJustLinked] = useState(false);
+
+  // 認可 callback から ?serverOAuth=linked で戻ってきたら「連携できました」を出し、param を掃除する。
+  useEffect(() => {
+    const p = new URLSearchParams(window.location.search);
+    if (p.get('serverOAuth') === 'linked') {
+      setJustLinked(true);
+      p.delete('serverOAuth');
+      const q = p.toString();
+      window.history.replaceState(null, '', window.location.pathname + (q ? `?${q}` : ''));
+    }
+  }, []);
+
+  // 連携状態を確認して表示する (以前は状態が画面に出ず「連携できたか分からない」だった)。
+  useEffect(() => {
+    let cancelled = false;
+    setStatus(null);
+    setStatusErr(null);
+    getServerOAuthStatus(agent)
+      .then((s) => { if (!cancelled) setStatus(s); })
+      .catch((e) => { if (!cancelled) setStatusErr(e instanceof Error ? e.message : '状態取得に失敗しました'); });
+    return () => { cancelled = true; };
+  }, [agent]);
+
+  const onLink = async () => {
+    setBusy(true);
+    setErr(null);
+    try {
+      await startServerOAuth(agent); // 成功時は認可サーバーへ遷移する
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : '連携に失敗しました');
+      setBusy(false);
+    }
+  };
+
+  const fmt = (sec?: number) => (sec ? new Date(sec * 1000).toLocaleString('ja-JP') : '—');
+  const expired = status?.linked && status.expiresAt !== undefined && status.expiresAt * 1000 < Date.now();
+
+  return (
+    <section style={{ marginTop: '2em' }}>
+      <h3 style={{ fontSize: '0.95em' }}>サーバー連携</h3>
+      <p style={{ fontSize: '0.8em', color: 'var(--color-muted)', marginBottom: '0.5em' }}>
+        ゲームの権威データを書き込むサーバーアカウントの連携。
+      </p>
+      {justLinked && (
+        <p style={{ fontSize: '0.8em', color: 'var(--color-accent)', marginBottom: '0.5em' }}>連携できました ✅</p>
+      )}
+      {/* 連携状態 */}
+      <div style={{ fontSize: '0.8em', marginBottom: '0.6em' }}>
+        {statusErr ? (
+          <span style={{ color: 'var(--color-muted)' }}>状態を確認できません: {statusErr}</span>
+        ) : status === null ? (
+          <span style={{ color: 'var(--color-muted)' }}>状態を確認中…</span>
+        ) : status.linked ? (
+          <span style={{ color: expired ? 'var(--color-danger, crimson)' : 'var(--color-accent)' }}>
+            {expired ? '⚠ 連携済み (アクセストークン失効・cron 更新待ち)' : '✓ 連携済み'}
+            {status.did ? <span style={{ color: 'var(--color-muted)' }}> ({status.did})</span> : null}
+            <br />
+            <span style={{ color: 'var(--color-muted)' }}>
+              トークン失効: {fmt(status.expiresAt)} / 最終更新: {fmt(status.updatedAt)}
+            </span>
+          </span>
+        ) : (
+          <span style={{ color: 'var(--color-muted)' }}>未連携</span>
+        )}
+      </div>
+      <button onClick={onLink} disabled={busy}>
+        {busy ? '連携中…' : status?.linked ? '再連携する' : 'サーバーアカウントと連携'}
+      </button>
+      {err && <p style={{ fontSize: '0.8em', color: 'var(--color-danger, crimson)', marginTop: '0.4em' }}>{err}</p>}
+    </section>
+  );
+}

--- a/apps/web/src/components/admin/world-reset-admin.tsx
+++ b/apps/web/src/components/admin/world-reset-admin.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from 'react';
+import type { Agent } from '@atproto/api';
+import { resetOnboarding, armOnboardingReplay } from '@/lib/onboarding-reset';
+
+/**
+ * 管理者専用 (dev のみ): あおぞらワールドを「はじめから」やり直す完全ワイプ。
+ * 管理ダッシュボード (#417) に集約 (以前は設定ページ)。
+ *
+ * **リセットするだけ**で遷移はしない (この画面に留まる — オーナー指摘 2026-07-20)。
+ * armOnboardingReplay でイントロ再表示フラグと祝福マークを storage に立てておくので、管理者が
+ * 自分で通常どおり精霊ブルスコン→「冒険する」→ワールドと進めば、新規ユーザーと同じ
+ * 「ブルスコン画面→冒険する→イントロ→手渡し→祝福」を頭から辿れる。
+ */
+export function WorldResetAdmin({ agent, did }: { agent: Agent; did: string }) {
+  const [busy, setBusy] = useState(false);
+  const [done, setDone] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  // 成功表示は数秒で自然に消す (この画面に留まって他操作を続けても居座らせない — レビュー ★★)。
+  useEffect(() => {
+    if (!done) return;
+    const t = window.setTimeout(() => setDone(false), 6000);
+    return () => window.clearTimeout(t);
+  }, [done]);
+
+  const onReset = async () => {
+    if (busy) return;
+    // 前回の成功/失敗メッセージはボタンを押した時点で消す (confirm でキャンセルしても残像を残さない)。
+    setErr(null);
+    setDone(false);
+    if (!window.confirm('あおぞらワールドを「はじめから」やり直します。\n所持品・装備・レベル・位置がすべて初期化され、元に戻せません (投稿で貯めたパワー残高は残ります)。よろしいですか?')) return;
+    setBusy(true);
+    let timeoutId: number | undefined;
+    try {
+      // 30s の全体タイムアウト (PDS 無応答でも「リセット中…」で固着しない fail-safe)。
+      await Promise.race([
+        resetOnboarding(agent, did),
+        new Promise<never>((_, reject) => { timeoutId = window.setTimeout(() => reject(new Error('reset timeout')), 30_000); }),
+      ]);
+      // 次に管理者が自分でワールドへ入ったとき新規と同じ導入を再生するための準備 (イントロ再表示 +
+      // 祝福マーク)。ここでは遷移しない (オーナー指摘 2026-07-20)。
+      armOnboardingReplay();
+      setDone(true);
+    } catch (e) {
+      console.warn('[admin] onboarding reset failed', e);
+      const detail = e instanceof Error ? e.message : '';
+      setErr(`リセットに失敗しました (${detail || '通信エラー'})。もう一度どうぞ。`);
+    } finally {
+      setBusy(false);
+      if (timeoutId !== undefined) window.clearTimeout(timeoutId);
+    }
+  };
+
+  return (
+    <section style={{ marginTop: '2em' }}>
+      <h3 style={{ fontSize: '0.95em' }}>ワールドリセット</h3>
+      <p style={{ fontSize: '0.8em', color: 'var(--color-muted)', marginBottom: '0.5em' }}>
+        ワールドを「はじめから」やり直す。所持品・装備・レベル・位置を初期化 (投稿で貯めたパワー
+        残高は残る)。リセット後、精霊ブルスコンの画面から冒険すると新規と同じ導入を辿れる。
+      </p>
+      <button onClick={onReset} disabled={busy}>
+        {busy ? 'リセット中…' : '⟲ あおぞらワールドを はじめから'}
+      </button>
+      {/* 重い I/O (最大 30s) 中は「固まった?」に見えないよう明滅で処理継続を示す。 */}
+      {busy && (
+        <p aria-live="polite" style={{ fontSize: '0.8em', color: 'var(--color-muted)', marginTop: '0.4em' }}>
+          <style>{'@keyframes reset-pulse{0%,100%{opacity:0.4}50%{opacity:1}}'}</style>
+          <span style={{ animation: 'reset-pulse 1.4s ease-in-out infinite' }}>はじめの地へ もどしています…</span>
+        </p>
+      )}
+      {done && !busy && (
+        <p aria-live="polite" style={{ fontSize: '0.8em', color: 'var(--color-accent)', marginTop: '0.4em' }}>
+          はじめの地へ もどりました。精霊ブルスコンから 冒険できます。
+        </p>
+      )}
+      {err && <p style={{ fontSize: '0.8em', color: 'var(--color-danger, crimson)', marginTop: '0.4em' }}>{err}</p>}
+    </section>
+  );
+}

--- a/apps/web/src/components/debug-battle-sim.tsx
+++ b/apps/web/src/components/debug-battle-sim.tsx
@@ -138,7 +138,7 @@ export function DebugBattleSim() {
 
   return (
     <section style={{ marginTop: '2em' }}>
-      <h3 style={{ fontSize: '0.95em' }}>管理者 · 模擬戦</h3>
+      <h3 style={{ fontSize: '0.95em' }}>模擬戦</h3>
       <p style={{ fontSize: '0.78em', color: 'var(--color-muted)', marginBottom: '0.5em' }}>
         物理ランダムなしの模擬戦。敵・ジョブ・装備・レベルを選んで、バランスを数値で確認する。
       </p>

--- a/apps/web/src/routes/admin-dashboard.tsx
+++ b/apps/web/src/routes/admin-dashboard.tsx
@@ -2,6 +2,11 @@ import { Link } from 'react-router-dom';
 import { useSession } from '@/lib/session';
 import { isAdminDid } from '@/lib/runtime-config';
 import { WORLD_PREVIEW_ENABLED } from '@/lib/world-preview';
+import { serverOAuthConfigured } from '@/lib/server-oauth';
+import { ServerOAuthAdmin } from '@/components/admin/server-oauth-admin';
+import { WorldResetAdmin } from '@/components/admin/world-reset-admin';
+import { PowerGrantAdmin } from '@/components/admin/power-grant-admin';
+import { DebugBattleSim } from '@/components/debug-battle-sim';
 
 /**
  * あおぞらワールド 管理ダッシュボードの土台 (issue #417 / エピック #416)。
@@ -34,14 +39,6 @@ const CONTENT_SECTIONS: Section[] = [
   { key: 'quests', title: 'クエスト', desc: 'ゲーム内クエストの作成・編集', issue: 423 },
   { key: 'npc', title: 'NPC (将来)', desc: 'NPC の CRUD と配置', issue: 425 },
   { key: 'flags', title: 'フラグ (将来)', desc: '進行フラグでゲート', issue: 426 },
-];
-
-/** 既に別画面にある管理ツール (当面はリンクで集約。将来 /admin へ移設するかは #416 で判断)。
- *  リンク先はページ下部の該当セクションなので、着地点を desc で明示する (アンカー未対応)。 */
-const EXISTING_TOOLS: Section[] = [
-  { key: 'sim', title: '模擬戦シミュレータ', desc: 'バランス検証 → 精霊ページ下部', to: '/spirit' },
-  { key: 'server', title: 'サーバー連携', desc: 'サーバーアカウント連携 → 設定ページ下部', to: '/settings' },
-  { key: 'reset', title: 'ワールドリセット', desc: 'はじめからやり直す → 設定ページ下部', to: '/settings' },
 ];
 
 function Card({ s }: { s: Section }) {
@@ -86,6 +83,8 @@ export function AdminDashboard() {
     );
   }
 
+  const agent = session.agent ?? null;
+  const did = session.did ?? null;
   const grid: React.CSSProperties = { display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(150px, 1fr))', gap: '0.6em', marginTop: '0.5em' };
 
   return (
@@ -100,10 +99,19 @@ export function AdminDashboard() {
         {CONTENT_SECTIONS.map((s) => (<Card key={s.key} s={s} />))}
       </div>
 
-      <h3 style={{ fontSize: '0.95em', marginTop: '1.4em' }}>既存の管理ツール</h3>
-      <div style={grid}>
-        {EXISTING_TOOLS.map((s) => (<Card key={s.key} s={s} />))}
-      </div>
+      {/* 管理ツールはここに**集約 (埋め込み)** する。別画面へ飛ばさない (ハブの意味がなくなる —
+          オーナー指摘 2026-07-20)。CRUD が実装されたら上のカードもここに埋め込みで生えていく。 */}
+      <h3 style={{ fontSize: '0.95em', marginTop: '1.4em' }}>ツール</h3>
+      {agent && did ? (
+        <>
+          <PowerGrantAdmin agent={agent} did={did} />
+          <WorldResetAdmin agent={agent} did={did} />
+          <DebugBattleSim />
+          {serverOAuthConfigured && <ServerOAuthAdmin agent={agent} />}
+        </>
+      ) : (
+        <p style={{ fontSize: '0.85em', color: 'var(--color-muted)' }}>ログインが必要です。</p>
+      )}
     </div>
   );
 }

--- a/apps/web/src/routes/admin-dashboard.tsx
+++ b/apps/web/src/routes/admin-dashboard.tsx
@@ -71,7 +71,12 @@ export function AdminDashboard() {
   if (session.status === 'loading') {
     return <p style={{ padding: '1em' }}>読み込み中…</p>;
   }
-  const isAdmin = WORLD_PREVIEW_ENABLED && isAdminDid(session.did);
+  // ダッシュボード自体は**管理者なら本番でも開ける** (isAdminDid のみ)。中の露出は 2 層:
+  //  - コンテンツ CRUD + dev ツール (パワー付与/リセット/模擬戦) は WORLD_PREVIEW_ENABLED (dev 限定)。
+  //  - サーバー連携 (ServerOAuthAdmin) は**本番でも到達可能** — トークン失効時の再連携が本番運用
+  //    タスクだから (docs/21 §12。旧 settings も WORLD_PREVIEW に依らず出していた — レビュー ★★)。
+  const isAdmin = isAdminDid(session.did);
+  const devTools = WORLD_PREVIEW_ENABLED;
 
   if (!isAdmin) {
     return (
@@ -94,23 +99,27 @@ export function AdminDashboard() {
         ゲーム内容の編集ハブ (エピック #416)。CRUD の中身は データ化 (#418) 後に各セクションへ実装。
       </p>
 
-      <h3 style={{ fontSize: '0.95em', marginTop: '1.2em' }}>コンテンツ</h3>
-      <div style={grid}>
-        {CONTENT_SECTIONS.map((s) => (<Card key={s.key} s={s} />))}
-      </div>
+      {devTools && (
+        <>
+          <h3 style={{ fontSize: '0.95em', marginTop: '1.2em' }}>コンテンツ (準備中)</h3>
+          <div style={grid}>
+            {CONTENT_SECTIONS.map((s) => (<Card key={s.key} s={s} />))}
+          </div>
+        </>
+      )}
 
       {/* 管理ツールはここに**集約 (埋め込み)** する。別画面へ飛ばさない (ハブの意味がなくなる —
-          オーナー指摘 2026-07-20)。CRUD が実装されたら上のカードもここに埋め込みで生えていく。 */}
+          オーナー指摘 2026-07-20)。並びは軽いもの順、重い模擬戦フォームを末尾に (レビュー ★★)。 */}
       <h3 style={{ fontSize: '0.95em', marginTop: '1.4em' }}>ツール</h3>
       {agent && did ? (
         <>
-          <PowerGrantAdmin agent={agent} did={did} />
-          <WorldResetAdmin agent={agent} did={did} />
-          <DebugBattleSim />
           {serverOAuthConfigured && <ServerOAuthAdmin agent={agent} />}
+          {devTools && <PowerGrantAdmin agent={agent} did={did} />}
+          {devTools && <WorldResetAdmin agent={agent} did={did} />}
+          {devTools && <DebugBattleSim />}
         </>
       ) : (
-        <p style={{ fontSize: '0.85em', color: 'var(--color-muted)' }}>ログインが必要です。</p>
+        <p style={{ fontSize: '0.85em', color: 'var(--color-muted)' }}>セッションを準備中…</p>
       )}
     </div>
   );

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -1,12 +1,10 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { AtpAgent, type Agent } from '@atproto/api';
+import { AtpAgent } from '@atproto/api';
 import type { Archetype, DiagnosisResult, StatVector } from '@aozoraquest/core';
 import { ARCHETYPES, JOBS_BY_ID, jobDisplayName, jobTagline, statArrayToVector } from '@aozoraquest/core';
 import { useSession } from '@/lib/session';
 import { isAdminDid } from '@/lib/runtime-config';
-import { startServerOAuth, serverOAuthConfigured, getServerOAuthStatus, type ServerOAuthStatus } from '@/lib/server-oauth';
-import { resetOnboarding, armOnboardingReplay } from '@/lib/onboarding-reset';
 import { WORLD_PREVIEW_ENABLED } from '@/lib/world-preview';
 import { signOut } from '@/lib/oauth';
 import { createTaggedPost, getRecord, putRecord } from '@/lib/atproto';
@@ -345,16 +343,11 @@ export function Settings() {
           <p style={{ fontSize: '0.8em', color: 'var(--color-muted)', marginBottom: '0.5em' }}>
             モンスター・アイテム・マップ・店・クエストの編集ハブ (管理者専用)。
           </p>
+          <p style={{ fontSize: '0.75em', color: 'var(--color-muted)', marginTop: '0.4em' }}>
+            サーバー連携・ワールドリセット・模擬戦・パワー付与はダッシュボードに集約しました。
+          </p>
           <button onClick={() => navigate('/admin')}>管理ダッシュボードを開く</button>
         </section>
-      )}
-
-      {isAdminDid(session.did) && serverOAuthConfigured && session.agent && (
-        <ServerOAuthAdmin agent={session.agent} />
-      )}
-
-      {isAdminDid(session.did) && WORLD_PREVIEW_ENABLED && session.agent && session.did && (
-        <WorldResetAdmin agent={session.agent} did={session.did} />
       )}
 
       <section style={{ marginTop: '2em' }}>
@@ -629,160 +622,3 @@ function AnalyzePostsToggle() {
   );
 }
 
-/** 管理者専用: サーバーアカウント (権威 state の持ち主) の OAuth 連携を開始する。docs/21 §12。 */
-function ServerOAuthAdmin({ agent }: { agent: Agent }) {
-  const [busy, setBusy] = useState(false);
-  const [err, setErr] = useState<string | null>(null);
-  const [status, setStatus] = useState<ServerOAuthStatus | null>(null);
-  const [statusErr, setStatusErr] = useState<string | null>(null);
-  const [justLinked, setJustLinked] = useState(false);
-
-  // 認可 callback から ?serverOAuth=linked で戻ってきたら「連携できました」を出し、param を掃除する。
-  useEffect(() => {
-    const p = new URLSearchParams(window.location.search);
-    if (p.get('serverOAuth') === 'linked') {
-      setJustLinked(true);
-      p.delete('serverOAuth');
-      const q = p.toString();
-      window.history.replaceState(null, '', window.location.pathname + (q ? `?${q}` : ''));
-    }
-  }, []);
-
-  // 連携状態を確認して表示する (以前は状態が画面に出ず「連携できたか分からない」だった)。
-  useEffect(() => {
-    let cancelled = false;
-    setStatus(null);
-    setStatusErr(null);
-    getServerOAuthStatus(agent)
-      .then((s) => { if (!cancelled) setStatus(s); })
-      .catch((e) => { if (!cancelled) setStatusErr(e instanceof Error ? e.message : '状態取得に失敗しました'); });
-    return () => { cancelled = true; };
-  }, [agent]);
-
-  const onLink = async () => {
-    setBusy(true);
-    setErr(null);
-    try {
-      await startServerOAuth(agent); // 成功時は認可サーバーへ遷移する
-    } catch (e) {
-      setErr(e instanceof Error ? e.message : '連携に失敗しました');
-      setBusy(false);
-    }
-  };
-
-  const fmt = (sec?: number) => (sec ? new Date(sec * 1000).toLocaleString('ja-JP') : '—');
-  const expired = status?.linked && status.expiresAt !== undefined && status.expiresAt * 1000 < Date.now();
-
-  return (
-    <section style={{ marginTop: '2em' }}>
-      <h3 style={{ fontSize: '0.95em' }}>管理者 (サーバー連携)</h3>
-      <p style={{ fontSize: '0.8em', color: 'var(--color-muted)', marginBottom: '0.5em' }}>
-        ゲームの権威データを書き込むサーバーアカウントの連携。
-      </p>
-      {justLinked && (
-        <p style={{ fontSize: '0.8em', color: 'var(--color-accent)', marginBottom: '0.5em' }}>連携できました ✅</p>
-      )}
-      {/* 連携状態 */}
-      <div style={{ fontSize: '0.8em', marginBottom: '0.6em' }}>
-        {statusErr ? (
-          <span style={{ color: 'var(--color-muted)' }}>状態を確認できません: {statusErr}</span>
-        ) : status === null ? (
-          <span style={{ color: 'var(--color-muted)' }}>状態を確認中…</span>
-        ) : status.linked ? (
-          <span style={{ color: expired ? 'var(--color-danger, crimson)' : 'var(--color-accent)' }}>
-            {expired ? '⚠ 連携済み (アクセストークン失効・cron 更新待ち)' : '✓ 連携済み'}
-            {status.did ? <span style={{ color: 'var(--color-muted)' }}> ({status.did})</span> : null}
-            <br />
-            <span style={{ color: 'var(--color-muted)' }}>
-              トークン失効: {fmt(status.expiresAt)} / 最終更新: {fmt(status.updatedAt)}
-            </span>
-          </span>
-        ) : (
-          <span style={{ color: 'var(--color-muted)' }}>未連携</span>
-        )}
-      </div>
-      <button onClick={onLink} disabled={busy}>
-        {busy ? '連携中…' : status?.linked ? '再連携する' : 'サーバーアカウントと連携'}
-      </button>
-      {err && <p style={{ fontSize: '0.8em', color: 'var(--color-danger, crimson)', marginTop: '0.4em' }}>{err}</p>}
-    </section>
-  );
-}
-
-/**
- * 管理者専用 (dev のみ): あおぞらワールドを「はじめから」やり直す完全ワイプ。
- * 地図メニューから**設定画面へ移設**した (地図上でリセットすると「いきなり地図」から再開し、
- * 新規のオンボードルートと食い違うため — オーナー指摘 2026-07-20)。
- *
- * **リセットするだけ**で遷移はしない (この設定画面に留まる — オーナー指摘 2026-07-20)。
- * armOnboardingReplay でイントロ再表示フラグと祝福マークを storage に立てておくので、管理者が
- * 自分で通常どおり精霊ブルスコン→「冒険する」→ワールドと進めば、新規ユーザーと同じ
- * 「ブルスコン画面→冒険する→イントロ→手渡し→祝福」を頭から辿れる。
- */
-function WorldResetAdmin({ agent, did }: { agent: Agent; did: string }) {
-  const [busy, setBusy] = useState(false);
-  const [done, setDone] = useState(false);
-  const [err, setErr] = useState<string | null>(null);
-
-  // 成功表示は数秒で自然に消す (この設定画面に留まって他操作を続けても居座らせない — レビュー ★★)。
-  useEffect(() => {
-    if (!done) return;
-    const t = window.setTimeout(() => setDone(false), 6000);
-    return () => window.clearTimeout(t);
-  }, [done]);
-
-  const onReset = async () => {
-    if (busy) return;
-    // 前回の成功/失敗メッセージはボタンを押した時点で消す (confirm でキャンセルしても残像を残さない)。
-    setErr(null);
-    setDone(false);
-    if (!window.confirm('あおぞらワールドを「はじめから」やり直します。\n所持品・装備・レベル・位置がすべて初期化され、元に戻せません (投稿で貯めたパワー残高は残ります)。よろしいですか?')) return;
-    setBusy(true);
-    let timeoutId: number | undefined;
-    try {
-      // 30s の全体タイムアウト (PDS 無応答でも「リセット中…」で固着しない fail-safe)。
-      await Promise.race([
-        resetOnboarding(agent, did),
-        new Promise<never>((_, reject) => { timeoutId = window.setTimeout(() => reject(new Error('reset timeout')), 30_000); }),
-      ]);
-      // 次に管理者が自分でワールドへ入ったとき新規と同じ導入を再生するための準備 (イントロ再表示 +
-      // 祝福マーク)。ここでは遷移しない — この設定画面に留まる (オーナー指摘 2026-07-20)。
-      armOnboardingReplay();
-      setDone(true);
-    } catch (e) {
-      console.warn('[settings] onboarding reset failed', e);
-      const detail = e instanceof Error ? e.message : '';
-      setErr(`リセットに失敗しました (${detail || '通信エラー'})。もう一度どうぞ。`);
-    } finally {
-      setBusy(false);
-      if (timeoutId !== undefined) window.clearTimeout(timeoutId);
-    }
-  };
-
-  return (
-    <section style={{ marginTop: '2em' }}>
-      <h3 style={{ fontSize: '0.95em' }}>管理者 (ワールド)</h3>
-      <p style={{ fontSize: '0.8em', color: 'var(--color-muted)', marginBottom: '0.5em' }}>
-        ワールドを「はじめから」やり直す。所持品・装備・レベル・位置を初期化 (投稿で貯めたパワー
-        残高は残る)。リセット後、精霊ブルスコンの画面から冒険すると新規と同じ導入を辿れる。
-      </p>
-      <button onClick={onReset} disabled={busy}>
-        {busy ? 'リセット中…' : '⟲ あおぞらワールドを はじめから'}
-      </button>
-      {/* 重い I/O (最大 30s) 中は「固まった?」に見えないよう明滅で処理継続を示す
-          (旧地図の全画面オーバーレイの脈動を最小構成で踏襲 — レビュー ★★)。 */}
-      {busy && (
-        <p aria-live="polite" style={{ fontSize: '0.8em', color: 'var(--color-muted)', marginTop: '0.4em' }}>
-          <style>{'@keyframes reset-pulse{0%,100%{opacity:0.4}50%{opacity:1}}'}</style>
-          <span style={{ animation: 'reset-pulse 1.4s ease-in-out infinite' }}>はじめの地へ もどしています…</span>
-        </p>
-      )}
-      {done && !busy && (
-        <p aria-live="polite" style={{ fontSize: '0.8em', color: 'var(--color-accent)', marginTop: '0.4em' }}>
-          はじめの地へ もどりました。精霊ブルスコンから 冒険できます。
-        </p>
-      )}
-      {err && <p style={{ fontSize: '0.8em', color: 'var(--color-danger, crimson)', marginTop: '0.4em' }}>{err}</p>}
-    </section>
-  );
-}

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -5,7 +5,6 @@ import type { Archetype, DiagnosisResult, StatVector } from '@aozoraquest/core';
 import { ARCHETYPES, JOBS_BY_ID, jobDisplayName, jobTagline, statArrayToVector } from '@aozoraquest/core';
 import { useSession } from '@/lib/session';
 import { isAdminDid } from '@/lib/runtime-config';
-import { WORLD_PREVIEW_ENABLED } from '@/lib/world-preview';
 import { signOut } from '@/lib/oauth';
 import { createTaggedPost, getRecord, putRecord } from '@/lib/atproto';
 import { COL } from '@/lib/collections';
@@ -337,7 +336,9 @@ export function Settings() {
         <PostQuestNotificationsToggle />
       </section>
 
-      {isAdminDid(session.did) && WORLD_PREVIEW_ENABLED && (
+      {/* 管理者なら本番でも出す (ダッシュボード内でサーバー連携=本番運用タスクへ入れるように)。
+          コンテンツ CRUD・dev ツールはダッシュボード側で dev 限定にゲートする。 */}
+      {isAdminDid(session.did) && (
         <section style={{ marginTop: '2em' }}>
           <h3 style={{ fontSize: '0.95em' }}>あおぞらワールド 管理</h3>
           <p style={{ fontSize: '0.8em', color: 'var(--color-muted)', marginBottom: '0.5em' }}>

--- a/apps/web/src/routes/spirit.tsx
+++ b/apps/web/src/routes/spirit.tsx
@@ -21,8 +21,6 @@ import { useRuntimeConfig } from '@/components/config-provider';
 import { applyPromptTemplate } from '@/lib/prompt-template';
 import { bumpPower, loadPointsState, SUMMON_THRESHOLD, type PointsState } from '@/lib/points';
 import { WORLD_PREVIEW_ENABLED } from '@/lib/world-preview';
-import { DebugBattleSim } from '@/components/debug-battle-sim';
-import { isAdminDid } from '@/lib/runtime-config';
 
 /**
  * 精霊ブルスコンのページ。
@@ -52,8 +50,6 @@ export function Spirit() {
   const [questXp, setQuestXp] = useState(0);
   const [loaded, setLoaded] = useState(false);
   const [ritualOpen, setRitualOpen] = useState(false);
-  // 管理者用パワー付与の書込み中フラグ (dev 限定・多重押し防止)
-  const [grantingPower, setGrantingPower] = useState(false);
 
   const agent = session.agent ?? null;
   const did = session.did ?? null;
@@ -278,54 +274,8 @@ export function Spirit() {
             </section>
           )}
 
-          {/* 管理者用: dev でパワーを付与してテストする。VITE_ADMIN_DIDS の DID かつ
-              プレビュー環境 (dev/local) のときだけ表示。本番遮断は WORLD_PREVIEW_ENABLED
-              (本番ビルドでは false → dead-code) が担い、isAdminDid は dev 内での権限分離。
-              加算は残高に純増する salePowerEarned に乗せる (viaPosts は召喚進捗ゲージ・
-              toSummon も動かす別セマンティクスなので、残高だけ盛る用途では使わない)。 */}
-          {WORLD_PREVIEW_ENABLED && agent && did && isAdminDid(did) && (
-            <section style={{ marginTop: '1em', textAlign: 'center' }}>
-              <div
-                style={{
-                  display: 'inline-flex',
-                  gap: '0.5em',
-                  alignItems: 'center',
-                  fontSize: '0.78em',
-                  border: '1px dashed var(--color-muted)',
-                  borderRadius: 6,
-                  padding: '0.45em 0.7em',
-                  color: 'var(--color-muted)',
-                }}
-              >
-                <span>{grantingPower ? '管理者 · 付与中…' : `管理者 · パワー ${points.balance}`}</span>
-                {[100, 1000].map((n) => (
-                  <button
-                    key={n}
-                    type="button"
-                    disabled={grantingPower}
-                    onClick={async () => {
-                      setGrantingPower(true);
-                      try {
-                        await bumpPower(agent, did, { salePowerEarned: n });
-                        const next = await loadPointsState(agent, did);
-                        setPoints(next);
-                      } catch (e) {
-                        console.warn('admin power grant failed', e);
-                      } finally {
-                        setGrantingPower(false);
-                      }
-                    }}
-                    style={{ fontSize: '1em', padding: '0.2em 0.6em' }}
-                  >
-                    +{n}
-                  </button>
-                ))}
-              </div>
-            </section>
-          )}
-
-          {/* 管理者デバッグ模擬戦 (issue #414)。dev + 管理者のみ。 */}
-          {WORLD_PREVIEW_ENABLED && did && isAdminDid(did) && <DebugBattleSim />}
+          {/* 管理者ツール (パワー付与・模擬戦・リセット・連携) は管理ダッシュボード /admin に
+              集約した (以前はここ。バラバラに置かない — オーナー指摘 2026-07-20)。 */}
         </>
       )}
 


### PR DESCRIPTION
Closes #428
Epic #416

## 背景 (オーナー指摘 2026-07-20)
> 模擬戦シミュレーターとか世界リセットは管理ダッシュボードの方に集約して欲しい。バラバラの画面に飛ばしたら意味ないよ

#417 のダッシュボードは既存ツールへ**リンク**していた。**埋め込み**で集約する。

## 変更
- `ServerOAuthAdmin` / `WorldResetAdmin` を settings から **`components/admin/`** へ抽出、パワー付与を spirit から `components/admin/power-grant-admin.tsx` へ抽出 (自己完結)。
- **/admin ダッシュボードに埋め込み**。settings/spirit から撤去 (設定は導線だけ残す)。
- **2 層ゲート**: ダッシュボードは管理者なら本番でも開け、コンテンツ CRUD + dev ツールは dev 限定、**サーバー連携は本番でも到達可能** (トークン再連携=本番運用タスク)。

## 検証
- `web typecheck` / `test 346` / `build` 緑。抽出は verbatim (レビュー済みロジック保持)。

## Review

§1.5 3 並列レビュー (設計/実装/UX)。**★★★ 0 件。**

**★★ (PR 内で対応済み)**
- **サーバー連携が本番で到達不能** (設計・実装が合致): 旧ゲートは WORLD_PREVIEW に依らず本番到達可 (docs/21 §12 のロックアウト復旧導線)。→ 2 層ゲート化し ServerOAuth を本番でも出す。(637ee16)
- **見出し不統一** (UX): 「管理者 · 模擬戦」→「模擬戦」。(637ee16)
- **縦の重み付け** (UX): 重い模擬戦を末尾へ並べ替え (サーバー連携→パワー付与→リセット→模擬戦)。(637ee16)

**★ (PR 内で対応済み)**
- 「コンテンツ (準備中)」/ パワー付与に説明文 / フォールバック文言を「セッションを準備中…」に。(637ee16)

**★ (記録・別 issue 化候補)**: WorldResetAdmin (confirm キャンセル/成功/失敗/タイムアウト分岐) の単体テスト — 独立コンポーネント化した今が好機だが本 PR では見送り。見出しの h4 セマンティクスも任意。

**確認済み**: 抽出等価性 (verbatim)、settings/spirit の残骸なし、OAuth callback returnTo が /admin で正しく戻る。