### PR TITLE
feat(combat): 戦闘プラグイン基盤 — 属性/SkillDef/状態異常/敵AI レジストリ (#452)

### DIFF
--- a/packages/core/src/__tests__/elements.test.ts
+++ b/packages/core/src/__tests__/elements.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { elementMultiplier, ELEMENT_MULT, type Element } from '../elements.js';
+
+describe('elementMultiplier (属性相性 #452)', () => {
+  it('無属性 (null/undefined) が絡めば常に等倍', () => {
+    expect(elementMultiplier(null, 'fire')).toBe(1);
+    expect(elementMultiplier('fire', null)).toBe(1);
+    expect(elementMultiplier(undefined, undefined)).toBe(1);
+  });
+
+  it('輪 地→水→火→風→地 で「強い」側が有利 (×strong)', () => {
+    expect(elementMultiplier('earth', 'water')).toBe(ELEMENT_MULT.strong);
+    expect(elementMultiplier('water', 'fire')).toBe(ELEMENT_MULT.strong);
+    expect(elementMultiplier('fire', 'wind')).toBe(ELEMENT_MULT.strong);
+    expect(elementMultiplier('wind', 'earth')).toBe(ELEMENT_MULT.strong);
+  });
+
+  it('逆側は不利 (×weak)', () => {
+    expect(elementMultiplier('water', 'earth')).toBe(ELEMENT_MULT.weak);
+    expect(elementMultiplier('fire', 'water')).toBe(ELEMENT_MULT.weak);
+    expect(elementMultiplier('wind', 'fire')).toBe(ELEMENT_MULT.weak);
+    expect(elementMultiplier('earth', 'wind')).toBe(ELEMENT_MULT.weak);
+  });
+
+  it('正面以外 (地↔火 / 水↔風) は中立', () => {
+    expect(elementMultiplier('earth', 'fire')).toBe(1);
+    expect(elementMultiplier('fire', 'earth')).toBe(1);
+    expect(elementMultiplier('water', 'wind')).toBe(1);
+    expect(elementMultiplier('wind', 'water')).toBe(1);
+  });
+
+  it('空 (void) は攻撃も被弾も 1.2', () => {
+    for (const e of ['earth', 'water', 'fire', 'wind', 'void'] as Element[]) {
+      expect(elementMultiplier('void', e)).toBe(ELEMENT_MULT.voidMult); // 空で殴る
+      expect(elementMultiplier(e, 'void')).toBe(ELEMENT_MULT.voidMult); // 空を殴る
+    }
+  });
+
+  it('相性は対称 (X が Y に有利なら Y は X に不利 = 輪の一貫性)', () => {
+    const els: Element[] = ['earth', 'water', 'fire', 'wind'];
+    for (const a of els) for (const b of els) {
+      if (a === b) continue;
+      const ab = elementMultiplier(a, b);
+      const ba = elementMultiplier(b, a);
+      if (ab === ELEMENT_MULT.strong) expect(ba).toBe(ELEMENT_MULT.weak);
+      if (ab === ELEMENT_MULT.weak) expect(ba).toBe(ELEMENT_MULT.strong);
+    }
+  });
+});

--- a/packages/core/src/__tests__/skills.test.ts
+++ b/packages/core/src/__tests__/skills.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { SKILLS, runSkill, EFFECT_HANDLERS, type SkillContext } from '../skills.js';
+import type { Combatant, AttackOptions } from '../battle.js';
+
+function makeCombatant(over: Partial<Combatant> = {}): Combatant {
+  return {
+    name: 'test',
+    maxHp: 100,
+    hp: 100,
+    maxMp: 20,
+    mp: 20,
+    atk: 20,
+    def: 10,
+    agi: 15,
+    int: 25,
+    luk: 30,
+    guarding: false,
+    parrying: false,
+    charging: false,
+    focus: 0,
+    ...over,
+  };
+}
+
+/** doAttack をスパイに差し替え、SKILLS が「どんな opts で何回 doAttack を呼ぶか」を検証する。 */
+function runWithSpy(skillId: string, attacker: Combatant, defender: Combatant, rng = () => 0.5) {
+  const calls: AttackOptions[] = [];
+  const ctx: SkillContext = {
+    attacker,
+    defender,
+    rng,
+    events: [],
+    skillName: skillId,
+    engine: {
+      doAttack: (_a, _d, _r, _e, _actor, opts = {}) => {
+        calls.push(opts);
+      },
+    },
+  };
+  runSkill(SKILLS[skillId], ctx);
+  return { calls, ctx };
+}
+
+describe('とくぎプラグイン基盤 (#452)', () => {
+  it('既存 6 種すべてが SKILLS に登録されている', () => {
+    for (const id of ['smash', 'parry', 'flurry', 'spell', 'gamble', 'heal']) {
+      expect(SKILLS[id], id).toBeDefined();
+      expect(SKILLS[id].id).toBe(id);
+    }
+  });
+
+  it('smash: atk 基準 1.7 倍・hitBonus -0.1 で 1 回', () => {
+    const { calls } = runWithSpy('smash', makeCombatant(), makeCombatant());
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ power: 1.7, hitBonus: -0.1 });
+    expect(calls[0].useInt).toBeUndefined();
+    expect(calls[0].atkOverride).toBeUndefined(); // 素の atk
+  });
+
+  it('parry: 効果なし (宣言は resolveTurn 側)', () => {
+    const { calls } = runWithSpy('parry', makeCombatant(), makeCombatant());
+    expect(calls).toHaveLength(0);
+  });
+
+  it('flurry: agi 基準 0.65 倍を 2 撃', () => {
+    const atk = makeCombatant({ agi: 15 });
+    const { calls } = runWithSpy('flurry', atk, makeCombatant());
+    expect(calls).toHaveLength(2);
+    for (const c of calls) expect(c).toMatchObject({ power: 0.65, atkOverride: 15 });
+  });
+
+  it('flurry: 1 撃目で対象が倒れたら 2 撃目は撃たない', () => {
+    const dead = makeCombatant({ hp: 0 });
+    const { calls } = runWithSpy('flurry', makeCombatant(), dead);
+    expect(calls).toHaveLength(0); // 開始時点で hp<=0 なら 0 撃
+  });
+
+  it('spell: int 基準 (useInt) ・防御半減 (defFactor 0.5)', () => {
+    const { calls } = runWithSpy('spell', makeCombatant(), makeCombatant());
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ power: 1.0, useInt: true, defFactor: 0.5 });
+  });
+
+  it('gamble: luk 基準・power は floor〜max で抽選 (rng で変わる)', () => {
+    const atk = makeCombatant({ luk: 30 }); // floor = min(0.6, 30*0.012=0.36) = 0.36
+    const lo = runWithSpy('gamble', atk, makeCombatant(), () => 0).calls[0];
+    const hi = runWithSpy('gamble', atk, makeCombatant(), () => 1).calls[0];
+    expect(lo.atkOverride).toBe(30);
+    expect(lo.power).toBeCloseTo(0.36); // rng=0 → floor
+    expect(hi.power).toBeCloseTo(2.6); // rng=1 → max
+  });
+
+  it('heal: doAttack を呼ばず maxHp の 0.35 回復 (上限クランプ)', () => {
+    const atk = makeCombatant({ maxHp: 100, hp: 50 });
+    const { calls, ctx } = runWithSpy('heal', atk, makeCombatant());
+    expect(calls).toHaveLength(0); // 攻撃しない
+    expect(atk.hp).toBe(85); // 50 + round(100*0.35)=85
+    expect(ctx.events.some((e) => e.text.includes('回復'))).toBe(true);
+  });
+
+  it('heal: maxHp を超えない', () => {
+    const atk = makeCombatant({ maxHp: 100, hp: 90 });
+    runWithSpy('heal', atk, makeCombatant());
+    expect(atk.hp).toBe(100);
+  });
+
+  it('EFFECT_HANDLERS は damage/heal をカバー', () => {
+    expect(EFFECT_HANDLERS.damage).toBeTypeOf('function');
+    expect(EFFECT_HANDLERS.heal).toBeTypeOf('function');
+  });
+});

--- a/packages/core/src/__tests__/skills.test.ts
+++ b/packages/core/src/__tests__/skills.test.ts
@@ -165,4 +165,33 @@ describe('効果 ↔ 状態異常の接続 (#452)', () => {
     );
     expect(dead.statuses ?? []).toHaveLength(0);
   });
+
+  it('element: damage 効果が攻撃属性を AttackOptions に渡す (doAttack が相性判定に使う)', () => {
+    const { calls } = runWithSpy2({ id: 'x', effects: [{ kind: 'damage', stat: 'int', element: 'fire' }] });
+    expect(calls[0]!.element).toBe('fire');
+  });
+
+  it('element: 未指定なら opts.element も undefined (無属性=等倍)', () => {
+    const { calls } = runWithSpy2({ id: 'x', effects: [{ kind: 'damage', stat: 'atk' }] });
+    expect(calls[0]!.element).toBeUndefined();
+  });
 });
+
+/** 任意の SkillDef を spy で実行し、doAttack に渡った opts 列を返す。 */
+function runWithSpy2(def: SkillDef, rng = () => 0.5) {
+  const calls: AttackOptions[] = [];
+  runSkill(def, {
+    attacker: makeCombatant(),
+    defender: makeCombatant(),
+    rng,
+    events: [],
+    skillName: 'x',
+    engine: {
+      doAttack: (_a, d, _r, _e, _actor, opts = {}) => {
+        calls.push(opts);
+        return { hit: d.hp > 0, damage: 5, fatal: false, crit: false };
+      },
+    },
+  });
+  return { calls };
+}

