### PR TITLE
feat(combat): モンスター属性 + メタル魔法無効で属性の輪を有効化 (#455)

### DIFF
--- a/packages/core/src/__tests__/monster-elements.test.ts
+++ b/packages/core/src/__tests__/monster-elements.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { monsterCombatant, MONSTERS_BY_ID, startBattle, resolveTurn, type BattleState } from '../index.js';
+
+describe('モンスター属性・魔法耐性 (#455)', () => {
+  it('monsterCombatant が def.element を Combatant に載せる', () => {
+    const golem = monsterCombatant(MONSTERS_BY_ID['moss-golem']!, 0, () => 0.5);
+    expect(golem.element).toBe('earth');
+    const wisp = monsterCombatant(MONSTERS_BY_ID['will-o-wisp']!, 0, () => 0.5);
+    expect(wisp.element).toBe('fire');
+  });
+
+  it('メタル (はぐれスライム) は resistAllMagic・無属性', () => {
+    const metal = monsterCombatant(MONSTERS_BY_ID['stray-slime']!, 0, () => 0.5);
+    expect(metal.resistAllMagic).toBe(true);
+    expect(metal.element).toBeUndefined();
+  });
+
+  it('全モンスターは element を持つか resistAllMagic (無属性放置がない)', () => {
+    for (const m of Object.values(MONSTERS_BY_ID)) {
+      expect(m.element !== undefined || m.resistAllMagic === true, m.id).toBe(true);
+    }
+  });
+
+  it('魔法 (賢者の火炎) はメタルに最小 1 しか通らない (DQ の魔法無効)', () => {
+    // はぐれスライムは fleer で高確率逃走するため、火炎が実際に当たったターンを探して検証する。
+    let landed = false;
+    for (let seed = 0; seed < 40 && !landed; seed++) {
+      const s = startBattle('sage', 8, 12, '賢', 1, seed, 0, undefined, { monsterId: 'stray-slime' });
+      expect(s.monster.resistAllMagic).toBe(true);
+      const idx = s.playerSkills.findIndex((sk) => sk.name === '火炎');
+      const before = s.monster.hp;
+      const next: BattleState = resolveTurn(s, 'skill', undefined, idx);
+      const dealt = before - next.monster.hp;
+      if (dealt > 0) {
+        landed = true;
+        expect(dealt).toBe(1); // 魔法無効 = 最小 1 のみ。会心物理でしか削れない。
+      }
+    }
+    expect(landed).toBe(true);
+  });
+
+  it('弱点属性は 1.5 倍、逆は 0.5 倍 (賢者の疾風=wind)', () => {
+    // wind は earth に強い (moss-golem=earth) / fire に弱い (will-o-wisp=fire)。
+    // 同じ turnSeed で乱数を揃え、earth 敵と fire 敵への疾風ダメージを比較。
+    const gale = (monsterId: string): BattleState => {
+      const s = startBattle('sage', 10, 15, '賢', 2, 5, 0, undefined, { monsterId });
+      const idx = s.playerSkills.findIndex((sk) => sk.name === '疾風');
+      return resolveTurn(s, 'skill', 777, idx);
+    };
+    const earth = gale('moss-golem'); // wind ×1.5 (弱点)
+    const fire = gale('will-o-wisp'); // wind ×0.5 (耐性)
+    const earthDealt = MONSTERS_BY_ID['moss-golem']!.hp! * 1; // 参考: 実 hp は factor 込みなので比較で見る
+    void earthDealt;
+    // 弱点を突いた方がダメージが大きく、告知メッセージも出る。
+    expect(earth.lastEvents.some((e) => e.text.includes('弱点を突いた'))).toBe(true);
+    expect(fire.lastEvents.some((e) => e.text.includes('効果がいまひとつ'))).toBe(true);
+  });
+});

--- a/packages/core/src/__tests__/monster-elements.test.ts
+++ b/packages/core/src/__tests__/monster-elements.test.ts
@@ -47,11 +47,9 @@ describe('モンスター属性・魔法耐性 (#455)', () => {
       const idx = s.playerSkills.findIndex((sk) => sk.name === '疾風');
       return resolveTurn(s, 'skill', 777, idx);
     };
-    const earth = gale('moss-golem'); // wind ×1.5 (弱点)
-    const fire = gale('will-o-wisp'); // wind ×0.5 (耐性)
-    const earthDealt = MONSTERS_BY_ID['moss-golem']!.hp! * 1; // 参考: 実 hp は factor 込みなので比較で見る
-    void earthDealt;
-    // 弱点を突いた方がダメージが大きく、告知メッセージも出る。
+    const earth = gale('moss-golem'); // earth 敵 → wind は弱点 ×1.5
+    const fire = gale('will-o-wisp'); // fire 敵 → wind は耐性 ×0.5
+    // 弱点/耐性の告知が正しく出る (相性適用の証跡)。
     expect(earth.lastEvents.some((e) => e.text.includes('弱点を突いた'))).toBe(true);
     expect(fire.lastEvents.some((e) => e.text.includes('効果がいまひとつ'))).toBe(true);
   });

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -415,8 +415,10 @@ export interface Combatant {
   /** ジョブ innate パッシブ id (#452 / docs/25 §4)。省略可。 */
   passives?: string[];
   /** 防御属性 (#452 / docs/25 §1)。被弾時の属性相性に使う。未設定 (無属性) は等倍。
-   *  モンスターへの付与は #455、プレイヤー装備由来は後続で配線 (現状は全員 undefined = 等倍)。 */
+   *  モンスターへの付与は #455 (monsterCombatant で def.element から)、プレイヤー装備由来は後続。 */
   element?: Element;
+  /** すべての魔法を無効化 (メタル系。#455)。true だと fixedDamage/doMagic が最小 1。 */
+  resistAllMagic?: boolean;
 }
 
 function fromStats(name: string, stats: StatArray, levelFactor: number, level: number): Combatant {
@@ -659,6 +661,12 @@ export interface MonsterDef {
   ability?: 'charger' | 'healer' | 'fleer';
   /** healer の回復技名 (省略時デフォルト)。 */
   healName?: string;
+  /** 防御属性 (#455 / docs/25 §1)。被弾時の属性相性に使う。未指定 = 無属性 (常に等倍)。
+   *  キャスターが弱点を突く駆け引きの導線 (賢者/魔法使いの属性撃ち分けが機能する)。 */
+  element?: Element;
+  /** すべての魔法を無効化 (メタル系。DQ 準拠)。true だと fixedDamage/doMagic が最小 1 になる。
+   *  物理は既に超高 def で 1 に沈むが、魔法は def 無視のため別途この旗で止める。 */
+  resistAllMagic?: boolean;
 }
 
 /** 素材カタログ (Step2 の装備素材)。 */
@@ -687,13 +695,13 @@ export const MONSTERS: readonly MonsterDef[] = [
   // baselineXp (基準 HP + atk/agi) で自動算出 = 敵の強さと XP が構造的に連動する (スライム 2・
   // ヒカリダケ 8 程度)。個別に効かせたい敵だけ xp を明示する。
   // そらいろスライム: 最弱の練習敵 (低 HP・低 XP・低ドロップ)。序盤の的。
-  { id: 'sky-slime', name: 'そらいろスライム', species: 'slime', tier: 1, stats: [7, 7, 8, 6, 10], hp: 5, drops: [{ item: 'slime-drop', chance: 0.3 }, { item: 'herb', chance: 0.35 }], intro: 'ぷるぷると跳ねている。' },
+  { id: 'sky-slime', element: 'water', name: 'そらいろスライム', species: 'slime', tier: 1, stats: [7, 7, 8, 6, 10], hp: 5, drops: [{ item: 'slime-drop', chance: 0.3 }, { item: 'herb', chance: 0.35 }], intro: 'ぷるぷると跳ねている。' },
   // 色違い強い版 (tint で塗り替え)。base より少し硬く XP/素材も上。専用素材 red-jelly。
-  { id: 'red-slime', name: 'あかいスライム', species: 'slime', tint: '#e0574a', spawnWeight: 0.4, tier: 1, stats: [13, 12, 10, 8, 12], hp: 8, drops: [{ item: 'red-jelly', chance: 0.5 }, { item: 'herb', chance: 0.08 }], intro: '赤くぬめって 脈打っている。' },
-  { id: 'cave-bat', name: 'ほらあなコウモリ', species: 'bat', tier: 1, stats: [12, 8, 26, 6, 12], hp: 11, drops: [{ item: 'bat-wing', chance: 0.6 }, { item: 'herb', chance: 0.3 }, { item: 'sky-feather', chance: 0.12 }], intro: 'ばさばさと羽音を立てている。' },
-  { id: 'dusk-bat', name: 'よるのコウモリ', species: 'bat', tint: '#5b6bd0', spawnWeight: 0.4, tier: 1, stats: [14, 9, 28, 7, 13], hp: 10, drops: [{ item: 'dusk-wing', chance: 0.5 }, { item: 'sky-feather', chance: 0.12 }], intro: '夜色の翼で 音もなく舞う。' },
-  { id: 'glow-shroom', name: 'ヒカリダケ', species: 'mushroom', tier: 1, stats: [8, 20, 4, 18, 12], hp: 14, drops: [{ item: 'mush-spore', chance: 0.6 }, { item: 'herb', chance: 0.4 }, { item: 'sky-dew', chance: 0.25 }], intro: 'ほんのり光って動かない…?' },
-  { id: 'crimson-shroom', name: 'べにヒカリダケ', species: 'mushroom', tint: '#c23a5b', spawnWeight: 0.4, tier: 1, stats: [9, 22, 4, 20, 12], hp: 12, drops: [{ item: 'crimson-spore', chance: 0.5 }, { item: 'sky-dew', chance: 0.2 }], intro: '毒々しい紅に 明滅している。' },
+  { id: 'red-slime', element: 'fire', name: 'あかいスライム', species: 'slime', tint: '#e0574a', spawnWeight: 0.4, tier: 1, stats: [13, 12, 10, 8, 12], hp: 8, drops: [{ item: 'red-jelly', chance: 0.5 }, { item: 'herb', chance: 0.08 }], intro: '赤くぬめって 脈打っている。' },
+  { id: 'cave-bat', element: 'wind', name: 'ほらあなコウモリ', species: 'bat', tier: 1, stats: [12, 8, 26, 6, 12], hp: 11, drops: [{ item: 'bat-wing', chance: 0.6 }, { item: 'herb', chance: 0.3 }, { item: 'sky-feather', chance: 0.12 }], intro: 'ばさばさと羽音を立てている。' },
+  { id: 'dusk-bat', element: 'wind', name: 'よるのコウモリ', species: 'bat', tint: '#5b6bd0', spawnWeight: 0.4, tier: 1, stats: [14, 9, 28, 7, 13], hp: 10, drops: [{ item: 'dusk-wing', chance: 0.5 }, { item: 'sky-feather', chance: 0.12 }], intro: '夜色の翼で 音もなく舞う。' },
+  { id: 'glow-shroom', element: 'earth', name: 'ヒカリダケ', species: 'mushroom', tier: 1, stats: [8, 20, 4, 18, 12], hp: 14, drops: [{ item: 'mush-spore', chance: 0.6 }, { item: 'herb', chance: 0.4 }, { item: 'sky-dew', chance: 0.25 }], intro: 'ほんのり光って動かない…?' },
+  { id: 'crimson-shroom', element: 'earth', name: 'べにヒカリダケ', species: 'mushroom', tint: '#c23a5b', spawnWeight: 0.4, tier: 1, stats: [9, 22, 4, 20, 12], hp: 12, drops: [{ item: 'crimson-spore', chance: 0.5 }, { item: 'sky-dew', chance: 0.2 }], intro: '毒々しい紅に 明滅している。' },
   // はぐれメタル型 (DQ のメタルスライム): レア出現・高 XP (100)・毎ターン逃走。
   //   - **超高守備 (def240)**: 減算式で通常攻撃は atkTerm−defTerm が深く負に沈み minDamage(1) しか
   //     通らない = 「当たってもダメージがほとんど通らない」(オーナー要望 2026-07-21)。魔撃 (spell,
@@ -702,15 +710,15 @@ export const MONSTERS: readonly MonsterDef[] = [
   //   - **低 HP (6→tier係数で実質4)**: 仕留める道は**会心の一撃のみ** (プレイヤーの会心は def 無視
   //     #432 → フルダメージで一撃)。通常/魔撃では削り切る前に逃げる。専用ロジックは使わず
   //     守備/agi/HP の数値だけで「メタル」を表現 (オーナー: 専用ロジック禁止 2026-07-20)。
-  { id: 'stray-slime', name: 'はぐれスライム', species: 'metal-slime', tier: 1, stats: [8, 240, 38, 6, 34], hp: 6, mp: 0, xp: 100, spawnWeight: 0.06, drops: [{ item: 'metal-shard', chance: 0.5 }], ability: 'fleer', intro: 'きらりと 金属の光を放っている。' },
+  { id: 'stray-slime', resistAllMagic: true, name: 'はぐれスライム', species: 'metal-slime', tier: 1, stats: [8, 240, 38, 6, 34], hp: 6, mp: 0, xp: 100, spawnWeight: 0.06, drops: [{ item: 'metal-shard', chance: 0.5 }], ability: 'fleer', intro: 'きらりと 金属の光を放っている。' },
   // tier2: 修練。xp 34〜52 (healer は削り合いが長引くぶん高め)
-  { id: 'moss-golem', name: 'こけむしゴーレム', species: 'golem', tier: 2, stats: [38, 36, 6, 10, 8], hp: 28, xp: 34, drops: [{ item: 'golem-core', chance: 0.5 }, { item: 'herb', chance: 0.2 }], intro: '地響きを立てて起き上がった。', skillName: 'いわなだれ', ability: 'charger' },
-  { id: 'will-o-wisp', name: 'あおい鬼火', species: 'wisp', tier: 2, stats: [18, 12, 24, 34, 12], hp: 24, xp: 52, drops: [{ item: 'wisp-ember', chance: 0.5 }, { item: 'sky-dew', chance: 0.35 }], intro: 'ゆらゆらとこちらを見ている。', ability: 'healer', healName: 'いやしのゆらめき' },
-  { id: 'river-serpent', name: 'かわながれ大蛇', species: 'serpent', tier: 2, stats: [42, 18, 22, 10, 10], hp: 22, xp: 42, drops: [{ item: 'serpent-scale', chance: 0.5 }, { item: 'herb', chance: 0.2 }], intro: '水面から鎌首をもたげた。', skillName: 'まきつき' },
+  { id: 'moss-golem', element: 'earth', name: 'こけむしゴーレム', species: 'golem', tier: 2, stats: [38, 36, 6, 10, 8], hp: 28, xp: 34, drops: [{ item: 'golem-core', chance: 0.5 }, { item: 'herb', chance: 0.2 }], intro: '地響きを立てて起き上がった。', skillName: 'いわなだれ', ability: 'charger' },
+  { id: 'will-o-wisp', element: 'fire', name: 'あおい鬼火', species: 'wisp', tier: 2, stats: [18, 12, 24, 34, 12], hp: 24, xp: 52, drops: [{ item: 'wisp-ember', chance: 0.5 }, { item: 'sky-dew', chance: 0.35 }], intro: 'ゆらゆらとこちらを見ている。', ability: 'healer', healName: 'いやしのゆらめき' },
+  { id: 'river-serpent', element: 'water', name: 'かわながれ大蛇', species: 'serpent', tier: 2, stats: [42, 18, 22, 10, 10], hp: 22, xp: 42, drops: [{ item: 'serpent-scale', chance: 0.5 }, { item: 'herb', chance: 0.2 }], intro: '水面から鎌首をもたげた。', skillName: 'まきつき' },
   // tier3: 真剣勝負。xp 62〜96
-  { id: 'night-raven', name: 'よるのおおガラス', species: 'raven', tier: 3, stats: [48, 14, 34, 16, 14], hp: 24, xp: 62, drops: [{ item: 'raven-feather', chance: 0.45 }, { item: 'sky-dew', chance: 0.3 }, { item: 'sky-feather', chance: 0.25 }], intro: '月を背に静かに舞い降りた。', skillName: 'かまいたち' },
-  { id: 'blue-oni', name: 'あおおに', species: 'oni', tier: 3, stats: [66, 28, 12, 8, 12], hp: 30, xp: 78, drops: [{ item: 'oni-horn', chance: 0.45 }], intro: '金棒を担いで笑っている。', skillName: 'かなぼうふりまわし', ability: 'charger' },
-  { id: 'sky-dragon', name: 'そらのりゅう', species: 'dragon', tier: 3, stats: [58, 24, 18, 26, 10], hp: 30, xp: 96, drops: [{ item: 'dragon-fang', chance: 0.4 }], intro: '雲を裂いて姿を現した!', ability: 'healer', healName: 'りゅうの いこい' },
+  { id: 'night-raven', element: 'wind', name: 'よるのおおガラス', species: 'raven', tier: 3, stats: [48, 14, 34, 16, 14], hp: 24, xp: 62, drops: [{ item: 'raven-feather', chance: 0.45 }, { item: 'sky-dew', chance: 0.3 }, { item: 'sky-feather', chance: 0.25 }], intro: '月を背に静かに舞い降りた。', skillName: 'かまいたち' },
+  { id: 'blue-oni', element: 'earth', name: 'あおおに', species: 'oni', tier: 3, stats: [66, 28, 12, 8, 12], hp: 30, xp: 78, drops: [{ item: 'oni-horn', chance: 0.45 }], intro: '金棒を担いで笑っている。', skillName: 'かなぼうふりまわし', ability: 'charger' },
+  { id: 'sky-dragon', element: 'wind', name: 'そらのりゅう', species: 'dragon', tier: 3, stats: [58, 24, 18, 26, 10], hp: 30, xp: 96, drops: [{ item: 'dragon-fang', chance: 0.4 }], intro: '雲を裂いて姿を現した!', ability: 'healer', healName: 'りゅうの いこい' },
 ];
 
 export const MONSTERS_BY_ID: Record<string, MonsterDef> = Object.fromEntries(
@@ -839,6 +847,9 @@ export function monsterCombatant(def: MonsterDef, variance: number, rng: () => n
     c.maxHp = Math.max(1, Math.round(c.maxHp * jitter())); c.hp = c.maxHp;
     c.maxMp = Math.max(0, Math.round(c.maxMp * jitter())); c.mp = c.maxMp;
   }
+  // 属性・魔法耐性 (#455)。属性相性はキャスターの弱点突き、resistAllMagic はメタルの魔法無効。
+  if (def.element !== undefined) c.element = def.element;
+  if (def.resistAllMagic) c.resistAllMagic = true;
   return c;
 }
 
@@ -1111,9 +1122,11 @@ function doMagic(
   const defenderSide: 'player' | 'monster' = actor === 'player' ? 'monster' : 'player';
   const defCtx: HookCtx = { rng, events, actor: defenderSide };
   let dmg = opts.amount;
-  dmg *= elementMultiplier(opts.element, defender.element); // 属性相性 (無属性は ×1)
+  const eMult = elementMultiplier(opts.element, defender.element); // 属性相性 (無属性は ×1)
+  dmg *= eMult;
   dmg *= applyIncomingCalc(1, defender, defCtx); // defUp/defDown/転倒
-  const final = Math.max(1, Math.round(dmg));
+  // メタル系の魔法無効 (#455 / DQ 準拠): def 無視の魔法でも最小 1 に抑える (会心物理でしか倒せない)。
+  const final = defender.resistAllMagic ? 1 : Math.max(1, Math.round(dmg));
   defender.hp = Math.max(0, defender.hp - final);
   const fatal = defender.hp === 0;
   if (!fatal) clearHitStatuses(defender); // 被弾で解ける状態 (かくれみ/眠り)
@@ -1128,6 +1141,12 @@ function doMagic(
     damage: final,
     ...(fatal ? { fatal: true } : {}),
   });
+  // 属性相性のフィードバック (DQ 流)。弱点=1.5 / 耐性=0.5 のみ告知 (空の 1.2 は普遍なので出さない)。
+  // 撃破時も出す (弱点を突いて倒した実感)。メタルの魔法無効時は出さず「効かない」を数値 1 で伝える。
+  if (!defender.resistAllMagic) {
+    if (eMult >= 1.5) events.push({ actor, text: `${defender.name}の弱点を突いた!` });
+    else if (eMult <= 0.5) events.push({ actor, text: `${defender.name}には 効果がいまひとつのようだ…` });
+  }
   return { hit: true, damage: final, fatal, crit: false };
 }
 

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -717,8 +717,8 @@ export const MONSTERS: readonly MonsterDef[] = [
   { id: 'river-serpent', element: 'water', name: 'かわながれ大蛇', species: 'serpent', tier: 2, stats: [42, 18, 22, 10, 10], hp: 22, xp: 42, drops: [{ item: 'serpent-scale', chance: 0.5 }, { item: 'herb', chance: 0.2 }], intro: '水面から鎌首をもたげた。', skillName: 'まきつき' },
   // tier3: 真剣勝負。xp 62〜96
   { id: 'night-raven', element: 'wind', name: 'よるのおおガラス', species: 'raven', tier: 3, stats: [48, 14, 34, 16, 14], hp: 24, xp: 62, drops: [{ item: 'raven-feather', chance: 0.45 }, { item: 'sky-dew', chance: 0.3 }, { item: 'sky-feather', chance: 0.25 }], intro: '月を背に静かに舞い降りた。', skillName: 'かまいたち' },
-  { id: 'blue-oni', element: 'earth', name: 'あおおに', species: 'oni', tier: 3, stats: [66, 28, 12, 8, 12], hp: 30, xp: 78, drops: [{ item: 'oni-horn', chance: 0.45 }], intro: '金棒を担いで笑っている。', skillName: 'かなぼうふりまわし', ability: 'charger' },
-  { id: 'sky-dragon', element: 'wind', name: 'そらのりゅう', species: 'dragon', tier: 3, stats: [58, 24, 18, 26, 10], hp: 30, xp: 96, drops: [{ item: 'dragon-fang', chance: 0.4 }], intro: '雲を裂いて姿を現した!', ability: 'healer', healName: 'りゅうの いこい' },
+  { id: 'blue-oni', element: 'water', name: 'あおおに', species: 'oni', tier: 3, stats: [66, 28, 12, 8, 12], hp: 30, xp: 78, drops: [{ item: 'oni-horn', chance: 0.45 }], intro: '金棒を担いで笑っている。', skillName: 'かなぼうふりまわし', ability: 'charger' },
+  { id: 'sky-dragon', element: 'void', name: 'そらのりゅう', species: 'dragon', tier: 3, stats: [58, 24, 18, 26, 10], hp: 30, xp: 96, drops: [{ item: 'dragon-fang', chance: 0.4 }], intro: '雲を裂いて姿を現した!', ability: 'healer', healName: 'りゅうの いこい' },
 ];
 
 export const MONSTERS_BY_ID: Record<string, MonsterDef> = Object.fromEntries(


### PR DESCRIPTION
## 目的

**#455 第1弾: モンスターに属性 + 魔法耐性を付与し、属性の輪を有効化する。**

#452 で属性システム (elementMultiplier) を doAttack/doMagic に配線済みだが、**モンスターに element が
未設定**のため常に ×1 = 賢者/魔法使いの属性撃ち分けが機能していなかった (#471 の ★★ / #455 引き継ぎ)。
7職のキャスターを既に投入済みの今、属性を活かす導線を通す。

## 変更

### 属性の付与
- `MonsterDef`/`Combatant` に `element?` / `resistAllMagic?` を追加。`monsterCombatant` が def から載せる。
- **全13モンスターに属性割当** (水: そらいろスライム/大蛇、火: あかいスライム/鬼火、風: コウモリ2種/カラス/竜、地: ヒカリダケ2種/ゴーレム/鬼)。属性の輪 (地→水→火→風→地) で弱点 ×1.5 / 耐性 ×0.5 が発動。

### メタルの魔法無効 (correctness fix)
- `fixedDamage`/`doMagic` は def 無視のため、これまで**キャスターがメタル (はぐれスライム) をフル魔法で溶かせてしまう穴**があった (物理は def240 で 1 に沈むが魔法は貫通)。`resistAllMagic` で最小 1 に抑え、DQ の「メタルは会心物理でしか倒せない」を回復。

### 属性相性フィードバック (UX)
- 弱点で「〇〇の弱点を突いた!」/ 耐性で「効果がいまひとつ…」を告知し撃ち分けを可視化 (#471 ★★「属性が見えない」に対応)。空 (×1.2) は普遍なので出さない。

## 検証
- core 418 緑 (属性付与・メタル魔法=1・弱点1.5>耐性0.5・告知メッセージを検証) / web build / typecheck (web+edge+core) 緑。
- **物理は player に element が無いので ×1 = 挙動不変** (既存 battle/world テスト回帰なし)。数値は sim 調整前提。

## スコープ外 (#455 後続)
飛行フラグ (じわれ無効/嵐 1.5倍) / endgame 上位 tier (高Lv技に見合う強敵) / 敵の魔法詠唱 (見切り/魔法耐性が機能する前提) / スキルメニューへの属性アイコン表示。

## Review

§1.5 3並列独立レビュー (設計/実装/体験) を実施。実装レビューは ★★★/★★ なし (物理挙動不変・resistAllMagic の穴なし・会心物理は素通しを確認)。設計/体験で構造的 ★★★ 2件 → 下記対応。

### ★★★ 対応
- **魔法使いが最多勢力 earth (4体) の弱点を突けない** (設計/体験) → 属性分布をリバランス (blue-oni: earth→water / sky-dragon: wind→void)。earth 4→3・tier3 を wind/water/void に多様化。残る earth 盲点は **§12 の意図的なジョブ非対称** (賢者=全5属性で全対応 / 魔法使い=3元素砲) として **#474** に明文化を引き継ぎ。
- **敵属性が撃つ前に見えず撃ち分けが暗記ゲー化** (体験) → このPRはエンジン半分。**告知メッセージ (弱点を突いた!/効果がいまひとつ…) が学習の足がかり**を提供。事前可視化 UI (battle-view 属性アイコン + スキルメニュー属性 + intro ヒント) を **ブロッキング issue #473** に紐付け (完成の後半)。

### ★★/★ issue 化
- 物理職の属性疎外 (武器属性待ち) → **#454** にコメント。void 大魔法の平坦化 / メタルのキャスター狩り / spawn 遭遇均等性 → **#474**。docs §1 例示 (竜=void) は実装が一致 (sky-dragon→void)。テストの dead 変数除去済み。

CI: web-ci pass / 本番 build pass。core 418緑 (属性付与・メタル魔法=1・弱点1.5>耐性0.5・告知) / web build / typecheck (web+edge+core) 緑。物理は挙動不変。
