### PR TITLE
fix(battle): 会心の一撃を DQ 流に強化 — 攻撃力1.5倍 + ぼうぎょ無視

### DIFF
--- a/packages/core/src/__tests__/battle.test.ts
+++ b/packages/core/src/__tests__/battle.test.ts
@@ -591,6 +591,27 @@ describe('resolveTurn', () => {
     expect(failSeen).toBe(true);
   });
 
+  it('会心: 守備力を無視して非会心の理論最大を超える (DQ 流。攻撃力1.5倍 + 守備無視)', () => {
+    // 高 def の敵 (ヒカリダケ) にプレイヤーが会心する (seed, turnSeed) を探す。会心は守備無視 +
+    // 1.5 倍なので、非会心の理論最大 (roll 1.15、守備軽減あり) を必ず超える。
+    const t = BATTLE_TUNING;
+    let found: { atk: number; def: number; dmg: number } | null = null;
+    for (let seed = 0; seed < 300 && !found; seed++) {
+      const b0 = startBattle('warrior', 3, 5, '戦士', 1, seed, 0, undefined, { monsterId: 'glow-shroom' });
+      for (let ts = 0; ts < 120; ts++) {
+        const next = resolveTurn(b0, 'attack', ts);
+        const ev = next.lastEvents.find(
+          (e) => e.actor === 'player' && e.damage !== undefined && e.text.includes('会心の一撃'),
+        );
+        if (ev) { found = { atk: b0.player.atk, def: b0.monster.def, dmg: ev.damage! }; break; }
+      }
+    }
+    expect(found).not.toBeNull();
+    // 守備無視が効いている証拠: 非会心の理論最大 (守備軽減あり) を会心が上回る。
+    const maxNonCrit = Math.round((found!.atk * 1.15 * t.damageScale) / (t.damageSoften + found!.def));
+    expect(found!.dmg).toBeGreaterThan(maxNonCrit);
+  });
+
   it('にげる成功率は agi 差で変わる (鈍足 guardian < 俊足 ninja、統計)', () => {
     const rate = (arch: 'ninja' | 'guardian') => {
       let fled = 0;

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -58,10 +58,13 @@ export const BATTLE_TUNING = {
   dodgeMin: 0.02,
   // focus 込みの実効上限は dodgeMax + guardFocusDodge (ぼうぎょ直後の高 agi 職で最大 0.47)
   dodgeMax: 0.32,
-  /** クリティカル率 = critBase + luk*critLukScale (1.5 倍) */
+  /** クリティカル率 = critBase + luk*critLukScale。会心 (かいしんのいちげき) は DQ 流に
+   *  **攻撃力 critAtkMultiplier 倍 + 相手のぼうぎょ無視** (守備力もぼうぎょ半減も貫通)。
+   *  守備無視だけで大幅増なので倍率は控えめ 1.5 (2 は高すぎ — オーナー指摘 2026-07-20)。
+   *  高防御の敵ほど効く一発逆転の一撃。値は模擬戦シミュレータで調整可。 */
   critBase: 0.04,
   critLukScale: 0.004,
-  critMultiplier: 1.5,
+  critAtkMultiplier: 1.5,
   /** ぼうぎょ: 被ダメージ半減 */
   guardReduction: 0.5,
   /** ため攻撃 (tier2+ が 1 ターン予告してから放つ) の倍率。予告を見て防御するのが正解
@@ -820,16 +823,17 @@ function doAttack(
   }
 
   const atkValue = opts.atkOverride ?? (opts.useInt ? attacker.int : attacker.atk);
-  const defValue = defender.def * (opts.defFactor ?? 1);
   const roll = 0.85 + rng() * 0.3;
-  let dmg = (atkValue * roll * t.damageScale * (opts.power ?? 1)) / (t.damageSoften + defValue);
-
-  // クリティカル (luk)
+  // クリティカル (luk)。会心は DQ のかいしんのいちげき流: **攻撃力 critAtkMultiplier 倍 +
+  // 相手のぼうぎょ無視** = ダメージ式の防御項を 0 にし、ぼうぎょ/見切りの半減も貫通する
+  // (守備の高い敵ほど効く一発逆転。オーナー要望 2026-07-20)。
   const crit = rng() < t.critBase + attacker.luk * t.critLukScale;
-  if (crit) dmg *= t.critMultiplier;
+  const critAtk = crit ? t.critAtkMultiplier : 1;
+  const defValue = crit ? 0 : defender.def * (opts.defFactor ?? 1);
+  let dmg = (atkValue * critAtk * roll * t.damageScale * (opts.power ?? 1)) / (t.damageSoften + defValue);
 
-  // 防御 / 見切りで半減
-  if (defender.guarding || defender.parrying) dmg *= t.guardReduction;
+  // 防御 / 見切りで半減 (会心は貫通 = ぼうぎょ無視)
+  if (!crit && (defender.guarding || defender.parrying)) dmg *= t.guardReduction;
 
   const final = Math.max(1, Math.round(dmg));
   defender.hp = Math.max(0, defender.hp - final);

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -59,9 +59,10 @@ export const BATTLE_TUNING = {
   // focus 込みの実効上限は dodgeMax + guardFocusDodge (ぼうぎょ直後の高 agi 職で最大 0.47)
   dodgeMax: 0.32,
   /** クリティカル率 = critBase + luk*critLukScale。会心 (かいしんのいちげき) は DQ 流に
-   *  **攻撃力 critAtkMultiplier 倍 + 相手のぼうぎょ無視** (守備力もぼうぎょ半減も貫通)。
-   *  守備無視だけで大幅増なので倍率は控えめ 1.5 (2 は高すぎ — オーナー指摘 2026-07-20)。
-   *  高防御の敵ほど効く一発逆転の一撃。値は模擬戦シミュレータで調整可。 */
+   *  **攻撃力 critAtkMultiplier 倍**。守備力 (def) 無視は**プレイヤーの会心のみ** (敵の会心は
+   *  1.5 倍のみ = タンク職を守る。バランス ★★★)。倍率は控えめ 1.5 (2 は高すぎ — オーナー指摘
+   *  2026-07-20)。守備の高い敵ほど効く一発逆転。ぼうぎょコマンドの半減は貫通しない。値は
+   *  模擬戦シミュレータで調整可。 */
   critBase: 0.04,
   critLukScale: 0.004,
   critAtkMultiplier: 1.5,
@@ -824,16 +825,18 @@ function doAttack(
 
   const atkValue = opts.atkOverride ?? (opts.useInt ? attacker.int : attacker.atk);
   const roll = 0.85 + rng() * 0.3;
-  // クリティカル (luk)。会心は DQ のかいしんのいちげき流: **攻撃力 critAtkMultiplier 倍 +
-  // 相手のぼうぎょ無視** = ダメージ式の防御項を 0 にし、ぼうぎょ/見切りの半減も貫通する
-  // (守備の高い敵ほど効く一発逆転。オーナー要望 2026-07-20)。
+  // クリティカル (luk)。会心は DQ のかいしんのいちげき流: **攻撃力 critAtkMultiplier 倍**。
+  // **守備力 (def) 無視はプレイヤーの会心のみ** (守備の高い敵を貫く一発逆転。オーナー要望
+  // 2026-07-20)。敵の会心を守備無視にすると、タンク職 (guardian) の「固く受ける」存在意義が
+  // 壊れ拮抗帯で事故死が倍増するため、敵の会心は 1.5 倍のみ (バランス ★★★)。ぼうぎょ/見切り
+  // **コマンドの半減はどちらも貫通しない** — 貫くと「予告を見て防御」の読み合いが崩れる (設計 ★★★)。
   const crit = rng() < t.critBase + attacker.luk * t.critLukScale;
   const critAtk = crit ? t.critAtkMultiplier : 1;
-  const defValue = crit ? 0 : defender.def * (opts.defFactor ?? 1);
+  const defValue = crit && actor === 'player' ? 0 : defender.def * (opts.defFactor ?? 1);
   let dmg = (atkValue * critAtk * roll * t.damageScale * (opts.power ?? 1)) / (t.damageSoften + defValue);
 
-  // 防御 / 見切りで半減 (会心は貫通 = ぼうぎょ無視)
-  if (!crit && (defender.guarding || defender.parrying)) dmg *= t.guardReduction;
+  // 防御 / 見切りで半減 (会心でもコマンド防御は効く = 防御の存在意義を守る)
+  if (defender.guarding || defender.parrying) dmg *= t.guardReduction;
 
   const final = Math.max(1, Math.round(dmg));
   defender.hp = Math.max(0, defender.hp - final);


### PR DESCRIPTION
Closes #431

## 背景 (オーナー指摘 2026-07-20)
> かいしんのいちげきのダメージ低すぎない？攻撃力2倍にして相手のぼうぎょ無視 / ドラクエの計算方法を参考に / 攻撃力2倍は高すぎるかも

## 変更 (DQ のかいしんのいちげき流)
- 会心 = **攻撃力 1.5 倍 + (プレイヤーの会心のみ) 守備力 (def) 無視**。守備の高い敵を貫く一発逆転。
- `critMultiplier(1.5)` → `critAtkMultiplier(1.5)`。値は模擬戦シミュレータ (#415) で調整可。
- **敵の会心は 1.5 倍のみ** (守備無視しない)。**ぼうぎょ/見切りコマンドの半減は貫通しない**。

## Review

§1.5 3 並列レビュー (設計/実装/バランス)。**★★★ 2 件を PR 内で対応。**

**★★★ (PR 内で対応済み)**
- **敵の守備無視会心がタンク職を破壊** (バランス): 敵の会心も守備無視だと guardian の勝率が拮抗帯で半減 (65%→32%)・事故死倍増。→ **守備無視はプレイヤーの会心のみ**に。敵の会心は 1.5 倍のみで守備が効く (タンク回復)。(f93bf34)
- **会心の guard 貫通が防御戦略を破壊** (設計): 会心が guardReduction を貫くと、ため攻撃の会心で「予告→防御」の核ループが崩れる。→ ぼうぎょ/見切りコマンドの半減は会心でも効く (守備無視=def項0 と防御コマンド貫通を分離)。(f93bf34)

**★★ (PR 内で対応済み)**
- 会心テスト追加 (プレイヤー会心が守備を無視して非会心の理論最大を超える)。core 312 緑。

**★★ (記録・oversell 訂正)**
- はぐれメタル型の「守備無視会心で一撃」ロマンは**実装上ゼロ寄与** (メタルは元々1発で死ぬ・ボトルネックは逃走/回避)。会心強化はメタル狩りには効かない。→ #408 (メタルの追う楽しさ) で別途。

**確認済み**: rng 順不変で決定論維持、サーバー権威 (edge は core import) 整合、critMultiplier 全参照置換。