### PR TITLE
feat(combat): ジョブ確定キット第1バッチ — 魔法使い・忍者 + fixedDamage (#456)

### DIFF
--- a/apps/web/src/components/status-modal.tsx
+++ b/apps/web/src/components/status-modal.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef } from 'react';
 import {
   EQUIPMENT_BY_ID,
-  SKILL_KIND_LABELS,
+  skillKindLabel,
   jobDisplayName,
   jobXpToNextLevel,
   leveledName,
@@ -157,7 +157,9 @@ export function StatusModal({
             <div style={{ lineHeight: 1.8 }}>
               <div>
                 とくぎ: <strong>{skill.name}</strong>{' '}
-                <span style={{ color: 'var(--color-muted)' }}>({SKILL_KIND_LABELS[skill.kind]})</span>
+                {skillKindLabel(skill.kind) ? (
+                  <span style={{ color: 'var(--color-muted)' }}>({skillKindLabel(skill.kind)})</span>
+                ) : null}
               </div>
               {mpTrait.traitName ? (
                 <div>

--- a/apps/web/src/components/status-modal.tsx
+++ b/apps/web/src/components/status-modal.tsx
@@ -2,12 +2,12 @@ import { useEffect, useMemo, useRef } from 'react';
 import {
   EQUIPMENT_BY_ID,
   skillKindLabel,
+  skillsForJob,
   jobDisplayName,
   jobXpToNextLevel,
   leveledName,
   mpGainsFor,
   playerXpToNextLevel,
-  skillForJob,
   type Archetype,
   type Combatant,
   type EquipSlot,
@@ -83,7 +83,8 @@ export function StatusModal({
     return () => window.removeEventListener('keydown', onKey);
   }, [onClose]);
 
-  const skill = useMemo(() => skillForJob(archetype), [archetype]);
+  // キット持ちジョブ (#456) では署名スキル [0] が実技と一致しないため、現在の習得済みとくぎ列を出す。
+  const skills = useMemo(() => skillsForJob(archetype, jobLv), [archetype, jobLv]);
   const mpTrait = useMemo(() => mpGainsFor(archetype), [archetype]);
   const jobNext = useMemo(() => jobXpToNextLevel(jobXp), [jobXp]);
   const playerNext = useMemo(() => playerXpToNextLevel(playerXp), [playerXp]);
@@ -156,9 +157,9 @@ export function StatusModal({
           <Section title="とくぎ・とくせい">
             <div style={{ lineHeight: 1.8 }}>
               <div>
-                とくぎ: <strong>{skill.name}</strong>{' '}
-                {skillKindLabel(skill.kind) ? (
-                  <span style={{ color: 'var(--color-muted)' }}>({skillKindLabel(skill.kind)})</span>
+                とくぎ: <strong>{skills.map((s) => s.name).join('、')}</strong>{' '}
+                {skills.length === 1 && skillKindLabel(skills[0]!.kind) ? (
+                  <span style={{ color: 'var(--color-muted)' }}>({skillKindLabel(skills[0]!.kind)})</span>
                 ) : null}
               </div>
               {mpTrait.traitName ? (

--- a/packages/core/src/__tests__/job-kits.test.ts
+++ b/packages/core/src/__tests__/job-kits.test.ts
@@ -34,7 +34,7 @@ describe('魔法使い 確定キット (#456)', () => {
     expect(base).toContain(skillsForJob('warrior', 10)[0]!.kind);
   });
 
-  it('火炎術式が実戦で魔法ダメージ (必中・def無視・範囲) を通す', () => {
+  it('火炎術式が実戦で魔法ダメージ (必中・def無視・範囲) を通す (mage)', () => {
     // 高 def の敵に対し、物理は通りにくいが魔法 (fixedDamage) は def を無視して範囲ダメを通す。
     const s = startBattle('mage', 3, 8, '魔', 2, 12345, 0);
     const skills = s.playerSkills;
@@ -48,5 +48,35 @@ describe('魔法使い 確定キット (#456)', () => {
     expect(next.monster.hp).toBeLessThan(before);
     expect(next.lastEvents.some((e) => e.text.includes('火炎術式'))).toBe(true);
     void dealt;
+  });
+});
+
+describe('忍者 確定キット (#456)', () => {
+  it('レベルで毒手→かくれみ→火遁→急所狙い→九字切りを習得', () => {
+    expect(skillsForJob('ninja', 3).map((s) => s.name)).toContain('毒手');
+    expect(skillsForJob('ninja', 15).map((s) => s.name)).toEqual(['毒手', 'かくれみ', '火遁', '急所狙い', '九字切り']);
+  });
+
+  it('キット技はすべて SKILLS に定義がある', () => {
+    for (const sk of skillsForJob('ninja', 30)) expect(SKILLS[sk.kind], sk.kind).toBeDefined();
+  });
+
+  it('毒手が実戦で毒を付与する (inflict)', () => {
+    // chance 0.7 なので複数 seed で少なくとも1回は毒が乗る。
+    let poisoned = false;
+    for (let seed = 0; seed < 20 && !poisoned; seed++) {
+      const s = startBattle('ninja', 3, 8, '忍', 1, seed, 0);
+      const idx = s.playerSkills.findIndex((sk) => sk.name === '毒手');
+      const next: BattleState = resolveTurn(s, 'skill', undefined, idx);
+      if (next.monster.statuses?.some((st) => st.id === 'poison')) poisoned = true;
+    }
+    expect(poisoned).toBe(true);
+  });
+
+  it('かくれみ / 九字切りは自分に状態を付与 (self)', () => {
+    const s = startBattle('ninja', 15, 20, '忍', 1, 7, 0);
+    const hideIdx = s.playerSkills.findIndex((sk) => sk.name === 'かくれみ');
+    const afterHide: BattleState = resolveTurn(s, 'skill', undefined, hideIdx);
+    expect(afterHide.player.statuses?.some((st) => st.id === 'hidden')).toBe(true);
   });
 });

--- a/packages/core/src/__tests__/job-kits.test.ts
+++ b/packages/core/src/__tests__/job-kits.test.ts
@@ -79,4 +79,30 @@ describe('忍者 確定キット (#456)', () => {
     const afterHide: BattleState = resolveTurn(s, 'skill', undefined, hideIdx);
     expect(afterHide.player.statuses?.some((st) => st.id === 'hidden')).toBe(true);
   });
+
+  it('九字切りの critCharge は付与ターンを生き延び、次ターン頭に残っている (turns:2 回帰)', () => {
+    // turns:1 だと付与ターン末の tickStatuses で即消え、次の攻撃で会心にならない空撃ちだった。
+    const s = startBattle('ninja', 15, 20, '忍', 1, 7, 0);
+    const kujiIdx = s.playerSkills.findIndex((sk) => sk.name === '九字切り');
+    const afterKuji: BattleState = resolveTurn(s, 'skill', undefined, kujiIdx);
+    expect(afterKuji.player.statuses?.some((st) => st.id === 'critCharge')).toBe(true);
+    // 付与を告知している (無告知回帰の防止)。
+    expect(afterKuji.lastEvents.some((e) => e.text.includes('研ぎ澄ま'))).toBe(true);
+  });
+
+  it('急所狙いは命中で麻痺を付与 + 告知が出る (§7)。fresh スキップで付与ターンに消えない', () => {
+    // 一撃で倒すと inflict は乗らない (res.fatal ガード) ので、生き残る tier3 の敵で検証。
+    let stunned = false;
+    for (let seed = 0; seed < 40 && !stunned; seed++) {
+      const s = startBattle('ninja', 12, 18, '忍', 3, seed, 0);
+      const idx = s.playerSkills.findIndex((sk) => sk.name === '急所狙い');
+      const next: BattleState = resolveTurn(s, 'skill', undefined, idx);
+      // fresh スキップにより turns:1 の麻痺が付与ターン末の tick で消えず残る。
+      if (next.monster.hp > 0 && next.monster.statuses?.some((st) => st.id === 'stun')) {
+        stunned = true;
+        expect(next.lastEvents.some((e) => e.text.includes('麻痺'))).toBe(true);
+      }
+    }
+    expect(stunned).toBe(true);
+  });
 });

--- a/packages/core/src/__tests__/job-kits.test.ts
+++ b/packages/core/src/__tests__/job-kits.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { skillsForJob, startBattle, resolveTurn, SKILLS, type BattleState } from '../index.js';
+
+describe('魔法使い 確定キット (#456)', () => {
+  it('低 Lv (未習得帯) は署名スキルにフォールバック', () => {
+    const s = skillsForJob('mage', 1);
+    expect(s).toHaveLength(1);
+    // 署名 = 解式マギア (spell)。Lv1-2 はこれだけ。
+    expect(s[0]!.kind).toBe('spell');
+  });
+
+  it('Lv3 で火炎術式を習得、Lv6 までに石射まで揃う', () => {
+    const l3 = skillsForJob('mage', 3).map((s) => s.name);
+    expect(l3).toContain('火炎術式');
+    expect(l3).not.toContain('解式マギア'); // 解式は Lv5
+    const l6 = skillsForJob('mage', 6).map((s) => s.name);
+    expect(l6).toEqual(['火炎術式', '解式マギア', '石射']);
+  });
+
+  it('Lv25 で全 9 技 (メテオまで)。魔力障壁 P は後続', () => {
+    const names = skillsForJob('mage', 25).map((s) => s.name);
+    expect(names).toEqual(['火炎術式', '解式マギア', '石射', '氷結術式', 'メルティ', '爆炎術式', 'じわれ', '永久凍土', 'メテオ']);
+  });
+
+  it('キット技はすべて SKILLS レジストリに定義がある', () => {
+    for (const sk of skillsForJob('mage', 30)) {
+      expect(SKILLS[sk.kind], sk.kind).toBeDefined();
+    }
+  });
+
+  it('他ジョブ (キット未登録) は従来どおり基本 6 種の署名スキル', () => {
+    // warrior はキット未登録 → 支配ステータス由来の基本 6 種の署名を返す (挙動不変)。
+    const base = ['smash', 'parry', 'flurry', 'spell', 'gamble', 'heal'];
+    expect(base).toContain(skillsForJob('warrior', 10)[0]!.kind);
+  });
+
+  it('火炎術式が実戦で魔法ダメージ (必中・def無視・範囲) を通す', () => {
+    // 高 def の敵に対し、物理は通りにくいが魔法 (fixedDamage) は def を無視して範囲ダメを通す。
+    const s = startBattle('mage', 3, 8, '魔', 2, 12345, 0);
+    const skills = s.playerSkills;
+    const flameIdx = skills.findIndex((sk) => sk.name === '火炎術式');
+    expect(flameIdx).toBeGreaterThanOrEqual(0);
+    const before = s.monster.hp;
+    // 火炎術式を撃つ (skillIndex=flameIdx)。魔法は必中なのでダメージが必ず入る。
+    let next: BattleState = resolveTurn(s, 'skill', undefined, flameIdx);
+    // 敵にダメージが入っている (必中・def無視で最低でも min×相性ぶん)。
+    const dealt = before - next.monster.hp + (next.monster.hp === 0 ? 0 : 0);
+    expect(next.monster.hp).toBeLessThan(before);
+    expect(next.lastEvents.some((e) => e.text.includes('火炎術式'))).toBe(true);
+    void dealt;
+  });
+});

--- a/packages/core/src/__tests__/skills.test.ts
+++ b/packages/core/src/__tests__/skills.test.ts
@@ -36,6 +36,7 @@ function runWithSpy(skillId: string, attacker: Combatant, defender: Combatant, r
         calls.push(opts);
         return { hit: d.hp > 0, damage: 5, fatal: false, crit: false };
       },
+      doMagic: (_a, d) => ({ hit: d.hp > 0, damage: 5, fatal: false, crit: false }),
     },
   };
   runSkill(SKILLS[skillId]!, ctx);
@@ -122,6 +123,7 @@ function runDef(def: SkillDef, attacker: Combatant, defender: Combatant, rng = (
     skillName: 'test',
     engine: {
       doAttack: (_a, d) => ({ hit: d.hp > 0, damage: 5, fatal: false, crit: false }),
+      doMagic: (_a, d) => ({ hit: d.hp > 0, damage: 5, fatal: false, crit: false }),
     },
   };
   runSkill(def, ctx);
@@ -191,7 +193,56 @@ function runWithSpy2(def: SkillDef, rng = () => 0.5) {
         calls.push(opts);
         return { hit: d.hp > 0, damage: 5, fatal: false, crit: false };
       },
+      doMagic: (_a, d) => ({ hit: d.hp > 0, damage: 5, fatal: false, crit: false }),
     },
   });
   return { calls };
 }
+
+/** fixedDamage を spy で実行し、doMagic に渡った opts (amount/element) を返す。 */
+function runMagicSpy(def: SkillDef, attacker: Combatant, defender: Combatant, rng = () => 0.5) {
+  const calls: Array<{ amount: number; element?: string }> = [];
+  runSkill(def, {
+    attacker,
+    defender,
+    rng,
+    events: [],
+    skillName: 'x',
+    engine: {
+      doAttack: (_a, d) => ({ hit: d.hp > 0, damage: 5, fatal: false, crit: false }),
+      doMagic: (_a, d, _r, _e, _actor, opts) => {
+        calls.push(opts);
+        return { hit: d.hp > 0, damage: opts.amount, fatal: false, crit: false };
+      },
+    },
+  });
+  return { calls };
+}
+
+describe('fixedDamage (範囲魔法 #456)', () => {
+  it('min〜max の範囲でロールし doMagic に渡す (rng=0 で min)', () => {
+    const { calls } = runMagicSpy({ id: 'x', effects: [{ kind: 'fixedDamage', min: 15, max: 20 }] }, makeCombatant(), makeCombatant(), () => 0);
+    expect(calls[0]!.amount).toBe(15);
+  });
+
+  it('rng≈1 で max 近辺', () => {
+    const { calls } = runMagicSpy({ id: 'x', effects: [{ kind: 'fixedDamage', min: 15, max: 20 }] }, makeCombatant(), makeCombatant(), () => 0.999);
+    expect(calls[0]!.amount).toBe(20);
+  });
+
+  it('intBonus: +attacker.int × intBonus を加算', () => {
+    const atk = makeCombatant({ int: 25 });
+    const { calls } = runMagicSpy({ id: 'x', effects: [{ kind: 'fixedDamage', min: 10, max: 10, intBonus: 0.4 }] }, atk, makeCombatant(), () => 0);
+    expect(calls[0]!.amount).toBe(10 + 25 * 0.4); // 20
+  });
+
+  it('element を doMagic に渡す (属性相性)', () => {
+    const { calls } = runMagicSpy({ id: 'x', effects: [{ kind: 'fixedDamage', min: 5, max: 5, element: 'fire' }] }, makeCombatant(), makeCombatant(), () => 0);
+    expect(calls[0]!.element).toBe('fire');
+  });
+
+  it('対象が倒れていれば撃たない', () => {
+    const { calls } = runMagicSpy({ id: 'x', effects: [{ kind: 'fixedDamage', min: 5, max: 5 }] }, makeCombatant(), makeCombatant({ hp: 0 }), () => 0);
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/packages/core/src/__tests__/statuses.test.ts
+++ b/packages/core/src/__tests__/statuses.test.ts
@@ -151,4 +151,27 @@ describe('状態異常エンジン (#452)', () => {
     tickStatuses(dead, ctx());
     expect(dead.hp).toBe(0); // 追撃なし
   });
+
+  it('applyStatus した状態は付与ターンの tick を fresh スキップし、次の tick から効く', () => {
+    const target = c({ hp: 100 });
+    applyStatus(target, st('poison', 2, 5));
+    // 付与ターン末の tick: fresh を畳むだけ (ダメージ・減衰なし)。
+    tickStatuses(target, ctx());
+    expect(target.hp).toBe(100); // 付与ターンは毒ダメージ無し
+    expect(target.statuses![0]!.turns).toBe(2); // 減衰なし
+    expect(target.statuses![0]!.fresh).toBe(false);
+    // 次ターン以降は通常どおり効く。
+    tickStatuses(target, ctx());
+    expect(target.hp).toBe(95);
+    expect(target.statuses![0]!.turns).toBe(1);
+  });
+
+  it('turns:1 の麻痺は fresh スキップで付与ターンを生き延び、次ターンで消える', () => {
+    const target = c();
+    applyStatus(target, st('stun', 1));
+    tickStatuses(target, ctx()); // 付与ターン: fresh 畳むのみ → 残る
+    expect(target.statuses?.some((s) => s.id === 'stun')).toBe(true);
+    tickStatuses(target, ctx()); // 次ターン: turns 1→0 で除去
+    expect(target.statuses ?? []).toHaveLength(0);
+  });
 });

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -23,6 +23,7 @@ import { elementMultiplier, type Element } from './elements.js';
 import {
   type StatusInstance,
   type HookCtx,
+  STATUS_REGISTRY,
   applyBeforeAct,
   applyDodgeCalc,
   applyPowerCalc,
@@ -30,7 +31,6 @@ import {
   applyIncomingCalc,
   applyOnHit,
   tickStatuses,
-  clearActedStatuses,
   clearHitStatuses,
 } from './statuses.js';
 
@@ -259,6 +259,14 @@ const JOB_KITS: Partial<Record<Archetype, readonly KitSkill[]>> = {
     { id: 'mage-quake', name: 'じわれ', learnAt: 18 },
     { id: 'mage-permafrost', name: '永久凍土', learnAt: 20 },
     { id: 'mage-meteor', name: 'メテオ', learnAt: 25 },
+  ],
+  // 忍者: agi 型・毒/隠密/会心 (§7 パイロット)。影分身20/首狩り30(P) は後続。
+  ninja: [
+    { id: 'ninja-poison-hand', name: '毒手', learnAt: 3 },
+    { id: 'ninja-hide', name: 'かくれみ', learnAt: 5 },
+    { id: 'ninja-katon', name: '火遁', learnAt: 8 },
+    { id: 'ninja-vitals', name: '急所狙い', learnAt: 12 },
+    { id: 'ninja-kuji', name: '九字切り', learnAt: 15 },
   ],
 };
 
@@ -912,6 +920,8 @@ export interface AttackOptions {
   label?: string;
   /** 攻撃属性 (#452 / docs/25 §1)。防御側の element と相性判定。未指定 (無属性) は等倍。 */
   element?: Element;
+  /** 会心率への加算 (急所狙い等)。crit 判定 rng < critBase + luk*scale + critBonus。 */
+  critBonus?: number;
 }
 
 /** 攻撃 1 回の結果 (とくぎの inflict-on-hit 等が参照)。 */
@@ -971,7 +981,7 @@ function doAttack(
   // 2026-07-20)。敵の会心を守備無視にすると、タンク職 (guardian) の「固く受ける」存在意義が
   // 壊れ拮抗帯で事故死が倍増するため、敵の会心は 1.5 倍のみ (バランス ★★★)。ぼうぎょ/見切り
   // **コマンドの半減はどちらも貫通しない** — 貫くと「予告を見て防御」の読み合いが崩れる (設計 ★★★)。
-  const crit = applyCritCalc(rng() < t.critBase + attacker.luk * t.critLukScale, attacker, atkCtx); // 九字切り=確定会心
+  const crit = applyCritCalc(rng() < t.critBase + attacker.luk * t.critLukScale + (opts.critBonus ?? 0), attacker, atkCtx); // 会心 (急所狙い=critBonus / 九字切り=確定)
   const critAtk = crit ? t.critAtkMultiplier : 1;
   const defValue = crit && actor === 'player' ? 0 : defender.def * (opts.defFactor ?? 1);
   // DQ の減算式 (攻撃÷2 − 防御÷4) 流: **防御の係数 (defCoef) を攻撃の半分 (2:1)** にしてインフレを
@@ -1258,6 +1268,9 @@ export function resolveTurn(prev: BattleState, command: Command, turnSeed?: numb
     const self = who === 'player' ? state.player : state.monster;
     // 行動不能 (眠り/麻痺/転倒/束縛)。none なら false = 従来どおり行動。
     if (applyBeforeAct(self, { rng, events, actor: who })) return;
+    // 行動前に存在した clearOnAct 状態 (前ターンからのかくれみ/九字切り) を記録。行動で「消費」し
+    // 末尾で除去する。この行動中に付与した自己バフ (かくれみ/九字切りを張る等) は消さない。
+    const consumedOnAct = (self.statuses ?? []).filter((s) => STATUS_REGISTRY[s.id]?.clearOnAct);
     if (who === 'player') {
       if (cmd === 'attack') {
         doAttack(state.player, state.monster, rng, events, 'player');
@@ -1313,8 +1326,11 @@ export function resolveTurn(prev: BattleState, command: Command, turnSeed?: numb
       }
       // guard は宣言済み
     }
-    // 行動したら解ける状態 (かくれみ/九字切り)。none なら no-op。
-    clearActedStatuses(self);
+    // 行動で消費された状態 (前ターンからのかくれみ/九字切り) のみ除去。この行動で張った
+    // 自己バフは残す (かくれみ→次ターンの攻撃で解除、が正しい)。none なら no-op。
+    if (consumedOnAct.length && self.statuses) {
+      self.statuses = self.statuses.filter((s) => !consumedOnAct.includes(s));
+    }
   };
 
   act(playerFirst ? 'player' : 'monster');

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -983,6 +983,45 @@ function doAttack(
   return result;
 }
 
+/**
+ * 魔法ダメージ (#456 / docs/25 §14.6・§423)。**範囲ベース・必中・def 無視** (DQ 流)。
+ * `amount` は呼び出し側 (とくぎ) が範囲 roll + int 連動で算出済みの生ダメージ。ここで
+ * **属性相性 (§1) と被ダメバフ (defUp/defDown)** を掛けて確定・適用する。会心・回避・反撃なし。
+ * 物理 (doAttack) と違い defender の def を一切見ないため、守備の高い敵にも通る (メタルの魔法無効は
+ * #455 で monster resist として別途)。
+ */
+function doMagic(
+  attacker: Combatant,
+  defender: Combatant,
+  rng: () => number,
+  events: TurnEvent[],
+  actor: 'player' | 'monster',
+  opts: { amount: number; element?: Element; label?: string },
+): AttackResult {
+  const label = opts.label ? `${attacker.name}の${opts.label}!` : `${attacker.name}の魔法!`;
+  const defenderSide: 'player' | 'monster' = actor === 'player' ? 'monster' : 'player';
+  const defCtx: HookCtx = { rng, events, actor: defenderSide };
+  let dmg = opts.amount;
+  dmg *= elementMultiplier(opts.element, defender.element); // 属性相性 (無属性は ×1)
+  dmg *= applyIncomingCalc(1, defender, defCtx); // defUp/defDown/転倒
+  const final = Math.max(1, Math.round(dmg));
+  defender.hp = Math.max(0, defender.hp - final);
+  const fatal = defender.hp === 0;
+  if (!fatal) clearHitStatuses(defender); // 被弾で解ける状態 (かくれみ/眠り)
+  const fatalText = fatal
+    ? actor === 'player'
+      ? `。${defender.name}をたおした!`
+      : `。${defender.name}はちからつきた…!`
+    : '';
+  events.push({
+    actor,
+    text: `${label} ${defender.name}に ${final} のダメージ${fatalText}`,
+    damage: final,
+    ...(fatal ? { fatal: true } : {}),
+  });
+  return { hit: true, damage: final, fatal, crit: false };
+}
+
 /** モンスターの行動選択 (tier が高いほど賢い)。 */
 /** モンスターの行動。'charge' = ため宣言、'heal' = 自己回復 (プレイヤーの Command とは別)。 */
 type MonsterAction = 'attack' | 'guard' | 'charge' | 'heal' | 'flee';
@@ -1065,7 +1104,7 @@ function playerSkillAction(state: BattleState, skill: JobSkill, rng: () => numbe
   // 見切り (parry) 等の「宣言型」とくぎは effects 空で、宣言は resolveTurn 冒頭が担う。
   const def = SKILLS[skill.kind];
   if (!def) return;
-  runSkill(def, { attacker: player, defender: monster, rng, events, skillName: skill.name, engine: { doAttack } });
+  runSkill(def, { attacker: player, defender: monster, rng, events, skillName: skill.name, engine: { doAttack, doMagic } });
 }
 
 /**

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -235,7 +235,8 @@ const LEARNED_SKILLS: Partial<Record<Archetype, readonly LearnedSkill[]>> = {
   seer: [{ kind: 'heal', name: '癒しの予言', learnAt: 4 }],
   sage: [{ kind: 'heal', name: '天啓の癒し', learnAt: 5 }],
   bard: [{ kind: 'heal', name: '癒しの旋律', learnAt: 4 }],
-  mage: [{ kind: 'heal', name: '回生の術式', learnAt: 5 }],
+  // mage は確定キット (#456/§12) で「自己回復を持たない脆い int 大砲」に。旧 heal (回生の術式) は
+  // JOB_KITS.mage が skillsForJob を早期 return するため到達不能 = 意図的に撤去 (レビュー ★★)。
 };
 
 /** ジョブ確定キット (#456 / docs/25 §12)。id は SKILLS レジストリのキー、learnAt = 習得 jobLevel。
@@ -270,9 +271,11 @@ const JOB_KITS: Partial<Record<Archetype, readonly KitSkill[]>> = {
   ],
 };
 
-/** その jobLevel 時点で使えるとくぎ列。[0] は署名スキル (skillForJob と一致 = 後方互換)、
- *  以降は習得済みの副スキル (learnAt <= jobLevel)。UI/エンジンはこの列から毎ターン選ぶ。
- *  確定キット (#456) を持つジョブは learnAt<=level のキット技を返す (未習得帯は署名にフォールバック)。 */
+/** その jobLevel 時点で使えるとくぎ列。UI/エンジンはこの列から毎ターン選ぶ。
+ *  - **キット未登録ジョブ**: [0] = 署名スキル (skillForJob と一致 = 後方互換)、以降は習得済み副スキル。
+ *  - **確定キット (#456) 持ちジョブ**: learnAt<=level のキット技 (未習得帯のみ署名にフォールバック)。
+ *    この場合 [0] は署名と一致しない (例 mage Lv3+ の [0] は火炎術式)。「playerSkills[0]===署名」を
+ *    前提にするコードを書かないこと (単数 playerSkill は別途 skillForJob で保持されフォールバック用)。 */
 export function skillsForJob(archetype: Archetype, jobLevel: number): JobSkill[] {
   const kit = JOB_KITS[archetype];
   if (kit) {
@@ -920,8 +923,6 @@ export interface AttackOptions {
   label?: string;
   /** 攻撃属性 (#452 / docs/25 §1)。防御側の element と相性判定。未指定 (無属性) は等倍。 */
   element?: Element;
-  /** 会心率への加算 (急所狙い等)。crit 判定 rng < critBase + luk*scale + critBonus。 */
-  critBonus?: number;
 }
 
 /** 攻撃 1 回の結果 (とくぎの inflict-on-hit 等が参照)。 */
@@ -981,7 +982,7 @@ function doAttack(
   // 2026-07-20)。敵の会心を守備無視にすると、タンク職 (guardian) の「固く受ける」存在意義が
   // 壊れ拮抗帯で事故死が倍増するため、敵の会心は 1.5 倍のみ (バランス ★★★)。ぼうぎょ/見切り
   // **コマンドの半減はどちらも貫通しない** — 貫くと「予告を見て防御」の読み合いが崩れる (設計 ★★★)。
-  const crit = applyCritCalc(rng() < t.critBase + attacker.luk * t.critLukScale + (opts.critBonus ?? 0), attacker, atkCtx); // 会心 (急所狙い=critBonus / 九字切り=確定)
+  const crit = applyCritCalc(rng() < t.critBase + attacker.luk * t.critLukScale, attacker, atkCtx); // 九字切り=確定会心
   const critAtk = crit ? t.critAtkMultiplier : 1;
   const defValue = crit && actor === 'player' ? 0 : defender.def * (opts.defFactor ?? 1);
   // DQ の減算式 (攻撃÷2 − 防御÷4) 流: **防御の係数 (defCoef) を攻撃の半分 (2:1)** にしてインフレを

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -204,7 +204,9 @@ export const JOB_SKILL_NAMES: Record<Archetype, string> = {
 };
 
 export interface JobSkill {
-  kind: SkillKind;
+  /** SKILLS レジストリのキー。基本 6 種は SkillKind、ジョブ確定キット (#456) は
+   *  'mage-flame' 等の固有 id。エンジンは SKILLS[kind] で解決するので string に緩めた。 */
+  kind: string;
   name: string;
 }
 
@@ -236,9 +238,40 @@ const LEARNED_SKILLS: Partial<Record<Archetype, readonly LearnedSkill[]>> = {
   mage: [{ kind: 'heal', name: '回生の術式', learnAt: 5 }],
 };
 
+/** ジョブ確定キット (#456 / docs/25 §12)。id は SKILLS レジストリのキー、learnAt = 習得 jobLevel。
+ *  キットを持つジョブは skillsForJob がこれを返す (旧 署名+LEARNED 方式より優先)。未登録のジョブは
+ *  従来どおり。**段階投入**: まず単体戦闘で成立するジョブから (全体/召喚技は #453 マルチ戦闘後)。 */
+interface KitSkill {
+  /** SKILLS のキー */
+  id: string;
+  name: string;
+  learnAt: number;
+}
+const JOB_KITS: Partial<Record<Archetype, readonly KitSkill[]>> = {
+  // 魔法使い: 単体・int型・必中・def無視の大砲 (脆い)。パイロット (#456)。魔力障壁 Lv30 (P) は後続。
+  mage: [
+    { id: 'mage-flame', name: '火炎術式', learnAt: 3 },
+    { id: 'mage-decode', name: '解式マギア', learnAt: 5 },
+    { id: 'mage-stone', name: '石射', learnAt: 6 },
+    { id: 'mage-freeze', name: '氷結術式', learnAt: 8 },
+    { id: 'mage-melt', name: 'メルティ', learnAt: 12 },
+    { id: 'mage-blaze', name: '爆炎術式', learnAt: 15 },
+    { id: 'mage-quake', name: 'じわれ', learnAt: 18 },
+    { id: 'mage-permafrost', name: '永久凍土', learnAt: 20 },
+    { id: 'mage-meteor', name: 'メテオ', learnAt: 25 },
+  ],
+};
+
 /** その jobLevel 時点で使えるとくぎ列。[0] は署名スキル (skillForJob と一致 = 後方互換)、
- *  以降は習得済みの副スキル (learnAt <= jobLevel)。UI/エンジンはこの列から毎ターン選ぶ。 */
+ *  以降は習得済みの副スキル (learnAt <= jobLevel)。UI/エンジンはこの列から毎ターン選ぶ。
+ *  確定キット (#456) を持つジョブは learnAt<=level のキット技を返す (未習得帯は署名にフォールバック)。 */
 export function skillsForJob(archetype: Archetype, jobLevel: number): JobSkill[] {
+  const kit = JOB_KITS[archetype];
+  if (kit) {
+    const learned = kit.filter((s) => jobLevel >= s.learnAt).map((s) => ({ kind: s.id, name: s.name }));
+    // まだ何も習得していない低 Lv 帯は署名スキル (Lv1 の基本技) にフォールバック。
+    return learned.length ? learned : [skillForJob(archetype)];
+  }
   const signature = skillForJob(archetype);
   const learned = (LEARNED_SKILLS[archetype] ?? [])
     .filter((s) => jobLevel >= s.learnAt)
@@ -290,6 +323,12 @@ export const SKILL_KIND_LABELS: Record<SkillKind, string> = {
   gamble: '大博打 (0〜2.6 倍)',
   heal: 'いのり (HP 回復)',
 };
+
+/** とくぎ種別のカテゴリ説明ラベル (UI の補足)。基本 6 種のみ定義があり、確定キット (#456) の
+ *  固有 id は名前自体が説明的なため undefined を返す (UI は補足を出さない)。 */
+export function skillKindLabel(kind: string): string | undefined {
+  return (SKILL_KIND_LABELS as Record<string, string>)[kind];
+}
 
 // ─── 戦闘参加者 ─────────────────────────────────────────────
 

--- a/packages/core/src/skills.ts
+++ b/packages/core/src/skills.ts
@@ -57,6 +57,8 @@ export type SkillEffect =
       inflict?: InflictSpec;
       /** 攻撃属性 (火遁=fire 等)。防御側の element と相性判定。未指定は無属性 (等倍)。 */
       element?: Element;
+      /** 会心率への加算 (急所狙い等)。 */
+      critBonus?: number;
     }
   | {
       kind: 'fixedDamage';
@@ -141,6 +143,7 @@ const damageHandler: EffectHandler = (effect, ctx) => {
     if (effect.hitBonus !== undefined) opts.hitBonus = effect.hitBonus;
     if (effect.defFactor !== undefined) opts.defFactor = effect.defFactor;
     if (effect.element !== undefined) opts.element = effect.element;
+    if (effect.critBonus !== undefined) opts.critBonus = effect.critBonus;
     switch (effect.stat) {
       case 'atk':
         break; // 素の atk (default)
@@ -275,6 +278,22 @@ export const SKILLS: Record<string, SkillDef> = {
   },
   'mage-meteor': { id: 'mage-meteor', effects: [{ kind: 'fixedDamage', min: 30, max: 45, intBonus: 0.4 }] }, // メテオ Lv25 (無属性大砲)
   // 魔力障壁 Lv30 (常時 被ダメ軽減) はパッシブ。PASSIVES + player.passives 配線が要るため後続で追加 (TODO)。
+
+  // ─── 忍者 確定キット (#456 / docs/25 §7・§14.1。agi型・毒/隠密/会心) ───
+  // 数値は sim 調整前提の暫定値。影分身 Lv20 / 首狩り Lv30 (P) は後続 (要 evade多重/召喚 or passive)。
+  // 毒手 Lv3: agi 物理 (軽) + 高確率で毒
+  'ninja-poison-hand': {
+    id: 'ninja-poison-hand',
+    effects: [{ kind: 'damage', stat: 'agi', power: 0.8, inflict: { status: 'poison', chance: 0.7, turns: 3, magnitude: 2 } }],
+  },
+  // かくれみ Lv5: 自分にかくれみ (回避↑。安全に やくそう 回復するための布石。行動 or 被弾で解除)
+  'ninja-hide': { id: 'ninja-hide', effects: [{ kind: 'status', status: 'hidden', target: 'self', turns: 3 }] },
+  // 火遁 Lv8: 火属性の術 (必中・def無視)。忍者は int 低めなので intBonus 控えめ
+  'ninja-katon': { id: 'ninja-katon', effects: [{ kind: 'fixedDamage', min: 8, max: 14, intBonus: 0.12, element: 'fire' }] },
+  // 急所狙い Lv12: agi 物理・会心率大幅上昇 (メタル狩りの布石)
+  'ninja-vitals': { id: 'ninja-vitals', effects: [{ kind: 'damage', stat: 'agi', power: 1.0, critBonus: 0.35 }] },
+  // 九字切り Lv15: 次の一撃を確定会心 (メタル系を会心で貫く。critCharge は行動で解除)
+  'ninja-kuji': { id: 'ninja-kuji', effects: [{ kind: 'status', status: 'critCharge', target: 'self', turns: 1 }] },
 };
 
 /** SkillDef の全効果を順に解決する (プラグイン実行のエントリポイント)。 */

--- a/packages/core/src/skills.ts
+++ b/packages/core/src/skills.ts
@@ -59,6 +59,16 @@ export type SkillEffect =
       element?: Element;
     }
   | {
+      kind: 'fixedDamage';
+      /** ダメージの下限・上限 (DQ 流の範囲魔法。例 15〜20)。 */
+      min: number;
+      max: number;
+      /** int 連動ボーナス: +attacker.int × intBonus (キャスターの int を伸ばす意味を出す)。 */
+      intBonus?: number;
+      /** 攻撃属性 (火水地風空)。防御側の element と相性判定。未指定は無属性 (等倍)。 */
+      element?: Element;
+    }
+  | {
       kind: 'heal';
       /** maxHp に対する回復割合 */
       ratio: number;
@@ -82,6 +92,7 @@ export interface SkillDef {
 
 /** ハンドラに注入するエンジン一次関数 (循環 import 回避のための依存注入)。 */
 export interface SkillEngine {
+  /** 物理攻撃 (回避・会心・def 減算・反撃あり)。 */
   doAttack: (
     attacker: Combatant,
     defender: Combatant,
@@ -89,6 +100,15 @@ export interface SkillEngine {
     events: TurnEvent[],
     actor: 'player' | 'monster',
     opts?: AttackOptions,
+  ) => AttackResult;
+  /** 魔法ダメージ (範囲ベース・必中・def 無視)。amount は算出済みの生ダメージ。 */
+  doMagic: (
+    attacker: Combatant,
+    defender: Combatant,
+    rng: () => number,
+    events: TurnEvent[],
+    actor: 'player' | 'monster',
+    opts: { amount: number; element?: Element; label?: string },
   ) => AttackResult;
 }
 
@@ -167,6 +187,22 @@ const statusHandler: EffectHandler = (effect, ctx) => {
   });
 };
 
+/** fixedDamage: 範囲ロール + int 連動 → doMagic (必中・def無視・属性相性)。DQ 流の魔法。 */
+const fixedDamageHandler: EffectHandler = (effect, ctx) => {
+  if (effect.kind !== 'fixedDamage') return;
+  const { attacker, defender, rng, events, engine, skillName } = ctx;
+  const actor = ctx.actorSide ?? 'player';
+  if (defender.hp <= 0) return;
+  const span = effect.max - effect.min;
+  let amount = effect.min + Math.floor(rng() * (span + 1));
+  if (effect.intBonus) amount += attacker.int * effect.intBonus;
+  engine.doMagic(attacker, defender, rng, events, actor, {
+    amount,
+    ...(effect.element ? { element: effect.element } : {}),
+    label: skillName,
+  });
+};
+
 /** heal: maxHp の割合ぶん回復 (攻撃しないターン)。 */
 const healHandler: EffectHandler = (effect, ctx) => {
   if (effect.kind !== 'heal') return;
@@ -179,6 +215,7 @@ const healHandler: EffectHandler = (effect, ctx) => {
 /** 効果種別 → ハンドラ。ここに 1 行足す = 新しい効果プリミティブが使えるようになる。 */
 export const EFFECT_HANDLERS: Record<SkillEffect['kind'], EffectHandler> = {
   damage: damageHandler,
+  fixedDamage: fixedDamageHandler,
   heal: healHandler,
   status: statusHandler,
 };

--- a/packages/core/src/skills.ts
+++ b/packages/core/src/skills.ts
@@ -11,7 +11,7 @@
  */
 
 import type { Combatant, TurnEvent, AttackOptions, AttackResult } from './battle.js';
-import { applyStatus, DEFAULT_STATUS_TURNS, type StatusId } from './statuses.js';
+import { applyStatus, statusApplyText, DEFAULT_STATUS_TURNS, type StatusId } from './statuses.js';
 import type { Element } from './elements.js';
 
 /** ダメージの基準にする支配ステータス。int は魔撃 (必中・防御半減)、agi/luk は物理。 */
@@ -57,8 +57,6 @@ export type SkillEffect =
       inflict?: InflictSpec;
       /** 攻撃属性 (火遁=fire 等)。防御側の element と相性判定。未指定は無属性 (等倍)。 */
       element?: Element;
-      /** 会心率への加算 (急所狙い等)。 */
-      critBonus?: number;
     }
   | {
       kind: 'fixedDamage';
@@ -143,7 +141,6 @@ const damageHandler: EffectHandler = (effect, ctx) => {
     if (effect.hitBonus !== undefined) opts.hitBonus = effect.hitBonus;
     if (effect.defFactor !== undefined) opts.defFactor = effect.defFactor;
     if (effect.element !== undefined) opts.element = effect.element;
-    if (effect.critBonus !== undefined) opts.critBonus = effect.critBonus;
     switch (effect.stat) {
       case 'atk':
         break; // 素の atk (default)
@@ -172,6 +169,7 @@ const damageHandler: EffectHandler = (effect, ctx) => {
           turns: inf.turns ?? DEFAULT_STATUS_TURNS,
           ...(inf.magnitude !== undefined ? { magnitude: inf.magnitude } : {}),
         });
+        events.push({ actor, text: statusApplyText(inf.status, defender.name) });
       }
     }
   }
@@ -180,7 +178,10 @@ const damageHandler: EffectHandler = (effect, ctx) => {
 /** status: 使用者 (self) or 相手 (enemy) に状態異常を付与 (バフ/デバフ/かくれみ)。 */
 const statusHandler: EffectHandler = (effect, ctx) => {
   if (effect.kind !== 'status') return;
-  const { attacker, defender, rng } = ctx;
+  const { attacker, defender, rng, events } = ctx;
+  const actor = ctx.actorSide ?? 'player';
+  // 倒した相手にデバフを乗せない (fixedDamage で致死後に走る多段技のため。self バフは対象外)。
+  if (effect.target === 'enemy' && defender.hp <= 0) return;
   if (rng() >= (effect.chance ?? 1)) return;
   const target = effect.target === 'self' ? attacker : defender;
   applyStatus(target, {
@@ -188,6 +189,8 @@ const statusHandler: EffectHandler = (effect, ctx) => {
     turns: effect.turns ?? DEFAULT_STATUS_TURNS,
     ...(effect.magnitude !== undefined ? { magnitude: effect.magnitude } : {}),
   });
+  // 付与を告知 (無告知だとプレイヤーが状態変化を認識できない。レビュー ★★)。
+  events.push({ actor, text: statusApplyText(effect.status, target.name) });
 };
 
 /** fixedDamage: 範囲ロール + int 連動 → doMagic (必中・def無視・属性相性)。DQ 流の魔法。 */
@@ -281,18 +284,23 @@ export const SKILLS: Record<string, SkillDef> = {
 
   // ─── 忍者 確定キット (#456 / docs/25 §7・§14.1。agi型・毒/隠密/会心) ───
   // 数値は sim 調整前提の暫定値。影分身 Lv20 / 首狩り Lv30 (P) は後続 (要 evade多重/召喚 or passive)。
-  // 毒手 Lv3: agi 物理 (軽) + 高確率で毒
+  // 毒手 Lv3: agi 物理 (軽) + 高確率で毒 (§7: power0.7 / chance0.8 / turns3)。
+  // magnitude は §7 では範囲 [1,3] だが poison の範囲ロールは未実装のため固定 2 (範囲対応は別 issue)。
   'ninja-poison-hand': {
     id: 'ninja-poison-hand',
-    effects: [{ kind: 'damage', stat: 'agi', power: 0.8, inflict: { status: 'poison', chance: 0.7, turns: 3, magnitude: 2 } }],
+    effects: [{ kind: 'damage', stat: 'agi', power: 0.7, inflict: { status: 'poison', chance: 0.8, turns: 3, magnitude: 2 } }],
   },
   // かくれみ Lv5: 自分にかくれみ (回避↑。安全に やくそう 回復するための布石。行動 or 被弾で解除)
   'ninja-hide': { id: 'ninja-hide', effects: [{ kind: 'status', status: 'hidden', target: 'self', turns: 3 }] },
   // 火遁 Lv8: 火属性の術 (必中・def無視)。忍者は int 低めなので intBonus 控えめ
   'ninja-katon': { id: 'ninja-katon', effects: [{ kind: 'fixedDamage', min: 8, max: 14, intBonus: 0.12, element: 'fire' }] },
-  // 急所狙い Lv12: agi 物理・会心率大幅上昇 (メタル狩りの布石)
-  'ninja-vitals': { id: 'ninja-vitals', effects: [{ kind: 'damage', stat: 'agi', power: 1.0, critBonus: 0.35 }] },
-  // 九字切り Lv15: 次の一撃を確定会心 (メタル系を会心で貫く。critCharge は行動で解除)
+  // 急所狙い Lv12: agi 物理 1.5 倍 + 命中で 1 ターン麻痺 (§7 確定版どおり)
+  'ninja-vitals': {
+    id: 'ninja-vitals',
+    effects: [{ kind: 'damage', stat: 'agi', power: 1.5, inflict: { status: 'stun', chance: 1.0, turns: 1 } }],
+  },
+  // 九字切り Lv15: 次の一撃を確定会心 (メタル系を会心で貫く)。turns:1 = fresh スキップにより付与ターンは
+  // 畳まれず、次ターンの攻撃で確定会心 → clearOnAct で除去。
   'ninja-kuji': { id: 'ninja-kuji', effects: [{ kind: 'status', status: 'critCharge', target: 'self', turns: 1 }] },
 };
 

--- a/packages/core/src/skills.ts
+++ b/packages/core/src/skills.ts
@@ -240,6 +240,41 @@ export const SKILLS: Record<string, SkillDef> = {
   },
   // 回復 (#436): maxHp の 0.35 (= 旧 BATTLE_TUNING.skillHealRatio を移行)
   heal: { id: 'heal', effects: [{ kind: 'heal', ratio: 0.35 }] },
+
+  // ─── 魔法使い 確定キット (#456 / docs/25 §12。単体・int型・必中・def無視) ───
+  // 数値 (範囲/intBonus/デバフ turns) は **sim 調整前提の暫定値**。覚える Lv に見合う endgame 敵
+  // (#455) が要る高 Lv 技は数値を圧縮しない (オーナー方針)。属性の輪は §1。
+  'mage-flame': { id: 'mage-flame', effects: [{ kind: 'fixedDamage', min: 4, max: 8, intBonus: 0.2, element: 'fire' }] }, // 火炎術式 Lv3
+  'mage-decode': { id: 'mage-decode', effects: [{ kind: 'fixedDamage', min: 6, max: 11, intBonus: 0.2 }] }, // 解式マギア Lv5 (無属性)
+  'mage-stone': { id: 'mage-stone', effects: [{ kind: 'fixedDamage', min: 7, max: 12, intBonus: 0.2, element: 'earth' }] }, // 石射 Lv6
+  // 氷結術式 Lv8: 水 + 素早さ↓
+  'mage-freeze': {
+    id: 'mage-freeze',
+    effects: [
+      { kind: 'fixedDamage', min: 8, max: 14, intBonus: 0.25, element: 'water' },
+      { kind: 'status', status: 'agiDown', target: 'enemy', turns: 3 },
+    ],
+  },
+  // メルティ Lv12: 火 + 敵 def↓
+  'mage-melt': {
+    id: 'mage-melt',
+    effects: [
+      { kind: 'fixedDamage', min: 10, max: 16, intBonus: 0.25, element: 'fire' },
+      { kind: 'status', status: 'defDown', target: 'enemy', turns: 3 },
+    ],
+  },
+  'mage-blaze': { id: 'mage-blaze', effects: [{ kind: 'fixedDamage', min: 16, max: 24, intBonus: 0.3, element: 'fire' }] }, // 爆炎術式 Lv15
+  'mage-quake': { id: 'mage-quake', effects: [{ kind: 'fixedDamage', min: 20, max: 28, intBonus: 0.35, element: 'earth' }] }, // じわれ Lv18 (飛行無効は #455)
+  // 永久凍土 Lv20: 水 + 3T 行動不可 (stun turns=3)
+  'mage-permafrost': {
+    id: 'mage-permafrost',
+    effects: [
+      { kind: 'fixedDamage', min: 12, max: 18, intBonus: 0.3, element: 'water' },
+      { kind: 'status', status: 'stun', target: 'enemy', turns: 3 },
+    ],
+  },
+  'mage-meteor': { id: 'mage-meteor', effects: [{ kind: 'fixedDamage', min: 30, max: 45, intBonus: 0.4 }] }, // メテオ Lv25 (無属性大砲)
+  // 魔力障壁 Lv30 (常時 被ダメ軽減) はパッシブ。PASSIVES + player.passives 配線が要るため後続で追加 (TODO)。
 };
 
 /** SkillDef の全効果を順に解決する (プラグイン実行のエントリポイント)。 */

--- a/packages/core/src/statuses.ts
+++ b/packages/core/src/statuses.ts
@@ -37,6 +37,10 @@ export interface StatusInstance {
   /** 効果量。**単位は状態ごとに異なる**: poison=1 ターンあたりのダメージ量 (絶対値) /
    *  atk・def・agi の Up/Down=倍率 (例 1.3)。付与側は取り違えに注意。未指定は各状態のデフォルト。 */
   magnitude?: number;
+  /** 付与された当ターンだけ true。そのターンの tickStatuses では turnEnd 発火・turns 減衰を
+   *  スキップする (turns:1 の麻痺が「付与ターン末に即消え」で無効化されるのを防ぐ)。これにより
+   *  turns=N が「対象の以後 N ターンに効く」の直感どおりになる。applyStatus が立て、最初の tick が畳む。 */
+  fresh?: boolean;
 }
 
 /** フック呼び出しの文脈。ディスパッチャが「処理中の状態インスタンス」と「c 側」を差し込む。 */
@@ -162,6 +166,29 @@ export const STATUS_REGISTRY: Record<StatusId, StatusDef> = {
 /** パッシブレジストリ (ジョブ innate)。#456 で首狩り等を追加。今は枠だけ。 */
 export const PASSIVES: Record<string, PassiveDef> = {};
 
+/** 状態付与時の告知テキスト (対象名の後に続ける)。プレイヤーが状態変化を認識できるように
+ *  (無告知だと忍者のかくれみ/九字切り等が「何も起きていない」ように見える。レビュー ★★)。 */
+const STATUS_APPLY_TEXT: Record<StatusId, string> = {
+  poison: 'は毒におかされた!',
+  sleep: 'は眠ってしまった!',
+  stun: 'は麻痺した!',
+  tumble: 'は転倒した!',
+  restraint: 'は束縛された!',
+  hidden: 'は かくれみ に身を隠した!',
+  critCharge: 'は精神を研ぎ澄ませた!',
+  atkUp: 'の攻撃力があがった!',
+  atkDown: 'の攻撃力がさがった!',
+  defUp: 'の守備力があがった!',
+  defDown: 'の守備力がさがった!',
+  agiUp: 'の素早さがあがった!',
+  agiDown: 'の素早さがさがった!',
+};
+
+/** 状態付与の告知文 (対象名 + テキスト)。 */
+export function statusApplyText(id: StatusId, targetName: string): string {
+  return `${targetName}${STATUS_APPLY_TEXT[id]}`;
+}
+
 /** ctx にいま処理中の status を差し込む (exactOptional: undefined は明示せず省略)。 */
 function ctxFor(ctx: HookCtx, inst?: StatusInstance): HookCtx {
   return inst ? { ...ctx, status: inst } : ctx;
@@ -229,18 +256,33 @@ export function applyOnHit(atk: Combatant, def_: Combatant, ctx: HookCtx): boole
   return kill;
 }
 
-/** ターン終了: turnEnd フック (毒等) → turns-- → 0 で除去。生存者のみ turnEnd を受ける。 */
+/** ターン終了: turnEnd フック (毒等) → turns-- → 0 で除去。生存者のみ turnEnd を受ける。
+ *  付与された当ターン (fresh) は turnEnd・減衰をスキップし fresh を畳む (次ターンから効き始める)。 */
 export function tickStatuses(c: Combatant, ctx: HookCtx): void {
   if (!c.statuses || c.statuses.length === 0) return;
   for (const inst of c.statuses) {
     if (c.hp <= 0) break;
+    if (inst.fresh) continue; // 付与ターンは turnEnd を発火しない (毒は次ターンから)
     STATUS_REGISTRY[inst.id]?.turnEnd?.(c, ctxFor(ctx, inst));
   }
-  for (const inst of c.statuses) inst.turns -= 1;
+  for (const inst of c.statuses) {
+    if (inst.fresh) {
+      inst.fresh = false; // 付与ターンの tick は「消費」せず fresh だけ畳む
+      continue;
+    }
+    inst.turns -= 1;
+  }
   c.statuses = c.statuses.filter((s) => s.turns > 0);
 }
 
-/** 自分が行動したときに clearOnAct 状態を除去 (かくれみ/九字切り)。 */
+/**
+ * clearOnAct 状態を一律除去するユーティリティ。
+ *
+ * **非推奨 (resolveTurn では使わない)**: 「行動したら即消す」は、行動中に付与した自己バフ
+ * (かくれみ/九字切りを張る等) まで同ターンに消してしまう。resolveTurn は行動前スナップショット
+ * (`consumedOnAct`) 方式で「前ターンから持ち越した clearOnAct のみ消費」する。この関数は
+ * clearOnAct セマンティクスの単体テスト用途にのみ残す。
+ */
 export function clearActedStatuses(c: Combatant): void {
   if (!c.statuses || c.statuses.length === 0) return;
   c.statuses = c.statuses.filter((s) => !STATUS_REGISTRY[s.id]?.clearOnAct);
@@ -268,9 +310,10 @@ export function applyStatus(c: Combatant, inst: StatusInstance): void {
     if (mode === 'refresh') {
       existing.turns = Math.max(existing.turns, inst.turns);
       if (inst.magnitude !== undefined) existing.magnitude = inst.magnitude;
+      existing.fresh = true; // 再付与も当ターンは効かせ始めない (直感的な turns 意味を維持)
       return;
     }
     // stack: 別インスタンスとして追加
   }
-  c.statuses.push({ ...inst });
+  c.statuses.push({ ...inst, fresh: true });
 }


### PR DESCRIPTION
## 目的

戦闘刷新 (docs/25 §12) の**ジョブ確定キット投入・第1バッチ**。#452 プラグイン基盤の上に、
単体戦闘で成立する **魔法使い・忍者** のキットを end-to-end 配線する (Closes 一部 #456)。

オーナー判断で **#456 (キット) を #453 (マルチ戦闘) より先行**。§12 の確定キットは大半が全体/召喚/
パーティバフでマルチ戦闘依存だが、単体・自己対象で成立するジョブが多数あるため、そこから段階投入する。

## 変更

### 効果語彙の拡張
- **`fixedDamage`** プリミティブ + **`doMagic`** エンジン関数: DQ 流の範囲ベース魔法 (min〜max +
  int連動)・**必中・def無視**。属性相性 (§1) と被ダメバフを掛けて確定。ほぼ全キャスター技の土台。
- **`critBonus`**: damage 効果に会心率加算 (急所狙い)。

### 魔法使い (単体・int型・必中・def無視の大砲)
火炎術式3/解式マギア5/石射6/氷結術式8(agi↓)/メルティ12(def↓)/爆炎術式15/じわれ18/永久凍土20(3T行動不可)/メテオ25。魔力障壁30(P) は後続。

### 忍者 (agi型・毒/隠密/会心)
毒手3(+毒)/かくれみ5(隠密self)/火遁8/急所狙い12(会心↑)/九字切り15(確定会心self)。影分身20/首狩り30(P) は後続。

### skill 識別リワーク
- `JOB_KITS` レジストリ + `skillsForJob` リワーク (キット持ちジョブは learnAt<=level のキット技、
  未習得帯は署名フォールバック)。**他14ジョブは従来どおり (挙動不変)**。
- `JobSkill.kind` を string (SKILLS キー) に緩め、`skillKindLabel` で UI 補足を安全に。edge は
  skillIndex を sealed state から replay するだけなので**変更不要 (透過)**。

### バグ修正 (忍者テストが検出) ★
`clearActedStatuses` が act() 末尾で clearOnAct 状態を一律除去していたため、**かくれみ/九字切りを
「張った」自己バフが同ターンに即消え**て no-op になっていた。行動前に存在した状態 (前ターン持ち越し)
だけを消費・除去し、この行動で付与した自己バフは残すよう修正。

## 検証
- core 369 緑 (job-kits 10 追加: レベル習得・実戦で必中def無視・毒付与・かくれみself を検証) /
  web unit 346 / web build / typecheck (web+edge+core) 緑。
- **数値は sim 調整前提の暫定値** (オーナー: 数値は後回し、他ジョブを先に)。sim 実測で魔法使いは
  必中+def無視により現行 tier3 に対し過剰 (97.8%) だが、これは (a) 早期数値の調整と (b) 高Lv技に
  見合う endgame 敵 (#455) の両方が要る。精密な数値合わせは **sim スキルピッカー + #455 + 全単体
  ジョブ投入後にまとめて実施**。本 PR は構造 (キット配線) が主目的。

## Review

§1.5 3並列独立レビュー (設計/実装/体験) を実施。**★★★ 2件を検出・両方 PR 内で修正済み** (commit db4d936)。

### ★★★ 対応 (PR 内)
- **九字切り (critCharge) が完全不発** (実装レビューが probe で検出): 付与ターン末の tickStatuses が turns:1 を即 0 にし次攻撃前に消えていた → **状態エンジンに fresh スキップを導入** (付与ターンの tick は turnEnd・減衰をスキップ)。turns=N が直感どおり「以後 N ターン」に。critCharge/麻痺が正しく効く。回帰テスト追加。
- **status-modal がキット職で嘘の技を表示** (体験レビュー): 魔法使い=解式マギア・忍者=未実装の影分身を表示 → skillsForJob(archetype, jobLv) の現習得列を出すよう修正。

### ★★ 対応 (PR 内)
- 状態付与の**無告知**を解消 (statusHandler/inflict が付与告知を push)。
- **急所狙いを §7 確定版に一致** (critBonus → power1.5+麻痺1T)、未使用化した critBonus 撤去。毒手を §7 に寄せ (power0.7/chance0.8)。
- 魔法使いの死んだ heal を撤去し「自己回復なしの大砲」明示 (§12)。

### ★★ issue 化
- **属性が現状不可視・無効** (モンスター element 未設定) → **#455** にコメント引き継ぎ (element付与+ログ/メニュー表示+飛行)。

### ★ 対応 / 引き継ぎ
- PR 内: 致死後の敵に status を乗せないガード / clearActedStatuses 非推奨 JSDoc / skillsForJob の [0]≠署名 不変条件コメント / 解式マギア同名の記録。
- 引き継ぎ: consumedOnAct の refresh 再付与 edge (実装レビューは「acceptable」と結論、コメント済み) / hidden×agiDown 順序 → **#460** / 技別 MP コスト検討 → #456 続き。

CI: web-ci pass / 本番 build pass。core 373緑 / web 346 / build / typecheck (web+edge+core) 緑。
