### PR TITLE
feat(combat): ジョブキット第3バッチ — 聖騎士・遊び人 + cleanse/restoreMp/recoil (#456)

### DIFF
--- a/apps/web/src/components/debug-battle-sim.tsx
+++ b/apps/web/src/components/debug-battle-sim.tsx
@@ -8,6 +8,7 @@ import {
   MONSTERS_BY_ID,
   autoBattleCommand,
   battleXpFor,
+  isPureHealSkill,
   jobDisplayName,
   resolveTurn,
   runAutoBattle,
@@ -245,7 +246,7 @@ export function DebugBattleSim() {
                 <button
                   key={i}
                   onClick={() => duelCmd('skill', i)}
-                  disabled={duel.player.mp < BATTLE_TUNING.skillMpCost || (sk.kind === 'heal' && duel.player.hp >= duel.player.maxHp)}
+                  disabled={duel.player.mp < BATTLE_TUNING.skillMpCost || (isPureHealSkill(sk.kind) && duel.player.hp >= duel.player.maxHp)}
                   style={{ fontSize: '0.85em', padding: '0.2em 0.5em' }}
                 >
                   {sk.name}

--- a/apps/web/src/components/world-battle-controls.tsx
+++ b/apps/web/src/components/world-battle-controls.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import type { BattleState, Command } from '@aozoraquest/core';
-import { BATTLE_TUNING, MONSTERS_BY_ID } from '@aozoraquest/core';
+import { BATTLE_TUNING, MONSTERS_BY_ID, isPureHealSkill } from '@aozoraquest/core';
 import { MonsterSvg } from './monster-svg';
 import { HpBar, TypedLines } from './battle-view';
 
@@ -98,8 +98,8 @@ export function WorldBattleControls({
                       key={i}
                       label={`${sk.name} (MP${BATTLE_TUNING.skillMpCost})`}
                       onClick={() => { setSkillMenu(false); onCommand('skill', i); }}
-                      // heal は満タンなら無意味 → 無効化 (やくそうと同じ配慮)
-                      disabled={busy || lowMp || (sk.kind === 'heal' && state.player.hp >= state.player.maxHp)}
+                      // 純回復技は満タンなら無意味 → 無効化 (キット技も効果ベースで判定)
+                      disabled={busy || lowMp || (isPureHealSkill(sk.kind) && state.player.hp >= state.player.maxHp)}
                     />
                   ))}
                   <DqRow label="もどる" onClick={() => setSkillMenu(false)} disabled={busy} />

--- a/packages/core/src/__tests__/job-kits.test.ts
+++ b/packages/core/src/__tests__/job-kits.test.ts
@@ -160,6 +160,15 @@ describe('聖騎士 確定キット (#456)', () => {
     for (const sk of skillsForJob('paladin', 30)) expect(SKILLS[sk.kind], sk.kind).toBeDefined();
   });
 
+  it('isPureHealSkill: 純回復技のみ true (サボる=restoreMp混在は false)', async () => {
+    const { isPureHealSkill } = await import('../index.js');
+    expect(isPureHealSkill('paladin-heal')).toBe(true); // heal のみ
+    expect(isPureHealSkill('heal')).toBe(true); // 基本 heal
+    expect(isPureHealSkill('performer-slack')).toBe(false); // restoreMp+heal
+    expect(isPureHealSkill('paladin-lightblade')).toBe(false); // 攻撃
+    expect(isPureHealSkill('unknown')).toBe(false);
+  });
+
   it('浄化は自分のデバフを回復するがバフは残す (cleanse)', () => {
     const s = startBattle('paladin', 18, 25, '聖', 1, 5, 0);
     // 手動でデバフ + バフを乗せてから浄化。
@@ -215,6 +224,14 @@ describe('遊び人 確定キット (#456)', () => {
     const next: BattleState = resolveTurn(s, 'skill', undefined, idx);
     expect(next.lastEvents.some((e) => e.text.includes('反動'))).toBe(true);
     expect(next.player.hp).toBeGreaterThanOrEqual(1);
+  });
+
+  it('いちかばちかは agi 基準 (遊び人の最強ステ)。luk 基準の弱火力ではない', () => {
+    // gamble の抽選を最大に固定 (turnSeed) しても、agi 基準なので luk 型より火力が出る想定。
+    // ここでは stat が agi であることを SKILLS 定義で担保 (実火力は sim)。
+    const def = SKILLS['performer-gamble']!;
+    const dmg = def.effects.find((e) => e.kind === 'damage');
+    expect(dmg && dmg.kind === 'damage' ? dmg.stat : undefined).toBe('agi');
   });
 });
 

--- a/packages/core/src/__tests__/job-kits.test.ts
+++ b/packages/core/src/__tests__/job-kits.test.ts
@@ -150,6 +150,74 @@ describe('詩人 確定キット (#456)', () => {
   });
 });
 
