### PR TITLE
chore(edge): kuda を API キー認証に対応 (Authorization: Bearer) (#447)

### DIFF
--- a/apps/edge/src/battle-resolver.ts
+++ b/apps/edge/src/battle-resolver.ts
@@ -181,7 +181,7 @@ export async function sealEncounter(env: ResolverEnv, userDid: string, state: Ga
     baseStats, equipIds: state.gear, gear: state.gearSel, tonics: state.materials['sky-dew'] ?? 0, vitalsVariance: BATTLE_TUNING.monsterVitalsVariance,
   });
   const rewarded = state.power >= BATTLE_TUNING.powerCost;
-  const pendingTurnSeed = (await entropyU32({ useKuda: true })).value;
+  const pendingTurnSeed = (await entropyU32({ useKuda: true, apiKey: env.KUDA_API_KEY })).value;
   const battleId = 'b' + [...crypto.getRandomValues(new Uint8Array(12))].map((b) => b.toString(16).padStart(2, '0')).join('');
   const nowIso = new Date(now * 1000).toISOString();
   // move では毎歩ガードを読まない (ステートレス高速化)。**client は戦闘中は move しない**ので、ここに
@@ -340,7 +340,7 @@ export async function handleSearch(env: ResolverEnv, userDid: string, token: str
   const { archetype, baseStats, handle, jobXp, playerXp } = await readDiagnosis(userDid, ns, fetchImpl);
   const luk = playerCombatant(archetype, jobLevelFromXp(jobXp), playerLevelFromXp(playerXp), handle, baseStats, state.gear, state.gearSel).luk;
   const tier = tierForDanger(regionDanger(regionOf(x, y)));
-  const found = rollSearch((await entropyU32({ useKuda: true })).value, luk, tier);
+  const found = rollSearch((await entropyU32({ useKuda: true, apiKey: env.KUDA_API_KEY })).value, luk, tier);
   if (!found) return { found: null, materials: state.materials };
   const written = await readModifyWrite(env, userDid, (cur) => ({ ...cur, materials: { ...cur.materials, [found]: (cur.materials[found] ?? 0) + 1 } }),
     { now, init: (d, iso) => migrateInitState(d, iso, ns, fetchImpl) });
@@ -398,8 +398,8 @@ export async function handleTurn(env: ResolverEnv, userDid: string, battleId: st
       throw e; // ServerWriteError(token 切れ) 等 → 上位で 503 (報酬なし)
     }
     // ここに来られるのはガードを消せた 1 リクエストだけ → 報酬を fail-closed で確定。
-    const rewardSeed = (await entropyU32({ useKuda: true })).value;
-    const lossSeed = (await entropyU32({ useKuda: true })).value;
+    const rewardSeed = (await entropyU32({ useKuda: true, apiKey: env.KUDA_API_KEY })).value;
+    const lossSeed = (await entropyU32({ useKuda: true, apiKey: env.KUDA_API_KEY })).value;
     let awarded: AwardBreakdown = {};
     let finalPos = { x: 0, y: 0 };
     const window = enemyWindow(now);
@@ -442,7 +442,7 @@ export async function handleTurn(env: ResolverEnv, userDid: string, battleId: st
 
   // ── 未決着: turn+1・新 pendingTurnSeed を CAS で確定してから応答 (並行二重解決/引き直しを弾く) ──
   // expiresAt も更新し、長い戦闘が move の flush 対象にならないようにする (ターンごとに寿命を延ばす)。
-  const nextPending = (await entropyU32({ useKuda: true })).value;
+  const nextPending = (await entropyU32({ useKuda: true, apiKey: env.KUDA_API_KEY })).value;
   const nowIso = new Date(now * 1000).toISOString();
   const advanced: Guard = { ...guard, turn: turn + 1, state: next, pendingTurnSeed: nextPending, expiresAt: new Date((now + GUARD_TTL_SEC) * 1000).toISOString(), updatedAt: nowIso };
   try {

--- a/apps/edge/src/kuda.ts
+++ b/apps/edge/src/kuda.ts
@@ -6,9 +6,16 @@
  * プール有限・外部依存・レイテンシがあるので**戦闘のクリティカルパスに必須で置かない**。
  * 障害/枯渇/タイムアウト時は必ず CSPRNG にフォールバックする (kuda 障害 = 全戦闘停止を避ける)。
  * クライアントは介在しない (Worker→kuda のみ)。
+ *
+ * **API キー認証 (429lab/kuda 新仕様)**: `/drop` は `Authorization: Bearer kuda_...` が必須。
+ * キーは Worker Secret (`KUDA_API_KEY`) から渡す。**ソースに直書きしない** (§4)。キー未設定なら
+ * kuda は使わず CSPRNG のみ (fail-safe)。
  */
 
 export const KUDA_URL = 'https://kuda.kojiran.workers.dev/drop';
+
+/** kuda 監査用のクライアント識別子 (429lab/kuda の ?client_id)。秘密ではない。 */
+const KUDA_CLIENT_ID = 'aozoraquest-edge';
 
 /** kuda /drop の応答 (1 バイト 0–255 + 監査メタ)。 */
 export interface KudaDrop {
@@ -41,13 +48,17 @@ export function csprngByte(): EntropyByte {
  * kuda から物理乱数 1 バイトを引く。タイムアウト・非2xx・不正値は throw。
  * **クリティカルパスでは直接使わず** `entropyByte` 経由でフォールバックさせること。
  */
-export async function drawKudaByte(opts: { timeoutMs?: number; fetchImpl?: typeof fetch } = {}): Promise<EntropyByte> {
+export async function drawKudaByte(opts: { apiKey?: string; timeoutMs?: number; fetchImpl?: typeof fetch } = {}): Promise<EntropyByte> {
   const timeoutMs = opts.timeoutMs ?? 1500;
   const f = opts.fetchImpl ?? fetch;
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), timeoutMs);
   try {
-    const res = await f(KUDA_URL, { signal: ctrl.signal });
+    // API キー認証 (新仕様): Authorization: Bearer kuda_...。キーは env (Secret) から。ソース直書き禁止。
+    const headers: Record<string, string> = {};
+    if (opts.apiKey) headers['Authorization'] = `Bearer ${opts.apiKey}`;
+    const url = `${KUDA_URL}?client_id=${KUDA_CLIENT_ID}`;
+    const res = await f(url, { signal: ctrl.signal, headers });
     if (!res.ok) throw new Error(`kuda ${res.status}`);
     const d = (await res.json()) as Partial<KudaDrop>;
     if (typeof d.value !== 'number' || !Number.isInteger(d.value) || d.value < 0 || d.value > 255) {
@@ -70,9 +81,10 @@ export async function drawKudaByte(opts: { timeoutMs?: number; fetchImpl?: typeo
  * 数え、kuda アウテージを可視化できるように)。
  */
 export async function entropyByte(
-  opts: { useKuda?: boolean; timeoutMs?: number; fetchImpl?: typeof fetch; onFallback?: (err: unknown) => void } = {},
+  opts: { useKuda?: boolean; apiKey?: string; timeoutMs?: number; fetchImpl?: typeof fetch; onFallback?: (err: unknown) => void } = {},
 ): Promise<EntropyByte> {
-  if (!opts.useKuda) return csprngByte();
+  // kuda は API キー必須 (新仕様)。useKuda 無効 or キー未設定なら CSPRNG のみ (fetch しない = fail-safe)。
+  if (!opts.useKuda || !opts.apiKey) return csprngByte();
   try {
     return await drawKudaByte(opts);
   } catch (err) {
@@ -89,7 +101,7 @@ export async function entropyByte(
  * (kuda 障害でも 32bit の質は CSPRNG が担保 = fail-safe)。返り値は符号なし 32bit。
  */
 export async function entropyU32(
-  opts: { useKuda?: boolean; timeoutMs?: number; fetchImpl?: typeof fetch; onFallback?: (err: unknown) => void } = {},
+  opts: { useKuda?: boolean; apiKey?: string; timeoutMs?: number; fetchImpl?: typeof fetch; onFallback?: (err: unknown) => void } = {},
 ): Promise<{ value: number; source: 'kuda+csprng' | 'csprng'; meta?: EntropyByte['meta'] }> {
   const buf = new Uint8Array(4);
   crypto.getRandomValues(buf);

--- a/apps/edge/src/oauth-config.ts
+++ b/apps/edge/src/oauth-config.ts
@@ -22,6 +22,8 @@ export interface OAuthEnv {
   PUBLIC_ORIGIN?: string;
   /** OAuth scope。既定 'atproto transition:generic'。 */
   OAUTH_SCOPE?: string;
+  /** kuda 物理乱数 API のキー (Bearer)。Secret。未設定なら kuda を使わず CSPRNG のみ (fail-safe)。 */
+  KUDA_API_KEY?: string;
 }
 
 export class OAuthConfigError extends Error {}

--- a/apps/edge/test/kuda.test.ts
+++ b/apps/edge/test/kuda.test.ts
@@ -43,13 +43,31 @@ describe('kuda', () => {
 
   it('entropyByte(useKuda:true) は kuda 障害時 CSPRNG にフォールバック', async () => {
     const f = (async () => { throw new Error('down'); }) as unknown as typeof fetch;
-    const b = await entropyByte({ useKuda: true, fetchImpl: f });
+    const b = await entropyByte({ useKuda: true, apiKey: 'kuda_test', fetchImpl: f });
     expect(b.source).toBe('csprng'); // 障害でも戦闘は止めない
   });
 
   it('entropyByte(useKuda:true) は成功時 kuda を返す', async () => {
-    const b = await entropyByte({ useKuda: true, fetchImpl: (async () => okDrop(200)) as unknown as typeof fetch });
+    const b = await entropyByte({ useKuda: true, apiKey: 'kuda_test', fetchImpl: (async () => okDrop(200)) as unknown as typeof fetch });
     expect(b).toMatchObject({ value: 200, source: 'kuda' });
+  });
+
+  it('entropyByte(useKuda:true) は apiKey 未設定なら kuda を使わず CSPRNG (fetch しない)', async () => {
+    let called = false;
+    const f = (async () => { called = true; return okDrop(1); }) as unknown as typeof fetch;
+    const b = await entropyByte({ useKuda: true, fetchImpl: f }); // apiKey なし
+    expect(b.source).toBe('csprng');
+    expect(called).toBe(false); // キー無しで kuda を叩かない (無駄な 401 を避ける)
+  });
+
+  it('drawKudaByte は apiKey を Authorization: Bearer で送る', async () => {
+    let authHeader: string | null = null;
+    const f = (async (_url: string, init?: RequestInit) => {
+      authHeader = new Headers(init?.headers).get('Authorization');
+      return okDrop(5);
+    }) as unknown as typeof fetch;
+    await drawKudaByte({ apiKey: 'kuda_abc', fetchImpl: f });
+    expect(authHeader).toBe('Bearer kuda_abc');
   });
 
   it('drawKudaByte は 2xx でも非 JSON 本文なら throw (プロキシ HTML 等)', async () => {
@@ -59,9 +77,9 @@ describe('kuda', () => {
 
   it('entropyByte の onFallback は kuda 障害時に呼ばれ、正常時は呼ばれない', async () => {
     let fell = 0;
-    await entropyByte({ useKuda: true, onFallback: () => { fell++; }, fetchImpl: (async () => { throw new Error('x'); }) as unknown as typeof fetch });
+    await entropyByte({ useKuda: true, apiKey: 'kuda_test', onFallback: () => { fell++; }, fetchImpl: (async () => { throw new Error('x'); }) as unknown as typeof fetch });
     expect(fell).toBe(1);
-    await entropyByte({ useKuda: true, onFallback: () => { fell++; }, fetchImpl: (async () => okDrop(9)) as unknown as typeof fetch });
+    await entropyByte({ useKuda: true, apiKey: 'kuda_test', onFallback: () => { fell++; }, fetchImpl: (async () => okDrop(9)) as unknown as typeof fetch });
     expect(fell).toBe(1); // 正常時は増えない
   });
 
@@ -84,7 +102,7 @@ describe('kuda', () => {
   });
 
   it('entropyU32(useKuda:true) は kuda 成功で物理バイトを混ぜ source を kuda+csprng に', async () => {
-    const r = await entropyU32({ useKuda: true, fetchImpl: (async () => okDrop(200)) as unknown as typeof fetch });
+    const r = await entropyU32({ useKuda: true, apiKey: 'kuda_test', fetchImpl: (async () => okDrop(200)) as unknown as typeof fetch });
     expect(r.source).toBe('kuda+csprng');
     expect(r.meta).toBeTruthy();
     expect(r.value).toBeGreaterThanOrEqual(0);
@@ -92,7 +110,7 @@ describe('kuda', () => {
   });
 
   it('entropyU32(useKuda:true) は kuda 障害でも 32bit CSPRNG で成立 (fail-safe)', async () => {
-    const r = await entropyU32({ useKuda: true, fetchImpl: (async () => { throw new Error('down'); }) as unknown as typeof fetch });
+    const r = await entropyU32({ useKuda: true, apiKey: 'kuda_test', fetchImpl: (async () => { throw new Error('down'); }) as unknown as typeof fetch });
     expect(r.source).toBe('csprng');
     expect(r.value).toBeLessThanOrEqual(0xffffffff);
   });

--- a/docs/22-edge-env-separation.md
+++ b/docs/22-edge-env-separation.md
@@ -24,6 +24,7 @@ dev は本番に**一切**触れられないのが原則。Web アプリが `aoz
 
 - ✅ step1 dev KV 作成 (`ef1a0429afc34c7da4ee5183752a5f3e`) → wrangler.toml 反映
 - ✅ step2 dev secret set (OAUTH_CLIENT/DPOP_JWK・WORLD_TOKEN_SECRET・SERVER_DID・ADMIN_DIDS=kojira.io の DID)
+- ⬜ `KUDA_API_KEY` を prod/dev 両方に set (kuda API キー化。未設定でも CSPRNG で動く)
 - ✅ step3 `wrangler deploy --env dev` → `https://aozoraquest-edge-dev.kojiran.workers.dev` 稼働
       (`/api/world/reset` が 401 = ルート存在。共有エッジは 404 だった)
 - ✅ step5 ローカル: `.env.development` に VITE_EDGE_URL/DID を dev エッジで追記
@@ -58,8 +59,13 @@ wrangler secret put WORLD_TOKEN_SECRET --env dev
 wrangler secret put SERVER_DID --env dev        # サーバーアカウントの DID (本番と同じ)
 wrangler secret put ADMIN_DIDS --env dev         # 管理者 DID (本番と同じ)
 wrangler secret put OAUTH_SCOPE --env dev         # 本番と同じ (例 "atproto transition:generic")
+wrangler secret put KUDA_API_KEY --env dev        # kuda 物理乱数 API キー (Bearer, kuda_...)。未設定なら CSPRNG のみで動く
 ```
 (`WORKER_DID` / `PUBLIC_ORIGIN` / `ALLOWED_ORIGINS` は wrangler.toml の `[env.dev.vars]` に記載済み = secret 不要。)
+
+**本番も同様に** `wrangler secret put KUDA_API_KEY` (top-level、`--env dev` なし) で set する。kuda は
+API キー必須 (429lab/kuda 新仕様、`Authorization: Bearer`)。キー未設定でも戦闘は CSPRNG で成立する
+(fail-safe) が、物理乱数エントロピーを混ぜたいなら prod/dev 両方に set すること。
 
 ### 3. dev エッジをデプロイ
 ```


### PR DESCRIPTION
Closes #447

## 背景
429lab/kuda 新仕様で `/drop` が API キー必須に (`Authorization: Bearer kuda_...`)。現状キー無しで叩いており新仕様では 401 → 物理乱数が使えない (戦闘は CSPRNG フォールバックで動く)。

## 変更
- `kuda.ts`: `drawKudaByte`/`entropyByte`/`entropyU32` に `apiKey` オプション + `Authorization: Bearer` ヘッダ + `?client_id`。**キー未設定なら kuda を叩かず CSPRNG のみ** (fail-safe・無駄な 401 回避)。
- `OAuthEnv` に `KUDA_API_KEY?` (Secret) 追加、`battle-resolver` の 5 箇所で `env.KUDA_API_KEY` を渡す。
- テスト: Bearer ヘッダ送出 / キー無し→CSPRNG を追加。edge 149 緑・typecheck 緑。
- docs/22 に secret set 手順追記。

## Secret (§4: ソース直書きしない)
キーは Worker Secret。`wrangler secret put KUDA_API_KEY` (prod) と `--env dev` で set。リポジトリ/チャットに値を残さない (git grep で不在を確認済み)。

## Review
§1.5 レビュー。auth/secret 変更のため **実装 + セキュリティ**の 1 観点に集中 (UI 変更ゼロ = UX 観点なし、設計は fail-safe ゲートのみ)。読み取り専用・origin/ diff。**★★★・APPROVE**。

### 検証済み (★★★)
- **キー漏洩なし**: ソース/テスト/docs に実キーなし (ダミー kuda_test/kuda_abc)、error メッセージ (`kuda ${status}`) と監査 meta (drop_seq/batch/pool_remaining) にキー含まず、Authorization は KUDA_URL 固定宛のみ (host 変更不可)。client_id は非秘密。
- **fail-safe 堅牢**: キー未設定 → fetch せず CSPRNG (無駄な 401 なし)、kuda 401/障害/タイムアウト → CSPRNG フォールバックで戦闘継続、entropyU32 は kuda 失敗でも 32bit CSPRNG で質担保。
- **波及完全**: battle-resolver の 5 箇所すべて env.KUDA_API_KEY 配線 (env は各関数 scope)、他に entropyU32/entropyByte の呼び出し経路なし。
- **API 仕様整合**: Authorization: Bearer kuda_... / /drop?client_id= が 429lab/kuda README と一致。value 0-255 検証不変。
- **テスト網羅**: Bearer ヘッダ送出・キー無し→CSPRNG (fetch しない)・障害フォールバックを追加。edge 149 緑。

★★★/★★ ブロッカーなし。typecheck / edge 149 緑。