### PR TITLE
fix(sim): 模擬戦で複数とくぎを選べるように (#436)

### DIFF
--- a/apps/web/src/components/debug-battle-sim.tsx
+++ b/apps/web/src/components/debug-battle-sim.tsx
@@ -140,8 +140,8 @@ export function DebugBattleSim() {
     // (summonMonster を通らず monsterCombatant の jitter も効かない)。戦闘中の乱数だけ下で新鮮に。
     setDuel(start(1, 0));
   };
-  const duelCmd = (cmd: Command) =>
-    setDuel((s) => (s && s.outcome === 'ongoing' ? resolveTurn(s, cmd, freshSeed()) : s));
+  const duelCmd = (cmd: Command, skillIndex = 0) =>
+    setDuel((s) => (s && s.outcome === 'ongoing' ? resolveTurn(s, cmd, freshSeed(), skillIndex) : s));
   const duelAuto = () =>
     setDuel((s) => (s && s.outcome === 'ongoing' ? resolveTurn(s, autoBattleCommand(s), freshSeed()) : s));
 
@@ -237,7 +237,21 @@ export function DebugBattleSim() {
           </div>
           {duel.outcome === 'ongoing' ? (
             <div style={{ display: 'flex', gap: '0.3em', flexWrap: 'wrap' }}>
-              {(['attack', 'guard', 'skill', 'herb', 'tonic', 'flee'] as const).map((c) => (
+              <button onClick={() => duelCmd('attack')} style={{ fontSize: '0.85em', padding: '0.2em 0.5em' }}>{CMD_LABEL.attack}</button>
+              <button onClick={() => duelCmd('guard')} style={{ fontSize: '0.85em', padding: '0.2em 0.5em' }}>{CMD_LABEL.guard}</button>
+              {/* とくぎは習得済みぶんを 1 個ずつボタン化 (#436 の複数とくぎを模擬戦で選べるように)。
+                  複数無いジョブは署名 1 個だけ出る。MP 不足 / heal 満タンは disabled。 */}
+              {(duel.playerSkills ?? [duel.playerSkill]).map((sk, i) => (
+                <button
+                  key={i}
+                  onClick={() => duelCmd('skill', i)}
+                  disabled={duel.player.mp < BATTLE_TUNING.skillMpCost || (sk.kind === 'heal' && duel.player.hp >= duel.player.maxHp)}
+                  style={{ fontSize: '0.85em', padding: '0.2em 0.5em' }}
+                >
+                  {sk.name}
+                </button>
+              ))}
+              {(['herb', 'tonic', 'flee'] as const).map((c) => (
                 <button key={c} onClick={() => duelCmd(c)} style={{ fontSize: '0.85em', padding: '0.2em 0.5em' }}>{CMD_LABEL[c]}</button>
               ))}
               <button onClick={duelAuto} style={{ fontSize: '0.85em', padding: '0.2em 0.5em' }}>自動1手</button>


### PR DESCRIPTION
Refs #436

## 症状 (オーナー報告)
**模擬戦シミュレータ**の1戦モードで、とくぎが署名の 1 個しか使えない (#436 の複数とくぎを選べない)。

## 原因と修正
1戦モードの 'skill' ボタンが `duelCmd('skill')` = skillIndex 0 固定 (署名スキル) だった。
- `duelCmd(cmd, skillIndex=0)` に拡張、`resolveTurn(s, cmd, freshSeed(), skillIndex)`。
- コマンド行で **とくぎを playerSkills から 1 個ずつボタン化** (名前ラベル)。MP不足/heal満タンは disabled。複数無いジョブは署名 1 個のまま。

## 確認
- warrior jobLv5 → 1 ボタン (鉄壁の構え)。miko jobLv5 → 2 ボタン (神楽の祈り / 神楽の癒し)。
- ※ 複数とくぎを見るには heal 習得職 (巫女/聖騎士/予言者/賢者/吟遊詩人/魔法使い) を jobLv 3〜5 に。
- web typecheck 緑。dev 専用ツール。

## Review
§1.5 レビュー (dev ツールの小変更につき実装+UX の 1 観点集中、読み取り専用)。**★★★ なし・マージ推奨**。
- 実装★★★: skillIndex の resolveTurn 伝播・playerSkills フォールバック・型安全・BATTLE_TUNING import すべて OK。バッチ/startDuel/自動1手/署名のみ職に波及なし (後方互換)。
- UX★★: とくぎ名ボタンの操作感自然、disabled 表現標準、ボタン数 1〜2 で flex 崩れなし。
- ★ (非対応/任意): index key は playerSkills が戦闘中不変なので安全 / CMD_LABEL.skill は未参照になるが Record 型維持のため保持 / 複数とくぎは jobLv3+ の heal 職が必要 (dev ツールなのでヒント不要)。
web typecheck 緑。dev 専用ツール。