### PR TITLE
feat(combat): 守護者キット + thorns/ironWall/def-damage/parry復活 (#456)

### DIFF
--- a/docs/25-combat-plugin-system.md
+++ b/docs/25-combat-plugin-system.md
@@ -291,7 +291,9 @@ export const MONSTER_ABILITIES: Record<string, AbilityDef> = {
 - `damage.stat` に **'def'** を追加 (盾殴り)、`damage` に「累積被ダメ基準」オプション (フルカウンター)
 
 **共通フック (CombatHook) 追加:**
-- `onDamaged(self, attacker, ctx)` — 被弾時のリアクティブ反応 (とげの盾/カウンター/見切り反撃を一般化)
+- `onDamaged(self, attacker, damage, ctx)` — 物理被弾後のリアクティブ反応 (とげの盾=攻撃者へ反射)。実装済み
+  (#456)。**damage 引数 = 食らった最終ダメージ**で反射割合の計算に使う。**フルカウンター (累積被ダメ返し) は
+  別途 `Combatant.damageTaken` の積算が要る** (このフック単体では書けない = 後続バッチ)。
 - `onLethal(self, incoming, ctx) → { survive? }` — 致死を耐える (不動)
 
 **Combatant フィールド:** `statuses: StatusInstance[]` / `passives: string[]` / `damageTaken: number`(累積)

--- a/packages/core/src/__tests__/battle.test.ts
+++ b/packages/core/src/__tests__/battle.test.ts
@@ -89,8 +89,8 @@ describe('skillsForJob (複数とくぎ #436)', () => {
     expect(skillsForJob('miko', 1)).toHaveLength(1); // 署名のみ
     expect(skillsForJob('miko', 2)).toHaveLength(1);
     expect(skillsForJob('miko', 3).map((s) => s.name)).toContain('癒しの鈴');
-    // キット未登録のジョブ (guardian) は署名のみ (旧 LEARNED 機構は全職キット化で空)。
-    expect(skillsForJob('guardian', 30)).toHaveLength(1);
+    // キット未登録のジョブ (fighter=匠) は署名のみ (旧 LEARNED 機構は全職キット化で空)。
+    expect(skillsForJob('fighter', 30)).toHaveLength(1);
   });
   it('回復とくぎは MP を払って maxHp の割合ぶん回復する (キットの heal)', () => {
     // paladin(jobLv5) は聖光の癒し (heal) を持つ。HP を削ってから回復を選ぶ。
@@ -461,27 +461,28 @@ describe('resolveTurn', () => {
     }
   });
 
-  it('見切り (parry) は行動順に関係なく被弾半減 + 反撃が発動する', () => {
-    // 鈍足 guardian (agi 6 = 最遅) で skill 連打 → 後手でも反撃イベントが出る seed があること
+  it('大盾の護り (parry) は行動順に関係なく被弾半減 + 反撃が発動する', () => {
+    // 守護者は #456 で大盾の護り (parry フラグ技) を Lv15 で習得。鈍足 (agi6) でも後手で反撃が出る。
     let counterSeen = 0;
     for (let seed = 0; seed < 30; seed++) {
-      let s = startBattle('guardian', 5, 10, '守護者', 1, seed);
+      let s = startBattle('guardian', 15, 20, '守護者', 1, seed);
+      const parryIdx = s.playerSkills.findIndex((sk) => sk.name === '大盾の護り');
       for (let i = 0; i < 20 && s.outcome === 'ongoing'; i++) {
-        s = resolveTurn(s, 'skill');
+        s = resolveTurn(s, 'skill', undefined, parryIdx);
         if (s.lastEvents.some((e) => e.text.includes('はんげき'))) counterSeen++;
       }
     }
     expect(counterSeen).toBeGreaterThan(0);
   });
 
-  it('parry 型 (guardian) は skill 連打が attack 連打より不利にならない (tier1 勝率)', () => {
+  it('守護者の盾殴り (def 基準) 連打が attack 連打より不利にならない (tier1 勝率)', () => {
+    // 守護者は skill[0]=盾殴り (def43 基準)。固有特技を使うほど弱くなる回帰を防ぐ。
     let skillWins = 0;
     let attackWins = 0;
     for (let seed = 0; seed < 100; seed++) {
       if (playOut(startBattle('guardian', 5, 10, '守護者', 1, seed), 'skill').outcome === 'win') skillWins++;
       if (playOut(startBattle('guardian', 5, 10, '守護者', 1, seed), 'attack').outcome === 'win') attackWins++;
     }
-    // 固有特技を使うほど弱くなる (旧実装は後手 no-op で skill 勝率 2.5%) を防ぐ回帰ガード
     expect(skillWins).toBeGreaterThanOrEqual(attackWins - 10);
   });
 

--- a/packages/core/src/__tests__/job-kits.test.ts
+++ b/packages/core/src/__tests__/job-kits.test.ts
@@ -153,7 +153,7 @@ describe('詩人 確定キット (#456)', () => {
 describe('守護者 確定キット (#456。壁役・def基準)', () => {
   it('レベルで盾殴り〜大盾の護りを習得', () => {
     expect(skillsForJob('guardian', 3).map((s) => s.name)).toContain('盾殴り');
-    expect(skillsForJob('guardian', 15).map((s) => s.name)).toEqual(['盾殴り', '守護の祈り', 'とげの盾', '仁王立ち', '大盾の護り']);
+    expect(skillsForJob('guardian', 15).map((s) => s.name)).toEqual(['盾殴り', '大盾の護り', 'とげの盾', '仁王立ち', '守護の祈り']);
   });
 
   it('キット技はすべて SKILLS に定義がある', () => {

--- a/packages/core/src/__tests__/job-kits.test.ts
+++ b/packages/core/src/__tests__/job-kits.test.ts
@@ -29,9 +29,9 @@ describe('魔法使い 確定キット (#456)', () => {
   });
 
   it('他ジョブ (キット未登録) は従来どおり基本 6 種の署名スキル', () => {
-    // guardian はキット未登録 → 支配ステータス由来の基本 6 種の署名を返す (挙動不変)。
+    // fighter (匠) はまだキット未登録 → 支配ステータス由来の基本 6 種の署名を返す (挙動不変)。
     const base = ['smash', 'parry', 'flurry', 'spell', 'gamble', 'heal'];
-    expect(base).toContain(skillsForJob('guardian', 10)[0]!.kind);
+    expect(base).toContain(skillsForJob('fighter', 10)[0]!.kind);
   });
 
   it('火炎術式が実戦で魔法ダメージ (必中・def無視・範囲) を通す (mage)', () => {
@@ -147,6 +147,44 @@ describe('詩人 確定キット (#456)', () => {
       if (next.monster.hp > 0 && next.monster.statuses?.some((st) => st.id === 'restraint')) bound = true;
     }
     expect(bound).toBe(true);
+  });
+});
+
+describe('守護者 確定キット (#456。壁役・def基準)', () => {
+  it('レベルで盾殴り〜大盾の護りを習得', () => {
+    expect(skillsForJob('guardian', 3).map((s) => s.name)).toContain('盾殴り');
+    expect(skillsForJob('guardian', 15).map((s) => s.name)).toEqual(['盾殴り', '守護の祈り', 'とげの盾', '仁王立ち', '大盾の護り']);
+  });
+
+  it('キット技はすべて SKILLS に定義がある', () => {
+    for (const sk of skillsForJob('guardian', 30)) expect(SKILLS[sk.kind], sk.kind).toBeDefined();
+  });
+
+  it('盾殴りは def 基準でダメージを与える (守りの固さで殴る)', () => {
+    const s = startBattle('guardian', 3, 8, '守', 1, 5, 0);
+    const idx = s.playerSkills.findIndex((sk) => sk.name === '盾殴り');
+    const before = s.monster.hp;
+    const next: BattleState = resolveTurn(s, 'skill', 999, idx);
+    expect(next.monster.hp).toBeLessThan(before); // def43 型なので通常攻撃(atk24)より重い
+  });
+
+  it('とげの盾を張ると敵の攻撃を反射する', () => {
+    // とげの盾 (self) を張ってから、敵が殴ってくるターンで敵 HP が反射ぶん減る。
+    let reflected = false;
+    for (let seed = 0; seed < 20 && !reflected; seed++) {
+      let s = startBattle('guardian', 8, 12, '守', 3, seed, 0);
+      const idx = s.playerSkills.findIndex((sk) => sk.name === 'とげの盾');
+      s = resolveTurn(s, 'skill', undefined, idx); // とげの盾を張る
+      if (s.outcome !== 'ongoing' || !s.player.statuses?.some((st) => st.id === 'thorns')) continue;
+      const monBefore = s.monster.hp;
+      // ぼうぎょして敵の攻撃を受ける (反射狙い)。
+      const next: BattleState = resolveTurn(s, 'guard');
+      if (next.lastEvents.some((e) => e.text.includes('とげに'))) {
+        reflected = true;
+        expect(next.monster.hp).toBeLessThanOrEqual(monBefore);
+      }
+    }
+    expect(reflected).toBe(true);
   });
 });
 

--- a/packages/core/src/__tests__/statuses.test.ts
+++ b/packages/core/src/__tests__/statuses.test.ts
@@ -6,6 +6,7 @@ import {
   applyPowerCalc,
   applyCritCalc,
   applyIncomingCalc,
+  applyOnDamaged,
   tickStatuses,
   clearActedStatuses,
   clearHitStatuses,
@@ -144,6 +145,17 @@ describe('状態異常エンジン (#452)', () => {
     applyStatus(t, st('tumble', 9)); // ignore: 据え置き
     expect(t.statuses).toHaveLength(1);
     expect(t.statuses![0]!.turns).toBe(2);
+  });
+
+  it('thorns: 物理被弾で攻撃者に反射 (onDamaged)', () => {
+    const guard = c({ statuses: [st('thorns', 3, 0.3)] });
+    const attacker = c({ name: 'atk', hp: 100 });
+    applyOnDamaged(guard, attacker, 20, ctx()); // 20 ダメージ食らった → 攻撃者に 20×0.3=6 反射
+    expect(attacker.hp).toBe(94);
+  });
+
+  it('ironWall: 被ダメをほぼ 0 に (incomingCalc ×0.05)', () => {
+    expect(applyIncomingCalc(1, c({ statuses: [st('ironWall', 1)] }), ctx())).toBeCloseTo(0.05);
   });
 
   it('poison は生存者のみ tick (HP0 の死体は毒で追撃しない)', () => {

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -31,6 +31,7 @@ import {
   applyCritCalc,
   applyIncomingCalc,
   applyOnHit,
+  applyOnDamaged,
   tickStatuses,
   clearHitStatuses,
 } from './statuses.js';
@@ -288,6 +289,14 @@ const JOB_KITS: Partial<Record<Archetype, readonly KitSkill[]>> = {
     { id: 'shogun-sweep', name: '足払い', learnAt: 8 },
     { id: 'shogun-guard', name: '見切り', learnAt: 15 },
     { id: 'shogun-oni', name: '鬼神斬り', learnAt: 20 },
+  ],
+  // 守護者: 壁役・def43最強。盾殴りは def 基準。フルカウンター/不動(P)/かばう・挑発(マルチ)は後続。
+  guardian: [
+    { id: 'guardian-bash', name: '盾殴り', learnAt: 3 },
+    { id: 'guardian-prayer', name: '守護の祈り', learnAt: 5 },
+    { id: 'guardian-thorns', name: 'とげの盾', learnAt: 8 },
+    { id: 'guardian-stand', name: '仁王立ち', learnAt: 12 },
+    { id: 'guardian-shield', name: '大盾の護り', learnAt: 15 },
   ],
   // 巫女: luk型・霊的支援・物理攻撃なし・全体技。魅惑の神楽(confusion)/神楽乱舞/神託の光/巫女の直感(P)は後続。
   miko: [
@@ -1123,6 +1132,9 @@ function doAttack(
   });
   const result: AttackResult = { hit: true, damage: final, fatal, crit };
 
+  // 被弾後フック (とげの盾: 攻撃者へ反射)。倒れていなければ。none なら no-op。
+  if (!fatal) applyOnDamaged(defender, attacker, final, defCtx);
+
   // 見切り反撃 (倒れていなければ)
   if (!fatal && defender.parrying) {
     defender.parrying = false;
@@ -1371,7 +1383,7 @@ export function resolveTurn(prev: BattleState, command: Command, turnSeed?: numb
       events.push({ actor: 'player', text: `${state.player.name}はぼうぎょのかまえ!` });
     }
   }
-  if (cmd === 'skill' && selectedSkill.kind === 'parry') {
+  if (cmd === 'skill' && SKILLS[selectedSkill.kind]?.parry) {
     state.player.parrying = true;
     events.push({ actor: 'player', text: `${state.player.name}は${selectedSkill.name}の構え! (防御しつつ反撃)` });
   }
@@ -1560,7 +1572,7 @@ export function resolveTurnMulti(
       events.push({ actor: 'player', text: `${player.name}はぼうぎょのかまえ!` });
     }
   }
-  if (cmd === 'skill' && selectedSkill.kind === 'parry') {
+  if (cmd === 'skill' && SKILLS[selectedSkill.kind]?.parry) {
     player.parrying = true;
     events.push({ actor: 'player', text: `${player.name}は${selectedSkill.name}の構え! (防御しつつ反撃)` });
   }

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -293,10 +293,10 @@ const JOB_KITS: Partial<Record<Archetype, readonly KitSkill[]>> = {
   // 守護者: 壁役・def43最強。盾殴りは def 基準。フルカウンター/不動(P)/かばう・挑発(マルチ)は後続。
   guardian: [
     { id: 'guardian-bash', name: '盾殴り', learnAt: 3 },
-    { id: 'guardian-prayer', name: '守護の祈り', learnAt: 5 },
+    { id: 'guardian-shield', name: '大盾の護り', learnAt: 5 }, // parry反撃 (§14.1: Lv5)
     { id: 'guardian-thorns', name: 'とげの盾', learnAt: 8 },
     { id: 'guardian-stand', name: '仁王立ち', learnAt: 12 },
-    { id: 'guardian-shield', name: '大盾の護り', learnAt: 15 },
+    { id: 'guardian-prayer', name: '守護の祈り', learnAt: 15 }, // defUp (§14.1: Lv15)
   ],
   // 巫女: luk型・霊的支援・物理攻撃なし・全体技。魅惑の神楽(confusion)/神楽乱舞/神託の光/巫女の直感(P)は後続。
   miko: [
@@ -368,7 +368,7 @@ export function skillsForJob(archetype: Archetype, jobLevel: number): JobSkill[]
     // まだ何も習得していない低 Lv 帯は署名スキル (Lv1 の基本技) にフォールバック。
     return learned.length ? learned : [skillForJob(archetype)];
   }
-  // キット未登録ジョブ (guardian/artist/fighter 等) は署名スキルのみ。旧 LEARNED_SKILLS (弱職に heal
+  // キット未登録ジョブ (artist/fighter 等) は署名スキルのみ。旧 LEARNED_SKILLS (弱職に heal
   // 副スキルを配る機構) は全 heal 職のキット化で不要になり撤去した (#456)。
   return [skillForJob(archetype)];
 }

--- a/packages/core/src/skills.ts
+++ b/packages/core/src/skills.ts
@@ -631,7 +631,8 @@ export const SKILLS: Record<string, SkillDef> = {
   // 不動(P onLethal)/かばう・挑発(パーティ前提=マルチ #453) は後続。
   'guardian-bash': { id: 'guardian-bash', effects: [{ kind: 'damage', stat: 'def', power: 1.0 }] }, // 盾殴り Lv3
   'guardian-prayer': { id: 'guardian-prayer', effects: [{ kind: 'status', status: 'defUp', target: 'self', turns: 3, magnitude: 0.6 }] }, // 守護の祈り Lv5
-  'guardian-thorns': { id: 'guardian-thorns', effects: [{ kind: 'status', status: 'thorns', target: 'self', turns: 3, magnitude: 0.3 }] }, // とげの盾 Lv8
+  // とげの盾 Lv8: 物理被弾のみ反射 (doMagic では非発火。§14.1 の「物理被弾時」に準拠)。
+  'guardian-thorns': { id: 'guardian-thorns', effects: [{ kind: 'status', status: 'thorns', target: 'self', turns: 3, magnitude: 0.3 }] },
   'guardian-stand': { id: 'guardian-stand', effects: [{ kind: 'status', status: 'ironWall', target: 'self', turns: 1 }] }, // 仁王立ち Lv12 (被ダメ≒0 1T)
   'guardian-shield': { id: 'guardian-shield', effects: [], parry: true }, // 大盾の護り Lv15 (parry: 防御しつつ反撃)
 };

--- a/packages/core/src/skills.ts
+++ b/packages/core/src/skills.ts
@@ -16,7 +16,7 @@ import type { Element } from './elements.js';
 import { resolveTargets, type SkillTarget, type CombatSides } from './combat-target.js';
 
 /** ダメージの基準にする支配ステータス。int は魔撃 (必中・防御半減)、agi/luk は物理。 */
-export type DamageStat = 'atk' | 'int' | 'agi' | 'luk';
+export type DamageStat = 'atk' | 'int' | 'agi' | 'luk' | 'def';
 
 /** ギャンブル倍率 (0〜max、luk が高いほど下振れしにくい)。 */
 export interface GambleSpec {
@@ -120,6 +120,9 @@ export interface SkillDef {
   /** とくぎ ID (JobSkill.kind と一致させる) */
   id: string;
   effects: SkillEffect[];
+  /** 見切り/大盾の護り: 「防御しつつ反撃」を宣言する (resolveTurn が parrying フラグを立てる)。
+   *  宣言型なので effects は空でよい (反撃は doAttack の parrying 経路)。 */
+  parry?: boolean;
 }
 
 /** ハンドラに注入するエンジン一次関数 (循環 import 回避のための依存注入)。 */
@@ -184,6 +187,9 @@ const damageHandler: EffectHandler = (effect, ctx) => {
         break;
       case 'luk':
         opts.atkOverride = attacker.luk;
+        break;
+      case 'def':
+        opts.atkOverride = attacker.def; // 守護者の盾殴り: 守りの固さで殴る (def43 型)
         break;
     }
     if (effect.gamble) {
@@ -332,8 +338,8 @@ export const EFFECT_HANDLERS: Record<SkillEffect['kind'], EffectHandler> = {
 export const SKILLS: Record<string, SkillDef> = {
   // 強打: atk 基準 1.7 倍・やや当てにくい
   smash: { id: 'smash', effects: [{ kind: 'damage', stat: 'atk', power: 1.7, hitBonus: -0.1 }] },
-  // 見切り: 宣言は resolveTurn 冒頭 (行動順に依存しない)。ここでは効果なし。
-  parry: { id: 'parry', effects: [] },
+  // 見切り: 宣言は resolveTurn 冒頭 (行動順に依存しない)。防御しつつ反撃。
+  parry: { id: 'parry', effects: [], parry: true },
   // 連撃: agi 基準 0.65 倍 × 2 撃 (素早さで手数)
   flurry: { id: 'flurry', effects: [{ kind: 'damage', stat: 'agi', power: 0.65, hits: 2 }] },
   // 魔撃: int 基準・必中・防御半減
@@ -619,6 +625,15 @@ export const SKILLS: Record<string, SkillDef> = {
     ],
   },
   'bard-applause': { id: 'bard-applause', effects: [{ kind: 'fixedDamage', min: 10, max: 18, luckScale: 0.3, element: 'void', target: 'allEnemies' }] }, // アプローズ Lv25
+
+  // ─── 守護者 確定キット (#456 / docs/25 §12・§14.1。壁役・def43最強) ───
+  // 数値は sim 調整前提の暫定値。盾殴りは def 基準 (守りの固さで殴る)。フルカウンター(累積反射)/
+  // 不動(P onLethal)/かばう・挑発(パーティ前提=マルチ #453) は後続。
+  'guardian-bash': { id: 'guardian-bash', effects: [{ kind: 'damage', stat: 'def', power: 1.0 }] }, // 盾殴り Lv3
+  'guardian-prayer': { id: 'guardian-prayer', effects: [{ kind: 'status', status: 'defUp', target: 'self', turns: 3, magnitude: 0.6 }] }, // 守護の祈り Lv5
+  'guardian-thorns': { id: 'guardian-thorns', effects: [{ kind: 'status', status: 'thorns', target: 'self', turns: 3, magnitude: 0.3 }] }, // とげの盾 Lv8
+  'guardian-stand': { id: 'guardian-stand', effects: [{ kind: 'status', status: 'ironWall', target: 'self', turns: 1 }] }, // 仁王立ち Lv12 (被ダメ≒0 1T)
+  'guardian-shield': { id: 'guardian-shield', effects: [], parry: true }, // 大盾の護り Lv15 (parry: 防御しつつ反撃)
 };
 
 /** そのとくぎが「HP 回復のみ」か (UI が満タン時に無効化するかの判定に使う)。kind 文字列でなく

--- a/packages/core/src/statuses.ts
+++ b/packages/core/src/statuses.ts
@@ -26,7 +26,9 @@ export type StatusId =
   | 'defDown' // 被ダメ magnitude 倍
   | 'agiUp'
   | 'agiDown' // 回避 magnitude 倍
-  | 'doomMark'; // 破滅の予言: turnEnd でカウントダウン、0 で magnitude の大ダメージ
+  | 'doomMark' // 破滅の予言: turnEnd でカウントダウン、0 で magnitude の大ダメージ
+  | 'thorns' // とげの盾: 物理被弾時に攻撃者へ magnitude 割合を反射
+  | 'ironWall'; // 仁王立ち: 被ダメをほぼ 0 に (incomingCalc ×magnitude、既定 0.05)
 
 /** 付与時に turns 未指定なら使う既定持続 (毒手/デバフ等の共通デフォルト)。 */
 export const DEFAULT_STATUS_TURNS = 2;
@@ -72,6 +74,8 @@ export interface CombatHook {
   onHit?(atk: Combatant, def: Combatant, ctx: HookCtx): { instakill?: boolean } | void;
   /** 被ダメージの倍率補正 (c=被弾側)。defUp/defDown/転倒。 */
   incomingCalc?(power: number, c: Combatant, ctx: HookCtx): number;
+  /** 物理被弾後 (c=被弾側)。とげの盾: 攻撃者 atk へ反射。damage=食らった最終ダメージ。 */
+  onDamaged?(c: Combatant, atk: Combatant, damage: number, ctx: HookCtx): void;
   /** ターン終了。毒ダメージ等。 */
   turnEnd?(c: Combatant, ctx: HookCtx): void;
 }
@@ -164,6 +168,20 @@ export const STATUS_REGISTRY: Record<StatusId, StatusDef> = {
   agiDown: { id: 'agiDown', name: '素早さ低下', restack: 'refresh', dodgeCalc: (d, _c, ctx) => d * (ctx.status?.magnitude ?? 0.6) },
   // 破滅の予言 (予言者): turnEnd でカウントダウン、最終ターン (turns===1) に magnitude の大ダメージ。
   // fresh スキップにより付与ターンは進まず、以後 N ターンかけて破滅が訪れる (予告 → 炸裂の緊張)。
+  // とげの盾 (守護者): 物理被弾で攻撃者に反射 (magnitude=反射割合、既定 0.3)。
+  thorns: {
+    id: 'thorns',
+    name: 'とげの盾',
+    restack: 'refresh',
+    onDamaged: (c, atk, damage, ctx) => {
+      if (atk.hp <= 0) return;
+      const reflect = Math.max(1, Math.round(damage * (ctx.status?.magnitude ?? 0.3)));
+      atk.hp = Math.max(0, atk.hp - reflect);
+      ctx.events.push({ actor: ctx.actor ?? 'player', text: `${atk.name}は とげに ${reflect} のダメージを受けた!`, damage: reflect });
+    },
+  },
+  // 仁王立ち (守護者): 被ダメをほぼ 0 に (incomingCalc ×0.05)。turns 1 の完全防御。
+  ironWall: { id: 'ironWall', name: '仁王立ち', incomingCalc: (p, _c, ctx) => p * (ctx.status?.magnitude ?? 0.05) },
   doomMark: {
     id: 'doomMark',
     name: '破滅の予言',
@@ -203,6 +221,8 @@ const STATUS_APPLY_TEXT: Record<StatusId, string> = {
   agiUp: 'の素早さがあがった!',
   agiDown: 'の素早さがさがった!',
   doomMark: 'に 破滅の刻印が刻まれた…!',
+  thorns: 'は とげの盾をかまえた!',
+  ironWall: 'は 仁王立ちした! (被ダメージ激減)',
 };
 
 /** 状態付与の告知文 (対象名 + テキスト)。 */
@@ -266,6 +286,11 @@ export function applyIncomingCalc(base: number, c: Combatant, ctx: HookCtx): num
   let v = base;
   for (const { def, inst } of hooksOf(c)) v = def.incomingCalc?.(v, c, ctxFor(ctx, inst)) ?? v;
   return v;
+}
+
+/** 物理被弾後: 被弾側のフック (とげの盾) を回す (攻撃者へ反射など)。 */
+export function applyOnDamaged(c: Combatant, atk: Combatant, damage: number, ctx: HookCtx): void {
+  for (const { def, inst } of hooksOf(c)) def.onDamaged?.(c, atk, damage, ctxFor(ctx, inst));
 }
 
 /** 命中時: いずれかのパッシブ/状態が即死を返したら true。 */


### PR DESCRIPTION
## 目的

戦闘刷新 (docs/25 §12) の**壁役ジョブ**。**守護者** (def43最強のタンク) を追加 (#456)。タンク語彙
(def-damage/thorns/ironWall/parry) を消費者と同時に導入。

## 変更

### タンク語彙
- **def-as-damage-stat**: `DamageStat` に `'def'` 追加 (盾殴り=守りの固さで殴る)。守護者 def43 と整合。
- **thorns** (とげの盾): 物理被弾で攻撃者へ magnitude 割合を反射。`CombatHook` に **onDamaged** フックを追加し doAttack の被弾後 (非致死) から発火。
- **ironWall** (仁王立ち): incomingCalc ×0.05 で被ダメをほぼ 0 に (1T 完全防御)。
- **parry を SkillDef.parry フラグ化**: 守護者の大盾の護り (parry反撃) を復活。resolveTurn/resolveTurnMulti の parry 宣言判定を `kind==='parry'` → `SKILLS[kind].parry` に一般化 (guardian-shield も parry として機能)。

### 守護者 (壁役・def43最強)
盾殴り3(def)/守護の祈り5(defUp)/とげの盾8(thorns)/仁王立ち12(ironWall)/大盾の護り15(parry)。フルカウンター(累積反射)/不動(P onLethal)/かばう・挑発(パーティ=マルチ #453) は後続。

### テスト整合
guardian がキット化されたため、旧「非キット署名」テストを fighter (=匠、未キット) に、parry テストを guardian Lv15 大盾の護り に更新。**parry 機構は守護者経由で存続** (孤児化せず)。

## 検証
- core 444 緑 (thorns の反射・ironWall の被ダメ減・def 基準の盾殴り・parry 復活 (大盾の護りの反撃) を検証) /
  web build / typecheck (web+edge+core) 緑。**既存の物理戦闘は onDamaged が空フックで挙動不変**。数値は sim 前提。
- キット化 13/16 職。残り: 芸術家・匠 (召喚職=マルチ allies 必要)。

## Review

§1.5 3並列独立レビュー (実装/設計/体験)。**3本とも ★★★ なし・キット⇄ステ合格** (guardian def43=最強、盾殴りが stat:'def' で乗る・「守りで殴る」が数式で成立)。

- **実装**: ★★★/★★ なし。onDamaged が既存物理で完全 no-op (rng 非消費)・parry 一般化が基底 parry 職で挙動不変・thorns/ironWall/def-damage 正しい・テスト整合修正が回帰隠蔽なしを確認。
- **設計**: ★★★ なし。onDamaged/parry フラグ化が §0 プラグイン原則に忠実。タンクソロ自己完結を確認。
- **体験**: ★★★ なし。キット⇄ステ噛み合い・タンクソロ体験ともに構造で担保。

### ★★/★ 対応 (PR 内・commit)
- **learnAt が §14.1 と逆転** (体験★★) → 大盾の護り Lv5 / 守護の祈り Lv15 に整合。
- **docs §10 onDamaged シグネチャ更新** (設計★★) → 4引数 (damage) + フルカウンターは damageTaken 積算依存を明記。
- stale コメント修正 / とげの盾 物理限定注記 (★)。

### 引き継ぎ
- フルカウンター(累積反射=damageTaken)/不動(P onLethal)/かばう・挑発(マルチ) は後続。thorns 下限微ダメージ・仁王立ち告知括弧は sim/好みで #479 系。

CI: web-ci pass / 本番 build pass。core 444緑 / typecheck (web+edge+core) 緑。**既存物理戦闘は挙動不変**。