--- a/packages/core/src/__tests__/skills.test.ts
+++ b/packages/core/src/__tests__/skills.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { SKILLS, runSkill, EFFECT_HANDLERS, type SkillContext } from '../skills.js';
+import { SKILLS, runSkill, EFFECT_HANDLERS, type SkillContext, type SkillDef } from '../skills.js';
 import type { Combatant, AttackOptions } from '../battle.js';
 
 function makeCombatant(over: Partial<Combatant> = {}): Combatant {
@@ -32,12 +32,13 @@ function runWithSpy(skillId: string, attacker: Combatant, defender: Combatant, r
     events: [],
     skillName: skillId,
     engine: {
-      doAttack: (_a, _d, _r, _e, _actor, opts = {}) => {
+      doAttack: (_a, d, _r, _e, _actor, opts = {}) => {
         calls.push(opts);
+        return { hit: d.hp > 0, damage: 5, fatal: false, crit: false };
       },
     },
   };
-  runSkill(SKILLS[skillId], ctx);
+  runSkill(SKILLS[skillId]!, ctx);
   return { calls, ctx };
 }
 
@@ -45,7 +46,7 @@ describe('とくぎプラグイン基盤 (#452)', () => {
   it('既存 6 種すべてが SKILLS に登録されている', () => {
     for (const id of ['smash', 'parry', 'flurry', 'spell', 'gamble', 'heal']) {
       expect(SKILLS[id], id).toBeDefined();
-      expect(SKILLS[id].id).toBe(id);
+      expect(SKILLS[id]!.id).toBe(id);
     }
   });
 
@@ -53,8 +54,8 @@ describe('とくぎプラグイン基盤 (#452)', () => {
     const { calls } = runWithSpy('smash', makeCombatant(), makeCombatant());
     expect(calls).toHaveLength(1);
     expect(calls[0]).toMatchObject({ power: 1.7, hitBonus: -0.1 });
-    expect(calls[0].useInt).toBeUndefined();
-    expect(calls[0].atkOverride).toBeUndefined(); // 素の atk
+    expect(calls[0]!.useInt).toBeUndefined();
+    expect(calls[0]!.atkOverride).toBeUndefined(); // 素の atk
   });
 
   it('parry: 効果なし (宣言は resolveTurn 側)', () => {
@@ -83,8 +84,8 @@ describe('とくぎプラグイン基盤 (#452)', () => {
 
   it('gamble: luk 基準・power は floor〜max で抽選 (rng で変わる)', () => {
     const atk = makeCombatant({ luk: 30 }); // floor = min(0.6, 30*0.012=0.36) = 0.36
-    const lo = runWithSpy('gamble', atk, makeCombatant(), () => 0).calls[0];
-    const hi = runWithSpy('gamble', atk, makeCombatant(), () => 1).calls[0];
+    const lo = runWithSpy('gamble', atk, makeCombatant(), () => 0).calls[0]!;
+    const hi = runWithSpy('gamble', atk, makeCombatant(), () => 1).calls[0]!;
     expect(lo.atkOverride).toBe(30);
     expect(lo.power).toBeCloseTo(0.36); // rng=0 → floor
     expect(hi.power).toBeCloseTo(2.6); // rng=1 → max
@@ -104,8 +105,64 @@ describe('とくぎプラグイン基盤 (#452)', () => {
     expect(atk.hp).toBe(100);
   });
 
-  it('EFFECT_HANDLERS は damage/heal をカバー', () => {
+  it('EFFECT_HANDLERS は damage/heal/status をカバー', () => {
     expect(EFFECT_HANDLERS.damage).toBeTypeOf('function');
     expect(EFFECT_HANDLERS.heal).toBeTypeOf('function');
+    expect(EFFECT_HANDLERS.status).toBeTypeOf('function');
+  });
+});
+
+/** 任意の SkillDef を spy エンジンで実行 (hit=defender.hp>0)。 */
+function runDef(def: SkillDef, attacker: Combatant, defender: Combatant, rng = () => 0) {
+  const ctx: SkillContext = {
+    attacker,
+    defender,
+    rng,
+    events: [],
+    skillName: 'test',
+    engine: {
+      doAttack: (_a, d) => ({ hit: d.hp > 0, damage: 5, fatal: false, crit: false }),
+    },
+  };
+  runSkill(def, ctx);
+}
+
+describe('効果 ↔ 状態異常の接続 (#452)', () => {
+  it('status(self): 使用者にバフを付与', () => {
+    const atk = makeCombatant();
+    runDef({ id: 'x', effects: [{ kind: 'status', status: 'atkUp', target: 'self', turns: 3 }] }, atk, makeCombatant());
+    expect(atk.statuses?.map((s) => s.id)).toContain('atkUp');
+  });
+
+  it('status(enemy): 相手にデバフを付与', () => {
+    const def = makeCombatant();
+    runDef({ id: 'x', effects: [{ kind: 'status', status: 'poison', target: 'enemy', turns: 3, magnitude: 4 }] }, makeCombatant(), def);
+    expect(def.statuses?.find((s) => s.id === 'poison')?.magnitude).toBe(4);
+  });
+
+  it('status: chance=0 なら付与されない', () => {
+    const def = makeCombatant();
+    runDef({ id: 'x', effects: [{ kind: 'status', status: 'poison', target: 'enemy', chance: 0 }] }, makeCombatant(), def, () => 0.5);
+    expect(def.statuses ?? []).toHaveLength(0);
+  });
+
+  it('inflict: 命中した攻撃に状態を乗せる (毒手)', () => {
+    const def = makeCombatant({ hp: 100 });
+    runDef(
+      { id: 'x', effects: [{ kind: 'damage', stat: 'atk', power: 1, inflict: { status: 'poison', chance: 1, turns: 3, magnitude: 2 } }] },
+      makeCombatant(),
+      def,
+    );
+    expect(def.statuses?.some((s) => s.id === 'poison')).toBe(true);
+  });
+
+  it('inflict: 対象が既に倒れている (miss) なら状態を乗せない', () => {
+    const dead = makeCombatant({ hp: 0 });
+    runDef(
+      { id: 'x', effects: [{ kind: 'damage', stat: 'atk', power: 1, inflict: { status: 'poison', chance: 1 } }] },
+      makeCombatant(),
+      dead,
+    );
+    expect(dead.statuses ?? []).toHaveLength(0);
   });
 });

--- a/packages/core/src/__tests__/statuses.test.ts
+++ b/packages/core/src/__tests__/statuses.test.ts
@@ -61,7 +61,9 @@ describe('状態異常エンジン (#452)', () => {
   });
 
   it('statuses undefined (旧 sealed state) でも落ちず no-op', () => {
-    const legacy = c({ statuses: undefined, passives: undefined });
+    const legacy = c();
+    delete (legacy as { statuses?: unknown }).statuses;
+    delete (legacy as { passives?: unknown }).passives;
     expect(applyBeforeAct(legacy, ctx())).toBe(false);
     expect(applyPowerCalc(1, legacy, ctx())).toBe(1);
     expect(() => tickStatuses(legacy, ctx())).not.toThrow();
@@ -72,7 +74,7 @@ describe('状態異常エンジン (#452)', () => {
     const p = c({ statuses: [st('poison', 2, 5)] });
     tickStatuses(p, ctx());
     expect(p.hp).toBe(95);
-    expect(p.statuses![0].turns).toBe(1);
+    expect(p.statuses![0]!.turns).toBe(1);
     tickStatuses(p, ctx());
     expect(p.hp).toBe(90);
     expect(p.statuses).toHaveLength(0); // turns 0 で除去
@@ -134,14 +136,14 @@ describe('状態異常エンジン (#452)', () => {
     applyStatus(p, st('poison', 2, 3));
     applyStatus(p, st('poison', 5, 4)); // refresh: turns=max, magnitude 更新
     expect(p.statuses).toHaveLength(1);
-    expect(p.statuses![0].turns).toBe(5);
-    expect(p.statuses![0].magnitude).toBe(4);
+    expect(p.statuses![0]!.turns).toBe(5);
+    expect(p.statuses![0]!.magnitude).toBe(4);
 
     const t = c();
     applyStatus(t, st('tumble', 2));
     applyStatus(t, st('tumble', 9)); // ignore: 据え置き
     expect(t.statuses).toHaveLength(1);
-    expect(t.statuses![0].turns).toBe(2);
+    expect(t.statuses![0]!.turns).toBe(2);
   });
 
   it('poison は生存者のみ tick (HP0 の死体は毒で追撃しない)', () => {

--- a/packages/core/src/__tests__/statuses.test.ts
+++ b/packages/core/src/__tests__/statuses.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest';
+import {
+  STATUS_REGISTRY,
+  applyBeforeAct,
+  applyDodgeCalc,
+  applyPowerCalc,
+  applyCritCalc,
+  applyIncomingCalc,
+  tickStatuses,
+  clearActedStatuses,
+  clearHitStatuses,
+  applyStatus,
+  type HookCtx,
+  type StatusInstance,
+} from '../statuses.js';
+import type { Combatant } from '../battle.js';
+
+function c(over: Partial<Combatant> = {}): Combatant {
+  return {
+    name: 'c',
+    maxHp: 100,
+    hp: 100,
+    maxMp: 10,
+    mp: 10,
+    atk: 20,
+    def: 10,
+    agi: 15,
+    int: 20,
+    luk: 10,
+    guarding: false,
+    parrying: false,
+    charging: false,
+    focus: 0,
+    statuses: [],
+    passives: [],
+    ...over,
+  };
+}
+const ctx = (): HookCtx => ({ rng: () => 0.5, events: [] });
+const st = (id: StatusInstance['id'], turns = 3, magnitude?: number): StatusInstance =>
+  magnitude === undefined ? { id, turns } : { id, turns, magnitude };
+
+describe('状態異常エンジン (#452)', () => {
+  it('全 StatusId が STATUS_REGISTRY に登録され id が一致', () => {
+    for (const id of Object.keys(STATUS_REGISTRY) as Array<keyof typeof STATUS_REGISTRY>) {
+      expect(STATUS_REGISTRY[id].id).toBe(id);
+    }
+  });
+
+  // ── no-op 保証 (behavior-preserving の要) ──
+  it('状態なしなら全ディスパッチが入力そのまま (no-op)', () => {
+    const bare = c();
+    expect(applyBeforeAct(bare, ctx())).toBe(false);
+    expect(applyDodgeCalc(0.2, bare, ctx())).toBe(0.2);
+    expect(applyPowerCalc(1, bare, ctx())).toBe(1);
+    expect(applyCritCalc(false, bare, ctx())).toBe(false);
+    expect(applyIncomingCalc(1, bare, ctx())).toBe(1);
+    const before = bare.hp;
+    tickStatuses(bare, ctx());
+    expect(bare.hp).toBe(before);
+  });
+
+  it('statuses undefined (旧 sealed state) でも落ちず no-op', () => {
+    const legacy = c({ statuses: undefined, passives: undefined });
+    expect(applyBeforeAct(legacy, ctx())).toBe(false);
+    expect(applyPowerCalc(1, legacy, ctx())).toBe(1);
+    expect(() => tickStatuses(legacy, ctx())).not.toThrow();
+  });
+
+  // ── 各状態の効果 ──
+  it('poison: turnEnd で magnitude ダメージ + turns 減衰', () => {
+    const p = c({ statuses: [st('poison', 2, 5)] });
+    tickStatuses(p, ctx());
+    expect(p.hp).toBe(95);
+    expect(p.statuses![0].turns).toBe(1);
+    tickStatuses(p, ctx());
+    expect(p.hp).toBe(90);
+    expect(p.statuses).toHaveLength(0); // turns 0 で除去
+  });
+
+  it('sleep/stun/tumble/restraint: beforeAct で行動不可', () => {
+    for (const id of ['sleep', 'stun', 'tumble', 'restraint'] as const) {
+      expect(applyBeforeAct(c({ statuses: [st(id)] }), ctx())).toBe(true);
+    }
+  });
+
+  it('tumble: 被ダメ 1.2 倍', () => {
+    expect(applyIncomingCalc(1, c({ statuses: [st('tumble')] }), ctx())).toBeCloseTo(1.2);
+  });
+
+  it('hidden: 回避を底上げ・行動 or 被弾で解除', () => {
+    expect(applyDodgeCalc(0.1, c({ statuses: [st('hidden')] }), ctx())).toBe(0.75);
+    const acted = c({ statuses: [st('hidden')] });
+    clearActedStatuses(acted);
+    expect(acted.statuses).toHaveLength(0);
+    const hit = c({ statuses: [st('hidden')] });
+    clearHitStatuses(hit);
+    expect(hit.statuses).toHaveLength(0);
+  });
+
+  it('critCharge: 確定会心・行動で解除', () => {
+    expect(applyCritCalc(false, c({ statuses: [st('critCharge')] }), ctx())).toBe(true);
+    const ch = c({ statuses: [st('critCharge')] });
+    clearActedStatuses(ch);
+    expect(ch.statuses).toHaveLength(0);
+  });
+
+  it('restraint: 被弾では解けない (clearHit no-op) が行動では解ける', () => {
+    const hit = c({ statuses: [st('restraint')] });
+    clearHitStatuses(hit);
+    expect(hit.statuses).toHaveLength(1); // 被弾で解けない
+    clearActedStatuses(hit);
+    expect(hit.statuses).toHaveLength(0);
+  });
+
+  it('atkUp/atkDown: 威力倍率 (magnitude 上書き可)', () => {
+    expect(applyPowerCalc(1, c({ statuses: [st('atkUp')] }), ctx())).toBeCloseTo(1.3);
+    expect(applyPowerCalc(1, c({ statuses: [st('atkDown', 3, 0.5)] }), ctx())).toBeCloseTo(0.5);
+  });
+
+  it('defUp/defDown: 被ダメ倍率', () => {
+    expect(applyIncomingCalc(1, c({ statuses: [st('defUp')] }), ctx())).toBeCloseTo(0.7);
+    expect(applyIncomingCalc(1, c({ statuses: [st('defDown')] }), ctx())).toBeCloseTo(1.3);
+  });
+
+  it('agiUp/agiDown: 回避倍率', () => {
+    expect(applyDodgeCalc(0.2, c({ statuses: [st('agiUp')] }), ctx())).toBeCloseTo(0.3);
+    expect(applyDodgeCalc(0.2, c({ statuses: [st('agiDown')] }), ctx())).toBeCloseTo(0.12);
+  });
+
+  // ── 付与 (restack) ──
+  it('applyStatus: refresh は turns を伸ばす / ignore は据え置き', () => {
+    const p = c();
+    applyStatus(p, st('poison', 2, 3));
+    applyStatus(p, st('poison', 5, 4)); // refresh: turns=max, magnitude 更新
+    expect(p.statuses).toHaveLength(1);
+    expect(p.statuses![0].turns).toBe(5);
+    expect(p.statuses![0].magnitude).toBe(4);
+
+    const t = c();
+    applyStatus(t, st('tumble', 2));
+    applyStatus(t, st('tumble', 9)); // ignore: 据え置き
+    expect(t.statuses).toHaveLength(1);
+    expect(t.statuses![0].turns).toBe(2);
+  });
+
+  it('poison は生存者のみ tick (HP0 の死体は毒で追撃しない)', () => {
+    const dead = c({ hp: 0, statuses: [st('poison', 2, 5)] });
+    tickStatuses(dead, ctx());
+    expect(dead.hp).toBe(0); // 追撃なし
+  });
+});

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -18,6 +18,7 @@
 import type { Archetype, StatArray } from './types.js';
 import { JOBS_BY_ID } from './jobs.js';
 import { gearBonus, gearBonusFromGear, type GearSelection } from './equipment.js';
+import { SKILLS, runSkill } from './skills.js';
 
 // ─── チューニング ───────────────────────────────────────────
 
@@ -833,7 +834,7 @@ export function startBattle(
   };
 }
 
-interface AttackOptions {
+export interface AttackOptions {
   /** 攻撃力の基準値を上書き (特技を支配ステータス基準にする: gamble=luk, flurry=agi)。
    *  素の atk が低い luk/agi 型ジョブでも「ジョブに合った能力」で火力が出るように。 */
   atkOverride?: number;
@@ -960,42 +961,11 @@ function monsterCommand(state: BattleState, rng: () => number): MonsterAction {
 
 function playerSkillAction(state: BattleState, skill: JobSkill, rng: () => number, events: TurnEvent[]): void {
   const { player, monster } = state;
-  const t = BATTLE_TUNING;
-  switch (skill.kind) {
-    case 'smash':
-      doAttack(player, monster, rng, events, 'player', { power: 1.7, hitBonus: -0.1, label: skill.name });
-      break;
-    case 'parry':
-      // 宣言は resolveTurn 冒頭 (行動順に関係なく効くように)。ここは no-op。
-      break;
-    case 'flurry':
-      // 支配ステータス (agi) 基準 — 素早さで手数を出すジョブの「らしさ」と火力を一致させる
-      doAttack(player, monster, rng, events, 'player', { power: 0.65, atkOverride: player.agi, label: skill.name });
-      if (state.monster.hp > 0) {
-        doAttack(player, monster, rng, events, 'player', { power: 0.65, atkOverride: player.agi, label: skill.name });
-      }
-      break;
-    case 'spell':
-      // 防御を半分だけ貫通 + 必中。完全無視 (旧仕様) は int 職が tier3 を蹂躙して
-      // 難易度設計が壊れたため 0.5 に緩和 (バランステストで固定)。
-      doAttack(player, monster, rng, events, 'player', { power: 1.0, useInt: true, defFactor: 0.5, label: skill.name });
-      break;
-    case 'gamble': {
-      // 0〜2.6 倍。luk が高いほど下振れしにくい。基準値も支配ステータス (luk) —
-      // atk 7〜9 の luk 型ジョブが「運で殴る」ジョブとして成立するように。
-      const floor = Math.min(0.6, player.luk * 0.012);
-      const mult = floor + rng() * (2.6 - floor);
-      doAttack(player, monster, rng, events, 'player', { power: mult, atkOverride: player.luk, label: skill.name });
-      break;
-    }
-    case 'heal': {
-      // 習得スキル (#436): MP を払って maxHp の割合ぶん回復。攻撃しないターンなので削り合いの読み合い。
-      const heal = Math.round(player.maxHp * t.skillHealRatio);
-      player.hp = Math.min(player.maxHp, player.hp + heal);
-      events.push({ actor: 'player', text: `${player.name}は${skill.name}! HP が ${heal} 回復。` });
-      break;
-    }
-  }
+  // プラグイン実行 (#452): とくぎは SKILLS[kind] のデータ定義を EFFECT_HANDLERS で解決する。
+  // 見切り (parry) 等の「宣言型」とくぎは effects 空で、宣言は resolveTurn 冒頭が担う。
+  const def = SKILLS[skill.kind];
+  if (!def) return;
+  runSkill(def, { attacker: player, defender: monster, rng, events, skillName: skill.name, engine: { doAttack } });
 }
 
 /**

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -978,8 +978,61 @@ function doAttack(
 /** モンスターの行動。'charge' = ため宣言、'heal' = 自己回復 (プレイヤーの Command とは別)。 */
 type MonsterAction = 'attack' | 'guard' | 'charge' | 'heal' | 'flee';
 
-/** モンスターの行動を能力 (ability) で分岐する (オーナー要望 2026-07-18: ため攻撃は
- *  一部 (~20%) に限定し、回復する敵などバリエーションで戦略性を出す)。 */
+/** モンスター能力プラグイン (#452 / docs/25 §5)。行動 AI を ability id → データ定義に置き、
+ *  monsterCommand の if 分岐を排す。null を返すと通常判定 (plain) にフォールバック。 */
+interface AbilityDecisionCtx {
+  state: BattleState;
+  /** そのターンの単一乱数 (全 ability で共有 = 決定性維持)。 */
+  r: number;
+  t: typeof BATTLE_TUNING;
+  hpRatio: number;
+  /** 低 HP で身を固める余地があるか (tier2+ かつ HP<35% かつ非ため中)。 */
+  canGuard: boolean;
+  monsterDef: MonsterDef | undefined;
+}
+
+interface AbilityDef {
+  id: string;
+  decideAction(ctx: AbilityDecisionCtx): MonsterAction | null;
+}
+
+/** 能力レジストリ。新しい敵 AI は CombatHook 同様「ここに 1 エントリ足すだけ」。 */
+const MONSTER_ABILITIES: Record<string, AbilityDef> = {
+  // charger: 1 ターン ため → 強攻撃 (予告を防御する読み合い。全体の ~20%)
+  charger: {
+    id: 'charger',
+    decideAction: ({ state, r, t, canGuard }) => {
+      if (state.monster.mp >= t.monsterChargeMpCost && r < t.chargerChargeChance) return 'charge';
+      if (canGuard && r < t.chargerChargeChance + 0.15) return 'guard';
+      return 'attack';
+    },
+  },
+  // healer: 低 HP でたまに自己回復 (削り切る前に倒す読み合い)
+  healer: {
+    id: 'healer',
+    decideAction: ({ state, r, t, hpRatio, canGuard }) => {
+      if (state.monster.mp >= t.monsterHealMpCost && hpRatio < t.healerLowHpRatio && r < t.healerHealChance) return 'heal';
+      if (canGuard && r < t.healerHealChance + 0.15) return 'guard';
+      return 'attack';
+    },
+  },
+  // fleer: 毎ターン逃走を試みる (はぐれメタル型)。逃走率は**基準 agi (レベル非依存)** で決める —
+  // factor でスケールする state.monster.agi を使うと高レベルほど逃走率が cap に張り付き、HP も
+  // 上がって「成長するほど倒せない」逆進になる (レビュー ★★)。常に同じ緊張感にする。
+  fleer: {
+    id: 'fleer',
+    decideAction: ({ r, t, monsterDef }) => {
+      const baseAgi = monsterDef?.stats[2] ?? 0;
+      const fleeChance = Math.min(t.monsterFleeMax, Math.max(0, t.monsterFleeBase + baseAgi * t.monsterFleeAgiScale));
+      if (r < fleeChance) return 'flee';
+      return 'attack';
+    },
+  },
+};
+
+/** モンスターの行動を能力 (ability) で決める (オーナー要望 2026-07-18: ため攻撃は
+ *  一部 (~20%) に限定し、回復する敵などバリエーションで戦略性を出す)。
+ *  #452: if 分岐でなく MONSTER_ABILITIES レジストリ引き (プラグイン化)。 */
 function monsterCommand(state: BattleState, rng: () => number): MonsterAction {
   const def = MONSTERS_BY_ID[state.monsterId];
   const t = BATTLE_TUNING;
@@ -987,26 +1040,12 @@ function monsterCommand(state: BattleState, rng: () => number): MonsterAction {
   const hpRatio = state.monster.hp / state.monster.maxHp;
   // 低 HP でたまに身を固める (charger のため中は別処理なのでここでは除外)
   const canGuard = (def?.tier ?? 1) >= 2 && hpRatio < 0.35 && !state.monster.charging;
-  if (def?.ability === 'charger') {
-    if (state.monster.mp >= t.monsterChargeMpCost && r < t.chargerChargeChance) return 'charge';
-    if (canGuard && r < t.chargerChargeChance + 0.15) return 'guard';
-    return 'attack';
-  }
-  if (def?.ability === 'healer') {
-    if (state.monster.mp >= t.monsterHealMpCost && hpRatio < t.healerLowHpRatio && r < t.healerHealChance) return 'heal';
-    if (canGuard && r < t.healerHealChance + 0.15) return 'guard';
-    return 'attack';
-  }
-  if (def?.ability === 'fleer') {
-    // 毎ターン逃走を試みる。逃走率は**基準 agi (レベル非依存)** で決める — factor で
-    // スケールする state.monster.agi を使うと高レベルほど逃走率が cap に張り付き、HP も
-    // 上がって「成長するほど倒せない」逆進になる (レビュー ★★)。常に同じ緊張感にする。
-    const baseAgi = def.stats[2] ?? 0;
-    const fleeChance = Math.min(t.monsterFleeMax, Math.max(0, t.monsterFleeBase + baseAgi * t.monsterFleeAgiScale));
-    if (r < fleeChance) return 'flee';
-    return 'attack';
-  }
-  // plain: 通常攻撃 + 低 HP でたまに防御
+
+  const ability = def?.ability ? MONSTER_ABILITIES[def.ability] : undefined;
+  const action = ability?.decideAction({ state, r, t, hpRatio, canGuard, monsterDef: def });
+  if (action) return action;
+
+  // plain (ability 無し / null): 通常攻撃 + 低 HP でたまに防御
   if (canGuard && r < 0.25) return 'guard';
   return 'attack';
 }

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -19,6 +19,7 @@ import type { Archetype, StatArray } from './types.js';
 import { JOBS_BY_ID } from './jobs.js';
 import { gearBonus, gearBonusFromGear, type GearSelection } from './equipment.js';
 import { SKILLS, runSkill } from './skills.js';
+import { elementMultiplier, type Element } from './elements.js';
 import {
   type StatusInstance,
   type HookCtx,
@@ -320,6 +321,9 @@ export interface Combatant {
   statuses?: StatusInstance[];
   /** ジョブ innate パッシブ id (#452 / docs/25 §4)。省略可。 */
   passives?: string[];
+  /** 防御属性 (#452 / docs/25 §1)。被弾時の属性相性に使う。未設定 (無属性) は等倍。
+   *  モンスターへの付与は #455、プレイヤー装備由来は後続で配線 (現状は全員 undefined = 等倍)。 */
+  element?: Element;
 }
 
 function fromStats(name: string, stats: StatArray, levelFactor: number, level: number): Combatant {
@@ -867,6 +871,8 @@ export interface AttackOptions {
   useInt?: boolean;
   /** 技名 (テキストに使う)。無指定は通常攻撃 */
   label?: string;
+  /** 攻撃属性 (#452 / docs/25 §1)。防御側の element と相性判定。未指定 (無属性) は等倍。 */
+  element?: Element;
 }
 
 /** 攻撃 1 回の結果 (とくぎの inflict-on-hit 等が参照)。 */
@@ -940,6 +946,9 @@ function doAttack(
   if (defender.guarding || defender.parrying) dmg *= t.guardReduction;
   // 被ダメバフ (defUp/defDown/転倒)。none なら ×1。
   dmg *= applyIncomingCalc(1, defender, defCtx);
+  // 属性相性 (#452 §1): 攻撃属性 × 防御属性。両者 undefined (無属性) なら ×1 = 従来挙動。
+  // モンスター/装備への属性付与は #455/#456 で配線。現状は常に ×1 (behavior-preserving)。
+  dmg *= elementMultiplier(opts.element, defender.element);
 
   // 丸めの後にも最低 1 を保証 (guardReduction で 0.5 に落ちて round(0) になる境界対策)。
   // minDamage を将来 0 等に変える場合、この行のハード 1 も一緒に見直すこと (二重下限の注意)。
@@ -1234,7 +1243,8 @@ export function resolveTurn(prev: BattleState, command: Command, turnSeed?: numb
   act(playerFirst ? 'monster' : 'player');
 
   // ターン終了の状態処理 (毒ダメージ等) → turns 減衰・除去。none なら no-op。
-  // 毒で HP0 になった場合は下の勝敗判定 (hp===0) が拾う。
+  // 毒で HP0 になった場合は下の勝敗判定 (hp===0) が拾う。両者が同ターンの毒で相討ちになった
+  // 場合、勝敗判定は monster.hp===0 を player より先に見るため win を優先する (仕様。決定的)。
   if (state.outcome === 'ongoing') {
     tickStatuses(state.player, { rng, events, actor: 'player' });
     tickStatuses(state.monster, { rng, events, actor: 'monster' });

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -19,6 +19,19 @@ import type { Archetype, StatArray } from './types.js';
 import { JOBS_BY_ID } from './jobs.js';
 import { gearBonus, gearBonusFromGear, type GearSelection } from './equipment.js';
 import { SKILLS, runSkill } from './skills.js';
+import {
+  type StatusInstance,
+  type HookCtx,
+  applyBeforeAct,
+  applyDodgeCalc,
+  applyPowerCalc,
+  applyCritCalc,
+  applyIncomingCalc,
+  applyOnHit,
+  tickStatuses,
+  clearActedStatuses,
+  clearHitStatuses,
+} from './statuses.js';
 
 // ─── チューニング ───────────────────────────────────────────
 
@@ -303,6 +316,10 @@ export interface Combatant {
   /** ぼうぎょの余韻 (残りターン数)。>0 の間は回避 +guardFocusDodge。
    *  防御した次のターンまで「相手の動きを読めている」状態。 */
   focus: number;
+  /** 状態異常 (#452 / docs/25 §3)。省略可 (旧 sealed state 互換)。エンジンが空/未定義を no-op 扱い。 */
+  statuses?: StatusInstance[];
+  /** ジョブ innate パッシブ id (#452 / docs/25 §4)。省略可。 */
+  passives?: string[];
 }
 
 function fromStats(name: string, stats: StatArray, levelFactor: number, level: number): Combatant {
@@ -326,6 +343,8 @@ function fromStats(name: string, stats: StatArray, levelFactor: number, level: n
     parrying: false,
     charging: false,
     focus: 0,
+    statuses: [],
+    passives: [],
   };
 }
 
@@ -860,18 +879,31 @@ function doAttack(
 ): void {
   const t = BATTLE_TUNING;
   const label = opts.label ? `${attacker.name}の${opts.label}!` : `${attacker.name}のこうげき!`;
+  // 状態異常/パッシブのフック文脈 (#452)。空 statuses なら applyXxx は入力そのまま = 従来挙動。
+  const defenderSide: 'player' | 'monster' = actor === 'player' ? 'monster' : 'player';
+  const atkCtx: HookCtx = { rng, events, actor };
+  const defCtx: HookCtx = { rng, events, actor: defenderSide };
 
   // 回避判定 (魔撃は必中)。ぼうぎょの余韻 (focus) 中は「動きを読めている」ので回避が上がる。
   if (!opts.useInt) {
     const focusBonus = defender.focus > 0 ? t.guardFocusDodge : 0;
-    const dodge = Math.min(
+    let dodge = Math.min(
       t.dodgeMax + focusBonus,
       Math.max(t.dodgeMin, t.dodgeBase + (defender.agi - attacker.agi) * t.agiDodgeScale - (opts.hitBonus ?? 0) + focusBonus),
     );
+    dodge = applyDodgeCalc(dodge, defender, defCtx); // かくれみ/agi バフ
     if (rng() < dodge) {
       events.push({ actor, text: `${label} しかし ${defender.name}は身をかわした!` });
       return;
     }
+  }
+
+  // 命中確定後、即死パッシブ (首狩り等) の判定。none なら false。
+  if (applyOnHit(attacker, defender, atkCtx)) {
+    defender.hp = 0;
+    clearHitStatuses(defender);
+    events.push({ actor, text: `${label} ${defender.name}を一撃で仕留めた!`, damage: defender.maxHp, fatal: true });
+    return;
   }
 
   const atkValue = opts.atkOverride ?? (opts.useInt ? attacker.int : attacker.atk);
@@ -881,23 +913,28 @@ function doAttack(
   // 2026-07-20)。敵の会心を守備無視にすると、タンク職 (guardian) の「固く受ける」存在意義が
   // 壊れ拮抗帯で事故死が倍増するため、敵の会心は 1.5 倍のみ (バランス ★★★)。ぼうぎょ/見切り
   // **コマンドの半減はどちらも貫通しない** — 貫くと「予告を見て防御」の読み合いが崩れる (設計 ★★★)。
-  const crit = rng() < t.critBase + attacker.luk * t.critLukScale;
+  const crit = applyCritCalc(rng() < t.critBase + attacker.luk * t.critLukScale, attacker, atkCtx); // 九字切り=確定会心
   const critAtk = crit ? t.critAtkMultiplier : 1;
   const defValue = crit && actor === 'player' ? 0 : defender.def * (opts.defFactor ?? 1);
   // DQ の減算式 (攻撃÷2 − 防御÷4) 流: **防御の係数 (defCoef) を攻撃の半分 (2:1)** にしてインフレを
   // 抑える (オーナー要望 2026-07-20)。高守備の敵 (メタル) は atkTerm−defTerm が負に沈み minDamage
   // しか通らず、会心 (defValue=0) のみ貫通できる = 専用ロジック不要で「守備が硬い」が表現される。
-  const atkTerm = atkValue * t.atkCoef * critAtk * (opts.power ?? 1);
+  // 攻撃威力バフ (atkUp/atkDown)。none なら ×1。
+  const atkTerm = atkValue * t.atkCoef * critAtk * (opts.power ?? 1) * applyPowerCalc(1, attacker, atkCtx);
   let dmg = Math.max(t.minDamage, (atkTerm - defValue * t.defCoef) * roll);
 
   // 防御 / 見切りで半減 (会心でもコマンド防御は効く = 防御の存在意義を守る)
   if (defender.guarding || defender.parrying) dmg *= t.guardReduction;
+  // 被ダメバフ (defUp/defDown/転倒)。none なら ×1。
+  dmg *= applyIncomingCalc(1, defender, defCtx);
 
   // 丸めの後にも最低 1 を保証 (guardReduction で 0.5 に落ちて round(0) になる境界対策)。
   // minDamage を将来 0 等に変える場合、この行のハード 1 も一緒に見直すこと (二重下限の注意)。
   const final = Math.max(1, Math.round(dmg));
   defender.hp = Math.max(0, defender.hp - final);
   const fatal = defender.hp === 0;
+  // 被弾で解ける状態 (かくれみ解除・眠り起床)。none なら no-op。
+  if (!fatal) clearHitStatuses(defender);
   // 決着文はプレイヤー視点: 敵を倒した =「◯◯をたおした!」、自分が倒れた =
   // 「◯◯はちからつきた!」(プレイヤーが「たおされる」対象になる文は視点が転倒する)。
   const fatalText = fatal
@@ -986,8 +1023,18 @@ export function resolveTurn(prev: BattleState, command: Command, turnSeed?: numb
   const state: BattleState = {
     ...prev,
     turn: prev.turn + 1,
-    player: { ...prev.player, guarding: false },
-    monster: { ...prev.monster, guarding: false },
+    // statuses は tick で破壊的に更新するため deep copy (passives は不変なので参照共有で可)。
+    // 旧 sealed state で statuses 未定義なら省略 (exactOptional 準拠・エンジンは undefined を no-op 扱い)。
+    player: {
+      ...prev.player,
+      guarding: false,
+      ...(prev.player.statuses ? { statuses: prev.player.statuses.map((s) => ({ ...s })) } : {}),
+    },
+    monster: {
+      ...prev.monster,
+      guarding: false,
+      ...(prev.monster.statuses ? { statuses: prev.monster.statuses.map((s) => ({ ...s })) } : {}),
+    },
     lastEvents: [],
   };
   // command==='skill' のとき使う特技 (#436: 毎ターン選択)。範囲外/未設定 (デプロイ跨ぎの旧 sealed
@@ -1067,6 +1114,9 @@ export function resolveTurn(prev: BattleState, command: Command, turnSeed?: numb
   const act = (who: 'player' | 'monster') => {
     if (state.outcome !== 'ongoing') return; // 敵が逃げる等で決着済みなら以降の行動をスキップ
     if (state.player.hp === 0 || state.monster.hp === 0) return;
+    const self = who === 'player' ? state.player : state.monster;
+    // 行動不能 (眠り/麻痺/転倒/束縛)。none なら false = 従来どおり行動。
+    if (applyBeforeAct(self, { rng, events, actor: who })) return;
     if (who === 'player') {
       if (cmd === 'attack') {
         doAttack(state.player, state.monster, rng, events, 'player');
@@ -1122,10 +1172,19 @@ export function resolveTurn(prev: BattleState, command: Command, turnSeed?: numb
       }
       // guard は宣言済み
     }
+    // 行動したら解ける状態 (かくれみ/九字切り)。none なら no-op。
+    clearActedStatuses(self);
   };
 
   act(playerFirst ? 'player' : 'monster');
   act(playerFirst ? 'monster' : 'player');
+
+  // ターン終了の状態処理 (毒ダメージ等) → turns 減衰・除去。none なら no-op。
+  // 毒で HP0 になった場合は下の勝敗判定 (hp===0) が拾う。
+  if (state.outcome === 'ongoing') {
+    tickStatuses(state.player, { rng, events, actor: 'player' });
+    tickStatuses(state.monster, { rng, events, actor: 'monster' });
+  }
 
   // 見切りは 1 ターン限り (発動しなかったら解除)。ぼうぎょの余韻 (focus) は 1 減衰。
   state.player.parrying = false;

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -869,6 +869,18 @@ export interface AttackOptions {
   label?: string;
 }
 
+/** 攻撃 1 回の結果 (とくぎの inflict-on-hit 等が参照)。 */
+export interface AttackResult {
+  /** 命中したか (回避されたら false)。 */
+  hit: boolean;
+  /** 与えたダメージ (miss は 0)。 */
+  damage: number;
+  /** 対象を倒したか。 */
+  fatal: boolean;
+  /** 会心だったか。 */
+  crit: boolean;
+}
+
 function doAttack(
   attacker: Combatant,
   defender: Combatant,
@@ -876,7 +888,7 @@ function doAttack(
   events: TurnEvent[],
   actor: 'player' | 'monster',
   opts: AttackOptions = {},
-): void {
+): AttackResult {
   const t = BATTLE_TUNING;
   const label = opts.label ? `${attacker.name}の${opts.label}!` : `${attacker.name}のこうげき!`;
   // 状態異常/パッシブのフック文脈 (#452)。空 statuses なら applyXxx は入力そのまま = 従来挙動。
@@ -894,16 +906,17 @@ function doAttack(
     dodge = applyDodgeCalc(dodge, defender, defCtx); // かくれみ/agi バフ
     if (rng() < dodge) {
       events.push({ actor, text: `${label} しかし ${defender.name}は身をかわした!` });
-      return;
+      return { hit: false, damage: 0, fatal: false, crit: false };
     }
   }
 
   // 命中確定後、即死パッシブ (首狩り等) の判定。none なら false。
   if (applyOnHit(attacker, defender, atkCtx)) {
+    const killDmg = defender.hp;
     defender.hp = 0;
     clearHitStatuses(defender);
-    events.push({ actor, text: `${label} ${defender.name}を一撃で仕留めた!`, damage: defender.maxHp, fatal: true });
-    return;
+    events.push({ actor, text: `${label} ${defender.name}を一撃で仕留めた!`, damage: killDmg, fatal: true });
+    return { hit: true, damage: killDmg, fatal: true, crit: false };
   }
 
   const atkValue = opts.atkOverride ?? (opts.useInt ? attacker.int : attacker.atk);
@@ -948,6 +961,7 @@ function doAttack(
     damage: final,
     ...(fatal ? { fatal: true } : {}),
   });
+  const result: AttackResult = { hit: true, damage: final, fatal, crit };
 
   // 見切り反撃 (倒れていなければ)
   if (!fatal && defender.parrying) {
@@ -957,6 +971,7 @@ function doAttack(
     // (見切り職は atk が低く、atk 基準だと tier3 で火力が出ずジリ貧になる)
     doAttack(defender, attacker, rng, events, counterActor, { power: 0.75, atkOverride: defender.def, label: 'はんげき' });
   }
+  return result;
 }
 
 /** モンスターの行動選択 (tier が高いほど賢い)。 */

--- a/packages/core/src/elements.ts
+++ b/packages/core/src/elements.ts
@@ -1,0 +1,42 @@
+/**
+ * 属性システム (戦闘刷新 #452 / docs/25 §1)。
+ *
+ * 4 元素は一方向の輪 **地→水→火→風→(地)**(矢印=「強い」)。空 (void) は輪の外で、
+ * 全属性に 1.2 倍で殴れる代わりに全属性から 1.2 倍食らう「万能だが脆い」属性。
+ * holy/聖は**無属性 (null)** として扱い、属性の輪の影響を受けない (常に等倍)。
+ *
+ * データ駆動: 輪は `BEATS` テーブル 1 個 + 空ルールだけ。if 地獄にしない。
+ */
+
+export type Element = 'earth' | 'water' | 'fire' | 'wind' | 'void';
+
+/** 輪: X が BEATS[X] に「強い」(有利)。空 (void) は輪の外なので null。 */
+const BEATS: Record<Element, Element | null> = {
+  earth: 'water',
+  water: 'fire',
+  fire: 'wind',
+  wind: 'earth',
+  void: null,
+};
+
+/** 有利/不利/空 の倍率 (数値は sim で調整可)。 */
+export const ELEMENT_MULT = {
+  strong: 1.5, // 輪で強い (弱点を突く)
+  weak: 0.5, //   輪で弱い
+  neutral: 1.0,
+  voidMult: 1.2, // 空: 攻撃も被弾も 1.2
+} as const;
+
+/**
+ * 攻撃属性 × 防御属性 → ダメージ倍率。
+ * - 無属性 (null) が絡めば常に等倍 (物理・holy はここ)。
+ * - 空 (void) が攻撃側 or 防御側にあれば 1.2 (器用貧乏の万能)。
+ * - それ以外は輪: atk が def に強ければ 1.5 / 弱ければ 0.5 / 正面以外は 1.0。
+ */
+export function elementMultiplier(atk: Element | null | undefined, def: Element | null | undefined): number {
+  if (!atk || !def) return ELEMENT_MULT.neutral; // 無属性は等倍
+  if (atk === 'void' || def === 'void') return ELEMENT_MULT.voidMult; // 空は攻撃/被弾とも 1.2
+  if (BEATS[atk] === def) return ELEMENT_MULT.strong; // 有利
+  if (BEATS[def] === atk) return ELEMENT_MULT.weak; // 不利
+  return ELEMENT_MULT.neutral; // 中立 (地↔火 / 水↔風)
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,5 +13,6 @@ export * from './spirit.js';
 export * from './card-rarity.js';
 export * from './card.js';
 export * from './battle.js';
+export * from './elements.js';
 export * from './world.js';
 export * from './equipment.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@ export * from './card-rarity.js';
 export * from './card.js';
 export * from './battle.js';
 export * from './skills.js';
+export * from './statuses.js';
 export * from './elements.js';
 export * from './world.js';
 export * from './equipment.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,7 @@ export * from './spirit.js';
 export * from './card-rarity.js';
 export * from './card.js';
 export * from './battle.js';
+export * from './skills.js';
 export * from './elements.js';
 export * from './world.js';
 export * from './equipment.js';

--- a/packages/core/src/skills.ts
+++ b/packages/core/src/skills.ts
@@ -10,7 +10,8 @@
  * (battle.ts が SKILLS/runSkill を import する値依存 ⇔ skills.ts は battle.ts の *型* だけ import)。
  */
 
-import type { Combatant, TurnEvent, AttackOptions } from './battle.js';
+import type { Combatant, TurnEvent, AttackOptions, AttackResult } from './battle.js';
+import { applyStatus, type StatusId } from './statuses.js';
 
 /** ダメージの基準にする支配ステータス。int は魔撃 (必中・防御半減)、agi/luk は物理。 */
 export type DamageStat = 'atk' | 'int' | 'agi' | 'luk';
@@ -22,6 +23,17 @@ export interface GambleSpec {
   /** 下限 = min(lukFloorCap, luk × lukFloorScale) */
   lukFloorScale: number;
   lukFloorCap: number;
+}
+
+/** 命中時に状態異常を付与する指定 (毒手など)。 */
+export interface InflictSpec {
+  status: StatusId;
+  /** 付与確率 (0〜1、未指定=1)。 */
+  chance?: number;
+  /** 持続ターン (未指定=2)。 */
+  turns?: number;
+  /** 効果量 (毒ダメージ/バフ倍率)。省略時は状態のデフォルト。 */
+  magnitude?: number;
 }
 
 /** とくぎの効果プリミティブ。ここに種類を足す = 新しい効果の語彙が増える。 */
@@ -40,11 +52,23 @@ export type SkillEffect =
       defFactor?: number;
       /** 指定すると power を luk 依存で抽選 (運ジョブ) */
       gamble?: GambleSpec;
+      /** 命中した攻撃に状態異常を乗せる (毒手など)。miss/即死には乗らない。 */
+      inflict?: InflictSpec;
     }
   | {
       kind: 'heal';
       /** maxHp に対する回復割合 */
       ratio: number;
+    }
+  | {
+      kind: 'status';
+      /** 付与する状態異常 */
+      status: StatusId;
+      /** self=使用者に (バフ/かくれみ/九字切り)、enemy=相手に (デバフ/毒/眠り) */
+      target: 'self' | 'enemy';
+      chance?: number;
+      turns?: number;
+      magnitude?: number;
     };
 
 export interface SkillDef {
@@ -62,7 +86,7 @@ export interface SkillEngine {
     events: TurnEvent[],
     actor: 'player' | 'monster',
     opts?: AttackOptions,
-  ) => void;
+  ) => AttackResult;
 }
 
 /** 効果を解決するための文脈 (誰が誰に、どの乱数で)。 */
@@ -107,8 +131,28 @@ const damageHandler: EffectHandler = (effect, ctx) => {
       const floor = Math.min(g.lukFloorCap, attacker.luk * g.lukFloorScale);
       opts.power = floor + rng() * (g.max - floor);
     }
-    engine.doAttack(attacker, defender, rng, events, 'player', opts);
+    const res = engine.doAttack(attacker, defender, rng, events, 'player', opts);
+    // 命中した攻撃にだけ状態異常を乗せる (miss/即死には乗らない)。
+    if (effect.inflict && res.hit && !res.fatal) {
+      const inf = effect.inflict;
+      if (rng() < (inf.chance ?? 1)) {
+        applyStatus(defender, { id: inf.status, turns: inf.turns ?? 2, ...(inf.magnitude !== undefined ? { magnitude: inf.magnitude } : {}) });
+      }
+    }
   }
+};
+
+/** status: 使用者 (self) or 相手 (enemy) に状態異常を付与 (バフ/デバフ/かくれみ)。 */
+const statusHandler: EffectHandler = (effect, ctx) => {
+  if (effect.kind !== 'status') return;
+  const { attacker, defender, rng } = ctx;
+  if (rng() >= (effect.chance ?? 1)) return;
+  const target = effect.target === 'self' ? attacker : defender;
+  applyStatus(target, {
+    id: effect.status,
+    turns: effect.turns ?? 2,
+    ...(effect.magnitude !== undefined ? { magnitude: effect.magnitude } : {}),
+  });
 };
 
 /** heal: maxHp の割合ぶん回復 (攻撃しないターン)。 */
@@ -124,6 +168,7 @@ const healHandler: EffectHandler = (effect, ctx) => {
 export const EFFECT_HANDLERS: Record<SkillEffect['kind'], EffectHandler> = {
   damage: damageHandler,
   heal: healHandler,
+  status: statusHandler,
 };
 
 /**

--- a/packages/core/src/skills.ts
+++ b/packages/core/src/skills.ts
@@ -1,0 +1,156 @@
+/**
+ * とくぎのプラグイン基盤 (戦闘刷新 #452 / docs/25 §2)。
+ *
+ * とくぎを **SkillDef = 効果プリミティブ (SkillEffect) の配列** として *データ* で表現し、
+ * 各プリミティブを `EFFECT_HANDLERS` レジストリで実行する。`switch (skill.kind)` の
+ * ベタ書き分岐を廃し、新しいとくぎは **SKILLS に 1 エントリ足すだけ** で追加できる
+ * (オーナー要望: 「ベタ書き if 文で分岐せずプラグインのように記述できる綺麗なソース」)。
+ *
+ * エンジンの一次関数 (doAttack 等) は循環 import を避けるため **ctx.engine 経由で注入**する
+ * (battle.ts が SKILLS/runSkill を import する値依存 ⇔ skills.ts は battle.ts の *型* だけ import)。
+ */
+
+import type { Combatant, TurnEvent, AttackOptions } from './battle.js';
+
+/** ダメージの基準にする支配ステータス。int は魔撃 (必中・防御半減)、agi/luk は物理。 */
+export type DamageStat = 'atk' | 'int' | 'agi' | 'luk';
+
+/** ギャンブル倍率 (0〜max、luk が高いほど下振れしにくい)。 */
+export interface GambleSpec {
+  /** 倍率の上限 */
+  max: number;
+  /** 下限 = min(lukFloorCap, luk × lukFloorScale) */
+  lukFloorScale: number;
+  lukFloorCap: number;
+}
+
+/** とくぎの効果プリミティブ。ここに種類を足す = 新しい効果の語彙が増える。 */
+export type SkillEffect =
+  | {
+      kind: 'damage';
+      /** 攻撃力の基準ステータス */
+      stat: DamageStat;
+      /** ダメージ倍率 (gamble 指定時は無視して抽選) */
+      power?: number;
+      /** 連撃回数 (未指定=1)。対象が倒れたら以降の追撃は撃たない */
+      hits?: number;
+      /** 命中補正 (負で外れやすく) */
+      hitBonus?: number;
+      /** 防御係数 (魔撃=0.5 で貫通気味) */
+      defFactor?: number;
+      /** 指定すると power を luk 依存で抽選 (運ジョブ) */
+      gamble?: GambleSpec;
+    }
+  | {
+      kind: 'heal';
+      /** maxHp に対する回復割合 */
+      ratio: number;
+    };
+
+export interface SkillDef {
+  /** とくぎ ID (JobSkill.kind と一致させる) */
+  id: string;
+  effects: SkillEffect[];
+}
+
+/** ハンドラに注入するエンジン一次関数 (循環 import 回避のための依存注入)。 */
+export interface SkillEngine {
+  doAttack: (
+    attacker: Combatant,
+    defender: Combatant,
+    rng: () => number,
+    events: TurnEvent[],
+    actor: 'player' | 'monster',
+    opts?: AttackOptions,
+  ) => void;
+}
+
+/** 効果を解決するための文脈 (誰が誰に、どの乱数で)。 */
+export interface SkillContext {
+  attacker: Combatant;
+  defender: Combatant;
+  rng: () => number;
+  events: TurnEvent[];
+  /** テキストに使うとくぎ名 */
+  skillName: string;
+  engine: SkillEngine;
+}
+
+type EffectHandler = (effect: SkillEffect, ctx: SkillContext) => void;
+
+/** damage: 支配ステータス基準で doAttack を hits 回。int は魔撃 (必中)。 */
+const damageHandler: EffectHandler = (effect, ctx) => {
+  if (effect.kind !== 'damage') return;
+  const { attacker, defender, rng, events, engine, skillName } = ctx;
+  const hits = effect.hits ?? 1;
+  for (let i = 0; i < hits; i++) {
+    // 対象が倒れていたら以降の追撃は無駄撃ちしない (flurry の 2 撃目 = 従来挙動)。
+    if (defender.hp <= 0) break;
+    const opts: AttackOptions = { label: skillName, power: effect.power ?? 1 };
+    if (effect.hitBonus !== undefined) opts.hitBonus = effect.hitBonus;
+    if (effect.defFactor !== undefined) opts.defFactor = effect.defFactor;
+    switch (effect.stat) {
+      case 'atk':
+        break; // 素の atk (default)
+      case 'int':
+        opts.useInt = true; // 魔撃: int 基準・必中
+        break;
+      case 'agi':
+        opts.atkOverride = attacker.agi;
+        break;
+      case 'luk':
+        opts.atkOverride = attacker.luk;
+        break;
+    }
+    if (effect.gamble) {
+      const g = effect.gamble;
+      const floor = Math.min(g.lukFloorCap, attacker.luk * g.lukFloorScale);
+      opts.power = floor + rng() * (g.max - floor);
+    }
+    engine.doAttack(attacker, defender, rng, events, 'player', opts);
+  }
+};
+
+/** heal: maxHp の割合ぶん回復 (攻撃しないターン)。 */
+const healHandler: EffectHandler = (effect, ctx) => {
+  if (effect.kind !== 'heal') return;
+  const { attacker, events, skillName } = ctx;
+  const heal = Math.round(attacker.maxHp * effect.ratio);
+  attacker.hp = Math.min(attacker.maxHp, attacker.hp + heal);
+  events.push({ actor: 'player', text: `${attacker.name}は${skillName}! HP が ${heal} 回復。` });
+};
+
+/** 効果種別 → ハンドラ。ここに 1 行足す = 新しい効果プリミティブが使えるようになる。 */
+export const EFFECT_HANDLERS: Record<SkillEffect['kind'], EffectHandler> = {
+  damage: damageHandler,
+  heal: healHandler,
+};
+
+/**
+ * とくぎ定義レジストリ (id → SkillDef)。既存 6 種を移行 (挙動は従来と同一)。
+ * 新しいとくぎは **ここに 1 エントリ追加するだけ**。
+ */
+export const SKILLS: Record<string, SkillDef> = {
+  // 強打: atk 基準 1.7 倍・やや当てにくい
+  smash: { id: 'smash', effects: [{ kind: 'damage', stat: 'atk', power: 1.7, hitBonus: -0.1 }] },
+  // 見切り: 宣言は resolveTurn 冒頭 (行動順に依存しない)。ここでは効果なし。
+  parry: { id: 'parry', effects: [] },
+  // 連撃: agi 基準 0.65 倍 × 2 撃 (素早さで手数)
+  flurry: { id: 'flurry', effects: [{ kind: 'damage', stat: 'agi', power: 0.65, hits: 2 }] },
+  // 魔撃: int 基準・必中・防御半減
+  spell: { id: 'spell', effects: [{ kind: 'damage', stat: 'int', power: 1.0, defFactor: 0.5 }] },
+  // 一か八か: luk 基準・0〜2.6 倍抽選 (luk で下振れ緩和)
+  gamble: {
+    id: 'gamble',
+    effects: [{ kind: 'damage', stat: 'luk', gamble: { max: 2.6, lukFloorScale: 0.012, lukFloorCap: 0.6 } }],
+  },
+  // 回復 (#436): maxHp の 0.35 (= 旧 BATTLE_TUNING.skillHealRatio を移行)
+  heal: { id: 'heal', effects: [{ kind: 'heal', ratio: 0.35 }] },
+};
+
+/** SkillDef の全効果を順に解決する (プラグイン実行のエントリポイント)。 */
+export function runSkill(def: SkillDef, ctx: SkillContext): void {
+  for (const effect of def.effects) {
+    EFFECT_HANDLERS[effect.kind](effect, ctx);
+  }
+}

--- a/packages/core/src/skills.ts
+++ b/packages/core/src/skills.ts
@@ -11,7 +11,8 @@
  */
 
 import type { Combatant, TurnEvent, AttackOptions, AttackResult } from './battle.js';
-import { applyStatus, type StatusId } from './statuses.js';
+import { applyStatus, DEFAULT_STATUS_TURNS, type StatusId } from './statuses.js';
+import type { Element } from './elements.js';
 
 /** ダメージの基準にする支配ステータス。int は魔撃 (必中・防御半減)、agi/luk は物理。 */
 export type DamageStat = 'atk' | 'int' | 'agi' | 'luk';
@@ -54,6 +55,8 @@ export type SkillEffect =
       gamble?: GambleSpec;
       /** 命中した攻撃に状態異常を乗せる (毒手など)。miss/即死には乗らない。 */
       inflict?: InflictSpec;
+      /** 攻撃属性 (火遁=fire 等)。防御側の element と相性判定。未指定は無属性 (等倍)。 */
+      element?: Element;
     }
   | {
       kind: 'heal';
@@ -98,6 +101,9 @@ export interface SkillContext {
   /** テキストに使うとくぎ名 */
   skillName: string;
   engine: SkillEngine;
+  /** 使用者の陣営 (#453 マルチ戦闘で敵もとくぎを撃つ時に使う。未指定は 'player')。
+   *  今は単体戦闘なので常に 'player' 相当だが、doAttack へ渡す actor を将来書き換えずに済ませる。 */
+  actorSide?: 'player' | 'monster';
 }
 
 type EffectHandler = (effect: SkillEffect, ctx: SkillContext) => void;
@@ -106,6 +112,7 @@ type EffectHandler = (effect: SkillEffect, ctx: SkillContext) => void;
 const damageHandler: EffectHandler = (effect, ctx) => {
   if (effect.kind !== 'damage') return;
   const { attacker, defender, rng, events, engine, skillName } = ctx;
+  const actor = ctx.actorSide ?? 'player';
   const hits = effect.hits ?? 1;
   for (let i = 0; i < hits; i++) {
     // 対象が倒れていたら以降の追撃は無駄撃ちしない (flurry の 2 撃目 = 従来挙動)。
@@ -113,6 +120,7 @@ const damageHandler: EffectHandler = (effect, ctx) => {
     const opts: AttackOptions = { label: skillName, power: effect.power ?? 1 };
     if (effect.hitBonus !== undefined) opts.hitBonus = effect.hitBonus;
     if (effect.defFactor !== undefined) opts.defFactor = effect.defFactor;
+    if (effect.element !== undefined) opts.element = effect.element;
     switch (effect.stat) {
       case 'atk':
         break; // 素の atk (default)
@@ -131,12 +139,16 @@ const damageHandler: EffectHandler = (effect, ctx) => {
       const floor = Math.min(g.lukFloorCap, attacker.luk * g.lukFloorScale);
       opts.power = floor + rng() * (g.max - floor);
     }
-    const res = engine.doAttack(attacker, defender, rng, events, 'player', opts);
+    const res = engine.doAttack(attacker, defender, rng, events, actor, opts);
     // 命中した攻撃にだけ状態異常を乗せる (miss/即死には乗らない)。
     if (effect.inflict && res.hit && !res.fatal) {
       const inf = effect.inflict;
       if (rng() < (inf.chance ?? 1)) {
-        applyStatus(defender, { id: inf.status, turns: inf.turns ?? 2, ...(inf.magnitude !== undefined ? { magnitude: inf.magnitude } : {}) });
+        applyStatus(defender, {
+          id: inf.status,
+          turns: inf.turns ?? DEFAULT_STATUS_TURNS,
+          ...(inf.magnitude !== undefined ? { magnitude: inf.magnitude } : {}),
+        });
       }
     }
   }
@@ -150,7 +162,7 @@ const statusHandler: EffectHandler = (effect, ctx) => {
   const target = effect.target === 'self' ? attacker : defender;
   applyStatus(target, {
     id: effect.status,
-    turns: effect.turns ?? 2,
+    turns: effect.turns ?? DEFAULT_STATUS_TURNS,
     ...(effect.magnitude !== undefined ? { magnitude: effect.magnitude } : {}),
   });
 };

--- a/packages/core/src/statuses.ts
+++ b/packages/core/src/statuses.ts
@@ -1,0 +1,269 @@
+/**
+ * 状態異常 + パッシブのフック機構 (戦闘刷新 #452 / docs/25 §3・§4)。
+ *
+ * 状態異常もパッシブも「戦闘ライフサイクルのフック点に反応する `CombatHook` 実装」という
+ * 同じ枠組みで扱う (オーナー方針 2026-07-22: 首狩り専用メソッドを作らず汎用フックにする)。
+ * エンジンは各フック点で「いま有効なフック (statuses→STATUS_REGISTRY + passives→PASSIVES) を
+ * 全部集めて回す」だけ。`if (status==='poison')` の分岐は書かない。
+ *
+ * **重要 (behavior-preserving)**: どのディスパッチ関数も、対象が状態異常・パッシブを持たない
+ * (空配列 or undefined) 場合は入力値をそのまま返す no-op。既存戦闘は挙動不変。
+ */
+
+import type { Combatant, TurnEvent } from './battle.js';
+
+export type StatusId =
+  | 'poison' // 毒: turnEnd で magnitude ダメージ
+  | 'sleep' // 眠り: beforeAct 行動不可 + 被弾で起床
+  | 'stun' // 麻痺: beforeAct 行動不可 (短い)
+  | 'tumble' // 転倒: beforeAct 行動不可 + 被ダメ 1.2 倍
+  | 'restraint' // 束縛: beforeAct 行動不可・被弾では解けない
+  | 'hidden' // かくれみ: 回避↑・行動 or 被弾で解除
+  | 'critCharge' // 九字切り: 次の攻撃を確定会心
+  | 'atkUp'
+  | 'atkDown' // 攻撃威力 magnitude 倍
+  | 'defUp'
+  | 'defDown' // 被ダメ magnitude 倍
+  | 'agiUp'
+  | 'agiDown'; // 回避 magnitude 倍
+
+export interface StatusInstance {
+  id: StatusId;
+  /** 残りターン数。ターン終了で 1 減り、0 で除去。 */
+  turns: number;
+  /** 効果量 (毒=ダメージ / バフ=倍率)。未指定は各状態のデフォルト。 */
+  magnitude?: number;
+}
+
+/** フック呼び出しの文脈。ディスパッチャが「処理中の状態インスタンス」と「c 側」を差し込む。 */
+export interface HookCtx {
+  rng: () => number;
+  events: TurnEvent[];
+  /** いま処理中の状態インスタンス (magnitude 参照用)。パッシブでは undefined。 */
+  status?: StatusInstance;
+  /** c がどちら側か (イベント文の話者)。 */
+  actor?: 'player' | 'monster';
+}
+
+/**
+ * 戦闘の各タイミングで呼ばれる任意ハンドラ群 (docs/25 §4)。状態異常もパッシブもこれを実装する。
+ * §14.3 の拡張フック (overrideAction/modifyHit/onIncomingMagic/onEnemyCast/onLethal) は
+ * マルチ戦闘・魔法系で使うため #453 以降で追加する (現段階では 7 コアフックのみ)。
+ */
+export interface CombatHook {
+  /** 行動直前。block=true で行動不可 (眠り/麻痺/転倒/束縛)。 */
+  beforeAct?(c: Combatant, ctx: HookCtx): { block?: boolean } | void;
+  /** 回避率の補正 (c=回避する側)。かくれみ/agi バフ。 */
+  dodgeCalc?(dodge: number, c: Combatant, ctx: HookCtx): number;
+  /** 攻撃威力の倍率補正 (c=攻撃側)。atkUp/atkDown。 */
+  powerCalc?(power: number, c: Combatant, ctx: HookCtx): number;
+  /** 会心の可否 (c=攻撃側)。九字切り=確定会心。 */
+  critCalc?(willCrit: boolean, c: Combatant, ctx: HookCtx): boolean;
+  /** 命中時 (atk→def)。首狩り等の即死パッシブ。 */
+  onHit?(atk: Combatant, def: Combatant, ctx: HookCtx): { instakill?: boolean } | void;
+  /** 被ダメージの倍率補正 (c=被弾側)。defUp/defDown/転倒。 */
+  incomingCalc?(power: number, c: Combatant, ctx: HookCtx): number;
+  /** ターン終了。毒ダメージ等。 */
+  turnEnd?(c: Combatant, ctx: HookCtx): void;
+}
+
+/** 状態異常 = 一時的フック (turns で消える) + 重ね方/解除条件のメタ。 */
+export interface StatusDef extends CombatHook {
+  id: StatusId;
+  name: string;
+  /** 同 id を再付与したときの扱い。未指定は refresh (turns 上書き)。 */
+  restack?: 'refresh' | 'ignore' | 'stack';
+  /** 免疫判定 (毒無効の敵など)。true なら付与されない。 */
+  immuneIf?(c: Combatant): boolean;
+  /** 自分が行動したら解除 (かくれみ/九字切り)。 */
+  clearOnAct?: boolean;
+  /** 被弾したら解除 (かくれみ)。 */
+  clearOnHit?: boolean;
+  /** 被弾で起床 (眠り)。 */
+  wakeOnHit?: boolean;
+}
+
+/** パッシブ = ジョブ innate な常時フック (turns なし)。 */
+export interface PassiveDef extends CombatHook {
+  id: string;
+  name: string;
+}
+
+function blockedActing(c: Combatant, ctx: HookCtx, label: string): { block?: boolean } {
+  ctx.events.push({ actor: ctx.actor ?? 'player', text: `${c.name}は${label}` });
+  return { block: true };
+}
+
+/** 状態異常レジストリ。新しい状態は CombatHook を実装してここに 1 エントリ足すだけ。 */
+export const STATUS_REGISTRY: Record<StatusId, StatusDef> = {
+  poison: {
+    id: 'poison',
+    name: '毒',
+    restack: 'refresh',
+    turnEnd: (c, ctx) => {
+      const dmg = ctx.status?.magnitude ?? 2;
+      c.hp = Math.max(0, c.hp - dmg);
+      ctx.events.push({ actor: ctx.actor ?? 'player', text: `${c.name}は毒のダメージ! ${dmg} のダメージ`, damage: dmg });
+    },
+  },
+  sleep: {
+    id: 'sleep',
+    name: '眠り',
+    wakeOnHit: true,
+    beforeAct: (c, ctx) => blockedActing(c, ctx, 'ねむっている…'),
+  },
+  stun: {
+    id: 'stun',
+    name: '麻痺',
+    beforeAct: (c, ctx) => blockedActing(c, ctx, 'しびれて動けない!'),
+  },
+  tumble: {
+    id: 'tumble',
+    name: '転倒',
+    restack: 'ignore',
+    beforeAct: (c, ctx) => blockedActing(c, ctx, 'ころんで動けない!'),
+    incomingCalc: (p) => p * 1.2, // 起き上がりざまは被弾が痛い
+  },
+  restraint: {
+    id: 'restraint',
+    name: '束縛',
+    clearOnAct: true,
+    clearOnHit: false, // 被弾では解けない (sleep/stun と区別)
+    beforeAct: (c, ctx) => blockedActing(c, ctx, 'しばられて動けない!'),
+  },
+  hidden: {
+    id: 'hidden',
+    name: 'かくれみ',
+    clearOnAct: true,
+    clearOnHit: true,
+    dodgeCalc: (dodge) => Math.max(dodge, 0.75), // 実質 agi 大幅上昇 (数値は sim で調整)
+  },
+  critCharge: {
+    id: 'critCharge',
+    name: '九字切り',
+    clearOnAct: true,
+    critCalc: () => true, // 次の一撃を確定会心
+  },
+  atkUp: { id: 'atkUp', name: '攻撃力上昇', restack: 'refresh', powerCalc: (p, _c, ctx) => p * (ctx.status?.magnitude ?? 1.3) },
+  atkDown: { id: 'atkDown', name: '攻撃力低下', restack: 'refresh', powerCalc: (p, _c, ctx) => p * (ctx.status?.magnitude ?? 0.7) },
+  defUp: { id: 'defUp', name: '守備力上昇', restack: 'refresh', incomingCalc: (p, _c, ctx) => p * (ctx.status?.magnitude ?? 0.7) },
+  defDown: { id: 'defDown', name: '守備力低下', restack: 'refresh', incomingCalc: (p, _c, ctx) => p * (ctx.status?.magnitude ?? 1.3) },
+  agiUp: { id: 'agiUp', name: '素早さ上昇', restack: 'refresh', dodgeCalc: (d, _c, ctx) => d * (ctx.status?.magnitude ?? 1.5) },
+  agiDown: { id: 'agiDown', name: '素早さ低下', restack: 'refresh', dodgeCalc: (d, _c, ctx) => d * (ctx.status?.magnitude ?? 0.6) },
+};
+
+/** パッシブレジストリ (ジョブ innate)。#456 で首狩り等を追加。今は枠だけ。 */
+export const PASSIVES: Record<string, PassiveDef> = {};
+
+/** ctx にいま処理中の status を差し込む (exactOptional: undefined は明示せず省略)。 */
+function ctxFor(ctx: HookCtx, inst?: StatusInstance): HookCtx {
+  return inst ? { ...ctx, status: inst } : ctx;
+}
+
+/** c に有効なフック (状態異常 + パッシブ) を、参照インスタンス付きで集める。 */
+function hooksOf(c: Combatant): Array<{ def: CombatHook; inst?: StatusInstance }> {
+  const out: Array<{ def: CombatHook; inst?: StatusInstance }> = [];
+  for (const inst of c.statuses ?? []) {
+    const def = STATUS_REGISTRY[inst.id];
+    if (def) out.push({ def, inst });
+  }
+  for (const pid of c.passives ?? []) {
+    const def = PASSIVES[pid];
+    if (def) out.push({ def });
+  }
+  return out;
+}
+
+// ─── フック点ディスパッチ (空なら入力そのまま = no-op) ───────────────
+
+/** 行動直前: いずれかのフックが block を返したら true (行動不可)。 */
+export function applyBeforeAct(c: Combatant, ctx: HookCtx): boolean {
+  let blocked = false;
+  for (const { def, inst } of hooksOf(c)) {
+    if (def.beforeAct?.(c, ctxFor(ctx, inst))?.block) blocked = true;
+  }
+  return blocked;
+}
+
+/** 回避率補正 (c=回避側)。 */
+export function applyDodgeCalc(dodge: number, c: Combatant, ctx: HookCtx): number {
+  let v = dodge;
+  for (const { def, inst } of hooksOf(c)) v = def.dodgeCalc?.(v, c, ctxFor(ctx, inst)) ?? v;
+  return v;
+}
+
+/** 攻撃威力倍率 (c=攻撃側)。基準 1 に対する乗数を返す。 */
+export function applyPowerCalc(base: number, c: Combatant, ctx: HookCtx): number {
+  let v = base;
+  for (const { def, inst } of hooksOf(c)) v = def.powerCalc?.(v, c, ctxFor(ctx, inst)) ?? v;
+  return v;
+}
+
+/** 会心の可否 (c=攻撃側)。 */
+export function applyCritCalc(willCrit: boolean, c: Combatant, ctx: HookCtx): boolean {
+  let v = willCrit;
+  for (const { def, inst } of hooksOf(c)) v = def.critCalc?.(v, c, ctxFor(ctx, inst)) ?? v;
+  return v;
+}
+
+/** 被ダメ倍率 (c=被弾側)。基準 1 に対する乗数を返す。 */
+export function applyIncomingCalc(base: number, c: Combatant, ctx: HookCtx): number {
+  let v = base;
+  for (const { def, inst } of hooksOf(c)) v = def.incomingCalc?.(v, c, ctxFor(ctx, inst)) ?? v;
+  return v;
+}
+
+/** 命中時: いずれかのパッシブ/状態が即死を返したら true。 */
+export function applyOnHit(atk: Combatant, def_: Combatant, ctx: HookCtx): boolean {
+  let kill = false;
+  for (const { def, inst } of hooksOf(atk)) {
+    if (def.onHit?.(atk, def_, ctxFor(ctx, inst))?.instakill) kill = true;
+  }
+  return kill;
+}
+
+/** ターン終了: turnEnd フック (毒等) → turns-- → 0 で除去。生存者のみ turnEnd を受ける。 */
+export function tickStatuses(c: Combatant, ctx: HookCtx): void {
+  if (!c.statuses || c.statuses.length === 0) return;
+  for (const inst of c.statuses) {
+    if (c.hp <= 0) break;
+    STATUS_REGISTRY[inst.id]?.turnEnd?.(c, ctxFor(ctx, inst));
+  }
+  for (const inst of c.statuses) inst.turns -= 1;
+  c.statuses = c.statuses.filter((s) => s.turns > 0);
+}
+
+/** 自分が行動したときに clearOnAct 状態を除去 (かくれみ/九字切り)。 */
+export function clearActedStatuses(c: Combatant): void {
+  if (!c.statuses || c.statuses.length === 0) return;
+  c.statuses = c.statuses.filter((s) => !STATUS_REGISTRY[s.id]?.clearOnAct);
+}
+
+/** 被弾したときに clearOnHit / wakeOnHit 状態を除去 (かくれみ解除・眠り起床)。 */
+export function clearHitStatuses(c: Combatant): void {
+  if (!c.statuses || c.statuses.length === 0) return;
+  c.statuses = c.statuses.filter((s) => {
+    const d = STATUS_REGISTRY[s.id];
+    return !(d?.clearOnHit || d?.wakeOnHit);
+  });
+}
+
+/** 状態を付与 (restack で重ね方を制御・免疫を尊重)。 */
+export function applyStatus(c: Combatant, inst: StatusInstance): void {
+  const def = STATUS_REGISTRY[inst.id];
+  if (!def) return;
+  if (def.immuneIf?.(c)) return;
+  if (!c.statuses) c.statuses = [];
+  const existing = c.statuses.find((s) => s.id === inst.id);
+  if (existing) {
+    const mode = def.restack ?? 'refresh';
+    if (mode === 'ignore') return;
+    if (mode === 'refresh') {
+      existing.turns = Math.max(existing.turns, inst.turns);
+      if (inst.magnitude !== undefined) existing.magnitude = inst.magnitude;
+      return;
+    }
+    // stack: 別インスタンスとして追加
+  }
+  c.statuses.push({ ...inst });
+}

--- a/packages/core/src/statuses.ts
+++ b/packages/core/src/statuses.ts
@@ -27,11 +27,15 @@ export type StatusId =
   | 'agiUp'
   | 'agiDown'; // 回避 magnitude 倍
 
+/** 付与時に turns 未指定なら使う既定持続 (毒手/デバフ等の共通デフォルト)。 */
+export const DEFAULT_STATUS_TURNS = 2;
+
 export interface StatusInstance {
   id: StatusId;
   /** 残りターン数。ターン終了で 1 減り、0 で除去。 */
   turns: number;
-  /** 効果量 (毒=ダメージ / バフ=倍率)。未指定は各状態のデフォルト。 */
+  /** 効果量。**単位は状態ごとに異なる**: poison=1 ターンあたりのダメージ量 (絶対値) /
+   *  atk・def・agi の Up/Down=倍率 (例 1.3)。付与側は取り違えに注意。未指定は各状態のデフォルト。 */
   magnitude?: number;
 }
 
@@ -136,7 +140,10 @@ export const STATUS_REGISTRY: Record<StatusId, StatusDef> = {
     name: 'かくれみ',
     clearOnAct: true,
     clearOnHit: true,
-    dodgeCalc: (dodge) => Math.max(dodge, 0.75), // 実質 agi 大幅上昇 (数値は sim で調整)
+    // 注意: agiUp/agiDown が乗算なのに対し hidden は「下限床」で異質。回避 cap (dodgeMax≒0.32)
+    // を意図的に踏み越えて確実に隠れる。agiDown と重なると hooksOf の順序依存になる (床 vs 乗算は
+    // 非可換)。値と床/乗算のどちらにするかは #456 パイロット (忍者) で sim 確定 (レビュー ★)。
+    dodgeCalc: (dodge) => Math.max(dodge, 0.75),
   },
   critCharge: {
     id: 'critCharge',


### PR DESCRIPTION
## 目的

戦闘刷新 (docs/25) の **プラグイン基盤** を実装する (Closes #452)。オーナー中核方針
「モンスターや各ジョブの処理はベタ書き if 文で分岐せずプラグインのように記述できる綺麗な
ソースコード」を満たすため、戦闘の分岐点をすべて **データ駆動レジストリ** に置き換える。

以降の #453 (マルチ戦闘) / #456 (全16ジョブ確定キット) が乗る土台。

## 変更 (5 コミット・各段階 behavior-preserving)

| ブロック | docs/25 | 内容 |
|---|---|---|
| 1. 属性 | §1 | `elements.ts` `elementMultiplier` 地水火風の輪 (地→水→火→風) ×1.5/×0.5 + 空 ×1.2 + 無属性=holy。輪は `BEATS` テーブル1個 |
| 2. とくぎ | §2 | `skills.ts` `SkillDef`+`EFFECT_HANDLERS`。既存6技 (smash/parry/flurry/spell/gamble/heal) をデータ移行し `switch(kind)` 撤廃。エンジン関数は ctx 経由で注入 (循環 import なし) |
| 3. 状態異常 | §3/§4 | `statuses.ts` `STATUS_REGISTRY`+`CombatHook` 7フック (beforeAct/dodgeCalc/powerCalc/critCalc/onHit/incomingCalc/turnEnd)。poison/sleep/stun/tumble/restraint/hidden/critCharge/atk・def・agi バフ。`Combatant.statuses?/passives?` を追加し doAttack/resolveTurn に挿入 |
| 4. 接続 | §2/§3 | `status`/`inflict` 効果 + `AttackResult`。とくぎが命中時に状態を付与できる (毒手など)。属性・SkillDef・状態異常の3基盤が相互接続 |
| 5. 敵AI | §5 | `MONSTER_ABILITIES` レジストリ。`monsterCommand` の `if(ability==='charger')` を ability id→decideAction のデータ引きに置換 |

### behavior-preserving の担保
- 状態異常ディスパッチは `statuses` 空/未定義で**入力そのまま = no-op** (旧 sealed state 互換)。
- 敵AIは**そのターンの単一乱数 r を全 ability で共有** = 従来と同じ r・閾値。
- 既存とくぎ6種は同じ `doAttack` 呼び出しにマップ。
- **core 352 緑** (battle 93 + world 23 = 戦闘/モンスターAIを網羅) / web unit 346 緑 / web build 緑 / web・edge typecheck 緑。数値・挙動は一切変えていない。

## スコープ外 (別 issue で消費者と一緒に)
- `scaleBy` (§14.5) / `resolve` (§14.6 首狩り/せっとく・BattleOutcome reconciled): 使い手 (ジョブキット) が居ないと dead code になるため **#456** で追加。
- 拡張フック overrideAction/modifyHit/onIncomingMagic/onEnemyCast/onLethal: マルチ戦闘・魔法系で使うため **#453** 以降。
- まだ状態を付与するとくぎは無い (#456 で確定キットをこのデータ語彙で記述)。

## Review

§1.5 の 3 並列独立レビュー (設計 / 実装 / 体験・バランス) を実施。**3 本とも ★★★ ゼロ・マージ可**の判定。behavior-preserving (空 statuses で RNG 消費順も不変・`×1.0` 素通しで丸め差なし・敵AIは単一乱数 r 共有) はコード + テスト両面で確認された。

### ★★ 対応 (PR 内修正: commit 6d527cf)
- **属性が dead code (3 本が指摘)** → `elementMultiplier` を `doAttack` に配線。`Combatant.element` / `AttackOptions.element` / `damage` 効果の `element?` を追加。モンスター/装備への属性付与は #455/#456 なので現状は全員 undefined = ×1 (behavior-preserving)。elements.ts が実配線された基盤になった。
- **damageHandler の actor 'player' ハードコード (設計/実装)** → `SkillContext.actorSide` を追加。#453 でモンスターがとくぎを撃つ時にハンドラ本体を書き換えずに済む前方投資 (今は常に player)。

### ★★ issue 化 (PR 外・後続で対応)
- **SkillKind / MonsterDef.ability の固定 union** (設計) → #459
- **状態異常バランス確定 (hidden 回避 cap / バフ乗算 magnitude)** (体験・設計) → #460
- **首狩り実装の前提 (instakill 非対称 / onHit の防御側耐性参照 / 敵首狩りの視点)** (実装・設計・体験) → #456 にコメントで引き継ぎ

### ★ 対応 / 引き継ぎ
- PR 内: `DEFAULT_STATUS_TURNS` 定数化、コメント追記 (magnitude の単位・hidden の床 vs 乗算非可換・相討ち毒死の win 優先)。
- 引き継ぎ: 状態インジケータ UI・付与テキスト → #457 / #456 にコメント。

CI: web-ci pass / 本番 build pass。core 354 緑 (battle 93 + world 23 で挙動不変を確認) / web unit 346 / web build / typecheck (web+edge+core) 緑。
