### PR TITLE
feat(combat): ジョブキット第6バッチ — 将軍 (物理ガラス大砲) (#456)

### DIFF
--- a/packages/core/src/__tests__/job-kits.test.ts
+++ b/packages/core/src/__tests__/job-kits.test.ts
@@ -150,6 +150,28 @@ describe('詩人 確定キット (#456)', () => {
   });
 });
 
+describe('将軍 確定キット (#456)', () => {
+  it('レベルで一閃〜鬼神斬りを習得', () => {
+    expect(skillsForJob('shogun', 3).map((s) => s.name)).toContain('一閃');
+    expect(skillsForJob('shogun', 20).map((s) => s.name)).toEqual(['一閃', '足払い', '見切り', '鬼神斬り']);
+  });
+
+  it('キット技はすべて SKILLS に定義がある', () => {
+    for (const sk of skillsForJob('shogun', 30)) expect(SKILLS[sk.kind], sk.kind).toBeDefined();
+  });
+
+  it('足払いは命中で転倒を付与 (次行動不可 + 被ダメ↑)', () => {
+    let tumbled = false;
+    for (let seed = 0; seed < 40 && !tumbled; seed++) {
+      const s = startBattle('shogun', 8, 12, '将', 3, seed, 0);
+      const idx = s.playerSkills.findIndex((sk) => sk.name === '足払い');
+      const next: BattleState = resolveTurn(s, 'skill', undefined, idx);
+      if (next.monster.hp > 0 && next.monster.statuses?.some((st) => st.id === 'tumble')) tumbled = true;
+    }
+    expect(tumbled).toBe(true);
+  });
+});
+
 describe('予言者 確定キット (#456)', () => {
   it('レベルで未来スイッチ〜蠱毒の王を習得', () => {
     expect(skillsForJob('seer', 3).map((s) => s.name)).toContain('未来スイッチ');

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -295,6 +295,13 @@ const JOB_KITS: Partial<Record<Archetype, readonly KitSkill[]>> = {
     { id: 'paladin-guard', name: '聖なる守り', learnAt: 15 },
     { id: 'paladin-purify', name: '浄化', learnAt: 18 },
   ],
+  // 将軍: 最強 atk・最脆 def・物理一本・対キャスター。全体技/覇王(P)/魔法かき消し・見切りの魔法回避は後続。
+  shogun: [
+    { id: 'shogun-flash', name: '一閃', learnAt: 3 },
+    { id: 'shogun-sweep', name: '足払い', learnAt: 8 },
+    { id: 'shogun-guard', name: '見切り', learnAt: 15 },
+    { id: 'shogun-oni', name: '鬼神斬り', learnAt: 20 },
+  ],
   // 遊び人: luk/agi 型・運任せ。ぶんどり(gain)/ルーレット・大道芸(random)/せっとく(resolve) は後続。
   performer: [
     { id: 'performer-slack', name: 'サボる', learnAt: 5 },

--- a/packages/core/src/skills.ts
+++ b/packages/core/src/skills.ts
@@ -518,7 +518,9 @@ export const SKILLS: Record<string, SkillDef> = {
     id: 'shogun-sweep',
     effects: [{ kind: 'damage', stat: 'atk', power: 1.2, inflict: { status: 'tumble', chance: 0.7, turns: 1 } }],
   },
-  'shogun-guard': { id: 'shogun-guard', effects: [{ kind: 'status', status: 'agiUp', target: 'self', turns: 3 }] }, // 見切り Lv15 (agi↑。魔法100%回避は後続)
+  // 見切り Lv15: 回避を大きく上げる構え (magnitude 2.5)。将軍は素の agi13 が低く乗算バフが効きにくい
+  // ため強めに。§12 の「次の敵魔法100%回避」は magicEvade (敵魔法詠唱 #455後続) が入るまで後続。
+  'shogun-guard': { id: 'shogun-guard', effects: [{ kind: 'status', status: 'agiUp', target: 'self', turns: 3, magnitude: 2.5 }] },
   'shogun-oni': { id: 'shogun-oni', effects: [{ kind: 'damage', stat: 'atk', power: 2.5 }] }, // 鬼神斬り Lv20 (かき消しは後続)
 };
 

--- a/packages/core/src/skills.ts
+++ b/packages/core/src/skills.ts
@@ -508,6 +508,18 @@ export const SKILLS: Record<string, SkillDef> = {
   // 破滅の予言 Lv12: doomMark を付与 (数ターン後に大ダメージ炸裂)。炸裂は int 連動 (基礎15 + int×0.3)。
   'seer-doom': { id: 'seer-doom', effects: [{ kind: 'status', status: 'doomMark', target: 'enemy', turns: 3, magnitude: 15, magIntBonus: 0.3 }] },
   'seer-king': { id: 'seer-king', effects: [{ kind: 'fixedDamage', min: 28, max: 42, intBonus: 0.4 }] }, // 蠱毒の王 Lv20 (必中大砲)
+
+  // ─── 将軍 確定キット (#456 / docs/25 §12。最強 atk39・最脆 def10・物理一本・対キャスター) ───
+  // 数値は sim 調整前提の暫定値。なぎ倒し/勝鬨(全体)・覇王(P onLethal)・見切り/鬼神斬りの魔法かき消し
+  // (magicEvade/onEnemyCast) は後続。int28 の魔法耐性活用も敵魔法詠唱 (#455後続) 待ち。
+  'shogun-flash': { id: 'shogun-flash', effects: [{ kind: 'damage', stat: 'atk', power: 1.5 }] }, // 一閃 Lv3
+  // 足払い Lv8: atk 1.2 + 高確率で転倒 (次行動不可 + 被ダメ↑)
+  'shogun-sweep': {
+    id: 'shogun-sweep',
+    effects: [{ kind: 'damage', stat: 'atk', power: 1.2, inflict: { status: 'tumble', chance: 0.7, turns: 1 } }],
+  },
+  'shogun-guard': { id: 'shogun-guard', effects: [{ kind: 'status', status: 'agiUp', target: 'self', turns: 3 }] }, // 見切り Lv15 (agi↑。魔法100%回避は後続)
+  'shogun-oni': { id: 'shogun-oni', effects: [{ kind: 'damage', stat: 'atk', power: 2.5 }] }, // 鬼神斬り Lv20 (かき消しは後続)
 };
 
 /** そのとくぎが「HP 回復のみ」か (UI が満タン時に無効化するかの判定に使う)。kind 文字列でなく


### PR DESCRIPTION
## 目的

戦闘刷新 (docs/25 §12) の**ジョブ確定キット第6バッチ**。**将軍** (最強 atk39・最脆 def10・物理一本・
対キャスター) を**既存語彙のみ**で追加 (#456)。

## 変更

### 将軍 (物理ガラス大砲)
一閃3(atk×1.5)/足払い8(atk×1.2+高確率で転倒)/見切り15(agiUp self)/鬼神斬り20(atk×2.5)。atk-dominant (atk39=最高ステ) なので damage stat=atk がキット⇄ステ整合。転倒 (tumble) は既存 status。

deferred: なぎ倒し/勝鬨(全体) はマルチ (#453) 待ち、覇王(P onLethal)・見切りの魔法100%回避 (magicEvade)・鬼神斬りの魔法かき消し (onEnemyCast)・int28 の魔法耐性は**敵の魔法詠唱 (#455後続)** が入って初めて意味を持つため後続。**新プリミティブ/状態の追加なし**。

## 検証
- core 426 緑 (将軍キットのレベル習得・足払いの転倒付与を実戦検証) / web build / typecheck (web+edge+core) 緑。
  既存ソロ resolveTurn 無変更。**数値は sim 調整前提の暫定値**。
- キット化 9/16 職 (魔法使い/忍者/詩人/戦士/聖騎士/遊び人/賢者/予言者/将軍)。

## Review

§1.5 レビュー (実装 + 設計/体験)。**両者 ★★★ なし・キット⇄ステ合格** (shogun atk39=最強、全 damage 技が stat:'atk')。

- **実装**: 指摘ゼロ。tumble の fresh スキップ・fatal ガード・pure-reuse (新プリミティブ無し)・LEARNED 二重なしを検証、426緑。
- **設計/体験**: ★★★ なし。★★ 1件を PR 内対応 (commit 94d7c79):
  - 見切り (agiUp) が将軍の低 agi13 で乗算バフがほぼ効かず「Lv15 で何も嬉しくない技」→ **magnitude 2.5 に強化**し実用的な回避構えに。§12 の核 (magicEvade) は敵魔法 (#455後続) 待ち。
  - 将軍 vs 戦士 の差別化は成立確認 (戦士=def41 継戦タンク / 将軍=atk39 転倒 burst)。

### ★/設計注記
- 将軍の対キャスター identity (int魔法耐性/魔法かき消し/覇王onLethal) は #455 敵魔法待ちで inert / 全体技はマルチ待ち → **#474** に引き継ぎ。

CI: web-ci pass / 本番 build pass。core 426緑 / typecheck (web+edge+core) 緑。
