### PR TITLE
feat(combat): ジョブキット第5バッチ — 予言者 + doomMark (破滅の予言) (#456)

### DIFF
--- a/packages/core/src/__tests__/job-kits.test.ts
+++ b/packages/core/src/__tests__/job-kits.test.ts
@@ -160,11 +160,14 @@ describe('予言者 確定キット (#456)', () => {
     for (const sk of skillsForJob('seer', 30)) expect(SKILLS[sk.kind], sk.kind).toBeDefined();
   });
 
-  it('破滅の予言は doomMark を敵に付与する', () => {
+  it('破滅の予言は doomMark を敵に付与し、炸裂は int 連動 (基礎15超)', () => {
     const s = startBattle('seer', 12, 18, '予', 3, 5, 0);
     const idx = s.playerSkills.findIndex((sk) => sk.name === '破滅の予言');
     const next: BattleState = resolveTurn(s, 'skill', undefined, idx);
-    expect(next.monster.statuses?.some((st) => st.id === 'doomMark')).toBe(true);
+    const doom = next.monster.statuses?.find((st) => st.id === 'doomMark');
+    expect(doom).toBeDefined();
+    // 炸裂ダメージ = 15 + int×0.3。seer は int 最高なので基礎 15 を上回る。
+    expect(doom!.magnitude).toBeGreaterThan(15);
     expect(next.lastEvents.some((e) => e.text.includes('破滅の刻印'))).toBe(true);
   });
 });

--- a/packages/core/src/__tests__/job-kits.test.ts
+++ b/packages/core/src/__tests__/job-kits.test.ts
@@ -150,6 +150,25 @@ describe('詩人 確定キット (#456)', () => {
   });
 });
 
