### PR TITLE
feat(combat): ジョブ確定キット第2バッチ — 詩人・戦士 (既存語彙のみ) (#456)

### DIFF
--- a/packages/core/src/__tests__/battle.test.ts
+++ b/packages/core/src/__tests__/battle.test.ts
@@ -89,8 +89,8 @@ describe('skillsForJob (複数とくぎ #436)', () => {
     expect(skillsForJob('miko', 1).map((s) => s.kind)).toEqual(['gamble']);
     expect(skillsForJob('miko', 2).map((s) => s.kind)).toEqual(['gamble']);
     expect(skillsForJob('miko', 3).map((s) => s.kind)).toEqual(['gamble', 'heal']);
-    // heal 未配布のジョブは署名のみ (warrior)
-    expect(skillsForJob('warrior', 30)).toHaveLength(1);
+    // heal 未配布・キット未登録のジョブは署名のみ (guardian)
+    expect(skillsForJob('guardian', 30)).toHaveLength(1);
   });
   it('heal とくぎは MP を払って maxHp の割合ぶん回復する', () => {
     // miko(jobLv5) は [gamble, heal]。HP を削ってから heal を選ぶ (skillIndex=1)

--- a/packages/core/src/__tests__/job-kits.test.ts
+++ b/packages/core/src/__tests__/job-kits.test.ts
@@ -106,3 +106,36 @@ describe('忍者 確定キット (#456)', () => {
     expect(stunned).toBe(true);
   });
 });
+
+describe('詩人 確定キット (#456)', () => {
+  it('レベルで心晴の韻〜心の詩を習得', () => {
+    expect(skillsForJob('poet', 3).map((s) => s.name)).toContain('心晴の韻');
+    expect(skillsForJob('poet', 12).map((s) => s.name)).toEqual(['心晴の韻', '静心', '昂ぶりの詩', '言の葉縛り', '無心']);
+    expect(skillsForJob('poet', 22).map((s) => s.name)).toContain('心の詩');
+  });
+
+  it('キット技はすべて SKILLS に定義がある', () => {
+    for (const sk of skillsForJob('poet', 30)) expect(SKILLS[sk.kind], sk.kind).toBeDefined();
+  });
+
+  it('心の詩は自分に atk/def/agi の3バフを一括付与 (複数 effect 合成)', () => {
+    const s = startBattle('poet', 22, 25, '詩', 1, 3, 0);
+    const idx = s.playerSkills.findIndex((sk) => sk.name === '心の詩');
+    const next: BattleState = resolveTurn(s, 'skill', undefined, idx);
+    const ids = new Set(next.player.statuses?.map((st) => st.id));
+    expect(ids.has('atkUp')).toBe(true);
+    expect(ids.has('defUp')).toBe(true);
+    expect(ids.has('agiUp')).toBe(true);
+  });
+
+  it('言の葉縛りは敵に束縛を付与 (被弾で解けない拘束)', () => {
+    let bound = false;
+    for (let seed = 0; seed < 20 && !bound; seed++) {
+      const s = startBattle('poet', 8, 12, '詩', 3, seed, 0);
+      const idx = s.playerSkills.findIndex((sk) => sk.name === '言の葉縛り');
+      const next: BattleState = resolveTurn(s, 'skill', undefined, idx);
+      if (next.monster.hp > 0 && next.monster.statuses?.some((st) => st.id === 'restraint')) bound = true;
+    }
+    expect(bound).toBe(true);
+  });
+});

--- a/packages/core/src/__tests__/job-kits.test.ts
+++ b/packages/core/src/__tests__/job-kits.test.ts
@@ -29,9 +29,9 @@ describe('魔法使い 確定キット (#456)', () => {
   });
 
   it('他ジョブ (キット未登録) は従来どおり基本 6 種の署名スキル', () => {
-    // warrior はキット未登録 → 支配ステータス由来の基本 6 種の署名を返す (挙動不変)。
+    // guardian はキット未登録 → 支配ステータス由来の基本 6 種の署名を返す (挙動不変)。
     const base = ['smash', 'parry', 'flurry', 'spell', 'gamble', 'heal'];
-    expect(base).toContain(skillsForJob('warrior', 10)[0]!.kind);
+    expect(base).toContain(skillsForJob('guardian', 10)[0]!.kind);
   });
 
   it('火炎術式が実戦で魔法ダメージ (必中・def無視・範囲) を通す (mage)', () => {
@@ -137,5 +137,27 @@ describe('詩人 確定キット (#456)', () => {
       if (next.monster.hp > 0 && next.monster.statuses?.some((st) => st.id === 'restraint')) bound = true;
     }
     expect(bound).toBe(true);
+  });
+});
+
+describe('戦士 確定キット (#456)', () => {
+  it('レベルでみだれ突き〜全力斬りを習得 (全体技は後続なので Lv3-4 は署名)', () => {
+    expect(skillsForJob('warrior', 4)[0]!.kind).not.toMatch(/^warrior-/); // Lv5 未満は署名フォールバック
+    expect(skillsForJob('warrior', 18).map((s) => s.name)).toEqual(['みだれ突き', 'かぶとわり', 'ためる', '全力斬り']);
+  });
+
+  it('キット技はすべて SKILLS に定義がある', () => {
+    for (const sk of skillsForJob('warrior', 30)) expect(SKILLS[sk.kind], sk.kind).toBeDefined();
+  });
+
+  it('かぶとわりは命中で守備力↓を付与 (継続戦)', () => {
+    let debuffed = false;
+    for (let seed = 0; seed < 40 && !debuffed; seed++) {
+      const s = startBattle('warrior', 10, 15, '戦', 3, seed, 0);
+      const idx = s.playerSkills.findIndex((sk) => sk.name === 'かぶとわり');
+      const next: BattleState = resolveTurn(s, 'skill', undefined, idx);
+      if (next.monster.hp > 0 && next.monster.statuses?.some((st) => st.id === 'defDown')) debuffed = true;
+    }
+    expect(debuffed).toBe(true);
   });
 });

