### PR TITLE
fix(battle): はぐれスライムを本物のメタル型に — 超高守備で通常1・会心のみ貫通 (#408)

### DIFF
--- a/packages/core/src/__tests__/battle.test.ts
+++ b/packages/core/src/__tests__/battle.test.ts
@@ -186,7 +186,7 @@ describe('summonMonster', () => {
       if (b.monsterId === 'stray-slime') { battle = b; break; }
     }
     expect(battle).not.toBeNull();
-    // HP 明示 (12) × tier1 係数 → 通常 tier1 (~70) より大幅に低い
+    // HP 明示 (6) × tier1 係数 → 通常 tier1 (~70) より大幅に低い (会心一撃圏)
     expect(battle!.monster.maxHp).toBeLessThan(25);
     // 逃走する turnSeed があり、そのとき outcome は monster-fled (win/lose ではない)
     let fled = false;
@@ -195,6 +195,25 @@ describe('summonMonster', () => {
       if (next.outcome === 'monster-fled') { fled = true; break; }
     }
     expect(fled).toBe(true);
+  });
+  it('はぐれメタル: 超高守備で通常攻撃は 1 ダメージ・会心 (def無視) のみ貫通', () => {
+    // メタルは守備 240 で減算式が minDamage に沈む。プレイヤーの会心だけが def を無視して
+    // 貫通する (#432)。専用ロジックなし = 守備の数値だけで「硬い」を表現。高 atk の shogun でも通常は 1。
+    let normalMax = 0;
+    let critDealt = 0;
+    for (let seed = 0; seed < 300; seed++) {
+      let s = startBattle('shogun', 8, 15, 'x', 1, seed, 0, undefined, { monsterId: 'stray-slime' });
+      for (let i = 0; i < 6 && s.outcome === 'ongoing'; i++) {
+        const before = s.monster.hp;
+        s = resolveTurn(s, 'attack', seed * 100 + i);
+        const dealt = before - s.monster.hp;
+        if (dealt <= 0) continue;
+        if (s.lastEvents.some((e) => e.text.includes('会心'))) critDealt = Math.max(critDealt, dealt);
+        else normalMax = Math.max(normalMax, dealt);
+      }
+    }
+    expect(normalMax).toBe(1); // 通常攻撃は必ず 1 (守備で沈む)
+    expect(critDealt).toBeGreaterThan(1); // 会心は貫通して低 HP を一撃
   });
   it('地域相性 (affinity) は tier プール内の favor 対象を出やすくする (index 方式、死角なし)', () => {
     // tier3 pool = [raven, oni, dragon]。affinity%3==0 は raven を favor

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -542,12 +542,15 @@ export const MONSTERS: readonly MonsterDef[] = [
   { id: 'dusk-bat', name: 'よるのコウモリ', species: 'bat', tint: '#5b6bd0', spawnWeight: 0.4, tier: 1, stats: [14, 9, 28, 7, 13], hp: 40, drops: [{ item: 'dusk-wing', chance: 0.5 }, { item: 'sky-feather', chance: 0.12 }], intro: '夜色の翼で 音もなく舞う。' },
   { id: 'glow-shroom', name: 'ヒカリダケ', species: 'mushroom', tier: 1, stats: [8, 20, 4, 18, 12], hp: 62, drops: [{ item: 'mush-spore', chance: 0.6 }, { item: 'herb', chance: 0.4 }, { item: 'sky-dew', chance: 0.25 }], intro: 'ほんのり光って動かない…?' },
   { id: 'crimson-shroom', name: 'べにヒカリダケ', species: 'mushroom', tint: '#c23a5b', spawnWeight: 0.4, tier: 1, stats: [9, 22, 4, 20, 12], hp: 56, drops: [{ item: 'crimson-spore', chance: 0.5 }, { item: 'sky-dew', chance: 0.2 }], intro: '毒々しい紅に 明滅している。' },
-  // はぐれメタル型: レア出現・低 HP・高 XP (100)・毎ターン逃走。倒せれば旨いが逃げられると何も残らない。
-  // 現 def22 では通常攻撃も普通に通る (超高守備ではない)。減算式なら守備を上げるだけで
-  // 「通常 1・会心で貫通」が成立するが、超高守備にすると通常が効かず
-  // 会心前に必ず逃げて討伐 0% になる (先制/メタル斬り等の噛み合わせが要る) → 高守備メタル化は #408 で
-  // 逃走/会心チューニングと一緒に扱う。この PR (減算式移行) では現状ステータス据え置き。
-  { id: 'stray-slime', name: 'はぐれスライム', species: 'metal-slime', tier: 1, stats: [8, 22, 38, 6, 34], hp: 12, mp: 0, xp: 100, spawnWeight: 0.06, drops: [{ item: 'metal-shard', chance: 0.5 }], ability: 'fleer', intro: 'きらりと 金属の光を放っている。' },
+  // はぐれメタル型 (DQ のメタルスライム): レア出現・高 XP (100)・毎ターン逃走。
+  //   - **超高守備 (def240)**: 減算式で通常攻撃は atkTerm−defTerm が深く負に沈み minDamage(1) しか
+  //     通らない = 「当たってもダメージがほとんど通らない」(オーナー要望 2026-07-21)。魔撃 (spell,
+  //     defFactor0.5) でも def が大きすぎて 1 = メタルは魔法も効かない (DQ 準拠)。
+  //   - **高 agi (38)**: 回避 (最大 dodgeMax) が張り付き「避けられる」。
+  //   - **低 HP (6→tier係数で実質4)**: 仕留める道は**会心の一撃のみ** (プレイヤーの会心は def 無視
+  //     #432 → フルダメージで一撃)。通常/魔撃では削り切る前に逃げる。専用ロジックは使わず
+  //     守備/agi/HP の数値だけで「メタル」を表現 (オーナー: 専用ロジック禁止 2026-07-20)。
+  { id: 'stray-slime', name: 'はぐれスライム', species: 'metal-slime', tier: 1, stats: [8, 240, 38, 6, 34], hp: 6, mp: 0, xp: 100, spawnWeight: 0.06, drops: [{ item: 'metal-shard', chance: 0.5 }], ability: 'fleer', intro: 'きらりと 金属の光を放っている。' },
   // tier2: 修練。xp 34〜52 (healer は削り合いが長引くぶん高め)
   { id: 'moss-golem', name: 'こけむしゴーレム', species: 'golem', tier: 2, stats: [26, 36, 6, 10, 8], xp: 34, drops: [{ item: 'golem-core', chance: 0.5 }, { item: 'herb', chance: 0.2 }], intro: '地響きを立てて起き上がった。', skillName: 'いわなだれ', ability: 'charger' },
   { id: 'will-o-wisp', name: 'あおい鬼火', species: 'wisp', tier: 2, stats: [10, 12, 24, 34, 12], xp: 52, drops: [{ item: 'wisp-ember', chance: 0.5 }, { item: 'sky-dew', chance: 0.35 }], intro: 'ゆらゆらとこちらを見ている。', ability: 'healer', healName: 'いやしのゆらめき' },


### PR DESCRIPTION
Refs #408

## 症状 (オーナー報告 + screenshot 2026-07-21)
はぐれスライムが「当たれば一撃」で倒せてしまい、「避けられるし当たってもダメージがほとんど通らない」メタルスライムになっていなかった。減算式移行 (#435) の際に高守備メタル化を #408 へ deferred したのが原因 (def22 のまま → 通常攻撃 ~10 通り hp12 をほぼ一撃)。

## 修正 (専用ロジックなし・数値だけでメタルを表現)
`stray-slime`: `stats def 22→240` / `hp 12→6`。agi38・fleer・xp100 は据置。
- **通常攻撃も魔撃も minDamage(1)**: 減算式で atkTerm−defTerm が深く負に沈む。魔撃 (defFactor0.5) でも def が大きすぎて 1 = DQ 同様メタルは魔法も効かない。
- **避けられる**: 高 agi で回避 (最大 dodgeMax) + 毎ターン逃走。
- **会心のみ貫通**: プレイヤーの会心は def 無視 (#432) → フルダメージで低 HP を一撃。仕留める唯一の道。

## 検証
- **討伐率 (auto, 3000 seeds)**: warrior 8% / shogun 8% (鈍足・低luk) 〜 miko 21% / bard 28% / ninja 49% (高agi先手 + flurry 2hit)。会心 (luk/手数) 依存で職の個性が出る。
- 通常攻撃ダメージは全職 1、会心は貫通を**テストで固定** (battle.test.ts)。
- core 313 / web typecheck / edge 147 緑。

## 残 (#408)
「追う楽しさ」の導線 (先制/拘束/猶予) と討伐率の最終チューニングは #408 で継続。本 PR は damage-resistance + evasion 部分。

## Review
§1.5 3並列レビュー (バランス/実装/UX、読み取り専用・origin/ diff)。**★★★ なし・全員マージ推奨**。

### 検証済み (バランス★★★ / 実装★★★)
- 通常攻撃・魔撃・flurry・gamble すべて minDamage(1)、会心 (def無視) のみ貫通で一撃 — 抜け道なし。
- farm 破壊性なし: xp100 × 討伐率~15% × 出現率2.1% ≈ 0.3 XP/戦 (通常敵 0.6 と同等以下)。
- 既存 tier1 バランステスト全緑、レア敵 (2%出現) で波及なし。def240→実効173 / hp6→実効4 の変換安全。テストは flaky ~1e-7。

### ★ (対応方針)
- **UX★ (HP非表示職で「1が続く=運ゲー」感 / 「追う楽しさ」導線)**: 先制・拘束・猶予の導線は **#408 スコープ**として継続 (本PRは damage-resistance + evasion 部分)。
- **UX★ (introで「硬い」を明示せよ)**: **不採用**。「会心で狙え」等の明示ヒントは MEMORY「敵情報は予想させる」に反する。金属光の intro + 「1ダメージ」の気づき自体を発見の楽しみとする (subtle 維持)。
- **実装★ (テストに回避率統計)**: 会心貫通・通常1の固定で十分 (impl レビューが flaky ~1e-7 と確認)。任意。

★★★/★★ なし。core 313 / web typecheck / edge 147 緑。