### PR TITLE
feat(battle): 複数とくぎ — レベルで習得 + 毎ターン選択 + heal (#436)

### DIFF
--- a/apps/edge/src/battle-resolver.ts
+++ b/apps/edge/src/battle-resolver.ts
@@ -373,7 +373,7 @@ export interface TurnResult {
  * turn: 1 コマンドを**サーバーが**確定 pendingTurnSeed で解決する。
  * 決着なら報酬を fail-closed で確定 + ガード削除。未決着なら CAS で turn を進めてから応答。
  */
-export async function handleTurn(env: ResolverEnv, userDid: string, battleId: string, turn: number, command: Command, now: number, ns: string = DEFAULT_NS): Promise<TurnResult> {
+export async function handleTurn(env: ResolverEnv, userDid: string, battleId: string, turn: number, command: Command, now: number, ns: string = DEFAULT_NS, skillIndex = 0): Promise<TurnResult> {
   if (!VALID_COMMANDS.includes(command)) throw new ResolverError('不正なコマンド', 400);
   const g = await readGuard<SealedMeta, BattleState>(env, userDid);
   if (!g) throw new ResolverError('戦闘中でない', 409);
@@ -381,7 +381,11 @@ export async function handleTurn(env: ResolverEnv, userDid: string, battleId: st
   // battleId / turn 不一致 = リプレイ/やり直し → 409 (応答しない)。
   if (guard.battleId !== battleId || guard.turn !== turn) throw new ResolverError('ターン不一致 (やり直し/リプレイ)', 409);
 
-  const next = resolveTurn(guard.state, command, guard.pendingTurnSeed);
+  // とくぎ選択 (#436) はサーバー権威の sealed state で検証: 実際に習得済みのとくぎだけ選べる
+  // (client が持っていない index を偽っても署名スキル [0] に落とす。詐称防止)。
+  const skills = guard.state.playerSkills ?? [];
+  const idx = Number.isInteger(skillIndex) && skillIndex >= 0 && skillIndex < skills.length ? skillIndex : 0;
+  const next = resolveTurn(guard.state, command, guard.pendingTurnSeed, idx);
 
   if (next.outcome !== 'ongoing') {
     // ── 決着: **まずガードを CAS 削除して「この決着ターンは自分が消費」を確定** ──

--- a/apps/edge/src/battle-resolver.ts
+++ b/apps/edge/src/battle-resolver.ts
@@ -383,7 +383,7 @@ export async function handleTurn(env: ResolverEnv, userDid: string, battleId: st
 
   // とくぎ選択 (#436) はサーバー権威の sealed state で検証: 実際に習得済みのとくぎだけ選べる
   // (client が持っていない index を偽っても署名スキル [0] に落とす。詐称防止)。
-  const skills = guard.state.playerSkills ?? [];
+  const skills = guard.state.playerSkills ?? [guard.state.playerSkill];
   const idx = Number.isInteger(skillIndex) && skillIndex >= 0 && skillIndex < skills.length ? skillIndex : 0;
   const next = resolveTurn(guard.state, command, guard.pendingTurnSeed, idx);
 

--- a/apps/edge/src/router.ts
+++ b/apps/edge/src/router.ts
@@ -142,13 +142,14 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
     } catch (e) {
       return cors(json({ error: 'unauthorized', reason: e instanceof ServiceAuthError ? e.message : 'verify_failed' }, 401), allowedOrigin);
     }
-    const body = (await req.json().catch(() => ({}))) as { dx?: number; dy?: number; token?: string; battleId?: string; turn?: number; command?: string };
+    const body = (await req.json().catch(() => ({}))) as { dx?: number; dy?: number; token?: string; battleId?: string; turn?: number; command?: string; skillIndex?: number };
     try {
       if (isTurn) {
         if (typeof body.battleId !== 'string' || typeof body.turn !== 'number' || typeof body.command !== 'string') {
           return cors(json({ error: 'bad_request' }, 400), allowedOrigin);
         }
-        return cors(json(await handleTurn(env, did, body.battleId, body.turn, body.command as Command, nowSec(), nsFromOrigin(req))), allowedOrigin);
+        const skillIndex = typeof body.skillIndex === 'number' ? body.skillIndex : 0; // とくぎ選択 (#436)。既定 0=署名
+        return cors(json(await handleTurn(env, did, body.battleId, body.turn, body.command as Command, nowSec(), nsFromOrigin(req), skillIndex)), allowedOrigin);
       }
       if (typeof body.dx !== 'number' || typeof body.dy !== 'number') return cors(json({ error: 'bad_request' }, 400), allowedOrigin);
       return cors(json(await handleMove(env, did, body.dx, body.dy, typeof body.token === 'string' ? body.token : undefined, nowSec(), nsFromOrigin(req))), allowedOrigin);

--- a/apps/web/src/components/world-battle-controls.tsx
+++ b/apps/web/src/components/world-battle-controls.tsx
@@ -41,10 +41,15 @@ export function WorldBattleControls({
   showEnemyVitals: boolean;
   /** result フェーズで出す報酬行 (経験値・素材など)。message/input では未使用。 */
   resultLines: readonly string[];
-  onCommand: (c: Command) => void;
+  onCommand: (c: Command, skillIndex?: number) => void;
   onAdvance: () => void;
 }) {
   const [itemMenu, setItemMenu] = useState(false);
+  const [skillMenu, setSkillMenu] = useState(false);
+  const lowMp = state.player.mp < BATTLE_TUNING.skillMpCost;
+  // デプロイ跨ぎの旧 sealed state は playerSkills が無いことがある → 署名スキル 1 個にフォールバック。
+  const skills = state.playerSkills ?? [state.playerSkill];
+  const multiSkill = skills.length > 1;
   const monsterDef = MONSTERS_BY_ID[state.monsterId];
   const messageLines =
     phase === 'result'
@@ -66,16 +71,35 @@ export function WorldBattleControls({
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.4em', height: '100%' }}>
             {/* 左: コマンド (2 列 3 行に詰める = 4 行メッセージ枠と同じ高さに収める) */}
             <div style={{ ...WINDOW, height: '100%', padding: '0.2em 0.3em', display: 'grid', gridTemplateColumns: '1fr 1fr', gridTemplateRows: 'repeat(3, 1fr)', gridAutoFlow: 'column', columnGap: '0.2em' }}>
-              <DqRow label="たたかう" onClick={() => onCommand('attack')} disabled={busy || itemMenu} />
-              <DqRow label={state.playerSkill.name} onClick={() => onCommand('skill')} disabled={busy || itemMenu || state.player.mp < BATTLE_TUNING.skillMpCost} />
-              <DqRow label="ぼうぎょ" onClick={() => onCommand('guard')} disabled={busy || itemMenu} />
+              <DqRow label="たたかう" onClick={() => onCommand('attack')} disabled={busy || itemMenu || skillMenu} />
+              {/* とくぎ: 複数持ちはサブメニューを開いて選ぶ (#436)。1 個だけの職は従来どおり即発動。 */}
+              <DqRow
+                label={multiSkill ? 'とくぎ' : state.playerSkill.name}
+                onClick={() => (multiSkill ? (setItemMenu(false), setSkillMenu((v) => !v)) : onCommand('skill', 0))}
+                disabled={busy || itemMenu || lowMp}
+                cursor={skillMenu}
+              />
+              <DqRow label="ぼうぎょ" onClick={() => onCommand('guard')} disabled={busy || itemMenu || skillMenu} />
               {/* どうぐ: 再タップで閉じる (DQ の戻る慣習) */}
-              <DqRow label="どうぐ" onClick={() => setItemMenu((v) => !v)} disabled={busy || (state.herbs <= 0 && state.tonics <= 0)} cursor={itemMenu} />
-              <DqRow label="にげる" onClick={() => onCommand('flee')} disabled={busy || itemMenu} />
+              <DqRow label="どうぐ" onClick={() => (setSkillMenu(false), setItemMenu((v) => !v))} disabled={busy || skillMenu || (state.herbs <= 0 && state.tonics <= 0)} cursor={itemMenu} />
+              <DqRow label="にげる" onClick={() => onCommand('flee')} disabled={busy || itemMenu || skillMenu} />
             </div>
             {/* 右: どうぐ選択中はアイテム、それ以外は敵リスト */}
             <div style={{ ...WINDOW, height: '100%', padding: '0.2em 0.4em', display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
-              {itemMenu ? (
+              {skillMenu ? (
+                <div style={{ display: 'flex', flexDirection: 'column', height: '100%', overflowY: 'auto' }}>
+                  {skills.map((sk, i) => (
+                    <DqRow
+                      key={i}
+                      label={`${sk.name} (MP${BATTLE_TUNING.skillMpCost})`}
+                      onClick={() => { setSkillMenu(false); onCommand('skill', i); }}
+                      // heal は満タンなら無意味 → 無効化 (やくそうと同じ配慮)
+                      disabled={busy || lowMp || (sk.kind === 'heal' && state.player.hp >= state.player.maxHp)}
+                    />
+                  ))}
+                  <DqRow label="もどる" onClick={() => setSkillMenu(false)} disabled={busy} />
+                </div>
+              ) : itemMenu ? (
                 <>
                   <DqRow label={`やくそう ×${state.herbs}`} onClick={() => { setItemMenu(false); onCommand('herb'); }} disabled={busy || state.herbs <= 0 || state.player.hp >= state.player.maxHp} />
                   <DqRow label={`そらのしずく ×${state.tonics}`} onClick={() => { setItemMenu(false); onCommand('tonic'); }} disabled={busy || state.tonics <= 0 || state.player.mp >= state.player.maxMp} />

--- a/apps/web/src/components/world-battle-controls.tsx
+++ b/apps/web/src/components/world-battle-controls.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { BattleState, Command } from '@aozoraquest/core';
 import { BATTLE_TUNING, MONSTERS_BY_ID } from '@aozoraquest/core';
 import { MonsterSvg } from './monster-svg';
@@ -46,6 +46,11 @@ export function WorldBattleControls({
 }) {
   const [itemMenu, setItemMenu] = useState(false);
   const [skillMenu, setSkillMenu] = useState(false);
+  // 入力フェーズを離れたら (メッセージ送り/リザルト) サブメニューを閉じておく。
+  // 描画上は input のときだけ出るが、state が開きっぱなしだと次の入力で一瞬開いて見えうる (レビュー ★★)。
+  useEffect(() => {
+    if (phase !== 'input') { setItemMenu(false); setSkillMenu(false); }
+  }, [phase]);
   const lowMp = state.player.mp < BATTLE_TUNING.skillMpCost;
   // デプロイ跨ぎの旧 sealed state は playerSkills が無いことがある → 署名スキル 1 個にフォールバック。
   const skills = state.playerSkills ?? [state.playerSkill];

--- a/apps/web/src/lib/world-server.ts
+++ b/apps/web/src/lib/world-server.ts
@@ -94,8 +94,9 @@ export function serverMove(agent: Agent, dx: number, dy: number, token?: string)
 }
 
 /** 攻撃 (1ターン): battleId + turn + command。解決 + 決着報酬はサーバー。 */
-export function serverTurn(agent: Agent, battleId: string, turn: number, command: string): Promise<ServerTurnResult> {
-  return callEdge<ServerTurnResult>(agent, LXM_TURN, '/api/battle/turn', { battleId, turn, command });
+export function serverTurn(agent: Agent, battleId: string, turn: number, command: string, skillIndex?: number): Promise<ServerTurnResult> {
+  // skillIndex: とくぎ選択 (#436)。command==='skill' のときどのとくぎか。省略/0 は署名スキル。
+  return callEdge<ServerTurnResult>(agent, LXM_TURN, '/api/battle/turn', { battleId, turn, command, ...(skillIndex ? { skillIndex } : {}) });
 }
 
 /** そらのはねワープ: 街 (x,y) へテレポート。位置・トークン・在庫 (そらのはね消費) をサーバーが返す。 */

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -516,7 +516,7 @@ export function World() {
   // 決着ターンの報酬 (XP/ドロップ/素材ロス) はサーバーが権威 state に確定し、awarded として返す。
   // タップ送り (onMessageAdvance) で「〜のダメージ！」を読んでから結果へ進む (DQ 風)。
   const onBattleCommand = useCallback(
-    (command: Command) => {
+    (command: Command, skillIndex?: number) => {
       const b = battleRef.current;
       if (!b || b.busy || b.phase !== 'input') return;
       if (!agent) { setBattle({ ...b, errorText: 'サーバーに接続できず 戦えない。' }); return; }
@@ -526,7 +526,7 @@ export function World() {
       setBattle(busy);
       void (async () => {
         try {
-          const res = await serverTurn(agent, b.battleId, b.state.turn, command);
+          const res = await serverTurn(agent, b.battleId, b.state.turn, command, skillIndex);
           const acting = { ...bClean, state: asBattleState(res.state), phase: 'message' as BattlePhase, busy: false,
             ...(res.awarded ? { awarded: res.awarded } : {}),
             ...(res.position ? { resultPos: res.position } : {}),

--- a/docs/24-combat-skills.md
+++ b/docs/24-combat-skills.md
@@ -1,0 +1,197 @@
+# 24. 複数とくぎ + 状態異常 (エピック #434: #436 / #437)
+
+戦闘刷新エピック #434 の後半。減算式ダメージ (#435, docs/18) の上に「**とくぎで戦略を
+楽しむ**」層を載せる。オーナーのビジョン (2026-07-20):
+
+> こうげきが低いジョブはとくぎと装備で補正する方向がよい。序盤はこうげきが弱いジョブでも
+> こなせる程のモンスターの弱さにして、装備や回復アイテムを揃えていくとこうげきよりも有利に
+> なるとよい。**とくぎは複数選択ができるようになるべき。弱いジョブ程とくぎが増えて戦略を
+> 楽しめる。相手を眠らせたり、デバフしたり、自分を強化したり**など。
+
+減算式は「atk が敵の防御項を超えるまで minDamage 床」という性質を持つ (docs/18)。
+低攻撃ジョブの火力の谷を、**通常攻撃の代わりに使うとくぎ**(状態異常・バフ・デバフ・
+ステータス非依存の割合/固定ダメージ等)で埋めるのが本エピックの狙い。
+
+---
+
+## 現状 (リファクタ前のアンカー)
+
+- **1 ジョブ = 1 とくぎ**。`skillForJob(archetype)` (battle.ts:191) が支配ステータスから
+  1 種 (`smash/parry/flurry/spell/gamble`) を導出し、`BattleState.playerSkill` (battle.ts:713)
+  に固定。`playerSkillAction` (battle.ts:919) が kind で分岐。
+- **MP コストは一律 4** (`skillMpCost`, battle.ts:96)。per-skill 差なし。
+- `Command = 'attack'|'guard'|'skill'|'herb'|'tonic'|'flee'` (battle.ts:692) はフラット文字列。
+  **どのとくぎか**を指定する payload は無い。`resolveTurn(prev, command, turnSeed?)` は
+  `cmd==='skill'` で単一 `playerSkill` を撃つ (battle.ts:1052)。
+- 状態フラグは `guarding` / `parrying` / `charging` (敵) / `focus` のみ (battle.ts:261-269)。
+  **眠り・バフ・デバフ・毒 (継続ダメージ) のフィールドは未実装**。
+- UI は `world-battle-controls.tsx:70` で `playerSkill.name` の単一ボタン。どうぐは
+  サブメニュー (トグル) 済みなので、とくぎのサブメニューはこれを踏襲できる。
+- サーバー権威: `battle-resolver.ts` は `startBattle` 内で `skillForJob` を呼ぶだけ
+  (sealed.state.playerSkill を保存)。`handleTurn` は毎ターン再導出せず sealed state を使う。
+  **どのとくぎかをプレイヤーが選ぶなら `handleTurn` に skill_id を通し、archetype で妥当性検証**が要る。
+
+---
+
+## 設計
+
+### A. とくぎをデータ化する (`SKILLS` テーブル)
+
+kind ベタ書き分岐 (`playerSkillAction` の switch) を、**とくぎ定義テーブル**に置き換える:
+
+```ts
+type SkillCategory = 'attack' | 'buff' | 'debuff' | 'ailment' | 'heal';
+interface SkillDef {
+  id: string;              // 'smash' | 'lull' | 'guard-break' | ...
+  name: string;            // 表示名 (ジョブ別名は JOB_SKILL_NAMES を継承 or 個別)
+  category: SkillCategory;
+  mpCost: number;          // per-skill (一律 4 を廃止)
+  // 攻撃系: 火力パラメータ
+  power?: number; stat?: 'atk'|'agi'|'int'|'luk'; defFactor?: number; hits?: number;
+  // 状態系: 付与する効果と成功率
+  effect?: { kind: EffectKind; magnitude?: number; turns?: number; chance?: number; target: 'self'|'enemy' };
+}
+```
+
+既存 5 kind は SkillDef に移植 (smash=attack power1.7 / spell=attack int defFactor0.5 / flurry=attack agi hits2 / gamble=attack luk power可変 / parry=特殊: 被弾半減+反撃)。
+
+### B. ジョブ別とくぎセット — レベルアップで習得 (弱ジョブほど多い) 【オーナー決定 2026-07-20】
+
+とくぎは**固定数ではなくレベルアップで増える**。各ジョブに「習得レベル付きのとくぎリスト」を
+持たせ、`skillsForJob(archetype, jobLevel): SkillDef[]` が**その時点で習得済みのとくぎ**を返す。
+
+```ts
+interface JobSkillEntry { skillId: string; learnAt: number; }  // learnAt = 習得 jobLevel
+const JOB_SKILLS: Record<Archetype, JobSkillEntry[]> = { ... };
+export function skillsForJob(a: Archetype, jobLevel: number): SkillDef[] =>
+  JOB_SKILLS[a].filter(e => jobLevel >= e.learnAt).map(e => SKILLS[e.skillId]);
+```
+
+- **1 個目 (learnAt:1)** は現状の支配ステータス由来スキル → 後方互換 (Lv1 で `skillsForJob()[0]`
+  = 旧 `skillForJob()`)。
+- **弱火力ジョブほどリストが長く・習得が早い** (オーナー: 「弱いジョブ程とくぎが増えて戦略を
+  楽しめる」)。目安として最終的なとくぎ数を素の atk に反比例させる:
+  - shogun(atk39)/captain(atk38) → 最終 1〜2 (脳筋は素殴りで強い、習得も遅め)
+  - warrior(25)/performer(25) → 2〜3
+  - guardian(24)/artist(15)/explorer(14)/fighter(12) → 3
+  - mage(7)/bard(7)/seer(8)/miko(8)/paladin(9) → 4〜5 (弱火力を戦術で補う、習得も早い)
+- 追加分は「バフ / デバフ / 眠り / 毒 / 回復」から世界観に合うものを配る (例: miko=味方バフ+
+  眠り+回復、mage=デバフ+int アタック、bard=眠り+全体デバフ寄り)。習得レベルの割り付けで
+  「新しいとくぎを覚える楽しみ」を progression に組み込む。
+- 具体的な配り方 (どのジョブが何を何レベルで) は #436/#437 実装時に sim で調整。
+
+### C. 戦闘中の複数選択 UI
+
+「とくぎ」ボタン → **とくぎサブメニュー** (どうぐメニューと同じトグル方式) → 各とくぎを
+リスト表示 (名前 + MP コスト + 一言効果)。MP 不足 / 既に付与済みの状態技は disabled。
+`onCommand('skill', skillId)` で撃つ。DQ の「じゅもん/とくぎ」リスト相当。
+
+### D. Command に skill_id を載せる
+
+- `Command` を `{ kind: 'skill', skillId: string }` を許すよう拡張 (または `resolveTurn` に
+  第 2 引数 `skillId?`)。既存のフラット文字列コマンドは互換維持。
+- `resolveTurn` は skillId から SkillDef を引き、`applySkill(def, ...)` で実行。
+- **サーバー権威**: `handleTurn` が skill_id を受け取り、`skillsForJob(sealed.archetype)` に
+  その id が含まれるか検証 (詐称防止)。`VALID_COMMANDS` (battle-resolver.ts:31) を拡張。
+
+### E. 状態異常モデル (#437)
+
+`Combatant` に継続状態を追加:
+
+```ts
+sleep: number;                         // 残りターン (0=なし)。行動時に自然回復判定
+buffs:  Partial<Record<Stat, {mult:number; turns:number}>>;  // 自己強化 (atk/def/agi…)
+debuffs: Partial<Record<Stat, {mult:number; turns:number}>>; // 相手弱体
+poison?: { damage: number; turns: number };                  // 継続ダメージ (将来)
+```
+
+- `doAttack` (battle.ts:826〜) で **buff/debuff をステータスに乗算**して評価。
+- **眠り**: 行動選択前に `sleep>0` なら行動スキップ + 毎ターン一定確率で起床。被弾で起床
+  (DQ 流)。強敵ほど耐性 (成功率を敵の何かで割る) を検討。
+- `resolveTurn` の cleanup (battle.ts:1106) で各状態の turns をデクリメント。
+- `TurnEvent` に `effect?: EffectKind` を足して UI 演出 (「〜は ねむってしまった!」等)。
+- 敵にも状態異常が乗る (プレイヤーが眠らせ・デバフする) = 低火力ジョブの主戦術。
+  敵→プレイヤーの状態異常は #437 のスコープで慎重に (理不尽回避、まずはプレイヤー有利側から)。
+
+### F. 後方互換 & 移行
+
+- `playerSkill` (単数) → `playerSkills: SkillDef[]` + 現在選択の一時状態は UI 側。
+  sealed state には `playerSkills` を保存 (archetype から再導出可能なので id 列だけでも可)。
+- `autoBattleCommand` (battle.ts:1149) を複数とくぎ対応に (眠り→デバフ→攻撃の優先度付け)。
+  模擬戦シミュレータ (debug-battle-sim / sim-*.ts) が新戦術で回るようにする。
+- 既存テスト (skillForJob 全16・skill 完走・parry 回帰・spell 優位) は
+  `skillsForJob()[0]` が旧 `skillForJob()` と一致する形で緑を維持。
+
+---
+
+## 実装ステップ (issue マッピング)
+
+**#436 複数とくぎ (框組み)** — 状態異常の中身は #437。ここは「複数持てる・選べる・撃てる」。
+1. `SKILLS` テーブル + `SkillDef` 型、既存 5 kind を移植 (挙動不変)。
+2. `JOB_SKILLS` (習得レベル付き) + `skillsForJob(archetype, jobLevel)` + `BattleState.playerSkills`。
+   Lv1 で [0] が旧 `skillForJob()` と一致 (後方互換)。**レベルアップで新とくぎ習得**の通知線も
+   (既存のレベルアップ演出に「〜を おぼえた!」を足す)。
+3. `resolveTurn` に skillId、`applySkill` ディスパッチ。既存単一挙動を [0] で維持。
+4. UI: とくぎサブメニュー (どうぐメニュー踏襲、毎ターン選択)。各とくぎに MP コスト表示・
+   MP 不足で disabled。
+5. サーバー権威: `handleTurn` skill_id 検証 (`skillsForJob(archetype, jobLevel)` に含まれるか) +
+   `VALID_COMMANDS` 拡張。
+6. `autoBattleCommand` 複数対応 + sim 更新。テスト緑維持。
+
+   ※ #436 単体では既存の**攻撃系とくぎ + レベルで増える枠組み**が入る (状態異常の中身は #437)。
+   テスト可能な最小形として、各ジョブに攻撃系のバリエーション or 既存 1 種のみでも framework は成立。
+
+**#437 状態異常 (眠り/デバフ/バフ)** — #436 の framework 上に効果種を足す。
+1. `Combatant` に sleep/buffs/debuffs。`doAttack` で乗算・眠りで行動スキップ。
+2. cleanup で turns デクリメント + 起床判定。`TurnEvent.effect` で演出。
+3. buff/debuff/ailment カテゴリのとくぎを各ジョブに配布 (§B の具体化)。
+4. sim で「弱ジョブが状態異常で強ジョブに追いつく」ことを実測して数値調整。
+5. 眠り耐性・命中率・敵側状態異常の理不尽回避を tier 別に検証。
+
+**#438 装備・回復 progression** (既存 issue) と合わせて「装備が揃うと攻撃より有利」を完成。
+
+---
+
+## 決定事項
+
+### 確定 (オーナー決定 2026-07-20)
+
+1. **とくぎ選択の粒度**: **毎ターンとくぎメニューから選ぶ (DQ 流)**。事前ロードアウトは採らない。
+   → §C / §D の framework で確定。
+2. **とくぎ数**: **レベルアップで増える** (固定数ではない)。習得レベル付きリスト
+   (`JOB_SKILLS`) + `skillsForJob(archetype, jobLevel)`。弱ジョブほど多く・早く習得。→ §B。
+3. **効果種のスコープ**: **幅広く** — 眠り / 攻撃バフ・デバフ / **防御デバフ** / **毒 (継続
+   ダメージ)** を含める。→ §E を広めに実装。
+
+### 実装時に詰める (sim で調整)
+
+4. **習得レベルの具体割り付け**: どのジョブが何を何レベルで覚えるか (§B の目安を sim で確定)。
+5. **敵側の状態異常**: プレイヤー→敵 (眠らせ・デバフ・毒) が主目的。敵→プレイヤーの状態異常は
+   framework 上は対称に作れるが、理不尽回避のため tier 別に慎重導入 (まずプレイヤー有利側から)。
+6. **とくぎ定義の置き場所**: 当面 core の `SKILLS` テーブル (コード)。将来 #418 (PDS データ化)
+   で管理ダッシュボードから編集可能にする射程に含める (データ構造を JSON 化しやすく保つ)。
+
+---
+
+## 実装状況
+
+### #436 (完了) — framework + heal
+上記設計のうち **framework 部分**を実装 (packages/core/src/battle.ts)。当初案の「`SkillDef` データ
+テーブル」までは行かず、**既存の `SkillKind` enum + `LEARNED_SKILLS` (習得レベル付きリスト)** で
+実装した (最小差分・後方互換優先)。
+- `skillsForJob(archetype, jobLevel)`: [0]=署名スキル (`skillForJob` 一致) + `LEARNED_SKILLS` から
+  習得済み副スキル。`BattleState.playerSkills` に格納。
+- `resolveTurn(..., skillIndex=0)` で毎ターン選択 (既定 0=署名 → auto-battle/sim/既存テスト不変)。
+- 新 kind `heal` (MP で maxHp の `skillHealRatio` 回復) を回復役・低攻撃ジョブに配布して複数選択を成立。
+- UI: とくぎサブメニュー (world-battle-controls)。edge: `/api/battle/turn` の skillIndex を sealed
+  state の playerSkills で検証 (サーバー権威・詐称防止)。
+- 習得レベル/heal 配布は暫定 (dev 体感で調整)。auto-battle は署名スキル固定なので sim は heal を
+  使わない = heal 職の実力を保守的に評価する (実プレイの回復で上振れ)。
+
+### #437 (未) — 状態異常 + データ化への移行メモ
+眠り/デバフ/バフ/毒は **状態エンジン** (`Combatant` に sleep/buffs/debuffs、`doAttack` で乗算、
+cleanup で turns 減算) が要る。このとき `playerSkillAction` の switch が肥大化するので、**kind enum →
+`SkillDef` データ (効果 category/magnitude/turns/chance) への移行**を #437 の頭で行うのが自然
+(#418 の PDS データ化ともここで接続する)。#436 の enum は移行の踏み台であり、`LEARNED_SKILLS` の
+形 (id + learnAt) はそのまま `SkillDef` 参照に置き換えられる。習得レベルの割り付け・敵側状態異常は
+#437 で sim 調整。

--- a/packages/core/src/__tests__/battle.test.ts
+++ b/packages/core/src/__tests__/battle.test.ts
@@ -4,6 +4,7 @@ import {
   createRng,
   turnRng,
   skillForJob,
+  skillsForJob,
   JOB_SKILL_NAMES,
   playerCombatant,
   summonMonster,
@@ -72,6 +73,44 @@ describe('skillForJob', () => {
     expect(skillForJob('ninja').kind).toBe('flurry');
     expect(skillForJob('sage').kind).toBe('spell');
     expect(skillForJob('miko').kind).toBe('gamble');
+  });
+});
+
+describe('skillsForJob (複数とくぎ #436)', () => {
+  it('[0] は常に署名スキル (skillForJob と一致 = 後方互換)', () => {
+    for (const job of JOBS) {
+      const sig = skillForJob(job.id);
+      const list1 = skillsForJob(job.id, 1);
+      expect(list1[0]).toEqual(sig);
+    }
+  });
+  it('副スキルはレベルアップで習得する (learnAt 未満は出ない)', () => {
+    // miko は jobLv3 で heal (神楽の癒し) を習得
+    expect(skillsForJob('miko', 1).map((s) => s.kind)).toEqual(['gamble']);
+    expect(skillsForJob('miko', 2).map((s) => s.kind)).toEqual(['gamble']);
+    expect(skillsForJob('miko', 3).map((s) => s.kind)).toEqual(['gamble', 'heal']);
+    // heal 未配布のジョブは署名のみ (warrior)
+    expect(skillsForJob('warrior', 30)).toHaveLength(1);
+  });
+  it('heal とくぎは MP を払って maxHp の割合ぶん回復する', () => {
+    // miko(jobLv5) は [gamble, heal]。HP を削ってから heal を選ぶ (skillIndex=1)
+    let s = startBattle('miko', 5, 8, '巫女', 2, 3, 0);
+    const healIdx = s.playerSkills.findIndex((x) => x.kind === 'heal');
+    expect(healIdx).toBeGreaterThan(0);
+    for (let i = 0; i < 3 && s.outcome === 'ongoing'; i++) s = resolveTurn(s, 'attack', i * 7 + 1);
+    if (s.outcome === 'ongoing' && s.player.hp < s.player.maxHp) {
+      const before = s.player.hp;
+      const mpBefore = s.player.mp;
+      s = resolveTurn(s, 'skill', 999, healIdx);
+      expect(s.player.hp).toBeGreaterThan(before); // 回復した
+      expect(s.player.hp).toBeLessThanOrEqual(s.player.maxHp); // maxHp を超えない
+      expect(s.player.mp).toBeLessThan(mpBefore); // MP を消費した
+    }
+  });
+  it('範囲外の skillIndex は署名スキルに安全側フォールバック (例外にしない)', () => {
+    const s = startBattle('warrior', 5, 8, '戦士', 1, 5, 0);
+    const next = resolveTurn(s, 'skill', 1, 99); // 存在しない index → [0] にフォールバック
+    expect(next.turn).toBe(1); // 例外を投げず 1 ターン進む
   });
 });
 

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -100,6 +100,8 @@ export const BATTLE_TUNING = {
    *  全員一律の回復はジョブの差をぼやけさせる (オーナー決定 2026-07-17)。
    *  特性なしジョブは MP プール + そらのしずくでやりくりする。 */
   skillMpCost: 4,
+  /** heal とくぎ (#436): 使うと maxHp のこの割合を回復 (MP 制。やくそうと違い在庫でなく MP を消費)。 */
+  skillHealRatio: 0.35,
   mpBase: 6,
   mpIntScale: 0.5,
   mpAttackGain: 0,
@@ -161,8 +163,9 @@ export function turnRng(seed: number, turn: number): () => number {
 
 // ─── 特技 (ジョブの支配ステータスで決まる) ──────────────────
 
-export type SkillKind = 'smash' | 'parry' | 'flurry' | 'spell' | 'gamble';
+export type SkillKind = 'smash' | 'parry' | 'flurry' | 'spell' | 'gamble' | 'heal';
 
+// 支配ステータス (atk/def/agi/int/luk) → 署名スキル。heal は署名ではなく「習得」する副スキル。
 const STAT_TO_SKILL: readonly SkillKind[] = ['smash', 'parry', 'flurry', 'spell', 'gamble'];
 
 /** ジョブ固有の特技名。kind はそのジョブの支配ステータスから導出。 */
@@ -201,6 +204,31 @@ export function skillForJob(archetype: Archetype): JobSkill {
     if (stats[i]! >= stats[maxI]!) maxI = i;
   }
   return { kind: STAT_TO_SKILL[maxI]!, name: JOB_SKILL_NAMES[archetype] };
+}
+
+/** 複数とくぎ (#436, エピック #434)。署名スキル (skillForJob) は常に [0]。ジョブは**レベルアップで
+ *  副スキルを習得**する (learnAt = 習得 jobLevel)。弱いジョブほど多く・早く覚えて戦術の幅を持つ
+ *  (オーナー方針。docs/24)。#436 では実装容易な `heal` (HP 回復) を配って複数選択を成立させ、
+ *  眠り/デバフ/バフ等の状態異常は #437 で状態エンジンと共に足す。 */
+interface LearnedSkill { kind: SkillKind; name: string; learnAt: number }
+const LEARNED_SKILLS: Partial<Record<Archetype, readonly LearnedSkill[]>> = {
+  // 回復役・低攻撃ジョブに「いのり (HP 回復)」を配る。攻撃が弱い職ほど早く覚える。
+  miko: [{ kind: 'heal', name: '神楽の癒し', learnAt: 3 }],
+  paladin: [{ kind: 'heal', name: '聖光の癒し', learnAt: 3 }],
+  seer: [{ kind: 'heal', name: '癒しの予言', learnAt: 4 }],
+  sage: [{ kind: 'heal', name: '天啓の癒し', learnAt: 5 }],
+  bard: [{ kind: 'heal', name: '癒しの旋律', learnAt: 4 }],
+  mage: [{ kind: 'heal', name: '回生の術式', learnAt: 5 }],
+};
+
+/** その jobLevel 時点で使えるとくぎ列。[0] は署名スキル (skillForJob と一致 = 後方互換)、
+ *  以降は習得済みの副スキル (learnAt <= jobLevel)。UI/エンジンはこの列から毎ターン選ぶ。 */
+export function skillsForJob(archetype: Archetype, jobLevel: number): JobSkill[] {
+  const signature = skillForJob(archetype);
+  const learned = (LEARNED_SKILLS[archetype] ?? [])
+    .filter((s) => jobLevel >= s.learnAt)
+    .map((s) => ({ kind: s.kind, name: s.name }));
+  return [signature, ...learned];
 }
 
 /** MP 回復のジョブ特性 (オーナー提案 2026-07-17「MP 回復はジョブの特別な要素に。
@@ -245,6 +273,7 @@ export const SKILL_KIND_LABELS: Record<SkillKind, string> = {
   flurry: '連撃 (2 回攻撃)',
   spell: '魔撃 (防御無視)',
   gamble: '大博打 (0〜2.6 倍)',
+  heal: 'いのり (HP 回復)',
 };
 
 // ─── 戦闘参加者 ─────────────────────────────────────────────
@@ -719,7 +748,10 @@ export interface BattleState {
   player: Combatant;
   monster: Combatant;
   monsterId: string;
+  /** 署名スキル ([0])。後方互換 (parry 判定・autoBattle 等はこれ)。 */
   playerSkill: JobSkill;
+  /** その jobLevel で使える全とくぎ ([0]=署名 + 習得済み副スキル)。UI は毎ターンここから選ぶ (#436)。 */
+  playerSkills: JobSkill[];
   outcome: BattleOutcome;
   /** 残りやくそう (持ち込み分)。使うと減る。 */
   herbs: number;
@@ -788,6 +820,7 @@ export function startBattle(
     monster: combatant,
     monsterId: def.id,
     playerSkill: skillForJob(archetype),
+    playerSkills: skillsForJob(archetype, jobLevel),
     outcome: 'ongoing',
     herbs: Math.max(0, Math.min(BATTLE_TUNING.herbCarryMax, Math.floor(herbs))),
     herbsUsed: 0,
@@ -925,33 +958,41 @@ function monsterCommand(state: BattleState, rng: () => number): MonsterAction {
   return 'attack';
 }
 
-function playerSkillAction(state: BattleState, rng: () => number, events: TurnEvent[]): void {
-  const { player, monster, playerSkill } = state;
-  switch (playerSkill.kind) {
+function playerSkillAction(state: BattleState, skill: JobSkill, rng: () => number, events: TurnEvent[]): void {
+  const { player, monster } = state;
+  const t = BATTLE_TUNING;
+  switch (skill.kind) {
     case 'smash':
-      doAttack(player, monster, rng, events, 'player', { power: 1.7, hitBonus: -0.1, label: playerSkill.name });
+      doAttack(player, monster, rng, events, 'player', { power: 1.7, hitBonus: -0.1, label: skill.name });
       break;
     case 'parry':
       // 宣言は resolveTurn 冒頭 (行動順に関係なく効くように)。ここは no-op。
       break;
     case 'flurry':
       // 支配ステータス (agi) 基準 — 素早さで手数を出すジョブの「らしさ」と火力を一致させる
-      doAttack(player, monster, rng, events, 'player', { power: 0.65, atkOverride: player.agi, label: playerSkill.name });
+      doAttack(player, monster, rng, events, 'player', { power: 0.65, atkOverride: player.agi, label: skill.name });
       if (state.monster.hp > 0) {
-        doAttack(player, monster, rng, events, 'player', { power: 0.65, atkOverride: player.agi, label: playerSkill.name });
+        doAttack(player, monster, rng, events, 'player', { power: 0.65, atkOverride: player.agi, label: skill.name });
       }
       break;
     case 'spell':
       // 防御を半分だけ貫通 + 必中。完全無視 (旧仕様) は int 職が tier3 を蹂躙して
       // 難易度設計が壊れたため 0.5 に緩和 (バランステストで固定)。
-      doAttack(player, monster, rng, events, 'player', { power: 1.0, useInt: true, defFactor: 0.5, label: playerSkill.name });
+      doAttack(player, monster, rng, events, 'player', { power: 1.0, useInt: true, defFactor: 0.5, label: skill.name });
       break;
     case 'gamble': {
       // 0〜2.6 倍。luk が高いほど下振れしにくい。基準値も支配ステータス (luk) —
       // atk 7〜9 の luk 型ジョブが「運で殴る」ジョブとして成立するように。
       const floor = Math.min(0.6, player.luk * 0.012);
       const mult = floor + rng() * (2.6 - floor);
-      doAttack(player, monster, rng, events, 'player', { power: mult, atkOverride: player.luk, label: playerSkill.name });
+      doAttack(player, monster, rng, events, 'player', { power: mult, atkOverride: player.luk, label: skill.name });
+      break;
+    }
+    case 'heal': {
+      // 習得スキル (#436): MP を払って maxHp の割合ぶん回復。攻撃しないターンなので削り合いの読み合い。
+      const heal = Math.round(player.maxHp * t.skillHealRatio);
+      player.hp = Math.min(player.maxHp, player.hp + heal);
+      events.push({ actor: 'player', text: `${player.name}は${skill.name}! HP が ${heal} 回復。` });
       break;
     }
   }
@@ -966,7 +1007,7 @@ function playerSkillAction(state: BattleState, rng: () => number, events: TurnEv
  * (CSPRNG/kuda) を注入し「先読み・引き直し」を封じるための薄い口。省略時は従来どおり
  * `turnRng(seed, turn)` = 完全決定的 (試練/テストは seed 方式のまま不変)。
  */
-export function resolveTurn(prev: BattleState, command: Command, turnSeed?: number): BattleState {
+export function resolveTurn(prev: BattleState, command: Command, turnSeed?: number, skillIndex = 0): BattleState {
   if (prev.outcome !== 'ongoing') return prev;
 
   // コピー (Combatant は現状 flat なので spread で足りる)。
@@ -979,6 +1020,8 @@ export function resolveTurn(prev: BattleState, command: Command, turnSeed?: numb
     monster: { ...prev.monster, guarding: false },
     lastEvents: [],
   };
+  // command==='skill' のとき使う特技 (#436: 毎ターン選択)。範囲外は署名スキル [0] に安全側フォールバック。
+  const selectedSkill = state.playerSkills[skillIndex] ?? state.playerSkills[0] ?? state.playerSkill;
   const events: TurnEvent[] = [];
   // 外部供給 seed があればそれで (サーバー権威: 先読み不可)、無ければ seed 由来 (決定的)。
   const rng = turnSeed === undefined ? turnRng(state.seed, state.turn) : createRng(turnSeed >>> 0);
@@ -1035,9 +1078,9 @@ export function resolveTurn(prev: BattleState, command: Command, turnSeed?: numb
       events.push({ actor: 'player', text: `${state.player.name}はぼうぎょのかまえ!` });
     }
   }
-  if (cmd === 'skill' && state.playerSkill.kind === 'parry') {
+  if (cmd === 'skill' && selectedSkill.kind === 'parry') {
     state.player.parrying = true;
-    events.push({ actor: 'player', text: `${state.player.name}は${state.playerSkill.name}の構え! (防御しつつ反撃)` });
+    events.push({ actor: 'player', text: `${state.player.name}は${selectedSkill.name}の構え! (防御しつつ反撃)` });
   }
   // ため中は防御宣言しない (このターンは必ず解放する。宣言すると「身を固めた直後に
   // ため攻撃」という矛盾イベント + 幻の防御半減が発生する)。
@@ -1059,7 +1102,7 @@ export function resolveTurn(prev: BattleState, command: Command, turnSeed?: numb
           state.player.mp = Math.min(state.player.maxMp, state.player.mp + state.mpAttackGain);
         }
       } else if (cmd === 'skill') {
-        playerSkillAction(state, rng, events);
+        playerSkillAction(state, selectedSkill, rng, events);
       } else if (cmd === 'herb') {
         const heal = Math.round(state.player.maxHp * t.herbHealRatio);
         state.player.hp = Math.min(state.player.maxHp, state.player.hp + heal);

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -1020,8 +1020,10 @@ export function resolveTurn(prev: BattleState, command: Command, turnSeed?: numb
     monster: { ...prev.monster, guarding: false },
     lastEvents: [],
   };
-  // command==='skill' のとき使う特技 (#436: 毎ターン選択)。範囲外は署名スキル [0] に安全側フォールバック。
-  const selectedSkill = state.playerSkills[skillIndex] ?? state.playerSkills[0] ?? state.playerSkill;
+  // command==='skill' のとき使う特技 (#436: 毎ターン選択)。範囲外/未設定 (デプロイ跨ぎの旧 sealed
+  // state で playerSkills が無い) は署名スキル playerSkill に安全側フォールバック。
+  const skills = state.playerSkills ?? [state.playerSkill];
+  const selectedSkill = skills[skillIndex] ?? skills[0] ?? state.playerSkill;
   const events: TurnEvent[] = [];
   // 外部供給 seed があればそれで (サーバー権威: 先読み不可)、無ければ seed 由来 (決定的)。
   const rng = turnSeed === undefined ? turnRng(state.seed, state.turn) : createRng(turnSeed >>> 0);


### PR DESCRIPTION
Closes #436
Epic #434 / 設計 docs/24

## 概要
ジョブが**複数のとくぎを持ち、毎ターン選べる**ように (オーナー方針: 弱ジョブほど多く・レベルで習得・DQ流の毎ターン選択)。#436 は framework + 実装容易な heal を配って複数選択を成立させる。眠り/デバフ/バフ等の状態異常は #437。

## 変更
**エンジン (packages/core)**
- `skillsForJob(archetype, jobLevel)`: [0]=署名スキル (skillForJob 一致=後方互換) + レベルで習得する副スキル (`LEARNED_SKILLS` の learnAt)。弱攻撃/回復役に heal を早めに配布。
- `BattleState.playerSkills` + `resolveTurn(prev, cmd, turnSeed?, skillIndex=0)`。既定 0=署名なので auto-battle/sim/既存テストは不変。
- 新スキル `heal` (いのり): MP を払って maxHp の 35% 回復。
**UI (apps/web)**: とくぎサブメニュー (どうぐメニュー踏襲)。複数持ちは一覧選択、1 個の職は即発動。heal は満タン時 disabled。
**edge (apps/edge)**: `/api/battle/turn` に skillIndex。**サーバー権威検証** — sealed state の playerSkills に含まれる index だけ許可 (詐称は署名 [0] に落とす)。

## 後方互換
デプロイ跨ぎの旧 sealed state (playerSkills 無し) は engine/edge/UI すべてで署名スキル 1 個にフォールバック。

## 検証
- skillsForJob のレベル習得・heal 実動 (MP消費/回復/上限)・範囲外 index フォールバックをテスト。
- core 317 / web 346 / edge 149 / 全 typecheck / build 緑。

## Review
§1.5 3並列レビュー (設計/実装/UX、読み取り専用・origin/ diff)。**★★★ ブロッカーなし。**

### 検証済み (実装★★★ / 設計★★ / UX★★)
- 壊れ・バグなし: skillIndex 検証 (edge 詐称防止 + engine/UI/edge の三層フォールバック)、heal の回復量/上限/MP消費、MP不足フォールバック、playerSkillAction シグネチャ変更の波及なし、旧 sealed state 互換。テスト (skillsForJob/heal/範囲外index) 健全。
- サーバー権威: sealEncounter 時の jobLevel で playerSkills 固定、未習得 index は署名 [0] に落とす。

### 対応 (PR 内)
- **docs/24 を PR に追加 (設計指摘)** + 実装状況追記 (kind enum + LEARNED_SKILLS で実装した旨・#437 での enum→SkillDef データ移行メモ)。
- **メニュー閉じ (実装★★)**: 入力フェーズを離れたら useEffect でサブメニューを閉じる。
- **edge フォールバック明示 (設計★)**: playerSkills 無し時を [] → [playerSkill] に。

### 評価済み・非対応 (方針明記)
- **UX★★「MP不足の可視化」**: プレイヤー MP は戦闘中も上部 WorldHud 帯に表示される (オーバーレイは paddingTop で帯を空けている) ため、とくぎ grayout の理由は やくそう×0 同様に発見可能。冗長 UI は足さない。
- **★ 群 (dev 体感 / 別対応)**: heal 習得レベルの sim 調整、MP コスト表記の要否、UI メニューの enum 化、edge skillIndex 詐称の unit test → dev 体感・edge テスト刷新時に。auto-battle が heal 非使用で sim が heal 職を保守評価する点は docs/24 に明記。

core 317 / web 346 / edge 149 / 全 typecheck / build 緑。