+describe('予言者 確定キット (#456)', () => {
+  it('レベルで未来スイッチ〜蠱毒の王を習得', () => {
+    expect(skillsForJob('seer', 3).map((s) => s.name)).toContain('未来スイッチ');
+    expect(skillsForJob('seer', 20).map((s) => s.name)).toEqual(['未来スイッチ', '雷の予言', '毒の予言', '破滅の予言', '蠱毒の王']);
+  });
+
+  it('キット技はすべて SKILLS に定義がある', () => {
+    for (const sk of skillsForJob('seer', 30)) expect(SKILLS[sk.kind], sk.kind).toBeDefined();
+  });
+
+  it('破滅の予言は doomMark を敵に付与する', () => {
+    const s = startBattle('seer', 12, 18, '予', 3, 5, 0);
+    const idx = s.playerSkills.findIndex((sk) => sk.name === '破滅の予言');
+    const next: BattleState = resolveTurn(s, 'skill', undefined, idx);
+    expect(next.monster.statuses?.some((st) => st.id === 'doomMark')).toBe(true);
+    expect(next.lastEvents.some((e) => e.text.includes('破滅の刻印'))).toBe(true);
+  });
+});
+
 describe('賢者 確定キット (#456)', () => {
   it('レベルで火炎〜星辰の大魔法を習得 (全5属性)', () => {
     expect(skillsForJob('sage', 3).map((s) => s.name)).toContain('火炎');

--- a/packages/core/src/__tests__/statuses.test.ts
+++ b/packages/core/src/__tests__/statuses.test.ts
@@ -166,6 +166,17 @@ describe('状態異常エンジン (#452)', () => {
     expect(target.statuses![0]!.turns).toBe(1);
   });
 
+  it('doomMark は restack ignore: 再付与でカウントダウンが巻き戻らない', () => {
+    const target = c();
+    applyStatus(target, st('doomMark', 3, 25));
+    tickStatuses(target, ctx()); // fresh 畳み (turns 3)
+    tickStatuses(target, ctx()); // turns 3→2
+    const before = target.statuses![0]!.turns;
+    applyStatus(target, st('doomMark', 3, 99)); // 再付与 → ignore で無視
+    expect(target.statuses![0]!.turns).toBe(before); // 巻き戻らない
+    expect(target.statuses![0]!.magnitude).toBe(25); // 上書きされない
+  });
+
   it('doomMark: カウントダウンの末に magnitude の大ダメージが炸裂', () => {
     const target = c({ hp: 100 });
     applyStatus(target, st('doomMark', 3, 25));

--- a/packages/core/src/__tests__/statuses.test.ts
+++ b/packages/core/src/__tests__/statuses.test.ts
@@ -166,6 +166,22 @@ describe('状態異常エンジン (#452)', () => {
     expect(target.statuses![0]!.turns).toBe(1);
   });
 
+  it('doomMark: カウントダウンの末に magnitude の大ダメージが炸裂', () => {
+    const target = c({ hp: 100 });
+    applyStatus(target, st('doomMark', 3, 25));
+    // 付与ターン (fresh) は畳むだけ・ダメージなし。
+    tickStatuses(target, ctx());
+    expect(target.hp).toBe(100);
+    // 以後 turns 3→2→1 とカウントダウン、turns===1 の tick で炸裂。
+    tickStatuses(target, ctx()); // turns 3→2 (近づいている)
+    expect(target.hp).toBe(100);
+    tickStatuses(target, ctx()); // turns 2→1 (近づいている)
+    expect(target.hp).toBe(100);
+    tickStatuses(target, ctx()); // turns 1 → 炸裂 25 → 除去
+    expect(target.hp).toBe(75);
+    expect(target.statuses ?? []).toHaveLength(0);
+  });
+
   it('turns:1 の麻痺は fresh スキップで付与ターンを生き延び、次ターンで消える', () => {
     const target = c();
     applyStatus(target, st('stun', 1));

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -233,7 +233,7 @@ const LEARNED_SKILLS: Partial<Record<Archetype, readonly LearnedSkill[]>> = {
   // 回復役・低攻撃ジョブに「いのり (HP 回復)」を配る。攻撃が弱い職ほど早く覚える。
   miko: [{ kind: 'heal', name: '神楽の癒し', learnAt: 3 }],
   // paladin は確定キット (#456) で聖光の癒しを持つため LEARNED は撤去 (JOB_KITS が優先)。
-  seer: [{ kind: 'heal', name: '癒しの予言', learnAt: 4 }],
+  // seer は §12 で「回復なしの破滅オラクル」= 確定キットに heal を持たないため LEARNED を撤去。
   // sage は確定キット (#456) で賢者の癒しを持つため LEARNED は撤去 (JOB_KITS が優先)。
   bard: [{ kind: 'heal', name: '癒しの旋律', learnAt: 4 }],
   // mage は確定キット (#456/§12) で「自己回復を持たない脆い int 大砲」に。旧 heal (回生の術式) は
@@ -300,6 +300,15 @@ const JOB_KITS: Partial<Record<Archetype, readonly KitSkill[]>> = {
     { id: 'performer-slack', name: 'サボる', learnAt: 5 },
     { id: 'performer-gamble', name: 'いちかばちか', learnAt: 12 },
     { id: 'performer-acrobat', name: '曲芸乱舞', learnAt: 15 },
+  ],
+  // 予言者: 最高 int・破滅のオラクル・遅延。全体予言 (地震/嵐/日照り/水難/アポカリプス) はマルチ待ち。
+  //   死の宣告 (毎ターンHP半分)/未来予知 (magicEvade)/全知(P) は後続。
+  seer: [
+    { id: 'seer-switch', name: '未来スイッチ', learnAt: 3 },
+    { id: 'seer-thunder', name: '雷の予言', learnAt: 4 },
+    { id: 'seer-poison', name: '毒の予言', learnAt: 7 },
+    { id: 'seer-doom', name: '破滅の予言', learnAt: 12 },
+    { id: 'seer-king', name: '蠱毒の王', learnAt: 20 },
   ],
   // 賢者: 最高 int・全5属性・支援。イディオット/知恵の加護/星辰以外の全体技/慧眼(P) は後続。
   sage: [

--- a/packages/core/src/skills.ts
+++ b/packages/core/src/skills.ts
@@ -109,6 +109,9 @@ export type SkillEffect =
       chance?: number;
       turns?: number;
       magnitude?: number;
+      /** magnitude への int 連動 (破滅の予言など。付与時に +round(attacker.int × magIntBonus))。
+       *  ダメージ系状態 (doomMark/poison) を int キャスターのステで伸ばすのに使う。 */
+      magIntBonus?: number;
     };
 
 export interface SkillDef {
@@ -212,10 +215,15 @@ const statusHandler: EffectHandler = (effect, ctx) => {
   if (effect.target !== 'self' && defender.hp <= 0) return;
   if (rng() >= (effect.chance ?? 1)) return;
   const target = effect.target === 'self' ? attacker : defender;
+  // magnitude に int 連動を足す (破滅の予言の炸裂を int キャスターのステで伸ばす。レビュー ★★)。
+  const mag =
+    effect.magnitude !== undefined || effect.magIntBonus !== undefined
+      ? (effect.magnitude ?? 0) + (effect.magIntBonus ? Math.round(attacker.int * effect.magIntBonus) : 0)
+      : undefined;
   applyStatus(target, {
     id: effect.status,
     turns: effect.turns ?? DEFAULT_STATUS_TURNS,
-    ...(effect.magnitude !== undefined ? { magnitude: effect.magnitude } : {}),
+    ...(mag !== undefined ? { magnitude: mag } : {}),
   });
   // 付与を告知 (無告知だとプレイヤーが状態変化を認識できない。レビュー ★★)。
   events.push({ actor, text: statusApplyText(effect.status, target.name) });
@@ -497,8 +505,8 @@ export const SKILLS: Record<string, SkillDef> = {
   'seer-switch': { id: 'seer-switch', effects: [{ kind: 'fixedDamage', min: 4, max: 10, intBonus: 0.2 }] }, // 未来スイッチ Lv3 (回避不能=必中)
   'seer-thunder': { id: 'seer-thunder', effects: [{ kind: 'fixedDamage', min: 6, max: 12, intBonus: 0.3 }] }, // 雷の予言 Lv4 (無属性・必中)
   'seer-poison': { id: 'seer-poison', effects: [{ kind: 'status', status: 'poison', target: 'enemy', turns: 4, magnitude: 3 }] }, // 毒の予言 Lv7
-  // 破滅の予言 Lv12: doomMark を付与 (数ターン後に大ダメージ炸裂)
-  'seer-doom': { id: 'seer-doom', effects: [{ kind: 'status', status: 'doomMark', target: 'enemy', turns: 3, magnitude: 25 }] },
+  // 破滅の予言 Lv12: doomMark を付与 (数ターン後に大ダメージ炸裂)。炸裂は int 連動 (基礎15 + int×0.3)。
+  'seer-doom': { id: 'seer-doom', effects: [{ kind: 'status', status: 'doomMark', target: 'enemy', turns: 3, magnitude: 15, magIntBonus: 0.3 }] },
   'seer-king': { id: 'seer-king', effects: [{ kind: 'fixedDamage', min: 28, max: 42, intBonus: 0.4 }] }, // 蠱毒の王 Lv20 (必中大砲)
 };
 

--- a/packages/core/src/skills.ts
+++ b/packages/core/src/skills.ts
@@ -236,6 +236,7 @@ const DEBUFF_STATUSES: ReadonlySet<StatusId> = new Set<StatusId>([
   'atkDown',
   'defDown',
   'agiDown',
+  'doomMark',
 ]);
 
 /** 使用者の自己バフ数 (scaleBy: 'buffCount' 用)。 */
@@ -489,6 +490,16 @@ export const SKILLS: Record<string, SkillDef> = {
   'sage-revelation': { id: 'sage-revelation', effects: [{ kind: 'fixedDamage', min: 12, max: 18, intBonus: 0.3, element: 'void' }] }, // 天啓 Lv12 (空)
   'sage-heal': { id: 'sage-heal', effects: [{ kind: 'heal', ratio: 0.35 }] }, // 賢者の癒し Lv16
   'sage-starlight': { id: 'sage-starlight', effects: [{ kind: 'fixedDamage', min: 25, max: 40, intBonus: 0.4, element: 'void' }] }, // 星辰の大魔法 Lv22
+
+  // ─── 予言者 確定キット (#456 / docs/25 §12。最高 int・破滅のオラクル・遅延) ───
+  // 数値は sim 調整前提の暫定値。int 連動の必中魔法 + 破滅の予言 (doomMark)。全体予言 (地震/嵐/日照り/
+  // 水難/アポカリプス) はマルチ (#453) 待ち。死の宣告 (毎ターンHP半分)/未来予知 (magicEvade)/全知(P) は後続。
+  'seer-switch': { id: 'seer-switch', effects: [{ kind: 'fixedDamage', min: 4, max: 10, intBonus: 0.2 }] }, // 未来スイッチ Lv3 (回避不能=必中)
+  'seer-thunder': { id: 'seer-thunder', effects: [{ kind: 'fixedDamage', min: 6, max: 12, intBonus: 0.3 }] }, // 雷の予言 Lv4 (無属性・必中)
+  'seer-poison': { id: 'seer-poison', effects: [{ kind: 'status', status: 'poison', target: 'enemy', turns: 4, magnitude: 3 }] }, // 毒の予言 Lv7
+  // 破滅の予言 Lv12: doomMark を付与 (数ターン後に大ダメージ炸裂)
+  'seer-doom': { id: 'seer-doom', effects: [{ kind: 'status', status: 'doomMark', target: 'enemy', turns: 3, magnitude: 25 }] },
+  'seer-king': { id: 'seer-king', effects: [{ kind: 'fixedDamage', min: 28, max: 42, intBonus: 0.4 }] }, // 蠱毒の王 Lv20 (必中大砲)
 };
 
 /** そのとくぎが「HP 回復のみ」か (UI が満タン時に無効化するかの判定に使う)。kind 文字列でなく

--- a/packages/core/src/statuses.ts
+++ b/packages/core/src/statuses.ts
@@ -25,7 +25,8 @@ export type StatusId =
   | 'defUp'
   | 'defDown' // 被ダメ magnitude 倍
   | 'agiUp'
-  | 'agiDown'; // 回避 magnitude 倍
+  | 'agiDown' // 回避 magnitude 倍
+  | 'doomMark'; // 破滅の予言: turnEnd でカウントダウン、0 で magnitude の大ダメージ
 
 /** 付与時に turns 未指定なら使う既定持続 (毒手/デバフ等の共通デフォルト)。 */
 export const DEFAULT_STATUS_TURNS = 2;
@@ -161,6 +162,23 @@ export const STATUS_REGISTRY: Record<StatusId, StatusDef> = {
   defDown: { id: 'defDown', name: '守備力低下', restack: 'refresh', incomingCalc: (p, _c, ctx) => p * (ctx.status?.magnitude ?? 1.3) },
   agiUp: { id: 'agiUp', name: '素早さ上昇', restack: 'refresh', dodgeCalc: (d, _c, ctx) => d * (ctx.status?.magnitude ?? 1.5) },
   agiDown: { id: 'agiDown', name: '素早さ低下', restack: 'refresh', dodgeCalc: (d, _c, ctx) => d * (ctx.status?.magnitude ?? 0.6) },
+  // 破滅の予言 (予言者): turnEnd でカウントダウン、最終ターン (turns===1) に magnitude の大ダメージ。
+  // fresh スキップにより付与ターンは進まず、以後 N ターンかけて破滅が訪れる (予告 → 炸裂の緊張)。
+  doomMark: {
+    id: 'doomMark',
+    name: '破滅の予言',
+    restack: 'refresh',
+    turnEnd: (c, ctx) => {
+      const remaining = ctx.status?.turns ?? 1;
+      if (remaining <= 1) {
+        const dmg = ctx.status?.magnitude ?? 20;
+        c.hp = Math.max(0, c.hp - dmg);
+        ctx.events.push({ actor: ctx.actor ?? 'player', text: `${c.name}に 破滅が訪れた! ${dmg} のダメージ`, damage: dmg });
+      } else {
+        ctx.events.push({ actor: ctx.actor ?? 'player', text: `${c.name}に 破滅の刻が近づいている… (あと${remaining - 1})` });
+      }
+    },
+  },
 };
 
 /** パッシブレジストリ (ジョブ innate)。#456 で首狩り等を追加。今は枠だけ。 */
@@ -182,6 +200,7 @@ const STATUS_APPLY_TEXT: Record<StatusId, string> = {
   defDown: 'の守備力がさがった!',
   agiUp: 'の素早さがあがった!',
   agiDown: 'の素早さがさがった!',
+  doomMark: 'に 破滅の刻印が刻まれた…!',
 };
 
 /** 状態付与の告知文 (対象名 + テキスト)。 */

--- a/packages/core/src/statuses.ts
+++ b/packages/core/src/statuses.ts
@@ -167,7 +167,9 @@ export const STATUS_REGISTRY: Record<StatusId, StatusDef> = {
   doomMark: {
     id: 'doomMark',
     name: '破滅の予言',
-    restack: 'refresh',
+    // ignore: 既に刻まれた予言は上書きしない (再詠唱でカウントダウンが巻き戻り永久に炸裂しない自己
+    // 妨害を防ぐ。「予言は一度告げたら覆らない」像とも一致。レビュー ★★)。
+    restack: 'ignore',
     turnEnd: (c, ctx) => {
       const remaining = ctx.status?.turns ?? 1;
       if (remaining <= 1) {


### PR DESCRIPTION
## 目的

戦闘刷新 (docs/25 §12) の**ジョブ確定キット第5バッチ**。**予言者** (最高 int43・破滅のオラクル・遅延) を
追加 (#456)。新状態 **doomMark** (破滅の予言) を消費者 (予言者) と同時に導入。

## 変更

### 新状態: doomMark (破滅の予言)
turnEnd でカウントダウン、`turns===1` の tick で `magnitude` の大ダメージ炸裂。fresh スキップにより
付与ターンは進まず「予告 → 数ターン後に破滅」の緊張を作る。DEBUFF なので浄化 (cleanse) で解除可。

### 予言者 (最高 int・破滅のオラクル・遅延)
未来スイッチ3(必中)/雷の予言4(必中)/毒の予言7(poison)/破滅の予言12(doomMark)/蠱毒の王20(必中大砲)。全て int 連動 (seer int43=最高ステ → キット⇄ステ整合、前バッチの ★★★ 教訓を踏襲)。

deferred: 全体予言 (地震/嵐/日照り/水難/アポカリプス) はマルチ (#453) 待ち、死の宣告 (毎ターンHP半分)/未来予知 (magicEvade)/全知(P) は後続。§12「予言者=回復なし」に従い旧 LEARNED_SKILLS.seer(heal) を撤去。

## 検証
- core 422 緑 (doomMark のカウントダウン→炸裂・fresh スキップ・予言者キットのレベル習得・doomMark 付与を検証) /
  web build / typecheck (web+edge+core) 緑。既存ソロ resolveTurn 無変更。**数値は sim 調整前提の暫定値**。
- キット化 8/16 職 (魔法使い/忍者/詩人/戦士/聖騎士/遊び人/賢者/予言者)。

## Review

§1.5 レビュー (実装 + 設計/体験)。**両者 ★★★ なし・キット⇄ステ整合合格** (seer int43=全16職最高、全 int 連動キット)。

- **実装**: 指摘ゼロ。doomMark の timing (付与から正確に3ターン後に1回炸裂・二重/未炸裂なし)、HP0スキップ、cleanse解除、restack、型網羅を probe 込みで検証。
- **設計/体験**: ★★★ なし。★★ 2件を PR 内対応 (commit ad3af04):
  - doomMark 炸裂が flat 25 で int 非連動 → **magIntBonus を追加し int 連動** (基礎15 + int×0.3)。予言者の看板技が最強ステを活かす。
  - doomMark restack refresh で再詠唱すると永久に炸裂しない自己妨害 → **restack 'ignore'** に。

### ★/設計注記
- doomMark 残ターン可視化 UI → **#473** に引き継ぎ。全体予言 (予言者の核) は #453 待ち。
- 回復撤去・無属性必中は §12 準拠の意図 (脆い必中オラクル。属性の弱点特効を捨てる代わりに必中)。

CI: web-ci pass / 本番 build pass。core 423緑 / typecheck (web+edge+core) 緑。
