### PR TITLE
feat(combat): 巫女・吟遊詩人キット + heal 全体対象化 (パーティ支援第2弾) (#456)

### DIFF
--- a/packages/core/src/__tests__/battle.test.ts
+++ b/packages/core/src/__tests__/battle.test.ts
@@ -84,19 +84,19 @@ describe('skillsForJob (複数とくぎ #436)', () => {
       expect(list1[0]).toEqual(sig);
     }
   });
-  it('副スキルはレベルアップで習得する (learnAt 未満は出ない)', () => {
-    // miko は jobLv3 で heal (神楽の癒し) を習得
-    expect(skillsForJob('miko', 1).map((s) => s.kind)).toEqual(['gamble']);
-    expect(skillsForJob('miko', 2).map((s) => s.kind)).toEqual(['gamble']);
-    expect(skillsForJob('miko', 3).map((s) => s.kind)).toEqual(['gamble', 'heal']);
-    // heal 未配布・キット未登録のジョブは署名のみ (guardian)
+  it('キット職はレベルで習得、未習得帯は署名にフォールバック (#456)', () => {
+    // miko は確定キット職。Lv1-2 は未習得帯で署名にフォールバック、Lv3 で癒しの鈴を習得。
+    expect(skillsForJob('miko', 1)).toHaveLength(1); // 署名のみ
+    expect(skillsForJob('miko', 2)).toHaveLength(1);
+    expect(skillsForJob('miko', 3).map((s) => s.name)).toContain('癒しの鈴');
+    // キット未登録のジョブ (guardian) は署名のみ (旧 LEARNED 機構は全職キット化で空)。
     expect(skillsForJob('guardian', 30)).toHaveLength(1);
   });
-  it('heal とくぎは MP を払って maxHp の割合ぶん回復する', () => {
-    // miko(jobLv5) は [gamble, heal]。HP を削ってから heal を選ぶ (skillIndex=1)
-    let s = startBattle('miko', 5, 8, '巫女', 2, 3, 0);
-    const healIdx = s.playerSkills.findIndex((x) => x.kind === 'heal');
-    expect(healIdx).toBeGreaterThan(0);
+  it('回復とくぎは MP を払って maxHp の割合ぶん回復する (キットの heal)', () => {
+    // paladin(jobLv5) は聖光の癒し (heal) を持つ。HP を削ってから回復を選ぶ。
+    let s = startBattle('paladin', 5, 8, '聖', 2, 3, 0);
+    const healIdx = s.playerSkills.findIndex((x) => x.name === '聖光の癒し');
+    expect(healIdx).toBeGreaterThanOrEqual(0);
     for (let i = 0; i < 3 && s.outcome === 'ongoing'; i++) s = resolveTurn(s, 'attack', i * 7 + 1);
     if (s.outcome === 'ongoing' && s.player.hp < s.player.maxHp) {
       const before = s.player.hp;
@@ -817,10 +817,13 @@ describe('序盤バランス (オーナー指摘 2026-07-17「序盤の敵が強
     }
   });
 
-  it('luk/agi 型の弱ジョブがレベルでちゃんと強くなる (bard/ninja の tier2 中位レベル)', () => {
-    // 旧仕様 (特技 atk 基準 + MP 特性なし) では bard の tier2 は 2 割前後だった。
-    // 支配ステータス基準 + MP 特性 + 平坦レベル成長でまともに戦えることを固定
-    expect(winRate('bard', 5, 8, 2)).toBeGreaterThanOrEqual(60);
+  it('luk/agi 型の弱ジョブがレベルでちゃんと強くなる (explorer/ninja の tier2 中位レベル)', () => {
+    // 旧仕様 (特技 atk 基準 + MP 特性なし) では tier2 は 2 割前後だった。
+    // 支配ステータス基準 + MP 特性 + 平坦レベル成長でまともに戦えることを固定。
+    // 注: bard は #456 で「歌の支援職」にキット化され skill[0] がバフ = ソロの naive auto-battle
+    // (skillIndex0) では攻撃せず弱い (支援職はパーティ前提。マルチ #453 で本領)。ここでは攻撃系の
+    // 弱 luk/agi ジョブ (explorer=非キット agi 署名 / ninja=毒手) で「レベルで戦える」ことを固定する。
+    expect(winRate('explorer', 5, 8, 2)).toBeGreaterThanOrEqual(60);
     expect(winRate('ninja', 5, 8, 2)).toBeGreaterThanOrEqual(60);
   });
 

--- a/packages/core/src/__tests__/job-kits.test.ts
+++ b/packages/core/src/__tests__/job-kits.test.ts
@@ -150,6 +150,65 @@ describe('詩人 確定キット (#456)', () => {
   });
 });
 
+describe('巫女 確定キット (#456。luk支援・全体技のソロ退化)', () => {
+  it('レベルで癒しの鈴〜払串を習得', () => {
+    expect(skillsForJob('miko', 3).map((s) => s.name)).toContain('癒しの鈴');
+    expect(skillsForJob('miko', 22).map((s) => s.name)).toEqual(['癒しの鈴', '風の舞', '眠りの鈴', '加護', '破魔の舞', '癒し神楽', '払串']);
+  });
+
+  it('キット技はすべて SKILLS に定義がある', () => {
+    for (const sk of skillsForJob('miko', 30)) expect(SKILLS[sk.kind], sk.kind).toBeDefined();
+  });
+
+  it('癒しの鈴 (heal allAllies) はソロで自分を回復する', () => {
+    const s = startBattle('miko', 3, 8, '巫', 1, 5, 0);
+    s.player.hp = Math.max(1, s.player.maxHp - 20);
+    const before = s.player.hp;
+    const idx = s.playerSkills.findIndex((sk) => sk.name === '癒しの鈴');
+    const next: BattleState = resolveTurn(s, 'skill', 999, idx);
+    expect(next.player.hp).toBeGreaterThan(before);
+  });
+
+  it('眠りの鈴 (sleep allEnemies) はソロで敵を眠らせる', () => {
+    let slept = false;
+    for (let seed = 0; seed < 30 && !slept; seed++) {
+      const s = startBattle('miko', 8, 12, '巫', 3, seed, 0);
+      const idx = s.playerSkills.findIndex((sk) => sk.name === '眠りの鈴');
+      const next: BattleState = resolveTurn(s, 'skill', undefined, idx);
+      if (next.monster.hp > 0 && next.monster.statuses?.some((st) => st.id === 'sleep')) slept = true;
+    }
+    expect(slept).toBe(true);
+  });
+});
+
+describe('吟遊詩人 確定キット (#456。空属性・歌支援)', () => {
+  it('レベルでプレリュード〜アプローズを習得', () => {
+    expect(skillsForJob('bard', 3).map((s) => s.name)).toContain('プレリュード');
+    expect(skillsForJob('bard', 25).map((s) => s.name)).toEqual(['プレリュード', 'デスペラード', 'ララバイ', 'スケルツォ', 'ディスコード', 'ラプソディ', 'アプローズ']);
+  });
+
+  it('キット技はすべて SKILLS に定義がある', () => {
+    for (const sk of skillsForJob('bard', 30)) expect(SKILLS[sk.kind], sk.kind).toBeDefined();
+  });
+
+  it('プレリュード (atkUp+agiUp allAllies) はソロで自分に2バフ', () => {
+    const s = startBattle('bard', 3, 8, '吟', 1, 5, 0);
+    const idx = s.playerSkills.findIndex((sk) => sk.name === 'プレリュード');
+    const next: BattleState = resolveTurn(s, 'skill', undefined, idx);
+    const ids = new Set(next.player.statuses?.map((st) => st.id));
+    expect(ids.has('atkUp')).toBe(true);
+    expect(ids.has('agiUp')).toBe(true);
+  });
+
+  it('デスペラード (void 魔法 allEnemies) が敵にダメージ', () => {
+    const s = startBattle('bard', 5, 8, '吟', 2, 3, 0);
+    const idx = s.playerSkills.findIndex((sk) => sk.name === 'デスペラード');
+    const before = s.monster.hp;
+    const next: BattleState = resolveTurn(s, 'skill', undefined, idx);
+    expect(next.monster.hp).toBeLessThan(before);
+  });
+});
+
 describe('隊長 確定キット (#456。全体バフはソロで自己/敵に退化)', () => {
   it('レベルで突撃号令〜攻陣を習得', () => {
     expect(skillsForJob('captain', 3).map((s) => s.name)).toContain('突撃号令');

--- a/packages/core/src/__tests__/skills.test.ts
+++ b/packages/core/src/__tests__/skills.test.ts
@@ -94,17 +94,18 @@ describe('とくぎプラグイン基盤 (#452)', () => {
   });
 
   it('heal: doAttack を呼ばず maxHp の 0.35 回復 (上限クランプ)', () => {
-    const atk = makeCombatant({ maxHp: 100, hp: 50 });
-    const { calls, ctx } = runWithSpy('heal', atk, makeCombatant());
+    // heal は ctx.defender (解決済み対象) を回復する。runSkill 低レベル呼びでは 3 番目の引数が対象。
+    const target = makeCombatant({ maxHp: 100, hp: 50 });
+    const { calls, ctx } = runWithSpy('heal', makeCombatant(), target);
     expect(calls).toHaveLength(0); // 攻撃しない
-    expect(atk.hp).toBe(85); // 50 + round(100*0.35)=85
+    expect(target.hp).toBe(85); // 50 + round(100*0.35)=85
     expect(ctx.events.some((e) => e.text.includes('回復'))).toBe(true);
   });
 
   it('heal: maxHp を超えない', () => {
-    const atk = makeCombatant({ maxHp: 100, hp: 90 });
-    runWithSpy('heal', atk, makeCombatant());
-    expect(atk.hp).toBe(100);
+    const target = makeCombatant({ maxHp: 100, hp: 90 });
+    runWithSpy('heal', makeCombatant(), target);
+    expect(target.hp).toBe(100);
   });
 
   it('EFFECT_HANDLERS は damage/heal/status をカバー', () => {

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -231,11 +231,8 @@ export function skillForJob(archetype: Archetype): JobSkill {
 interface LearnedSkill { kind: SkillKind; name: string; learnAt: number }
 const LEARNED_SKILLS: Partial<Record<Archetype, readonly LearnedSkill[]>> = {
   // 回復役・低攻撃ジョブに「いのり (HP 回復)」を配る。攻撃が弱い職ほど早く覚える。
-  miko: [{ kind: 'heal', name: '神楽の癒し', learnAt: 3 }],
-  // paladin は確定キット (#456) で聖光の癒しを持つため LEARNED は撤去 (JOB_KITS が優先)。
-  // seer は §12 で「回復なしの破滅オラクル」= 確定キットに heal を持たないため LEARNED を撤去。
-  // sage は確定キット (#456) で賢者の癒しを持つため LEARNED は撤去 (JOB_KITS が優先)。
-  bard: [{ kind: 'heal', name: '癒しの旋律', learnAt: 4 }],
+  // paladin/seer/sage/mage/miko/bard は確定キット (#456) を持つため LEARNED は撤去 (JOB_KITS が優先)。
+  //   miko は癒しの鈴/癒し神楽をキットに持つ。bard は §12「回復なし」の歌職。
   // mage は確定キット (#456/§12) で「自己回復を持たない脆い int 大砲」に。旧 heal (回生の術式) は
   // JOB_KITS.mage が skillsForJob を早期 return するため到達不能 = 意図的に撤去 (レビュー ★★)。
 };
@@ -301,6 +298,26 @@ const JOB_KITS: Partial<Record<Archetype, readonly KitSkill[]>> = {
     { id: 'shogun-sweep', name: '足払い', learnAt: 8 },
     { id: 'shogun-guard', name: '見切り', learnAt: 15 },
     { id: 'shogun-oni', name: '鬼神斬り', learnAt: 20 },
+  ],
+  // 巫女: luk型・霊的支援・物理攻撃なし・全体技。魅惑の神楽(confusion)/神楽乱舞/神託の光/巫女の直感(P)は後続。
+  miko: [
+    { id: 'miko-heal-bell', name: '癒しの鈴', learnAt: 3 },
+    { id: 'miko-wind-dance', name: '風の舞', learnAt: 5 },
+    { id: 'miko-sleep-bell', name: '眠りの鈴', learnAt: 8 },
+    { id: 'miko-blessing', name: '加護', learnAt: 12 },
+    { id: 'miko-purify-dance', name: '破魔の舞', learnAt: 15 },
+    { id: 'miko-heal-kagura', name: '癒し神楽', learnAt: 18 },
+    { id: 'miko-cleanse', name: '払串', learnAt: 22 },
+  ],
+  // 吟遊詩人: agi/luk型・空属性・歌でバフ/デバフ/眠り・回復なし。スタッカート/カプリッチョ/英雄叙事詩/名演(P)は後続。
+  bard: [
+    { id: 'bard-prelude', name: 'プレリュード', learnAt: 3 },
+    { id: 'bard-desperado', name: 'デスペラード', learnAt: 5 },
+    { id: 'bard-lullaby', name: 'ララバイ', learnAt: 8 },
+    { id: 'bard-scherzo', name: 'スケルツォ', learnAt: 12 },
+    { id: 'bard-discord', name: 'ディスコード', learnAt: 14 },
+    { id: 'bard-rhapsody', name: 'ラプソディ', learnAt: 15 },
+    { id: 'bard-applause', name: 'アプローズ', learnAt: 25 },
   ],
   // 隊長: タフな前衛指揮官・鼓舞。全体バフ/デバフはソロで自己/敵単体に退化、マルチで全体化。名将(P)は後続。
   captain: [

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -224,18 +224,8 @@ export function skillForJob(archetype: Archetype): JobSkill {
   return { kind: STAT_TO_SKILL[maxI]!, name: JOB_SKILL_NAMES[archetype] };
 }
 
-/** 複数とくぎ (#436, エピック #434)。署名スキル (skillForJob) は常に [0]。ジョブは**レベルアップで
- *  副スキルを習得**する (learnAt = 習得 jobLevel)。弱いジョブほど多く・早く覚えて戦術の幅を持つ
- *  (オーナー方針。docs/24)。#436 では実装容易な `heal` (HP 回復) を配って複数選択を成立させ、
- *  眠り/デバフ/バフ等の状態異常は #437 で状態エンジンと共に足す。 */
-interface LearnedSkill { kind: SkillKind; name: string; learnAt: number }
-const LEARNED_SKILLS: Partial<Record<Archetype, readonly LearnedSkill[]>> = {
-  // 回復役・低攻撃ジョブに「いのり (HP 回復)」を配る。攻撃が弱い職ほど早く覚える。
-  // paladin/seer/sage/mage/miko/bard は確定キット (#456) を持つため LEARNED は撤去 (JOB_KITS が優先)。
-  //   miko は癒しの鈴/癒し神楽をキットに持つ。bard は §12「回復なし」の歌職。
-  // mage は確定キット (#456/§12) で「自己回復を持たない脆い int 大砲」に。旧 heal (回生の術式) は
-  // JOB_KITS.mage が skillsForJob を早期 return するため到達不能 = 意図的に撤去 (レビュー ★★)。
-};
+// 旧 LEARNED_SKILLS (#436: 弱職に heal 副スキルを配る機構) は #456 で全 heal 職がキット化されたため
+// 撤去した。副スキルは JOB_KITS (確定キット) が担う。非キット職は署名スキルのみ (skillsForJob 参照)。
 
 /** ジョブ確定キット (#456 / docs/25 §12)。id は SKILLS レジストリのキー、learnAt = 習得 jobLevel。
  *  キットを持つジョブは skillsForJob がこれを返す (旧 署名+LEARNED 方式より優先)。未登録のジョブは
@@ -369,11 +359,9 @@ export function skillsForJob(archetype: Archetype, jobLevel: number): JobSkill[]
     // まだ何も習得していない低 Lv 帯は署名スキル (Lv1 の基本技) にフォールバック。
     return learned.length ? learned : [skillForJob(archetype)];
   }
-  const signature = skillForJob(archetype);
-  const learned = (LEARNED_SKILLS[archetype] ?? [])
-    .filter((s) => jobLevel >= s.learnAt)
-    .map((s) => ({ kind: s.kind, name: s.name }));
-  return [signature, ...learned];
+  // キット未登録ジョブ (guardian/artist/fighter 等) は署名スキルのみ。旧 LEARNED_SKILLS (弱職に heal
+  // 副スキルを配る機構) は全 heal 職のキット化で不要になり撤去した (#456)。
+  return [skillForJob(archetype)];
 }
 
 /** MP 回復のジョブ特性 (オーナー提案 2026-07-17「MP 回復はジョブの特別な要素に。

--- a/packages/core/src/skills.ts
+++ b/packages/core/src/skills.ts
@@ -610,12 +610,12 @@ export const SKILLS: Record<string, SkillDef> = {
       { kind: 'status', status: 'defDown', target: 'allEnemies', turns: 3 },
     ],
   },
-  // ラプソディ Lv15: 味方 atk・def を強化 (1.5倍/被ダメ減)
+  // ラプソディ Lv15: 味方 atk を強めに (1.5倍) + def は標準 (被ダメ ×0.7)。数値は sim 調整前提。
   'bard-rhapsody': {
     id: 'bard-rhapsody',
     effects: [
       { kind: 'status', status: 'atkUp', target: 'allAllies', turns: 3, magnitude: 1.5 },
-      { kind: 'status', status: 'defUp', target: 'allAllies', turns: 3, magnitude: 0.7 },
+      { kind: 'status', status: 'defUp', target: 'allAllies', turns: 3 },
     ],
   },
   'bard-applause': { id: 'bard-applause', effects: [{ kind: 'fixedDamage', min: 10, max: 18, luckScale: 0.3, element: 'void', target: 'allEnemies' }] }, // アプローズ Lv25

--- a/packages/core/src/skills.ts
+++ b/packages/core/src/skills.ts
@@ -83,6 +83,8 @@ export type SkillEffect =
       kind: 'heal';
       /** maxHp に対する回復割合 */
       ratio: number;
+      /** 対象。self=使用者 / allAllies=味方全体 (巫女の全体回復)。未指定は self。 */
+      target?: 'self' | 'allAllies';
     }
   | {
       kind: 'cleanse';
@@ -270,14 +272,14 @@ const fixedDamageHandler: EffectHandler = (effect, ctx) => {
   });
 };
 
-/** heal: maxHp の割合ぶん回復 (攻撃しないターン)。 */
+/** heal: 対象 (resolveTargets 済みの ctx.defender) の maxHp 割合ぶん回復。self は defender=attacker、
+ *  allAllies は各味方に解決される (runSkillMulti が対象ごとに defender を差し替える)。 */
 const healHandler: EffectHandler = (effect, ctx) => {
   if (effect.kind !== 'heal') return;
-  const { attacker, events, skillName } = ctx;
-  const heal = Math.round(attacker.maxHp * effect.ratio);
-  attacker.hp = Math.min(attacker.maxHp, attacker.hp + heal);
-  // actorSide を尊重 (他ハンドラと統一)。将来マルチで敵が自己回復を撃っても視点が転倒しない。
-  events.push({ actor: ctx.actorSide ?? 'player', text: `${attacker.name}は${skillName}! HP が ${heal} 回復。` });
+  const { defender, events, skillName } = ctx;
+  const heal = Math.round(defender.maxHp * effect.ratio);
+  defender.hp = Math.min(defender.maxHp, defender.hp + heal);
+  events.push({ actor: ctx.actorSide ?? 'player', text: `${defender.name}は${skillName}! HP が ${heal} 回復。` });
 };
 
 /** cleanse: 味方対象のデバフを除去 (浄化)。バフは残す。self は使用者、それ以外は解決済みの味方。 */
@@ -567,6 +569,56 @@ export const SKILLS: Record<string, SkillDef> = {
       { kind: 'status', status: 'agiDown', target: 'allEnemies', turns: 3 },
     ],
   },
+
+  // ─── 巫女 確定キット (#456 / docs/25 §12。luk型・霊的支援・物理攻撃なし・全体技) ───
+  // 数値は sim 調整前提の暫定値。全体技はソロで自己/敵単体に退化、マルチで全体化。luk37 最強なので
+  // 攻撃は wind luckScale。魅惑の神楽(confusion)/神楽乱舞/神託の光/巫女の直感(P) は後続。
+  'miko-heal-bell': { id: 'miko-heal-bell', effects: [{ kind: 'heal', ratio: 0.2, target: 'allAllies' }] }, // 癒しの鈴 Lv3
+  'miko-wind-dance': { id: 'miko-wind-dance', effects: [{ kind: 'fixedDamage', min: 5, max: 12, luckScale: 0.2, element: 'wind', target: 'allEnemies' }] }, // 風の舞 Lv5
+  'miko-sleep-bell': { id: 'miko-sleep-bell', effects: [{ kind: 'status', status: 'sleep', target: 'allEnemies', chance: 0.6, turns: 3 }] }, // 眠りの鈴 Lv8
+  // 加護 Lv12: 味方 atk↑ + def↑
+  'miko-blessing': {
+    id: 'miko-blessing',
+    effects: [
+      { kind: 'status', status: 'atkUp', target: 'allAllies', turns: 3 },
+      { kind: 'status', status: 'defUp', target: 'allAllies', turns: 3 },
+    ],
+  },
+  'miko-purify-dance': { id: 'miko-purify-dance', effects: [{ kind: 'fixedDamage', min: 8, max: 16, luckScale: 0.25, element: 'wind', target: 'allEnemies' }] }, // 破魔の舞 Lv15
+  'miko-heal-kagura': { id: 'miko-heal-kagura', effects: [{ kind: 'heal', ratio: 0.4, target: 'allAllies' }] }, // 癒し神楽 Lv18
+  'miko-cleanse': { id: 'miko-cleanse', effects: [{ kind: 'cleanse', target: 'allAllies' }] }, // 払串 Lv22
+
+  // ─── 吟遊詩人 確定キット (#456 / docs/25 §12。agi/luk型・空属性・歌でバフ/デバフ/眠り・回復なし) ───
+  // 数値は sim 調整前提の暫定値。luk31 最強で空属性 luckScale。スタッカート/カプリッチョ(random)/
+  // 英雄叙事詩(全能力2倍)/名演(P) は後続。**新プリミティブ追加なし**。
+  // プレリュード Lv3: 味方 atk↑ + agi↑
+  'bard-prelude': {
+    id: 'bard-prelude',
+    effects: [
+      { kind: 'status', status: 'atkUp', target: 'allAllies', turns: 3 },
+      { kind: 'status', status: 'agiUp', target: 'allAllies', turns: 3 },
+    ],
+  },
+  'bard-desperado': { id: 'bard-desperado', effects: [{ kind: 'fixedDamage', min: 3, max: 10, luckScale: 0.2, element: 'void', target: 'allEnemies' }] }, // デスペラード Lv5
+  'bard-lullaby': { id: 'bard-lullaby', effects: [{ kind: 'status', status: 'sleep', target: 'allEnemies', chance: 0.6, turns: 3 }] }, // ララバイ Lv8
+  'bard-scherzo': { id: 'bard-scherzo', effects: [{ kind: 'status', status: 'agiUp', target: 'allAllies', turns: 3, magnitude: 2.0 }] }, // スケルツォ Lv12 (agi 2倍)
+  // ディスコード Lv14: 敵 atk↓ + def↓
+  'bard-discord': {
+    id: 'bard-discord',
+    effects: [
+      { kind: 'status', status: 'atkDown', target: 'allEnemies', turns: 3 },
+      { kind: 'status', status: 'defDown', target: 'allEnemies', turns: 3 },
+    ],
+  },
+  // ラプソディ Lv15: 味方 atk・def を強化 (1.5倍/被ダメ減)
+  'bard-rhapsody': {
+    id: 'bard-rhapsody',
+    effects: [
+      { kind: 'status', status: 'atkUp', target: 'allAllies', turns: 3, magnitude: 1.5 },
+      { kind: 'status', status: 'defUp', target: 'allAllies', turns: 3, magnitude: 0.7 },
+    ],
+  },
+  'bard-applause': { id: 'bard-applause', effects: [{ kind: 'fixedDamage', min: 10, max: 18, luckScale: 0.3, element: 'void', target: 'allEnemies' }] }, // アプローズ Lv25
 };
 
 /** そのとくぎが「HP 回復のみ」か (UI が満タン時に無効化するかの判定に使う)。kind 文字列でなく
@@ -593,6 +645,7 @@ export function effectTarget(effect: SkillEffect): SkillTarget {
     case 'fixedDamage':
       return effect.target ?? 'oneEnemy';
     case 'heal':
+      return effect.target ?? 'self';
     case 'restoreMp':
     case 'recoil':
       return 'self';


### PR DESCRIPTION
## 目的

戦闘刷新 (docs/25 §12) の**パーティ支援職・第2弾**。全体バフ/回復/眠りの支援職 **巫女・吟遊詩人** を
追加 (#456)。全体技はソロで自己/敵単体に退化し、マルチ (#453) で全体化する。

## 変更

### heal の全体対象化 (基盤)
`heal` 効果に `target?: 'self' | 'allAllies'` を追加。healHandler を **ctx.defender (resolveTargets 済みの
対象) 回復**に統一。既存の自己回復技 (paladin/sage/performer) は self→[attacker]=defender で**挙動不変**
(battle 93 + world 23 緑で確認)。巫女の全体回復が可能に。

### 巫女 (luk37・霊的支援・物理攻撃なし・全体技)
癒しの鈴(全体回復)/風の舞(wind luk)/眠りの鈴(sleep)/加護(atk・defUp)/破魔の舞(wind)/癒し神楽/払串(cleanse)。luk37=最強で wind luckScale。魅惑の神楽(confusion)/神楽乱舞/神託の光/巫女の直感(P) は後続。

### 吟遊詩人 (luk31・空属性・歌でバフ/デバフ/眠り・回復なし)
プレリュード(atk・agiUp)/デスペラード(void luk)/ララバイ(sleep)/スケルツォ(agi2倍)/ディスコード(atk・defDown)/ラプソディ(atk・defUp)/アプローズ(void)。**新プリミティブ追加なし**。スタッカート/カプリッチョ/英雄叙事詩/名演(P) は後続。

### その他
- 旧 LEARNED_SKILLS.miko/bard を撤去 (キット優先・§12 の bard 回復なし)。全職キット化で LEARNED は空に。
- **支援職は skill[0] がバフのためソロの naive auto-battle (skillIndex0) では弱い** (支援職はパーティ前提・マルチ #453 で本領)。既存バランステストの bard を explorer (攻撃系 luk/agi) に差し替え、bard 支援化を明記。

## 検証
- core 438 緑 (巫女/吟遊詩人のソロ退化=全体回復/眠り/バフ・void 魔法を検証 / 自己回復の挙動不変) /
  web build / typecheck (web+edge+core) 緑。**数値は sim 調整前提**。キット化 12/16 職。

## Review

§1.5 3並列独立レビュー (実装/設計/体験)。**3本とも ★★★/★★ ブロッカーなし・キット⇄ステ合格** (miko luk37 / bard luk31 = 最強、攻撃技が luckScale で乗る)。

- **実装**: 指摘ゼロ。healHandler の対象変更が behavior-preserving (production heal は runSkillMulti 経由・self→[player]=defender で自己回復不変・battle 93緑)。LEARNED 空化の回帰なし。巫女/吟遊詩人のソロ退化を検証。
- **設計**: ★★★ なし。heal target が status/cleanse と同じ resolveTargets パターンに乗る一貫性を確認。★★ 2件を対応。
- **体験**: ★★★/★★ なし。**支援職ソロ弱さは world 手動選択 + isPureHealSkill 無効化で緩和済み** (非ブロッキング・sim 計測のみ過小評価)。差別化成立 (巫女=luk全体wind+眠り+cleanse / 吟遊=歌バフデバフvoid)。

### ★★/★ 対応 (PR 内・commit 21ce796)
- **LEARNED_SKILLS 完全 dead code 化** (設計★★) → 機構ごと撤去 (非キット職は署名のみ)。
- ラプソディ defUp の誇張注記を修正 (★)。

### issue 化
- 支援職の sim 過小評価 (auto-battle skill[0] バフ固定) / 状態異常命中の luk 連動 / バフ ×2上限 → **#479**

CI: web-ci pass / 本番 build pass。core 438緑 / typecheck (web+edge+core) 緑。**自己回復・既存戦闘は挙動不変**。