+describe('聖騎士 確定キット (#456)', () => {
+  it('レベルで聖光の癒し〜浄化を習得', () => {
+    expect(skillsForJob('paladin', 3).map((s) => s.name)).toContain('聖光の癒し');
+    expect(skillsForJob('paladin', 18).map((s) => s.name)).toEqual(['聖光の癒し', '光の加護', '光の剣', '聖なる守り', '浄化']);
+  });
+
+  it('キット技はすべて SKILLS に定義がある', () => {
+    for (const sk of skillsForJob('paladin', 30)) expect(SKILLS[sk.kind], sk.kind).toBeDefined();
+  });
+
+  it('浄化は自分のデバフを回復するがバフは残す (cleanse)', () => {
+    const s = startBattle('paladin', 18, 25, '聖', 1, 5, 0);
+    // 手動でデバフ + バフを乗せてから浄化。
+    s.player.statuses = [
+      { id: 'poison', turns: 3, magnitude: 2 },
+      { id: 'atkDown', turns: 3 },
+      { id: 'atkUp', turns: 3 },
+    ];
+    const purifyIdx = s.playerSkills.findIndex((sk) => sk.name === '浄化');
+    const next: BattleState = resolveTurn(s, 'skill', undefined, purifyIdx);
+    const ids = next.player.statuses?.map((st) => st.id) ?? [];
+    expect(ids).not.toContain('poison'); // デバフ除去
+    expect(ids).not.toContain('atkDown');
+    expect(ids).toContain('atkUp'); // バフは残る
+    expect(next.lastEvents.some((e) => e.text.includes('状態異常が回復'))).toBe(true);
+  });
+
+  it('光の剣が holy (無属性) 魔法で def 無視ダメージ', () => {
+    const s = startBattle('paladin', 8, 12, '聖', 2, 3, 0);
+    const idx = s.playerSkills.findIndex((sk) => sk.name === '光の剣');
+    const before = s.monster.hp;
+    const next: BattleState = resolveTurn(s, 'skill', undefined, idx);
+    expect(next.monster.hp).toBeLessThan(before);
+    expect(next.lastEvents.some((e) => e.text.includes('光の剣'))).toBe(true);
+  });
+});
+
+describe('遊び人 確定キット (#456)', () => {
+  it('レベルでサボる〜曲芸乱舞を習得', () => {
+    expect(skillsForJob('performer', 5).map((s) => s.name)).toContain('サボる');
+    expect(skillsForJob('performer', 15).map((s) => s.name)).toEqual(['サボる', 'いちかばちか', '曲芸乱舞']);
+  });
+
+  it('キット技はすべて SKILLS に定義がある', () => {
+    for (const sk of skillsForJob('performer', 30)) expect(SKILLS[sk.kind], sk.kind).toBeDefined();
+  });
+
+  it('サボるは MP を回復する (restoreMp)', () => {
+    const s = startBattle('performer', 5, 8, '遊', 1, 5, 0);
+    s.player.mp = 0; // MP を空に
+    const idx = s.playerSkills.findIndex((sk) => sk.name === 'サボる');
+    // MP0 だと skill が attack にフォールバックするので、サボる自体は MP コストを踏むが回復で上回る想定。
+    // ここでは MP を skillMpCost 以上にしてから撃つ。
+    s.player.mp = 6;
+    const next: BattleState = resolveTurn(s, 'skill', undefined, idx);
+    expect(next.player.mp).toBeGreaterThan(6 - 4); // 消費4を上回って回復
+    expect(next.lastEvents.some((e) => e.text.includes('MP が'))).toBe(true);
+  });
+
+  it('いちかばちかは反動で自分もダメージを受ける (recoil、HP1未満にはしない)', () => {
+    const s = startBattle('performer', 12, 18, '遊', 1, 5, 0);
+    const idx = s.playerSkills.findIndex((sk) => sk.name === 'いちかばちか');
+    const next: BattleState = resolveTurn(s, 'skill', undefined, idx);
+    expect(next.lastEvents.some((e) => e.text.includes('反動'))).toBe(true);
+    expect(next.player.hp).toBeGreaterThanOrEqual(1);
+  });
+});
+
 describe('戦士 確定キット (#456)', () => {
   it('レベルでみだれ突き〜全力斬りを習得 (全体技は後続なので Lv3-4 は署名)', () => {
     expect(skillsForJob('warrior', 4)[0]!.kind).not.toMatch(/^warrior-/); // Lv5 未満は署名フォールバック

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -232,7 +232,7 @@ interface LearnedSkill { kind: SkillKind; name: string; learnAt: number }
 const LEARNED_SKILLS: Partial<Record<Archetype, readonly LearnedSkill[]>> = {
   // 回復役・低攻撃ジョブに「いのり (HP 回復)」を配る。攻撃が弱い職ほど早く覚える。
   miko: [{ kind: 'heal', name: '神楽の癒し', learnAt: 3 }],
-  paladin: [{ kind: 'heal', name: '聖光の癒し', learnAt: 3 }],
+  // paladin は確定キット (#456) で聖光の癒しを持つため LEARNED は撤去 (JOB_KITS が優先)。
   seer: [{ kind: 'heal', name: '癒しの予言', learnAt: 4 }],
   sage: [{ kind: 'heal', name: '天啓の癒し', learnAt: 5 }],
   bard: [{ kind: 'heal', name: '癒しの旋律', learnAt: 4 }],
@@ -286,6 +286,20 @@ const JOB_KITS: Partial<Record<Archetype, readonly KitSkill[]>> = {
     { id: 'warrior-helmsplit', name: 'かぶとわり', learnAt: 10 },
     { id: 'warrior-charge', name: 'ためる', learnAt: 15 },
     { id: 'warrior-fullslash', name: '全力斬り', learnAt: 18 },
+  ],
+  // 聖騎士: 前衛・聖なる支援・holy(無属性)。全体技/聖光斬/清き心(P) は後続。
+  paladin: [
+    { id: 'paladin-heal', name: '聖光の癒し', learnAt: 3 },
+    { id: 'paladin-blessing', name: '光の加護', learnAt: 5 },
+    { id: 'paladin-lightblade', name: '光の剣', learnAt: 8 },
+    { id: 'paladin-guard', name: '聖なる守り', learnAt: 15 },
+    { id: 'paladin-purify', name: '浄化', learnAt: 18 },
+  ],
+  // 遊び人: luk/agi 型・運任せ。ぶんどり(gain)/ルーレット・大道芸(random)/せっとく(resolve) は後続。
+  performer: [
+    { id: 'performer-slack', name: 'サボる', learnAt: 5 },
+    { id: 'performer-gamble', name: 'いちかばちか', learnAt: 12 },
+    { id: 'performer-acrobat', name: '曲芸乱舞', learnAt: 15 },
   ],
 };
 

--- a/packages/core/src/skills.ts
+++ b/packages/core/src/skills.ts
@@ -224,7 +224,9 @@ const statusHandler: EffectHandler = (effect, ctx) => {
 /** 自己バフとして数える状態 (感情爆発の buffCount)。積み重ねてダメージに変換する。 */
 const BUFF_STATUSES: ReadonlySet<StatusId> = new Set<StatusId>(['atkUp', 'defUp', 'agiUp']);
 
-/** デバフ (浄化 cleanse で除去する状態)。バフ (atk/def/agiUp) は残す。 */
+/** デバフ (浄化 cleanse で除去する状態)。バフ (atk/def/agiUp) は残す。
+ *  **注意**: StatusId に新しいデバフ (confusion/flinch/accDown/doomMark/intDown 等) を足したら、
+ *  ここにも追記すること (型では検出できない。将来 BUFF/DEBUFF を StatusId 側の1テーブルに寄せたい)。 */
 const DEBUFF_STATUSES: ReadonlySet<StatusId> = new Set<StatusId>([
   'poison',
   'sleep',
@@ -438,8 +440,9 @@ export const SKILLS: Record<string, SkillDef> = {
       { kind: 'status', status: 'agiUp', target: 'self', turns: 3 },
     ],
   },
-  // 光の剣 Lv8: 無属性 (holy) 魔法・必中・def無視・int 連動
-  'paladin-lightblade': { id: 'paladin-lightblade', effects: [{ kind: 'fixedDamage', min: 8, max: 14, intBonus: 0.3 }] },
+  // 光の剣 Lv8: 無属性 (holy) 魔法・必中・def無視。§12 の "int差luck" と聖騎士の最強ステ luk34 を活かし
+  // int + luk の両刀に (int 単独だと最強 luk を無視してしまう。レビュー ★★)。範囲は §12 の 15-20 に寄せた。
+  'paladin-lightblade': { id: 'paladin-lightblade', effects: [{ kind: 'fixedDamage', min: 12, max: 18, intBonus: 0.2, luckScale: 0.2 }] },
   // 聖なる守り Lv15: 自 def を強めに上げる (defUp magnitude 0.6 = 被ダメ ×0.6)
   'paladin-guard': { id: 'paladin-guard', effects: [{ kind: 'status', status: 'defUp', target: 'self', turns: 3, magnitude: 0.6 }] },
   // 浄化 Lv18: 自分のデバフを回復 (cleanse)
@@ -456,17 +459,26 @@ export const SKILLS: Record<string, SkillDef> = {
       { kind: 'heal', ratio: 0.15 },
     ],
   },
-  // いちかばちか Lv12: luk 基準の大博打 + 反動 (一か八か)
+  // いちかばちか Lv12: **agi 基準** (遊び人の最強ステ) の大博打 + 反動。運任せ感は gamble の抽選幅と
+  // luk 依存の下限 (lukFloorScale) で表現する。基準を弱ステ luk にすると看板技が最弱火力になる (レビュー ★★★)。
   'performer-gamble': {
     id: 'performer-gamble',
     effects: [
-      { kind: 'damage', stat: 'luk', gamble: { max: 3.0, lukFloorScale: 0.012, lukFloorCap: 0.6 } },
+      { kind: 'damage', stat: 'agi', gamble: { max: 3.0, lukFloorScale: 0.012, lukFloorCap: 0.6 } },
       { kind: 'recoil', ratio: 0.15 },
     ],
   },
   // 曲芸乱舞 Lv15: agi 基準 3 連撃
   'performer-acrobat': { id: 'performer-acrobat', effects: [{ kind: 'damage', stat: 'agi', power: 0.6, hits: 3 }] },
 };
+
+/** そのとくぎが「HP 回復のみ」か (UI が満タン時に無効化するかの判定に使う)。kind 文字列でなく
+ *  効果ベースで判定するため、キット技 (paladin-heal 等) でも正しく効く。restoreMp+heal の
+ *  サボる等は「純回復でない」= false (満タンでも MP 回復に撃てる)。 */
+export function isPureHealSkill(kind: string): boolean {
+  const def = SKILLS[kind];
+  return !!def && def.effects.length > 0 && def.effects.every((e) => e.kind === 'heal');
+}
 
 /** SkillDef の全効果を順に解決する (ソロ戦闘のエントリポイント。ctx.defender 固定)。 */
 export function runSkill(def: SkillDef, ctx: SkillContext): void {

--- a/packages/core/src/skills.ts
+++ b/packages/core/src/skills.ts
@@ -85,6 +85,21 @@ export type SkillEffect =
       ratio: number;
     }
   | {
+      kind: 'cleanse';
+      /** 状態異常回復 (浄化/払串)。self=使用者 / allAllies=味方全体。デバフのみ除去 (バフは残す)。 */
+      target: 'self' | 'allAllies';
+    }
+  | {
+      kind: 'restoreMp';
+      /** maxMp に対する MP 回復割合 (サボる/野営)。使用者に。 */
+      ratio: number;
+    }
+  | {
+      kind: 'recoil';
+      /** maxHp に対する反動ダメージ割合 (いちかばちか/絶唱)。使用者に。HP 1 未満にはしない。 */
+      ratio: number;
+    }
+  | {
       kind: 'status';
       /** 付与する状態異常 */
       status: StatusId;
@@ -209,6 +224,18 @@ const statusHandler: EffectHandler = (effect, ctx) => {
 /** 自己バフとして数える状態 (感情爆発の buffCount)。積み重ねてダメージに変換する。 */
 const BUFF_STATUSES: ReadonlySet<StatusId> = new Set<StatusId>(['atkUp', 'defUp', 'agiUp']);
 
+/** デバフ (浄化 cleanse で除去する状態)。バフ (atk/def/agiUp) は残す。 */
+const DEBUFF_STATUSES: ReadonlySet<StatusId> = new Set<StatusId>([
+  'poison',
+  'sleep',
+  'stun',
+  'tumble',
+  'restraint',
+  'atkDown',
+  'defDown',
+  'agiDown',
+]);
+
 /** 使用者の自己バフ数 (scaleBy: 'buffCount' 用)。 */
 function countBuffs(c: Combatant): number {
   return (c.statuses ?? []).filter((s) => BUFF_STATUSES.has(s.id)).length;
@@ -242,12 +269,47 @@ const healHandler: EffectHandler = (effect, ctx) => {
   events.push({ actor: ctx.actorSide ?? 'player', text: `${attacker.name}は${skillName}! HP が ${heal} 回復。` });
 };
 
+/** cleanse: 味方対象のデバフを除去 (浄化)。バフは残す。self は使用者、それ以外は解決済みの味方。 */
+const cleanseHandler: EffectHandler = (effect, ctx) => {
+  if (effect.kind !== 'cleanse') return;
+  const { attacker, defender, events } = ctx;
+  const actor = ctx.actorSide ?? 'player';
+  // ソロ runSkill は ctx.defender=敵 固定なので、self は attacker を対象にする (敵を浄化しない)。
+  // マルチ runSkillMulti は allAllies を各味方に解決して defender に載せる。
+  const target = effect.target === 'self' ? attacker : defender;
+  if (!target.statuses || target.statuses.length === 0) return;
+  const had = target.statuses.some((s) => DEBUFF_STATUSES.has(s.id));
+  target.statuses = target.statuses.filter((s) => !DEBUFF_STATUSES.has(s.id));
+  if (had) events.push({ actor, text: `${target.name}の状態異常が回復した!` });
+};
+
+/** restoreMp: 使用者の MP を maxMp の割合ぶん回復 (サボる/野営)。 */
+const restoreMpHandler: EffectHandler = (effect, ctx) => {
+  if (effect.kind !== 'restoreMp') return;
+  const { attacker, events, skillName } = ctx;
+  const gain = Math.round(attacker.maxMp * effect.ratio);
+  attacker.mp = Math.min(attacker.maxMp, attacker.mp + gain);
+  events.push({ actor: ctx.actorSide ?? 'player', text: `${attacker.name}は${skillName}! MP が ${gain} 回復。` });
+};
+
+/** recoil: 使用者に反動ダメージ (maxHp 割合)。HP 1 未満にはしない (自滅は sim 調整後に検討)。 */
+const recoilHandler: EffectHandler = (effect, ctx) => {
+  if (effect.kind !== 'recoil') return;
+  const { attacker, events } = ctx;
+  const dmg = Math.round(attacker.maxHp * effect.ratio);
+  attacker.hp = Math.max(1, attacker.hp - dmg);
+  events.push({ actor: ctx.actorSide ?? 'player', text: `${attacker.name}は反動で ${dmg} のダメージ!` });
+};
+
 /** 効果種別 → ハンドラ。ここに 1 行足す = 新しい効果プリミティブが使えるようになる。 */
 export const EFFECT_HANDLERS: Record<SkillEffect['kind'], EffectHandler> = {
   damage: damageHandler,
   fixedDamage: fixedDamageHandler,
   heal: healHandler,
   status: statusHandler,
+  cleanse: cleanseHandler,
+  restoreMp: restoreMpHandler,
+  recoil: recoilHandler,
 };
 
 /**
@@ -362,6 +424,48 @@ export const SKILLS: Record<string, SkillDef> = {
   },
   'warrior-charge': { id: 'warrior-charge', effects: [{ kind: 'status', status: 'atkUp', target: 'self', turns: 2 }] }, // ためる Lv15 (次撃強化)
   'warrior-fullslash': { id: 'warrior-fullslash', effects: [{ kind: 'damage', stat: 'atk', power: 2.0 }] }, // 全力斬り Lv18
+
+  // ─── 聖騎士 確定キット (#456 / docs/25 §12。前衛・聖なる支援・holy=無属性) ───
+  // 数値は sim 調整前提の暫定値。裁きの光/女神降臨(全体)・聖光斬(int補正物理)・清き心(P魔法反射) は後続。
+  // 光の加護は §14.7 のフラット加算バフだが、フラット機構は未実装のため暫定で乗算バフ (atk/def/agiUp)。
+  'paladin-heal': { id: 'paladin-heal', effects: [{ kind: 'heal', ratio: 0.3 }] }, // 聖光の癒し Lv3
+  // 光の加護 Lv5: 自分の攻/守/速を強化 (§14.7 フラット化は後続 issue)
+  'paladin-blessing': {
+    id: 'paladin-blessing',
+    effects: [
+      { kind: 'status', status: 'atkUp', target: 'self', turns: 3 },
+      { kind: 'status', status: 'defUp', target: 'self', turns: 3 },
+      { kind: 'status', status: 'agiUp', target: 'self', turns: 3 },
+    ],
+  },
+  // 光の剣 Lv8: 無属性 (holy) 魔法・必中・def無視・int 連動
+  'paladin-lightblade': { id: 'paladin-lightblade', effects: [{ kind: 'fixedDamage', min: 8, max: 14, intBonus: 0.3 }] },
+  // 聖なる守り Lv15: 自 def を強めに上げる (defUp magnitude 0.6 = 被ダメ ×0.6)
+  'paladin-guard': { id: 'paladin-guard', effects: [{ kind: 'status', status: 'defUp', target: 'self', turns: 3, magnitude: 0.6 }] },
+  // 浄化 Lv18: 自分のデバフを回復 (cleanse)
+  'paladin-purify': { id: 'paladin-purify', effects: [{ kind: 'cleanse', target: 'self' }] },
+
+  // ─── 遊び人 確定キット (#456 / docs/25 §12・§14.1。luk/agi 型・運任せ) ───
+  // 数値は sim 調整前提の暫定値。ぶんどり(gain)/ルーレット・大道芸(random)/せっとく(resolve) は
+  // 要 新語彙のため後続。ここは restoreMp/recoil/連撃で成立する単体サブセット。
+  // サボる Lv5: MP 回復 + 少し HP 回復 (怠けて休む)
+  'performer-slack': {
+    id: 'performer-slack',
+    effects: [
+      { kind: 'restoreMp', ratio: 0.4 },
+      { kind: 'heal', ratio: 0.15 },
+    ],
+  },
+  // いちかばちか Lv12: luk 基準の大博打 + 反動 (一か八か)
+  'performer-gamble': {
+    id: 'performer-gamble',
+    effects: [
+      { kind: 'damage', stat: 'luk', gamble: { max: 3.0, lukFloorScale: 0.012, lukFloorCap: 0.6 } },
+      { kind: 'recoil', ratio: 0.15 },
+    ],
+  },
+  // 曲芸乱舞 Lv15: agi 基準 3 連撃
+  'performer-acrobat': { id: 'performer-acrobat', effects: [{ kind: 'damage', stat: 'agi', power: 0.6, hits: 3 }] },
 };
 
 /** SkillDef の全効果を順に解決する (ソロ戦闘のエントリポイント。ctx.defender 固定)。 */
@@ -379,7 +483,11 @@ export function effectTarget(effect: SkillEffect): SkillTarget {
     case 'fixedDamage':
       return effect.target ?? 'oneEnemy';
     case 'heal':
+    case 'restoreMp':
+    case 'recoil':
       return 'self';
+    case 'cleanse':
+      return effect.target;
     case 'status':
       return effect.target === 'enemy' ? 'oneEnemy' : effect.target;
   }


### PR DESCRIPTION
## 目的

戦闘刷新 (docs/25 §12) の**ジョブ確定キット・第3バッチ**。単体戦闘で成立する **聖騎士・遊び人** を追加
(#456 の一部)。効果プリミティブ3種 (cleanse/restoreMp/recoil) を**消費者となるキットと同時に**追加。

## 変更

### 新プリミティブ (消費者つき)
- **cleanse** (浄化): 対象のデバフを除去 (バフは残す。DEBUFF_STATUSES で判定)。
- **restoreMp** (サボる/野営): 使用者の MP を maxMp 割合ぶん回復。
- **recoil** (いちかばちか/絶唱): 使用者に反動ダメージ (HP1未満にはしない)。

### 聖騎士 (前衛・聖なる支援・holy=無属性)
聖光の癒し3(heal)/光の加護5(atk・def・agiUp self)/光の剣8(fixedDamage 無属性・必中)/聖なる守り15(defUp強)/浄化18(cleanse)。裁きの光/女神降臨(全体)・聖光斬(int補正物理)・清き心(P反射) は後続。**光の加護のフラット化 (§14.7) は暫定で乗算バフ** (フラット機構は後続)。旧 LEARNED_SKILLS.paladin(heal) はキット優先で撤去。

### 遊び人 (luk/agi・運任せ)
サボる5(restoreMp+heal)/いちかばちか12(luk大博打+recoil)/曲芸乱舞15(agi3連撃)。ぶんどり(gain)/ルーレット・大道芸(random)/せっとく(resolve) は要 新語彙のため後続。

## 検証
- core 407 緑 (聖騎士4 + 遊び人4: cleanse のバフ温存・restoreMp・recoil の HP 下限・holy 魔法を検証) /
  web build / typecheck (web+edge+core) 緑。既存ソロ resolveTurn は無変更。
- **数値は sim 調整前提の暫定値**。キット化 6/16 職。

## Review

§1.5 3並列独立レビュー (設計/実装/体験) を実施。**★★★ 1件を検出・PR 内修正** (commit b62e070)。

### ★★★ 対応 (PR 内)
- **遊び人いちかばちかが弱ステ luk (16) 基準** = 詩人と同じキット⇄ステ不整合 (体験レビュー) → **最強ステ agi (32) 基準に修正** (運任せ感は gamble の抽選幅 + luk 下限で表現)。

### ★★ 対応 (PR 内)
- 聖騎士 光の剣が int 単独で最強 luk (34) を無視 → **luckScale 追加で int+luk 両刀** (§12 int差luck)、範囲も §12 の 15-20 へ。
- **heal UI 満タンガードの回帰** (LEARNED→KIT で kind==='heal' 依存が聖光の癒しに効かず) → 効果ベースの `isPureHealSkill(kind)` に変更 (world-battle-controls / debug-battle-sim)。サボるは混在なので正しく非対象。
- DEBUFF_STATUSES のドリフト注意コメント (実装レビュー: 型で検出不能な取りこぼし防止)。

### ★★/★ issue 化
- 聖騎士の攻撃軸確定 (後続攻撃技と併せ) / BUFF・DEBUFF の StatusId 1テーブル化 / recoil のリスク設計 / 光の加護のフラット化 (§14.7) → **#470**
- heal の target self→oneAlly (マルチ回復) → #467 (マルチ後続) で対応

実装レビュー: ★★★/★★ なし (cleanse 対象解決・DEBUFF網羅・restoreMp/recoil 下限を確認)。設計レビュー: ★★★ なし。

CI: web-ci pass / 本番 build pass。core 409緑 / web build / typecheck (web+edge+core) 緑。
