### PR TITLE
fix(sim): 模擬戦1戦モードを本番同様の per-turn 乱数に (#441 fleer 見かけ100%逃走)

### DIFF
--- a/apps/web/src/components/debug-battle-sim.tsx
+++ b/apps/web/src/components/debug-battle-sim.tsx
@@ -24,8 +24,8 @@ import {
  * 敵をリスト選択、プレイヤー側もジョブ/装備/レベルを選択し、
  *  - バッチ: N 戦 (seed 0..N-1) を自動プレイ → 勝率・平均 XP・平均ターン・生存時残 HP・次 Lv まで何戦。
  *    catch 率 (fleer の討伐率) もここに出る (逃走 = 非 win)。統計はこちらで見る。
- *  - 1 戦: 敵ステータスは variance 0 で固定しつつ、**戦闘中の乱数は本番同様に毎ターン新鮮**
- *    (edge の pendingTurnSeed と同じ) にして自分でコマンドを選び挙動確認 (#441 で固定 seed を廃止)。
+ *  - 1 戦: 敵ステータスは variance 0 で固定しつつ、**戦闘中の乱数は毎ターン揺らす** (seed = 時刻)
+ *    ことで本番同様に fleer 等が毎回変わる。自分でコマンドを選び挙動確認 (#441 で固定 seed を廃止)。
  * を行う。固定強度化 (#409) の上でエリア/順路/XP カーブ (#412/#413) の数値を詰める道具。
  */
 
@@ -129,14 +129,11 @@ export function DebugBattleSim() {
     });
   };
 
-  // 本番 world 戦闘は edge が毎ターン新鮮な CSPRNG (entropyU32) を turnSeed に注入するので
-  // (battle-resolver.ts)、逃走/会心/回避は毎ターン揺れる。1戦モードも同じく毎ターン新鮮な
-  // エントロピーを渡して本番に一致させる (固定 seed だと fleer が毎回同じ判定 = 100%逃走に
-  // 見える乖離。#441)。敵の初期ステータスは variance 0 で固定 (再現性のため) にしつつ、
-  // 戦闘中の乱数だけ本番同様に揺らす。
-  // crypto はブラウザ Web Crypto (edge の kuda と同系)。このコンポーネントは
-  // WORLD_PREVIEW_ENABLED (dev + 管理者) でしか表示されずクライアント専用なので可用性は担保。
-  const freshSeed = () => crypto.getRandomValues(new Uint32Array(1))[0]!;
+  // 固定 seed だと fleer が毎ターン同じ判定 = 100%逃走に見える乖離があった (#441)。1戦モードは
+  // 「毎ターン判定が揺れる」だけでよく、本番 (edge) のような先読み防止 CSPRNG は不要 — seed を
+  // 時刻にするだけで十分 (オーナー指摘)。手動/自動1手はクリック駆動なので ms 衝突しない。
+  // 敵の初期ステータスは variance 0 で固定 (再現性)、戦闘中の乱数だけ毎ターン揺らす。
+  const freshSeed = () => Date.now();
   const startDuel = () => {
     setBatch(null);
     // 初期 seed は固定でよい: monsterId 固定 + variance 0 なので敵ステータスは seed 非依存で一定

--- a/apps/web/src/components/debug-battle-sim.tsx
+++ b/apps/web/src/components/debug-battle-sim.tsx
@@ -22,8 +22,10 @@ import {
  * 管理者デバッグ模擬戦シミュレータ (issue #414)。/spirit の管理者セクションから使う。
  *
  * 敵をリスト選択、プレイヤー側もジョブ/装備/レベルを選択し、
- *  - バッチ: N 戦を自動プレイ → 勝率・平均 XP・平均ターン・生存時残 HP・次 Lv まで何戦
- *  - 決定論 1 戦: variance 0 + 固定 seed で自分でコマンドを選び挙動確認
+ *  - バッチ: N 戦 (seed 0..N-1) を自動プレイ → 勝率・平均 XP・平均ターン・生存時残 HP・次 Lv まで何戦。
+ *    catch 率 (fleer の討伐率) もここに出る (逃走 = 非 win)。統計はこちらで見る。
+ *  - 1 戦: 敵ステータスは variance 0 で固定しつつ、**戦闘中の乱数は本番同様に毎ターン新鮮**
+ *    (edge の pendingTurnSeed と同じ) にして自分でコマンドを選び挙動確認 (#441 で固定 seed を廃止)。
  * を行う。固定強度化 (#409) の上でエリア/順路/XP カーブ (#412/#413) の数値を詰める道具。
  */
 
@@ -34,7 +36,7 @@ const WORLD_TONIC_MAX = 3;
 const clampInt = (v: number, def: number, min: number, max: number) =>
   Number.isFinite(v) ? Math.min(max, Math.max(min, Math.floor(v))) : def;
 
-/** 決定論1戦のコマンド表示名 (world 戦闘と同じ日本語で手触りを揃える)。 */
+/** 1戦モードのコマンド表示名 (world 戦闘と同じ日本語で手触りを揃える)。 */
 const CMD_LABEL: Record<Command, string> = {
   attack: 'たたかう', guard: 'ぼうぎょ', skill: 'とくぎ', herb: 'やくそう', tonic: 'しずく', flee: 'にげる',
 };
@@ -127,12 +129,20 @@ export function DebugBattleSim() {
     });
   };
 
+  // 本番 world 戦闘は edge が毎ターン新鮮な CSPRNG (entropyU32) を turnSeed に注入するので
+  // (battle-resolver.ts)、逃走/会心/回避は毎ターン揺れる。1戦モードも同じく毎ターン新鮮な
+  // エントロピーを渡して本番に一致させる (固定 seed だと fleer が毎回同じ判定 = 100%逃走に
+  // 見える乖離。#441)。敵の初期ステータスは variance 0 で固定 (再現性のため) にしつつ、
+  // 戦闘中の乱数だけ本番同様に揺らす。
+  const freshSeed = () => crypto.getRandomValues(new Uint32Array(1))[0]!;
   const startDuel = () => {
     setBatch(null);
-    setDuel(start(1, 0)); // 決定論: variance 0 + 固定 seed
+    setDuel(start(freshSeed(), 0)); // 敵ステータスは variance 0 で固定、per-turn 乱数は下で新鮮に
   };
-  const duelCmd = (cmd: Command) => setDuel((s) => (s && s.outcome === 'ongoing' ? resolveTurn(s, cmd) : s));
-  const duelAuto = () => setDuel((s) => (s && s.outcome === 'ongoing' ? resolveTurn(s, autoBattleCommand(s)) : s));
+  const duelCmd = (cmd: Command) =>
+    setDuel((s) => (s && s.outcome === 'ongoing' ? resolveTurn(s, cmd, freshSeed()) : s));
+  const duelAuto = () =>
+    setDuel((s) => (s && s.outcome === 'ongoing' ? resolveTurn(s, autoBattleCommand(s), freshSeed()) : s));
 
   const pct = (x: number) => `${Math.round(x * 100)}%`;
 
@@ -140,7 +150,8 @@ export function DebugBattleSim() {
     <section style={{ marginTop: '2em' }}>
       <h3 style={{ fontSize: '0.95em' }}>模擬戦</h3>
       <p style={{ fontSize: '0.78em', color: 'var(--color-muted)', marginBottom: '0.5em' }}>
-        物理ランダムなしの模擬戦。敵・ジョブ・装備・レベルを選んで、バランスを数値で確認する。
+        敵・ジョブ・装備・レベルを選んでバランスを数値で確認する。バッチは多数試行の統計 (catch 率も)、
+        1 戦は本番同様の乱数で自分で操作。
       </p>
 
       {/* 入力フォーム */}
@@ -196,7 +207,7 @@ export function DebugBattleSim() {
         <label style={{ fontSize: '0.8em' }}>N
           <input type="number" min={1} max={2000} value={trials} onChange={(e) => setTrials(Number(e.target.value))} style={{ width: '4em', marginLeft: '0.3em' }} />
         </label>
-        <button onClick={startDuel}>決定論1戦</button>
+        <button onClick={startDuel}>1戦プレイ</button>
       </div>
 
       {/* バッチ結果 */}
@@ -214,7 +225,7 @@ export function DebugBattleSim() {
         </div>
       )}
 
-      {/* 決定論 1 戦 */}
+      {/* 1 戦プレイ (本番同様の per-turn 乱数) */}
       {duel && (
         <div className="dq-window" style={{ marginTop: '0.6em', fontSize: '0.82em', padding: '0.6em 0.8em' }}>
           <div style={{ fontWeight: 700 }}>{`${jobDisplayName(job)} vs ${duel.monster.name}`}</div>

--- a/apps/web/src/components/debug-battle-sim.tsx
+++ b/apps/web/src/components/debug-battle-sim.tsx
@@ -134,10 +134,14 @@ export function DebugBattleSim() {
   // エントロピーを渡して本番に一致させる (固定 seed だと fleer が毎回同じ判定 = 100%逃走に
   // 見える乖離。#441)。敵の初期ステータスは variance 0 で固定 (再現性のため) にしつつ、
   // 戦闘中の乱数だけ本番同様に揺らす。
+  // crypto はブラウザ Web Crypto (edge の kuda と同系)。このコンポーネントは
+  // WORLD_PREVIEW_ENABLED (dev + 管理者) でしか表示されずクライアント専用なので可用性は担保。
   const freshSeed = () => crypto.getRandomValues(new Uint32Array(1))[0]!;
   const startDuel = () => {
     setBatch(null);
-    setDuel(start(freshSeed(), 0)); // 敵ステータスは variance 0 で固定、per-turn 乱数は下で新鮮に
+    // 初期 seed は固定でよい: monsterId 固定 + variance 0 なので敵ステータスは seed 非依存で一定
+    // (summonMonster を通らず monsterCombatant の jitter も効かない)。戦闘中の乱数だけ下で新鮮に。
+    setDuel(start(1, 0));
   };
   const duelCmd = (cmd: Command) =>
     setDuel((s) => (s && s.outcome === 'ongoing' ? resolveTurn(s, cmd, freshSeed()) : s));


### PR DESCRIPTION
Closes #441

## 症状
模擬戦シミュレータの**1戦モード**が固定 seed=1 + turnSeed 無しで `resolveTurn` を回すため、RNG が完全固定。はぐれスライム (fleer) だと毎回「逃走」に着地し、**100% 逃げられる**ように見えていた。

## 原因と修正
- 本番 world 戦闘は edge が毎ターン新鮮な CSPRNG (`entropyU32`) を `pendingTurnSeed` として注入 (battle-resolver.ts:184/384/445) → 逃走判定は毎ターン揺れる。1戦モードだけが乖離していた。
- 1戦モードも毎ターン seed を時刻 (Date.now) にして `resolveTurn` に渡す。本番のような先読み防止 CSPRNG は不要 (デバッグツールなので判定が揺れれば十分)。敵の初期ステータスは variance 0 で固定 (再現性)、戦闘中の乱数だけ本番同様に揺らす。
- バッチモード (seed 0..N-1 の統計) は変更なし。catch 率を正しく出している (win% = 討伐率)。
- UI ラベル「決定論1戦」→「1戦プレイ」、説明文も更新。

## 検証
- **本番 catch 率 (バッチ実測, はぐれスライム)**: warrior 37% / shogun 39% / ninja 96% (高agi先手) / warrior jobLv8 44%。本番は元々「毎回逃走」ではなかった。
- web typecheck / test (346) / build 緑。
- 本番の catch 率そのものの是非 (逃走/会心チューニング) は別途 #408。

## Review
§1.5 3並列レビュー実施 (設計 / 実装 / UX、いずれも読み取り専用・origin/ diff)。**★★★ なし・全員マージ推奨**。

### ★★ 対応 (PR 内)
- **設計★★ (敵ステの再現性が曖昧)**: 実際は monsterId 固定 + variance 0 で敵は seed 非依存に一定 (機能的には無問題) だが、`startDuel` の初期 seed を `freshSeed()`→固定(1) にして「敵ステータス完全再現・戦闘乱数のみ新鮮」の意図を明示 (レビュー案A)。
- **実装★★ (crypto 可用性の将来リスク)**: freshSeed コメントに dev限定表示 (WORLD_PREVIEW_ENABLED)・クライアント専用である旨を明記。
- **UX★★ (1戦の再現性喪失)**: 統計的再現性はバッチ (seed 0..N-1) で担保、1戦はインタラクティブ確認用と役割分担を説明文/コメントで明確化。トレードオフとして妥当と判断。

### ★ (別スコープ)
- 本番 catch 率そのものの是非 (warrior 37% は逃げられすぎ? 等) → 逃走/会心チューニングは #408。

全 ★★ を PR 内対応済み。web typecheck / test 346 / build 緑。