--- a/packages/core/src/__tests__/job-kits.test.ts
+++ b/packages/core/src/__tests__/job-kits.test.ts
@@ -111,7 +111,17 @@ describe('詩人 確定キット (#456)', () => {
   it('レベルで心晴の韻〜心の詩を習得', () => {
     expect(skillsForJob('poet', 3).map((s) => s.name)).toContain('心晴の韻');
     expect(skillsForJob('poet', 12).map((s) => s.name)).toEqual(['心晴の韻', '静心', '昂ぶりの詩', '言の葉縛り', '無心']);
+    expect(skillsForJob('poet', 20).map((s) => s.name)).toContain('感情爆発');
     expect(skillsForJob('poet', 22).map((s) => s.name)).toContain('心の詩');
+  });
+
+  it('感情爆発が実戦で水属性の大ダメージを通す (scaleBy の威力伸長は skills.test で単体検証)', () => {
+    const s = startBattle('poet', 20, 25, '詩', 3, 11, 0);
+    const burstIdx = s.playerSkills.findIndex((sk) => sk.name === '感情爆発');
+    expect(burstIdx).toBeGreaterThanOrEqual(0);
+    const next: BattleState = resolveTurn(s, 'skill', undefined, burstIdx);
+    expect(next.monster.hp).toBeLessThan(s.monster.hp);
+    expect(next.lastEvents.some((e) => e.text.includes('感情爆発'))).toBe(true);
   });
 
   it('キット技はすべて SKILLS に定義がある', () => {

--- a/packages/core/src/__tests__/skills.test.ts
+++ b/packages/core/src/__tests__/skills.test.ts
@@ -245,4 +245,26 @@ describe('fixedDamage (範囲魔法 #456)', () => {
     const { calls } = runMagicSpy({ id: 'x', effects: [{ kind: 'fixedDamage', min: 5, max: 5 }] }, makeCombatant(), makeCombatant({ hp: 0 }), () => 0);
     expect(calls).toHaveLength(0);
   });
+
+  it('luckScale: +attacker.luk × luckScale を加算 (luk 型魔法)', () => {
+    const atk = makeCombatant({ luk: 30 });
+    const { calls } = runMagicSpy({ id: 'x', effects: [{ kind: 'fixedDamage', min: 10, max: 10, luckScale: 0.2 }] }, atk, makeCombatant(), () => 0);
+    expect(calls[0]!.amount).toBe(10 + 30 * 0.2); // 16
+  });
+
+  it('scaleBy buffCount: 自己バフ数で威力が伸びる (感情爆発)', () => {
+    const bare = makeCombatant({ luk: 0, statuses: [] });
+    const buffed = makeCombatant({
+      luk: 0,
+      statuses: [
+        { id: 'atkUp', turns: 3 },
+        { id: 'defUp', turns: 3 },
+      ],
+    });
+    const def = { id: 'x', effects: [{ kind: 'fixedDamage' as const, min: 10, max: 10, scaleBy: 'buffCount' as const, scaleFactor: 0.5 }] };
+    const bareAmt = runMagicSpy(def, bare, makeCombatant(), () => 0).calls[0]!.amount;
+    const buffAmt = runMagicSpy(def, buffed, makeCombatant(), () => 0).calls[0]!.amount;
+    expect(bareAmt).toBe(10); // バフ 0 → ×1
+    expect(buffAmt).toBe(10 * (1 + 2 * 0.5)); // バフ 2 → ×2 = 20
+  });
 });

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -269,6 +269,15 @@ const JOB_KITS: Partial<Record<Archetype, readonly KitSkill[]>> = {
     { id: 'ninja-vitals', name: '急所狙い', learnAt: 12 },
     { id: 'ninja-kuji', name: '九字切り', learnAt: 15 },
   ],
+  // 詩人: 水属性・自己バフ火力・言葉の拘束。感傷/感情爆発/全体技/詩心(P) は後続 (要 新語彙)。
+  poet: [
+    { id: 'poet-verse', name: '心晴の韻', learnAt: 3 },
+    { id: 'poet-calm', name: '静心', learnAt: 5 },
+    { id: 'poet-rouse', name: '昂ぶりの詩', learnAt: 7 },
+    { id: 'poet-bind', name: '言の葉縛り', learnAt: 8 },
+    { id: 'poet-mushin', name: '無心', learnAt: 12 },
+    { id: 'poet-song', name: '心の詩', learnAt: 22 },
+  ],
 };
 
 /** その jobLevel 時点で使えるとくぎ列。UI/エンジンはこの列から毎ターン選ぶ。

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -276,6 +276,7 @@ const JOB_KITS: Partial<Record<Archetype, readonly KitSkill[]>> = {
     { id: 'poet-rouse', name: '昂ぶりの詩', learnAt: 7 },
     { id: 'poet-bind', name: '言の葉縛り', learnAt: 8 },
     { id: 'poet-mushin', name: '無心', learnAt: 12 },
+    { id: 'poet-outburst', name: '感情爆発', learnAt: 20 },
     { id: 'poet-song', name: '心の詩', learnAt: 22 },
   ],
   // 戦士: 純物理ブルーザー・無属性。なぎ払い/一騎当千(全体)・剣豪(P) は後続。

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -278,6 +278,13 @@ const JOB_KITS: Partial<Record<Archetype, readonly KitSkill[]>> = {
     { id: 'poet-mushin', name: '無心', learnAt: 12 },
     { id: 'poet-song', name: '心の詩', learnAt: 22 },
   ],
+  // 戦士: 純物理ブルーザー・無属性。なぎ払い/一騎当千(全体)・剣豪(P) は後続。
+  warrior: [
+    { id: 'warrior-thrust', name: 'みだれ突き', learnAt: 5 },
+    { id: 'warrior-helmsplit', name: 'かぶとわり', learnAt: 10 },
+    { id: 'warrior-charge', name: 'ためる', learnAt: 15 },
+    { id: 'warrior-fullslash', name: '全力斬り', learnAt: 18 },
+  ],
 };
 
 /** その jobLevel 時点で使えるとくぎ列。UI/エンジンはこの列から毎ターン選ぶ。

--- a/packages/core/src/skills.ts
+++ b/packages/core/src/skills.ts
@@ -320,6 +320,17 @@ export const SKILLS: Record<string, SkillDef> = {
       { kind: 'status', status: 'agiUp', target: 'self', turns: 3 },
     ],
   },
+
+  // ─── 戦士 確定キット (#456 / docs/25 §12。純物理ブルーザー・無属性) ───
+  // 数値は sim 調整前提の暫定値。なぎ払い/一騎当千(全体)・剣豪(P) は後続。かばう/挑発は §12 で一旦保留。
+  'warrior-thrust': { id: 'warrior-thrust', effects: [{ kind: 'damage', stat: 'atk', power: 0.7, hits: 2 }] }, // みだれ突き Lv5
+  // かぶとわり Lv10: atk 1.3 倍 + 命中で守備力↓ (継続戦の布石)
+  'warrior-helmsplit': {
+    id: 'warrior-helmsplit',
+    effects: [{ kind: 'damage', stat: 'atk', power: 1.3, inflict: { status: 'defDown', chance: 0.8, turns: 3 } }],
+  },
+  'warrior-charge': { id: 'warrior-charge', effects: [{ kind: 'status', status: 'atkUp', target: 'self', turns: 2 }] }, // ためる Lv15 (次撃強化)
+  'warrior-fullslash': { id: 'warrior-fullslash', effects: [{ kind: 'damage', stat: 'atk', power: 2.0 }] }, // 全力斬り Lv18
 };
 
 /** SkillDef の全効果を順に解決する (プラグイン実行のエントリポイント)。 */

--- a/packages/core/src/skills.ts
+++ b/packages/core/src/skills.ts
@@ -63,10 +63,16 @@ export type SkillEffect =
       /** ダメージの下限・上限 (DQ 流の範囲魔法。例 15〜20)。 */
       min: number;
       max: number;
-      /** int 連動ボーナス: +attacker.int × intBonus (キャスターの int を伸ばす意味を出す)。 */
+      /** int 連動ボーナス: +attacker.int × intBonus (int キャスター)。 */
       intBonus?: number;
+      /** luk 連動ボーナス: +attacker.luk × luckScale (luk 型魔法: 巫女/芸術家/詩人。§423)。 */
+      luckScale?: number;
       /** 攻撃属性 (火水地風空)。防御側の element と相性判定。未指定は無属性 (等倍)。 */
       element?: Element;
+      /** データ駆動の計算値参照 (§14.5)。'buffCount' = 使用者の自己バフ数 (感情爆発)。 */
+      scaleBy?: 'buffCount';
+      /** scaleBy の1件あたり倍率: amount ×= 1 + count × scaleFactor。未指定 0.4。 */
+      scaleFactor?: number;
     }
   | {
       kind: 'heal';
@@ -193,7 +199,15 @@ const statusHandler: EffectHandler = (effect, ctx) => {
   events.push({ actor, text: statusApplyText(effect.status, target.name) });
 };
 
-/** fixedDamage: 範囲ロール + int 連動 → doMagic (必中・def無視・属性相性)。DQ 流の魔法。 */
+/** 自己バフとして数える状態 (感情爆発の buffCount)。積み重ねてダメージに変換する。 */
+const BUFF_STATUSES: ReadonlySet<StatusId> = new Set<StatusId>(['atkUp', 'defUp', 'agiUp']);
+
+/** 使用者の自己バフ数 (scaleBy: 'buffCount' 用)。 */
+function countBuffs(c: Combatant): number {
+  return (c.statuses ?? []).filter((s) => BUFF_STATUSES.has(s.id)).length;
+}
+
+/** fixedDamage: 範囲ロール + int/luk 連動 → doMagic (必中・def無視・属性相性)。DQ 流の魔法。 */
 const fixedDamageHandler: EffectHandler = (effect, ctx) => {
   if (effect.kind !== 'fixedDamage') return;
   const { attacker, defender, rng, events, engine, skillName } = ctx;
@@ -202,6 +216,8 @@ const fixedDamageHandler: EffectHandler = (effect, ctx) => {
   const span = effect.max - effect.min;
   let amount = effect.min + Math.floor(rng() * (span + 1));
   if (effect.intBonus) amount += attacker.int * effect.intBonus;
+  if (effect.luckScale) amount += attacker.luk * effect.luckScale;
+  if (effect.scaleBy === 'buffCount') amount *= 1 + countBuffs(attacker) * (effect.scaleFactor ?? 0.4);
   engine.doMagic(attacker, defender, rng, events, actor, {
     amount,
     ...(effect.element ? { element: effect.element } : {}),
@@ -305,12 +321,19 @@ export const SKILLS: Record<string, SkillDef> = {
 
   // ─── 詩人 確定キット (#456 / docs/25 §12。水属性・自己バフ火力・言葉の拘束) ───
   // 数値は sim 調整前提の暫定値。感傷(会心↑)/感情爆発(scaleBy)/全体技/詩心(P) は後続 (要 新語彙)。
-  'poet-verse': { id: 'poet-verse', effects: [{ kind: 'fixedDamage', min: 5, max: 10, intBonus: 0.12, element: 'water' }] }, // 心晴の韻 Lv3
+  // 心晴の韻 Lv3: 水属性魔法。詩人の強み luk (34) 連動 (int8 は最低クラスなので luckScale に。§423 luk型)。
+  'poet-verse': { id: 'poet-verse', effects: [{ kind: 'fixedDamage', min: 4, max: 12, luckScale: 0.2, element: 'water' }] },
   'poet-calm': { id: 'poet-calm', effects: [{ kind: 'status', status: 'defUp', target: 'self', turns: 3 }] }, // 静心 Lv5
   'poet-rouse': { id: 'poet-rouse', effects: [{ kind: 'status', status: 'atkUp', target: 'self', turns: 3 }] }, // 昂ぶりの詩 Lv7
   // 言の葉縛り Lv8: 敵を束縛 (1-2T 行動不可・被弾で解けない)
   'poet-bind': { id: 'poet-bind', effects: [{ kind: 'status', status: 'restraint', target: 'enemy', chance: 0.7, turns: 2 }] },
   'poet-mushin': { id: 'poet-mushin', effects: [{ kind: 'status', status: 'agiUp', target: 'self', turns: 3 }] }, // 無心 Lv12 (回避↑。次被ダメ半減は barrier 未実装で後続)
+  // 感情爆発 Lv20: 水属性・単体大ダメージ。**今の自己バフ数 × 係数**で威力が伸びる (§12/§14.5 scaleBy)。
+  // 自己バフを積んでから撃つ = 詩人「自己バフ火力」の核 (buff→爆発ループの payoff)。
+  'poet-outburst': {
+    id: 'poet-outburst',
+    effects: [{ kind: 'fixedDamage', min: 12, max: 22, luckScale: 0.2, element: 'water', scaleBy: 'buffCount', scaleFactor: 0.5 }],
+  },
   // 心の詩 Lv22: 自分の全能力↑ (atk/def/agi を一括バフ = 複数 effect 合成)
   'poet-song': {
     id: 'poet-song',

--- a/packages/core/src/skills.ts
+++ b/packages/core/src/skills.ts
@@ -302,6 +302,24 @@ export const SKILLS: Record<string, SkillDef> = {
   // 九字切り Lv15: 次の一撃を確定会心 (メタル系を会心で貫く)。turns:1 = fresh スキップにより付与ターンは
   // 畳まれず、次ターンの攻撃で確定会心 → clearOnAct で除去。
   'ninja-kuji': { id: 'ninja-kuji', effects: [{ kind: 'status', status: 'critCharge', target: 'self', turns: 1 }] },
+
+  // ─── 詩人 確定キット (#456 / docs/25 §12。水属性・自己バフ火力・言葉の拘束) ───
+  // 数値は sim 調整前提の暫定値。感傷(会心↑)/感情爆発(scaleBy)/全体技/詩心(P) は後続 (要 新語彙)。
+  'poet-verse': { id: 'poet-verse', effects: [{ kind: 'fixedDamage', min: 5, max: 10, intBonus: 0.12, element: 'water' }] }, // 心晴の韻 Lv3
+  'poet-calm': { id: 'poet-calm', effects: [{ kind: 'status', status: 'defUp', target: 'self', turns: 3 }] }, // 静心 Lv5
+  'poet-rouse': { id: 'poet-rouse', effects: [{ kind: 'status', status: 'atkUp', target: 'self', turns: 3 }] }, // 昂ぶりの詩 Lv7
+  // 言の葉縛り Lv8: 敵を束縛 (1-2T 行動不可・被弾で解けない)
+  'poet-bind': { id: 'poet-bind', effects: [{ kind: 'status', status: 'restraint', target: 'enemy', chance: 0.7, turns: 2 }] },
+  'poet-mushin': { id: 'poet-mushin', effects: [{ kind: 'status', status: 'agiUp', target: 'self', turns: 3 }] }, // 無心 Lv12 (回避↑。次被ダメ半減は barrier 未実装で後続)
+  // 心の詩 Lv22: 自分の全能力↑ (atk/def/agi を一括バフ = 複数 effect 合成)
+  'poet-song': {
+    id: 'poet-song',
+    effects: [
+      { kind: 'status', status: 'atkUp', target: 'self', turns: 3 },
+      { kind: 'status', status: 'defUp', target: 'self', turns: 3 },
+      { kind: 'status', status: 'agiUp', target: 'self', turns: 3 },
+    ],
+  },
 };
 
 /** SkillDef の全効果を順に解決する (プラグイン実行のエントリポイント)。 */


### PR DESCRIPTION
## 目的

戦闘刷新 (docs/25 §12) の**ジョブ確定キット・第2バッチ**。#461 (魔法使い/忍者) に続き、
**既存語彙のみで成立する単体戦闘ジョブ 詩人・戦士** を追加する (#456 の一部)。

**foundation churn ゼロ**: 新しいプリミティブ・状態・フックの追加なし。#452/#461 でレビュー済みの
効果語彙 (damage/fixedDamage/status/inflict/element + 状態レジストリ) の再利用のみ。

## 変更

### 詩人 (水属性・自己バフ火力・言葉の拘束)
心晴の韻3(fixedDamage water)/静心5(defUp self)/昂ぶりの詩7(atkUp self)/言の葉縛り8(restraint enemy)/無心12(agiUp self)/心の詩22(atk+def+agi 一括 self)。感傷(会心↑)/感情爆発(scaleBy)/全体技/詩心(P) は要 新語彙のため後続。

### 戦士 (純物理ブルーザー・無属性)
みだれ突き5(atk×0.7×2)/かぶとわり10(atk×1.3+defDown)/ためる15(atkUp self)/全力斬り18(atk×2.0)。なぎ払い/一騎当千(全体) は #453 後、剣豪(P) は後続。かばう/挑発は §12 で保留 (要マルチ戦闘)。

### その他
- 既存 battle.test の warrior 前提テストを guardian (真のキット未登録職) に更新。

## 検証
- core 380 緑 (job-kits 詩人4+戦士3 追加: レベル習得・心の詩の3バフ一括・言の葉縛りの束縛・
  かぶとわりの defDown を実戦検証) / web build / typecheck (web+edge+core) 緑。
- **数値は sim 調整前提の暫定値**。精密な数値合わせは sim スキルピッカー + #455 + 全単体ジョブ投入後にまとめて実施。

## Review

§1.5 3並列独立レビュー (設計/実装/体験) を実施。

- **設計**: ★★★/★★ なし。「新語彙ゼロ・§12 整合・deferred 線引き妥当」を確認。★2 (暫定値/無心片翼) は許容。
- **実装**: ★★★/★★ なし。restraint の fresh 相互作用・inflict の fatal ガード・skillsForJob フォールバック・warrior→guardian テスト変更すべて穴なし。★3 はコメント微修正等で対応任意。
- **体験**: **★★★ 1件を検出 → PR 内で構造修正** (下記)。★★2/★1 は issue 化。

### ★★★ 対応 (PR 内・commit b4a52b2)
**詩人キットが詩人の強みと構造的に不一致** (数値では吸収不能): 心晴の韻が intBonus (詩人 int8=最低) 依存、自己バフ (atkUp) が atk 基準通常攻撃しか伸ばさず (詩人 atk11=最低)、実際の強み def32/luk34 を捨てていた。
→ **心晴の韻を luck 連動に** (fixedDamage に luckScale 追加・§423 luk型魔法。範囲も §12 の4-12に一致)。**感情爆発 Lv20 を追加** (scaleBy:'buffCount' §14.5) で自己バフに payoff を与え「積む→爆発」ループを成立させた。luckScale・scaleBy を単体テスト + 感情爆発を実戦検証。

### ★★/★ issue 化
- 複数 self バフの告知集約 (心の詩の3行) → **#463**
- 戦士の MP 経済 (MP特性なし・4技MP消費で枯れる) → **#464**
- 戦士 Lv3-4 攻撃技空白 / 詩人 無心の barrier 未実装 → **#465**

CI: web-ci pass / 本番 build pass。core 383緑 / web build / typecheck (web+edge+core) 緑。
