### PR TITLE
feat(combat): ジョブキット第4バッチ — 賢者 (全5属性キャスター) (#456)

### DIFF
--- a/packages/core/src/__tests__/job-kits.test.ts
+++ b/packages/core/src/__tests__/job-kits.test.ts
@@ -150,6 +150,38 @@ describe('詩人 確定キット (#456)', () => {
   });
 });
 
+describe('賢者 確定キット (#456)', () => {
+  it('レベルで火炎〜星辰の大魔法を習得 (全5属性)', () => {
+    expect(skillsForJob('sage', 3).map((s) => s.name)).toContain('火炎');
+    expect(skillsForJob('sage', 22).map((s) => s.name)).toEqual([
+      '火炎', '解式', '石射', '氷結', '疾風', '天啓', '賢者の癒し', '星辰の大魔法',
+    ]);
+  });
+
+  it('キット技はすべて SKILLS に定義がある', () => {
+    for (const sk of skillsForJob('sage', 30)) expect(SKILLS[sk.kind], sk.kind).toBeDefined();
+  });
+
+  it('全5属性 (fire/water/earth/wind/void) を網羅する', () => {
+    const els = new Set<string>();
+    for (const sk of skillsForJob('sage', 22)) {
+      for (const e of SKILLS[sk.kind]!.effects) {
+        if (e.kind === 'fixedDamage' && e.element) els.add(e.element);
+      }
+    }
+    expect(els).toEqual(new Set(['fire', 'earth', 'water', 'wind', 'void']));
+  });
+
+  it('天啓 (void) が実戦でダメージを通す (空属性の初使用)', () => {
+    const s = startBattle('sage', 12, 18, '賢', 2, 3, 0);
+    const idx = s.playerSkills.findIndex((sk) => sk.name === '天啓');
+    const before = s.monster.hp;
+    const next: BattleState = resolveTurn(s, 'skill', undefined, idx);
+    expect(next.monster.hp).toBeLessThan(before);
+    expect(next.lastEvents.some((e) => e.text.includes('天啓'))).toBe(true);
+  });
+});
+
 describe('聖騎士 確定キット (#456)', () => {
   it('レベルで聖光の癒し〜浄化を習得', () => {
     expect(skillsForJob('paladin', 3).map((s) => s.name)).toContain('聖光の癒し');

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -234,7 +234,7 @@ const LEARNED_SKILLS: Partial<Record<Archetype, readonly LearnedSkill[]>> = {
   miko: [{ kind: 'heal', name: '神楽の癒し', learnAt: 3 }],
   // paladin は確定キット (#456) で聖光の癒しを持つため LEARNED は撤去 (JOB_KITS が優先)。
   seer: [{ kind: 'heal', name: '癒しの予言', learnAt: 4 }],
-  sage: [{ kind: 'heal', name: '天啓の癒し', learnAt: 5 }],
+  // sage は確定キット (#456) で賢者の癒しを持つため LEARNED は撤去 (JOB_KITS が優先)。
   bard: [{ kind: 'heal', name: '癒しの旋律', learnAt: 4 }],
   // mage は確定キット (#456/§12) で「自己回復を持たない脆い int 大砲」に。旧 heal (回生の術式) は
   // JOB_KITS.mage が skillsForJob を早期 return するため到達不能 = 意図的に撤去 (レビュー ★★)。
@@ -300,6 +300,17 @@ const JOB_KITS: Partial<Record<Archetype, readonly KitSkill[]>> = {
     { id: 'performer-slack', name: 'サボる', learnAt: 5 },
     { id: 'performer-gamble', name: 'いちかばちか', learnAt: 12 },
     { id: 'performer-acrobat', name: '曲芸乱舞', learnAt: 15 },
+  ],
+  // 賢者: 最高 int・全5属性・支援。イディオット/知恵の加護/星辰以外の全体技/慧眼(P) は後続。
+  sage: [
+    { id: 'sage-flame', name: '火炎', learnAt: 3 },
+    { id: 'sage-decode', name: '解式', learnAt: 5 },
+    { id: 'sage-stone', name: '石射', learnAt: 6 },
+    { id: 'sage-frost', name: '氷結', learnAt: 8 },
+    { id: 'sage-gale', name: '疾風', learnAt: 10 },
+    { id: 'sage-revelation', name: '天啓', learnAt: 12 },
+    { id: 'sage-heal', name: '賢者の癒し', learnAt: 16 },
+    { id: 'sage-starlight', name: '星辰の大魔法', learnAt: 22 },
   ],
 };
 

--- a/packages/core/src/skills.ts
+++ b/packages/core/src/skills.ts
@@ -470,6 +470,25 @@ export const SKILLS: Record<string, SkillDef> = {
   },
   // 曲芸乱舞 Lv15: agi 基準 3 連撃
   'performer-acrobat': { id: 'performer-acrobat', effects: [{ kind: 'damage', stat: 'agi', power: 0.6, hits: 3 }] },
+
+  // ─── 賢者 確定キット (#456 / docs/25 §12。最高 int・全5属性・支援) ───
+  // 数値は sim 調整前提の暫定値。全属性魔法 (火水地風空) を必中・def無視で撃つ。イディオット(intDown)/
+  // 知恵の加護(intUp)/星辰以外の全体技/慧眼(P) は要 新語彙のため後続。属性の輪 (§1) をフル活用。
+  'sage-flame': { id: 'sage-flame', effects: [{ kind: 'fixedDamage', min: 5, max: 10, intBonus: 0.25, element: 'fire' }] }, // 火炎 Lv3
+  'sage-decode': { id: 'sage-decode', effects: [{ kind: 'fixedDamage', min: 6, max: 11, intBonus: 0.25 }] }, // 解式 Lv5 (無属性)
+  'sage-stone': { id: 'sage-stone', effects: [{ kind: 'fixedDamage', min: 7, max: 12, intBonus: 0.25, element: 'earth' }] }, // 石射 Lv6
+  // 氷結 Lv8: 水 + 素早さ↓
+  'sage-frost': {
+    id: 'sage-frost',
+    effects: [
+      { kind: 'fixedDamage', min: 8, max: 14, intBonus: 0.3, element: 'water' },
+      { kind: 'status', status: 'agiDown', target: 'enemy', turns: 3 },
+    ],
+  },
+  'sage-gale': { id: 'sage-gale', effects: [{ kind: 'fixedDamage', min: 10, max: 16, intBonus: 0.3, element: 'wind' }] }, // 疾風 Lv10
+  'sage-revelation': { id: 'sage-revelation', effects: [{ kind: 'fixedDamage', min: 12, max: 18, intBonus: 0.3, element: 'void' }] }, // 天啓 Lv12 (空)
+  'sage-heal': { id: 'sage-heal', effects: [{ kind: 'heal', ratio: 0.35 }] }, // 賢者の癒し Lv16
+  'sage-starlight': { id: 'sage-starlight', effects: [{ kind: 'fixedDamage', min: 25, max: 40, intBonus: 0.4, element: 'void' }] }, // 星辰の大魔法 Lv22
 };
 
 /** そのとくぎが「HP 回復のみ」か (UI が満タン時に無効化するかの判定に使う)。kind 文字列でなく


### PR DESCRIPTION
## 目的

戦闘刷新 (docs/25 §12) の**ジョブ確定キット・第4バッチ**。単体戦闘で成立する **賢者** (最高 int・
全5属性・支援) を**既存語彙のみ**で追加 (#456)。**属性の輪 (§1) をフル活用**する初のキット。

## 変更

### 賢者 (最高 int・全5属性・支援)
火炎3(fire)/解式5(無属性)/石射6(earth)/氷結8(water+agiDown)/疾風10(wind)/天啓12(void)/賢者の癒し16(heal)/星辰の大魔法22(void 大砲)。全て fixedDamage (必中・def無視・intBonus=賢者の最高 int を活かす) + heal。**wind/void を初めて使うキット**で属性相性 (地水火風の輪 + 空1.2) がフル活用される。

deferred: イディオット(intDown)/知恵の加護(intUp)/星辰以外の全体技/慧眼(P) は要 新語彙のため後続。旧 LEARNED_SKILLS.sage(heal) はキット優先で撤去。

### foundation churn
**新プリミティブ/状態の追加なし** (fixedDamage + heal + agiDown status の再利用のみ)。

## 検証
- core 413 緑 (全5属性 fire/water/earth/wind/void の網羅・void の実戦ダメージ・レベル習得を検証) /
  web build / typecheck (web+edge+core) 緑。既存ソロ resolveTurn 無変更。**数値は sim 調整前提の暫定値**。
- キット⇄ステ整合: 賢者=最高 int → 全技 intBonus で int を活かす (前バッチの ★★★ 教訓を踏襲)。
- キット化 7/16 職。

## Review

§1.5 レビュー (実装 + 体験/バランス。純データ再利用バッチのため設計次元は前バッチから不変)。**両者 ★★★ なし・マージ可**。

- **実装**: 指摘ゼロ。wind/void の初使用・多段効果 (氷結 agiDown)・skillsForJob フォールスルー・heal 一意供給を確認、413テスト緑・回帰なし。
- **体験/バランス**: **キット⇄ステ噛み合い良好** (sage int40=最強ステ、全技 intBonus。前2バッチの ★★★ 教訓クリア)。★★ 2件はいずれも設計記録/issue 引き継ぎで対応:
  - **賢者の癒し Lv16** (旧 LEARNED heal は Lv5 で早期回復喪失、seer と非対称)。**§12 が賢者の癒し=Lv16 と規定**しているため意図的 (seer 非対称は seer 未キット化の混在期アーティファクト、seer キット化時に §12 どおり移動)。sim で回復タイミング再評価。
  - **属性の輪が monster element 未設定で常に ×1** → 賢者の目玉 (全5属性撃ち分け) が #455 まで無意味 → **#455 にコメント引き継ぎ**。★ (賢者 vs 魔法使い差別化) も #455 後に再評価。

CI: web-ci pass / 本番 build pass。core 413緑 / web build / typecheck (web+edge+core) 緑。
