### PR TITLE
feat(combat): 隊長キット + ソロとくぎ経路の統一 (パーティ支援のソロ退化) (#456)

### DIFF
--- a/packages/core/src/__tests__/job-kits.test.ts
+++ b/packages/core/src/__tests__/job-kits.test.ts
@@ -150,6 +150,35 @@ describe('詩人 確定キット (#456)', () => {
   });
 });
 
+describe('隊長 確定キット (#456。全体バフはソロで自己/敵に退化)', () => {
+  it('レベルで突撃号令〜攻陣を習得', () => {
+    expect(skillsForJob('captain', 3).map((s) => s.name)).toContain('突撃号令');
+    expect(skillsForJob('captain', 25).map((s) => s.name)).toEqual(['突撃号令', '鼓舞', '防陣', '突進', '檄', '捨て身攻撃', '攻陣']);
+  });
+
+  it('キット技はすべて SKILLS に定義がある', () => {
+    for (const sk of skillsForJob('captain', 30)) expect(SKILLS[sk.kind], sk.kind).toBeDefined();
+  });
+
+  it('鼓舞 (atkUp allAllies) はソロで自分に atk バフを付与', () => {
+    const s = startBattle('captain', 5, 8, '隊', 1, 5, 0);
+    const idx = s.playerSkills.findIndex((sk) => sk.name === '鼓舞');
+    const next: BattleState = resolveTurn(s, 'skill', undefined, idx);
+    expect(next.player.statuses?.some((st) => st.id === 'atkUp')).toBe(true);
+    expect(next.monster.statuses?.some((st) => st.id === 'atkUp')).toBe(false); // 敵には付かない
+  });
+
+  it('攻陣 (atkDown allEnemies) はソロで敵に atk/agi デバフを付与', () => {
+    const s = startBattle('captain', 25, 28, '隊', 3, 5, 0);
+    const idx = s.playerSkills.findIndex((sk) => sk.name === '攻陣');
+    const next: BattleState = resolveTurn(s, 'skill', undefined, idx);
+    const ids = new Set(next.monster.statuses?.map((st) => st.id));
+    expect(ids.has('atkDown')).toBe(true);
+    expect(ids.has('agiDown')).toBe(true);
+    expect(next.player.statuses?.some((st) => st.id === 'atkDown')).toBe(false); // 自分には付かない
+  });
+});
+
 describe('将軍 確定キット (#456)', () => {
   it('レベルで一閃〜鬼神斬りを習得', () => {
     expect(skillsForJob('shogun', 3).map((s) => s.name)).toContain('一閃');

--- a/packages/core/src/__tests__/job-kits.test.ts
+++ b/packages/core/src/__tests__/job-kits.test.ts
@@ -168,14 +168,13 @@ describe('隊長 確定キット (#456。全体バフはソロで自己/敵に�
     expect(next.monster.statuses?.some((st) => st.id === 'atkUp')).toBe(false); // 敵には付かない
   });
 
-  it('攻陣 (atkDown allEnemies) はソロで敵に atk/agi デバフを付与', () => {
+  it('攻陣 (§12: 味方atk↑+敵agi↓) はソロで自分に atkUp・敵に agiDown を付与', () => {
     const s = startBattle('captain', 25, 28, '隊', 3, 5, 0);
     const idx = s.playerSkills.findIndex((sk) => sk.name === '攻陣');
     const next: BattleState = resolveTurn(s, 'skill', undefined, idx);
-    const ids = new Set(next.monster.statuses?.map((st) => st.id));
-    expect(ids.has('atkDown')).toBe(true);
-    expect(ids.has('agiDown')).toBe(true);
-    expect(next.player.statuses?.some((st) => st.id === 'atkDown')).toBe(false); // 自分には付かない
+    expect(next.player.statuses?.some((st) => st.id === 'atkUp')).toBe(true); // 味方 (自分) に atk↑
+    expect(next.monster.statuses?.some((st) => st.id === 'agiDown')).toBe(true); // 敵に agi↓
+    expect(next.monster.statuses?.some((st) => st.id === 'atkUp')).toBe(false); // 敵にはバフが付かない
   });
 });
 

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -302,6 +302,16 @@ const JOB_KITS: Partial<Record<Archetype, readonly KitSkill[]>> = {
     { id: 'shogun-guard', name: '見切り', learnAt: 15 },
     { id: 'shogun-oni', name: '鬼神斬り', learnAt: 20 },
   ],
+  // 隊長: タフな前衛指揮官・鼓舞。全体バフ/デバフはソロで自己/敵単体に退化、マルチで全体化。名将(P)は後続。
+  captain: [
+    { id: 'captain-charge', name: '突撃号令', learnAt: 3 },
+    { id: 'captain-inspire', name: '鼓舞', learnAt: 5 },
+    { id: 'captain-defense', name: '防陣', learnAt: 8 },
+    { id: 'captain-rush', name: '突進', learnAt: 12 },
+    { id: 'captain-rally', name: '檄', learnAt: 15 },
+    { id: 'captain-desperate', name: '捨て身攻撃', learnAt: 18 },
+    { id: 'captain-encircle', name: '攻陣', learnAt: 25 },
+  ],
   // 遊び人: luk/agi 型・運任せ。ぶんどり(gain)/ルーレット・大道芸(random)/せっとく(resolve) は後続。
   performer: [
     { id: 'performer-slack', name: 'サボる', learnAt: 5 },

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -1248,7 +1248,20 @@ function playerSkillAction(state: BattleState, skill: JobSkill, rng: () => numbe
   // 見切り (parry) 等の「宣言型」とくぎは effects 空で、宣言は resolveTurn 冒頭が担う。
   const def = SKILLS[skill.kind];
   if (!def) return;
-  runSkill(def, { attacker: player, defender: monster, rng, events, skillName: skill.name, engine: { doAttack, doMagic } });
+  // ソロでも runSkillMulti で**効果ごとに対象解決**する (#453/#456)。ソロ陣営は allies=[player] /
+  // enemies=[monster] の退化ケース。これにより allAllies (=自分) / allEnemies (=敵) を使うパーティ
+  // 支援職 (隊長/巫女/吟遊詩人) の全体技がソロでは自己バフ/敵デバフとして機能する。既存の
+  // self/oneEnemy 技は [player]/[monster] に解決され**挙動不変**。
+  const sides: CombatSides = { allies: [player], enemies: [monster] };
+  runSkillMulti(def, player, sides, (defender) => ({
+    attacker: player,
+    defender,
+    rng,
+    events,
+    skillName: skill.name,
+    actorSide: 'player',
+    engine: { doAttack, doMagic },
+  }));
 }
 
 /**

--- a/packages/core/src/skills.ts
+++ b/packages/core/src/skills.ts
@@ -526,7 +526,9 @@ export const SKILLS: Record<string, SkillDef> = {
   // ─── 隊長 確定キット (#456 / docs/25 §12。タフな前衛指揮官・鼓舞) ───
   // 数値は sim 調整前提の暫定値。全体バフ/デバフ (allAllies/allEnemies) はソロでは自己バフ/敵デバフに
   // 退化し、マルチ (#453) で味方全体/敵全体に効く。名将 (P atk/def+10%) は passive 配線待ちで後続。
-  // 突撃号令 Lv3: atk×1.5 + 味方に atk 微上昇 (allAllies=ソロは自分)
+  // 突撃号令 Lv3: atk×1.5 + 味方に atk 微上昇 (allAllies=ソロは自分)。
+  // 注意: atkUp は restack refresh なので、鼓舞 (1.30) の後に突撃号令 (1.15) を撃つとバフが下がる。
+  // sim 調整時に「オマケ側を鼓舞と同値」or「refresh を max 採用」を検討 (#460)。
   'captain-charge': {
     id: 'captain-charge',
     effects: [
@@ -575,7 +577,8 @@ export function isPureHealSkill(kind: string): boolean {
   return !!def && def.effects.length > 0 && def.effects.every((e) => e.kind === 'heal');
 }
 
-/** SkillDef の全効果を順に解決する (ソロ戦闘のエントリポイント。ctx.defender 固定)。 */
+/** SkillDef の全効果を単一 ctx.defender に解決する低レベル API (テスト用)。**production の解決は
+ *  runSkillMulti** (ソロ/マルチとも効果ごとに resolveTargets で対象解決する) に統一済み (#456)。 */
 export function runSkill(def: SkillDef, ctx: SkillContext): void {
   for (const effect of def.effects) {
     EFFECT_HANDLERS[effect.kind](effect, ctx);

--- a/packages/core/src/skills.ts
+++ b/packages/core/src/skills.ts
@@ -549,7 +549,7 @@ export const SKILLS: Record<string, SkillDef> = {
       { kind: 'status', status: 'agiUp', target: 'allAllies', turns: 3 },
     ],
   },
-  // 捨て身攻撃 Lv18: 敵全体 atk×1.6・自 def↓ (リスク)
+  // 捨て身攻撃 Lv18: 敵全体 atk×1.6・自 def↓ (リスク)。§12 の「会心↑」は critUp 語彙が未整備で後続。
   'captain-desperate': {
     id: 'captain-desperate',
     effects: [
@@ -557,11 +557,11 @@ export const SKILLS: Record<string, SkillDef> = {
       { kind: 'status', status: 'defDown', target: 'self', turns: 1 },
     ],
   },
-  // 攻陣 Lv25: 敵全体 atk↓ + agi↓
+  // 攻陣 Lv25: 敵を囲い 味方 atk↑ + 敵 agi↓ (§12 確定版: 鼓舞と包囲のハイブリッド陣形)
   'captain-encircle': {
     id: 'captain-encircle',
     effects: [
-      { kind: 'status', status: 'atkDown', target: 'allEnemies', turns: 3 },
+      { kind: 'status', status: 'atkUp', target: 'allAllies', turns: 3 },
       { kind: 'status', status: 'agiDown', target: 'allEnemies', turns: 3 },
     ],
   },

--- a/packages/core/src/skills.ts
+++ b/packages/core/src/skills.ts
@@ -522,6 +522,49 @@ export const SKILLS: Record<string, SkillDef> = {
   // ため強めに。§12 の「次の敵魔法100%回避」は magicEvade (敵魔法詠唱 #455後続) が入るまで後続。
   'shogun-guard': { id: 'shogun-guard', effects: [{ kind: 'status', status: 'agiUp', target: 'self', turns: 3, magnitude: 2.5 }] },
   'shogun-oni': { id: 'shogun-oni', effects: [{ kind: 'damage', stat: 'atk', power: 2.5 }] }, // 鬼神斬り Lv20 (かき消しは後続)
+
+  // ─── 隊長 確定キット (#456 / docs/25 §12。タフな前衛指揮官・鼓舞) ───
+  // 数値は sim 調整前提の暫定値。全体バフ/デバフ (allAllies/allEnemies) はソロでは自己バフ/敵デバフに
+  // 退化し、マルチ (#453) で味方全体/敵全体に効く。名将 (P atk/def+10%) は passive 配線待ちで後続。
+  // 突撃号令 Lv3: atk×1.5 + 味方に atk 微上昇 (allAllies=ソロは自分)
+  'captain-charge': {
+    id: 'captain-charge',
+    effects: [
+      { kind: 'damage', stat: 'atk', power: 1.5 },
+      { kind: 'status', status: 'atkUp', target: 'allAllies', turns: 3, magnitude: 1.15 },
+    ],
+  },
+  'captain-inspire': { id: 'captain-inspire', effects: [{ kind: 'status', status: 'atkUp', target: 'allAllies', turns: 3 }] }, // 鼓舞 Lv5
+  'captain-defense': { id: 'captain-defense', effects: [{ kind: 'status', status: 'defUp', target: 'allAllies', turns: 3 }] }, // 防陣 Lv8
+  // 突進 Lv12: atk×1.5 + 中確率で転倒
+  'captain-rush': {
+    id: 'captain-rush',
+    effects: [{ kind: 'damage', stat: 'atk', power: 1.5, inflict: { status: 'tumble', chance: 0.5, turns: 1 } }],
+  },
+  // 檄 Lv15: 味方全体 atk↑ + agi↑
+  'captain-rally': {
+    id: 'captain-rally',
+    effects: [
+      { kind: 'status', status: 'atkUp', target: 'allAllies', turns: 3 },
+      { kind: 'status', status: 'agiUp', target: 'allAllies', turns: 3 },
+    ],
+  },
+  // 捨て身攻撃 Lv18: 敵全体 atk×1.6・自 def↓ (リスク)
+  'captain-desperate': {
+    id: 'captain-desperate',
+    effects: [
+      { kind: 'damage', stat: 'atk', power: 1.6, target: 'allEnemies' },
+      { kind: 'status', status: 'defDown', target: 'self', turns: 1 },
+    ],
+  },
+  // 攻陣 Lv25: 敵全体 atk↓ + agi↓
+  'captain-encircle': {
+    id: 'captain-encircle',
+    effects: [
+      { kind: 'status', status: 'atkDown', target: 'allEnemies', turns: 3 },
+      { kind: 'status', status: 'agiDown', target: 'allEnemies', turns: 3 },
+    ],
+  },
 };
 
 /** そのとくぎが「HP 回復のみ」か (UI が満タン時に無効化するかの判定に使う)。kind 文字列でなく


### PR DESCRIPTION
## 目的

戦闘刷新 (docs/25 §12) の**パーティ支援職・第1弾**。**隊長** (前衛指揮官・鼓舞) を追加 (#456)。
併せて、パーティ支援職をソロ戦でも成立させる**ソロのとくぎ経路統一**を含む。

## 変更

### ソロのとくぎ経路を runSkillMulti に統一 (基盤)
`playerSkillAction` を `runSkill` → `runSkillMulti (ソロ陣営 allies=[player]/enemies=[monster])` に。
効果ごとに `resolveTargets` で対象解決するため、**allAllies (=自分) / allEnemies (=敵) がソロで正しく
退化**し、パーティ支援職の全体技がソロでは自己バフ/敵デバフとして機能する。既存の self/oneEnemy/heal
技は [player]/[monster] に解決され**挙動完全不変** (battle 93 + world 23 + job-kits = 426→430緑で確認)。

### 隊長 (タフな前衛指揮官・鼓舞)
突撃号令3(atk×1.5+味方atk微↑)/鼓舞5(味方atk↑)/防陣8(味方def↑)/突進12(atk×1.5+転倒)/檄15(味方atk↑agi↑)/捨て身攻撃18(敵全体atk×1.6+自def↓)/攻陣25(敵全体atk↓agi↓)。atk38=最強ステ整合。**新プリミティブ追加なし** (既存 status の allAllies/allEnemies 対象を活用)。名将 (P) は後続。

## 検証
- core 430 緑 (ソロで鼓舞=自分に atk↑・攻陣=敵に atk/agi↓ の退化を実戦検証 / 挙動不変)。web build / typecheck (web+edge+core) 緑。**数値は sim 調整前提**。
- キット化 10/16 職。マルチ (#453) 実装後に隊長のバフが味方全体へ効く。

## Review

§1.5 3並列独立レビュー (実装/設計/体験)。**3本とも ★★★ なし・キット⇄ステ合格** (captain atk38=最強、全 damage 技 stat:'atk')。

- **実装**: 指摘ゼロ。ソロ経路統一の挙動保存を効果種別・RNG消費・イベント順の3軸で全パターン検証し完全不変 (死んだ敵への多段・致死ガード含む)。隊長の全体技のソロ退化 (バフ=自分/デバフ=敵) をテスト検証。430緑。
- **設計**: ★★★ なし。統一は低リスク (既存とくぎに all-target 消費者ゼロ・makeCtx がマルチと一致・手戻りなし)。将来 resolveTurn 統一への布石として整合。
- **体験**: ★★★ なし・差別化成立 (戦士=def継戦 / 将軍=atk転倒burst / 隊長=atk+バフ指揮官)。

### ★★/★ 対応 (PR 内・commit 48139d1, d2bb0c1)
- **攻陣が §12 確定版と乖離** (設計/体験 ★★): 純デバフ (atkDown+agiDown) → §12 どおり **atkUp(allAllies)+agiDown(allEnemies)** に修正 (指揮官バッファーの手触り回復)。テストも更新。
- 捨て身の会心↑ deferred 明記 (critUp 語彙待ち)。runSkill docstring 更新 (テスト用低レベル API 化)。突撃号令 の refresh ダウングレード注記 (#460 sim 調整)。

### 引き継ぎ
- 名将 (P atk/def+10%) は passive 配線待ち → 後続。会心↑ (critUp) 語彙整備 → #460 系。

CI: web-ci pass / 本番 build pass。core 430緑 / typecheck (web+edge+core) 緑。**既存ソロ戦闘は挙動不変**。
