### PR TITLE
feat(combat): 冒険者・芸術家・匠キット — 全16職キット化完成 + accDown/scaleBy (#456)

### DIFF
--- a/packages/core/src/__tests__/battle.test.ts
+++ b/packages/core/src/__tests__/battle.test.ts
@@ -89,8 +89,9 @@ describe('skillsForJob (複数とくぎ #436)', () => {
     expect(skillsForJob('miko', 1)).toHaveLength(1); // 署名のみ
     expect(skillsForJob('miko', 2)).toHaveLength(1);
     expect(skillsForJob('miko', 3).map((s) => s.name)).toContain('癒しの鈴');
-    // キット未登録のジョブ (fighter=匠) は署名のみ (旧 LEARNED 機構は全職キット化で空)。
-    expect(skillsForJob('fighter', 30)).toHaveLength(1);
+    // 全16職キット化済み。fighter (匠) も Lv3 でキット技を習得する (Lv1-2 は署名のみ)。
+    expect(skillsForJob('fighter', 1)).toHaveLength(1);
+    expect(skillsForJob('fighter', 3).map((s) => s.name)).toContain('からくり仕掛け');
   });
   it('回復とくぎは MP を払って maxHp の割合ぶん回復する (キットの heal)', () => {
     // paladin(jobLv5) は聖光の癒し (heal) を持つ。HP を削ってから回復を選ぶ。

--- a/packages/core/src/__tests__/job-kits.test.ts
+++ b/packages/core/src/__tests__/job-kits.test.ts
@@ -28,10 +28,13 @@ describe('魔法使い 確定キット (#456)', () => {
     }
   });
 
-  it('他ジョブ (キット未登録) は従来どおり基本 6 種の署名スキル', () => {
-    // fighter (匠) はまだキット未登録 → 支配ステータス由来の基本 6 種の署名を返す (挙動不変)。
+  it('全16職キット化済み — 未習得帯 (Lv1) は署名スキル (基本6種) にフォールバック', () => {
+    // 全職が確定キットを持つ。最初の習得 (Lv3) 未満は署名スキルにフォールバックする。
     const base = ['smash', 'parry', 'flurry', 'spell', 'gamble', 'heal'];
-    expect(base).toContain(skillsForJob('fighter', 10)[0]!.kind);
+    for (const job of ['mage', 'guardian', 'fighter', 'artist', 'explorer'] as const) {
+      expect(skillsForJob(job, 1), job).toHaveLength(1);
+      expect(base, job).toContain(skillsForJob(job, 1)[0]!.kind);
+    }
   });
 
   it('火炎術式が実戦で魔法ダメージ (必中・def無視・範囲) を通す (mage)', () => {
@@ -147,6 +150,51 @@ describe('詩人 確定キット (#456)', () => {
       if (next.monster.hp > 0 && next.monster.statuses?.some((st) => st.id === 'restraint')) bound = true;
     }
     expect(bound).toBe(true);
+  });
+});
+
+describe('冒険者・芸術家・匠 確定キット (#456。全16職完成)', () => {
+  it('3職ともレベルで習得し、全技が SKILLS に定義がある', () => {
+    expect(skillsForJob('explorer', 25).map((s) => s.name)).toContain('背水の陣');
+    expect(skillsForJob('artist', 15).map((s) => s.name)).toContain('芸術は爆発だ');
+    expect(skillsForJob('fighter', 18).map((s) => s.name)).toContain('高圧放水');
+    for (const job of ['explorer', 'artist', 'fighter'] as const) {
+      for (const sk of skillsForJob(job, 30)) expect(SKILLS[sk.kind], `${job}:${sk.kind}`).toBeDefined();
+    }
+  });
+
+  it('全16職が確定キットを持つ', () => {
+    const all = ['mage', 'ninja', 'poet', 'warrior', 'paladin', 'performer', 'sage', 'seer', 'shogun', 'captain', 'miko', 'bard', 'guardian', 'explorer', 'artist', 'fighter'] as const;
+    for (const job of all) {
+      // Lv30 でキット技 (署名でない = kind が SKILLS の固有 id) を持つ。
+      const skills = skillsForJob(job, 30);
+      expect(skills.length, job).toBeGreaterThan(1);
+    }
+  });
+
+  it('背水の陣は自 HP が低いほど威力が上がる (scaleBy missingHpRatio)', () => {
+    const full = startBattle('explorer', 25, 28, '冒', 3, 5, 0);
+    const idx = full.playerSkills.findIndex((sk) => sk.name === '背水の陣');
+    const fullDmg = full.monster.hp - resolveTurn(full, 'skill', 111, idx).monster.hp;
+    const hurt = startBattle('explorer', 25, 28, '冒', 3, 5, 0);
+    hurt.player.hp = Math.max(1, Math.round(hurt.player.maxHp * 0.2)); // 瀕死
+    const hurtDmg = hurt.monster.hp - resolveTurn(hurt, 'skill', 111, idx).monster.hp;
+    expect(hurtDmg).toBeGreaterThan(fullDmg); // HP 低いほど大きい
+  });
+
+  it('かく乱 (accDown) を撒くと敵の命中が下がる (回避しやすくなる)', () => {
+    const s = startBattle('explorer', 15, 20, '冒', 3, 5, 0);
+    const idx = s.playerSkills.findIndex((sk) => sk.name === 'かく乱');
+    const next: BattleState = resolveTurn(s, 'skill', undefined, idx);
+    expect(next.monster.statuses?.some((st) => st.id === 'accDown')).toBe(true);
+  });
+
+  it('匠のからくり仕掛けは int 連動の必中魔法 (int43 型)', () => {
+    const s = startBattle('fighter', 3, 8, '匠', 2, 3, 0);
+    const idx = s.playerSkills.findIndex((sk) => sk.name === 'からくり仕掛け');
+    const before = s.monster.hp;
+    const next: BattleState = resolveTurn(s, 'skill', undefined, idx);
+    expect(next.monster.hp).toBeLessThan(before);
   });
 });
 

--- a/packages/core/src/__tests__/statuses.test.ts
+++ b/packages/core/src/__tests__/statuses.test.ts
@@ -7,6 +7,7 @@ import {
   applyCritCalc,
   applyIncomingCalc,
   applyOnDamaged,
+  applyModifyHit,
   tickStatuses,
   clearActedStatuses,
   clearHitStatuses,
@@ -156,6 +157,12 @@ describe('状態異常エンジン (#452)', () => {
 
   it('ironWall: 被ダメをほぼ 0 に (incomingCalc ×0.05)', () => {
     expect(applyIncomingCalc(1, c({ statuses: [st('ironWall', 1)] }), ctx())).toBeCloseTo(0.05);
+  });
+
+  it('accDown: 攻撃側の hitBonus を下げる (modifyHit)', () => {
+    expect(applyModifyHit(0, c({ statuses: [st('accDown', 3)] }), ctx())).toBeCloseTo(-0.2);
+    expect(applyModifyHit(0.1, c({ statuses: [st('accDown', 3, 0.3)] }), ctx())).toBeCloseTo(-0.2);
+    expect(applyModifyHit(0, c(), ctx())).toBe(0); // なしは no-op
   });
 
   it('poison は生存者のみ tick (HP0 の死体は毒で追撃しない)', () => {

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -226,19 +226,19 @@ export function skillForJob(archetype: Archetype): JobSkill {
   return { kind: STAT_TO_SKILL[maxI]!, name: JOB_SKILL_NAMES[archetype] };
 }
 
-// 旧 LEARNED_SKILLS (#436: 弱職に heal 副スキルを配る機構) は #456 で全 heal 職がキット化されたため
-// 撤去した。副スキルは JOB_KITS (確定キット) が担う。非キット職は署名スキルのみ (skillsForJob 参照)。
+// 旧 LEARNED_SKILLS (#436: 弱職に heal 副スキルを配る機構) は #456 で全職キット化されたため撤去した。
+// とくぎは全て JOB_KITS (確定キット) が担う。
 
 /** ジョブ確定キット (#456 / docs/25 §12)。id は SKILLS レジストリのキー、learnAt = 習得 jobLevel。
- *  キットを持つジョブは skillsForJob がこれを返す (旧 署名+LEARNED 方式より優先)。未登録のジョブは
- *  従来どおり。**段階投入**: まず単体戦闘で成立するジョブから (全体/召喚技は #453 マルチ戦闘後)。 */
+ *  **全16職が確定キットを持つ** (Record 全キー必須。職を足したらここにも必須)。skillsForJob が返す。
+ *  未習得帯 (最初の learnAt 未満) のみ署名スキルにフォールバックする。 */
 interface KitSkill {
   /** SKILLS のキー */
   id: string;
   name: string;
   learnAt: number;
 }
-const JOB_KITS: Partial<Record<Archetype, readonly KitSkill[]>> = {
+const JOB_KITS: Record<Archetype, readonly KitSkill[]> = {
   // 魔法使い: 単体・int型・必中・def無視の大砲 (脆い)。パイロット (#456)。魔力障壁 Lv30 (P) は後続。
   mage: [
     { id: 'mage-flame', name: '火炎術式', learnAt: 3 },
@@ -389,21 +389,15 @@ const JOB_KITS: Partial<Record<Archetype, readonly KitSkill[]>> = {
   ],
 };
 
-/** その jobLevel 時点で使えるとくぎ列。UI/エンジンはこの列から毎ターン選ぶ。
- *  - **キット未登録ジョブ**: [0] = 署名スキル (skillForJob と一致 = 後方互換)、以降は習得済み副スキル。
- *  - **確定キット (#456) 持ちジョブ**: learnAt<=level のキット技 (未習得帯のみ署名にフォールバック)。
- *    この場合 [0] は署名と一致しない (例 mage Lv3+ の [0] は火炎術式)。「playerSkills[0]===署名」を
- *    前提にするコードを書かないこと (単数 playerSkill は別途 skillForJob で保持されフォールバック用)。 */
+/** その jobLevel 時点で使えるとくぎ列。UI/エンジンはこの列から毎ターン選ぶ。全16職キット化済み (#456)。
+ *  learnAt<=level のキット技を返す。未習得帯 (最初の技より前の Lv) のみ署名スキルにフォールバック。
+ *  **[0] は署名と一致しない** (例 mage Lv3+ の [0] は火炎術式)。「playerSkills[0]===署名」を前提にする
+ *  コードを書かないこと (単数 playerSkill は別途 skillForJob で保持されフォールバック用)。 */
 export function skillsForJob(archetype: Archetype, jobLevel: number): JobSkill[] {
-  const kit = JOB_KITS[archetype];
-  if (kit) {
-    const learned = kit.filter((s) => jobLevel >= s.learnAt).map((s) => ({ kind: s.id, name: s.name }));
-    // まだ何も習得していない低 Lv 帯は署名スキル (Lv1 の基本技) にフォールバック。
-    return learned.length ? learned : [skillForJob(archetype)];
-  }
-  // キット未登録ジョブ (artist/fighter 等) は署名スキルのみ。旧 LEARNED_SKILLS (弱職に heal
-  // 副スキルを配る機構) は全 heal 職のキット化で不要になり撤去した (#456)。
-  return [skillForJob(archetype)];
+  // 全16職が確定キットを持つ (#456)。learnAt<=level のキット技を返し、未習得帯 (最初の技より前) は
+  // 署名スキル (Lv1 の基本技) にフォールバックする。
+  const learned = JOB_KITS[archetype].filter((s) => jobLevel >= s.learnAt).map((s) => ({ kind: s.id, name: s.name }));
+  return learned.length ? learned : [skillForJob(archetype)];
 }
 
 /** MP 回復のジョブ特性 (オーナー提案 2026-07-17「MP 回復はジョブの特別な要素に。

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -32,6 +32,7 @@ import {
   applyIncomingCalc,
   applyOnHit,
   applyOnDamaged,
+  applyModifyHit,
   tickStatuses,
   clearHitStatuses,
 } from './statuses.js';
@@ -289,6 +290,38 @@ const JOB_KITS: Partial<Record<Archetype, readonly KitSkill[]>> = {
     { id: 'shogun-sweep', name: '足払い', learnAt: 8 },
     { id: 'shogun-guard', name: '見切り', learnAt: 15 },
     { id: 'shogun-oni', name: '鬼神斬り', learnAt: 20 },
+  ],
+  // 冒険者: 万能スカーミッシャー・luk34/agi25。武器投げ(装備)/秘境探索(random)/全体技/旅の勘(P)は後続。
+  explorer: [
+    { id: 'explorer-pebble', name: '石つぶて', learnAt: 3 },
+    { id: 'explorer-snare', name: '足がらめ', learnAt: 5 },
+    { id: 'explorer-reveal', name: 'みやぶる', learnAt: 7 },
+    { id: 'explorer-survival', name: 'サバイバル', learnAt: 8 },
+    { id: 'explorer-gale', name: '疾風の一撃', learnAt: 10 },
+    { id: 'explorer-confuse', name: 'かく乱', learnAt: 15 },
+    { id: 'explorer-hitrun', name: '一撃離脱', learnAt: 18 },
+    { id: 'explorer-lastditch', name: '背水の陣', learnAt: 25 },
+  ],
+  // 芸術家: 幻術師・luk/def26・空属性。だまし討ち/幻影の分身/創造の絵筆(summon)/混乱系/傑作/審美眼(P)は後続。
+  artist: [
+    { id: 'artist-bolt', name: '色彩の弾', learnAt: 3 },
+    { id: 'artist-daze', name: '幻惑の色', learnAt: 5 },
+    { id: 'artist-trompe', name: 'だまし絵', learnAt: 7 },
+    { id: 'artist-mist', name: '極彩の霧', learnAt: 8 },
+    { id: 'artist-blind', name: '目くらまし', learnAt: 10 },
+    { id: 'artist-blade', name: '原色の刃', learnAt: 12 },
+    { id: 'artist-explosion', name: '芸術は爆発だ', learnAt: 15 },
+  ],
+  // 匠: からくり技師・int43・罠と装置。自爆人形/からくり兵(summon)/大発破/兵器解放/発明家(P)は後続。
+  fighter: [
+    { id: 'fighter-contraption', name: 'からくり仕掛け', learnAt: 3 },
+    { id: 'fighter-smoke', name: '煙玉', learnAt: 5 },
+    { id: 'fighter-poisongas', name: '毒煙装置', learnAt: 7 },
+    { id: 'fighter-pitfall', name: '落とし穴', learnAt: 8 },
+    { id: 'fighter-ironball', name: '鉄球投擲', learnAt: 10 },
+    { id: 'fighter-flamethrower', name: '火炎放射器', learnAt: 12 },
+    { id: 'fighter-net', name: '拘束網', learnAt: 15 },
+    { id: 'fighter-waterjet', name: '高圧放水', learnAt: 18 },
   ],
   // 守護者: 壁役・def43最強。盾殴りは def 基準。フルカウンター/不動(P)/かばう・挑発(マルチ)は後続。
   guardian: [
@@ -1065,9 +1098,11 @@ function doAttack(
   // 回避判定 (魔撃は必中)。ぼうぎょの余韻 (focus) 中は「動きを読めている」ので回避が上がる。
   if (!opts.useInt) {
     const focusBonus = defender.focus > 0 ? t.guardFocusDodge : 0;
+    // 命中補正 (accDown: 攻撃側の命中が下がる)。none なら opts.hitBonus のまま。
+    const effHitBonus = applyModifyHit(opts.hitBonus ?? 0, attacker, atkCtx);
     let dodge = Math.min(
       t.dodgeMax + focusBonus,
-      Math.max(t.dodgeMin, t.dodgeBase + (defender.agi - attacker.agi) * t.agiDodgeScale - (opts.hitBonus ?? 0) + focusBonus),
+      Math.max(t.dodgeMin, t.dodgeBase + (defender.agi - attacker.agi) * t.agiDodgeScale - effHitBonus + focusBonus),
     );
     dodge = applyDodgeCalc(dodge, defender, defCtx); // かくれみ/agi バフ
     if (rng() < dodge) {

--- a/packages/core/src/skills.ts
+++ b/packages/core/src/skills.ts
@@ -78,7 +78,9 @@ export type SkillEffect =
       element?: Element;
       /** 対象 (マルチ戦闘 #453)。未指定は oneEnemy。allEnemies で全体魔法 (メテオ全体版等)。 */
       target?: SkillTarget;
-      /** データ駆動の計算値参照 (§14.5)。'buffCount' = 使用者の自己バフ数 (感情爆発)。 */
+      /** データ駆動の計算値参照 (§14.5)。'buffCount' = 使用者の自己バフ数 (感情爆発)。
+       *  TODO: damage 側の 'missingHpRatio' と将来の 'weaponPower' を含め、§14.5 の scaleBy を
+       *  共通型に寄せる (現状は effect 種別ごとに使う参照だけを許して二重定義になっている)。 */
       scaleBy?: 'buffCount';
       /** scaleBy の1件あたり倍率: amount ×= 1 + count × scaleFactor。未指定 0.4。 */
       scaleFactor?: number;

--- a/packages/core/src/skills.ts
+++ b/packages/core/src/skills.ts
@@ -60,6 +60,10 @@ export type SkillEffect =
       element?: Element;
       /** 対象 (マルチ戦闘 #453)。未指定は oneEnemy。allEnemies で全体物理 (なぎ払い等)。 */
       target?: SkillTarget;
+      /** 計算値参照 (§14.5)。'missingHpRatio' = 使用者の失った HP 割合 (背水の陣: HP 低いほど威力↑)。 */
+      scaleBy?: 'missingHpRatio';
+      /** scaleBy の倍率: power ×= 1 + value × scaleFactor。未指定 1.0。 */
+      scaleFactor?: number;
     }
   | {
       kind: 'fixedDamage';
@@ -169,10 +173,16 @@ const damageHandler: EffectHandler = (effect, ctx) => {
   const { attacker, defender, rng, events, engine, skillName } = ctx;
   const actor = ctx.actorSide ?? 'player';
   const hits = effect.hits ?? 1;
+  // 背水の陣: 使用者の失った HP 割合ぶん power を伸ばす (HP 低いほど威力↑)。
+  let basePower = effect.power ?? 1;
+  if (effect.scaleBy === 'missingHpRatio') {
+    const missing = attacker.maxHp > 0 ? 1 - attacker.hp / attacker.maxHp : 0;
+    basePower *= 1 + missing * (effect.scaleFactor ?? 1.0);
+  }
   for (let i = 0; i < hits; i++) {
     // 対象が倒れていたら以降の追撃は無駄撃ちしない (flurry の 2 撃目 = 従来挙動)。
     if (defender.hp <= 0) break;
-    const opts: AttackOptions = { label: skillName, power: effect.power ?? 1 };
+    const opts: AttackOptions = { label: skillName, power: basePower };
     if (effect.hitBonus !== undefined) opts.hitBonus = effect.hitBonus;
     if (effect.defFactor !== undefined) opts.defFactor = effect.defFactor;
     if (effect.element !== undefined) opts.element = effect.element;
@@ -253,6 +263,7 @@ const DEBUFF_STATUSES: ReadonlySet<StatusId> = new Set<StatusId>([
   'defDown',
   'agiDown',
   'doomMark',
+  'accDown',
 ]);
 
 /** 使用者の自己バフ数 (scaleBy: 'buffCount' 用)。 */
@@ -635,6 +646,82 @@ export const SKILLS: Record<string, SkillDef> = {
   'guardian-thorns': { id: 'guardian-thorns', effects: [{ kind: 'status', status: 'thorns', target: 'self', turns: 3, magnitude: 0.3 }] },
   'guardian-stand': { id: 'guardian-stand', effects: [{ kind: 'status', status: 'ironWall', target: 'self', turns: 1 }] }, // 仁王立ち Lv12 (被ダメ≒0 1T)
   'guardian-shield': { id: 'guardian-shield', effects: [], parry: true }, // 大盾の護り Lv15 (parry: 防御しつつ反撃)
+
+  // ─── 冒険者 確定キット (#456 / docs/25 §12。万能スカーミッシャー・luk34/agi25・生存/逆転) ───
+  // 数値は sim 調整前提の暫定値。武器投げ(装備 #454)/秘境探索(random)/全体技/旅の勘(P) は後続。
+  'explorer-pebble': { id: 'explorer-pebble', effects: [{ kind: 'fixedDamage', min: 4, max: 12, luckScale: 0.2, element: 'earth' }] }, // 石つぶて Lv3
+  'explorer-snare': { id: 'explorer-snare', effects: [{ kind: 'status', status: 'agiDown', target: 'enemy', turns: 3 }] }, // 足がらめ Lv5
+  'explorer-reveal': { id: 'explorer-reveal', effects: [{ kind: 'status', status: 'defDown', target: 'enemy', turns: 3 }] }, // みやぶる Lv7 (弱点表示は後続)
+  // サバイバル Lv8: HP 回復 + MP 少回復 (旅の知恵)
+  'explorer-survival': {
+    id: 'explorer-survival',
+    effects: [
+      { kind: 'heal', ratio: 0.25 },
+      { kind: 'restoreMp', ratio: 0.2 },
+    ],
+  },
+  'explorer-gale': { id: 'explorer-gale', effects: [{ kind: 'fixedDamage', min: 8, max: 16, luckScale: 0.25, element: 'wind' }] }, // 疾風の一撃 Lv10 (先制は後続)
+  'explorer-confuse': { id: 'explorer-confuse', effects: [{ kind: 'status', status: 'accDown', target: 'allEnemies', turns: 3 }] }, // かく乱 Lv15
+  // 一撃離脱 Lv18: 攻撃 + 自回避↑ (ヒットアンドアウェイ)
+  'explorer-hitrun': {
+    id: 'explorer-hitrun',
+    effects: [
+      { kind: 'fixedDamage', min: 12, max: 22, luckScale: 0.3 },
+      { kind: 'status', status: 'agiUp', target: 'self', turns: 2 },
+    ],
+  },
+  // 背水の陣 Lv25: luk 基準の特大 + 自 HP が低いほど威力↑ (scaleBy missingHpRatio)
+  'explorer-lastditch': { id: 'explorer-lastditch', effects: [{ kind: 'damage', stat: 'luk', power: 1.5, scaleBy: 'missingHpRatio', scaleFactor: 2.0 }] },
+
+  // ─── 芸術家 確定キット (#456 / docs/25 §12。幻術師・luk/def26・空属性魔法) ───
+  // 数値は sim 調整前提の暫定値。だまし討ち/幻影の分身(evade-next)/創造の絵筆(summon)/混乱系/傑作(random)/
+  // 審美眼(P) は後続 (要 新語彙)。
+  'artist-bolt': { id: 'artist-bolt', effects: [{ kind: 'fixedDamage', min: 3, max: 12, luckScale: 0.2, element: 'void' }] }, // 色彩の弾 Lv3
+  // 幻惑の色 Lv5: 敵の命中↓ + 攻撃↓
+  'artist-daze': {
+    id: 'artist-daze',
+    effects: [
+      { kind: 'status', status: 'accDown', target: 'enemy', turns: 3 },
+      { kind: 'status', status: 'atkDown', target: 'enemy', turns: 3 },
+    ],
+  },
+  'artist-trompe': { id: 'artist-trompe', effects: [{ kind: 'status', status: 'agiUp', target: 'self', turns: 3 }] }, // だまし絵 Lv7 (自回避↑)
+  'artist-mist': { id: 'artist-mist', effects: [{ kind: 'fixedDamage', min: 4, max: 10, luckScale: 0.2, element: 'void', target: 'allEnemies' }] }, // 極彩の霧 Lv8 (混乱は後続)
+  'artist-blind': { id: 'artist-blind', effects: [{ kind: 'status', status: 'accDown', target: 'allEnemies', turns: 3 }] }, // 目くらまし Lv10
+  // 原色の刃 Lv12: 空 + 高確率で攻撃↓
+  'artist-blade': {
+    id: 'artist-blade',
+    effects: [
+      { kind: 'fixedDamage', min: 10, max: 20, luckScale: 0.25, element: 'void' },
+      { kind: 'status', status: 'atkDown', target: 'enemy', chance: 0.7, turns: 3 },
+    ],
+  },
+  'artist-explosion': { id: 'artist-explosion', effects: [{ kind: 'fixedDamage', min: 15, max: 25, luckScale: 0.3, element: 'fire', target: 'allEnemies' }] }, // 芸術は爆発だ Lv15
+
+  // ─── 匠 確定キット (#456 / docs/25 §12。からくり技師・罠と装置・int43・範囲) ───
+  // 数値は sim 調整前提の暫定値。自爆人形(遅延全体)/からくり兵(summon)/大発破/兵器解放(全体)/発明家(P) は後続。
+  'fighter-contraption': { id: 'fighter-contraption', effects: [{ kind: 'fixedDamage', min: 4, max: 12, intBonus: 0.2 }] }, // からくり仕掛け Lv3 (無属性・必中)
+  'fighter-smoke': { id: 'fighter-smoke', effects: [{ kind: 'status', status: 'accDown', target: 'allEnemies', turns: 3 }] }, // 煙玉 Lv5
+  'fighter-poisongas': { id: 'fighter-poisongas', effects: [{ kind: 'status', status: 'poison', target: 'enemy', turns: 4, magnitude: 3 }] }, // 毒煙装置 Lv7
+  // 落とし穴 Lv8: 地属性 + 高確率で転倒
+  'fighter-pitfall': {
+    id: 'fighter-pitfall',
+    effects: [
+      { kind: 'fixedDamage', min: 5, max: 12, intBonus: 0.2, element: 'earth' },
+      { kind: 'status', status: 'tumble', target: 'enemy', chance: 0.7, turns: 1 },
+    ],
+  },
+  'fighter-ironball': { id: 'fighter-ironball', effects: [{ kind: 'fixedDamage', min: 8, max: 16, intBonus: 0.25 }] }, // 鉄球投擲 Lv10 (防御無視=fixedDamage は元々 def 無視)
+  'fighter-flamethrower': { id: 'fighter-flamethrower', effects: [{ kind: 'fixedDamage', min: 10, max: 18, intBonus: 0.25, element: 'fire', target: 'allEnemies' }] }, // 火炎放射器 Lv12
+  'fighter-net': { id: 'fighter-net', effects: [{ kind: 'status', status: 'restraint', target: 'enemy', chance: 0.7, turns: 2 }] }, // 拘束網 Lv15
+  // 高圧放水 Lv18: 全体水 + 押し流し転倒
+  'fighter-waterjet': {
+    id: 'fighter-waterjet',
+    effects: [
+      { kind: 'fixedDamage', min: 10, max: 18, intBonus: 0.3, element: 'water', target: 'allEnemies' },
+      { kind: 'status', status: 'tumble', target: 'allEnemies', chance: 0.5, turns: 1 },
+    ],
+  },
 };
 
 /** そのとくぎが「HP 回復のみ」か (UI が満タン時に無効化するかの判定に使う)。kind 文字列でなく

--- a/packages/core/src/statuses.ts
+++ b/packages/core/src/statuses.ts
@@ -28,7 +28,8 @@ export type StatusId =
   | 'agiDown' // 回避 magnitude 倍
   | 'doomMark' // 破滅の予言: turnEnd でカウントダウン、0 で magnitude の大ダメージ
   | 'thorns' // とげの盾: 物理被弾時に攻撃者へ magnitude 割合を反射
-  | 'ironWall'; // 仁王立ち: 被ダメをほぼ 0 に (incomingCalc ×magnitude、既定 0.05)
+  | 'ironWall' // 仁王立ち: 被ダメをほぼ 0 に (incomingCalc ×magnitude、既定 0.05)
+  | 'accDown'; // 命中低下 (煙玉/かく乱/幻惑): 保持者の攻撃が当たりにくくなる (modifyHit)
 
 /** 付与時に turns 未指定なら使う既定持続 (毒手/デバフ等の共通デフォルト)。 */
 export const DEFAULT_STATUS_TURNS = 2;
@@ -68,6 +69,8 @@ export interface CombatHook {
   dodgeCalc?(dodge: number, c: Combatant, ctx: HookCtx): number;
   /** 攻撃威力の倍率補正 (c=攻撃側)。atkUp/atkDown。 */
   powerCalc?(power: number, c: Combatant, ctx: HookCtx): number;
+  /** 命中補正 (c=攻撃側)。accDown: hitBonus を下げて当てにくく。 */
+  modifyHit?(hitBonus: number, c: Combatant, ctx: HookCtx): number;
   /** 会心の可否 (c=攻撃側)。九字切り=確定会心。 */
   critCalc?(willCrit: boolean, c: Combatant, ctx: HookCtx): boolean;
   /** 命中時 (atk→def)。首狩り等の即死パッシブ。 */
@@ -182,6 +185,8 @@ export const STATUS_REGISTRY: Record<StatusId, StatusDef> = {
   },
   // 仁王立ち (守護者): 被ダメをほぼ 0 に (incomingCalc ×0.05)。turns 1 の完全防御。
   ironWall: { id: 'ironWall', name: '仁王立ち', incomingCalc: (p, _c, ctx) => p * (ctx.status?.magnitude ?? 0.05) },
+  // 命中低下 (煙玉/かく乱/幻惑): 保持者が攻撃する際 hitBonus を下げて当てにくく (magnitude=低下量、既定 0.2)。
+  accDown: { id: 'accDown', name: '命中低下', restack: 'refresh', modifyHit: (hb, _c, ctx) => hb - (ctx.status?.magnitude ?? 0.2) },
   doomMark: {
     id: 'doomMark',
     name: '破滅の予言',
@@ -223,6 +228,7 @@ const STATUS_APPLY_TEXT: Record<StatusId, string> = {
   doomMark: 'に 破滅の刻印が刻まれた…!',
   thorns: 'は とげの盾をかまえた!',
   ironWall: 'は 仁王立ちした! (被ダメージ激減)',
+  accDown: 'の命中が下がった!',
 };
 
 /** 状態付与の告知文 (対象名 + テキスト)。 */
@@ -271,6 +277,13 @@ export function applyDodgeCalc(dodge: number, c: Combatant, ctx: HookCtx): numbe
 export function applyPowerCalc(base: number, c: Combatant, ctx: HookCtx): number {
   let v = base;
   for (const { def, inst } of hooksOf(c)) v = def.powerCalc?.(v, c, ctxFor(ctx, inst)) ?? v;
+  return v;
+}
+
+/** 命中補正 (c=攻撃側)。accDown で hitBonus を下げる。 */
+export function applyModifyHit(hitBonus: number, c: Combatant, ctx: HookCtx): number {
+  let v = hitBonus;
+  for (const { def, inst } of hooksOf(c)) v = def.modifyHit?.(v, c, ctxFor(ctx, inst)) ?? v;
   return v;
 }
 


### PR DESCRIPTION
## 目的

戦闘刷新 (docs/25 §12) の**単体戦闘キット完成**。最後の3職 **冒険者・芸術家・匠** を配線し、
**全16職が確定キットを持つ**状態に到達 (#456)。

## 変更

### 新語彙 (消費者つき)
- **accDown** (命中低下) + **modifyHit** フック: 保持者の攻撃 hitBonus を下げる (煙玉/かく乱/幻惑/目くらまし)。doAttack の命中判定に applyModifyHit を挿入 (**accDown なしなら hitBonus のまま = 挙動不変**)。
- **scaleBy 'missingHpRatio'**: damage 効果に自 HP 欠損割合連動 (背水の陣: HP 低いほど威力↑)。

### 冒険者 (luk34/agi25・逆転スカーミッシャー)
石つぶて(earth)/足がらめ(agiDown)/みやぶる(defDown)/サバイバル(heal+MP)/疾風の一撃(wind)/かく乱(accDown全体)/一撃離脱(damage+自回避↑)/背水の陣(scaleBy missingHp)。武器投げ(#454)/秘境探索(random)/全体技/旅の勘(P) は後続。

### 芸術家 (luk/def26・空幻術)
色彩の弾/幻惑の色(accDown+atkDown)/だまし絵/極彩の霧(全体)/目くらまし(accDown全体)/原色の刃(+atkDown)/芸術は爆発だ(全体火)。混乱系/創造の絵筆(summon)/幻影の分身/傑作(random)/審美眼(P) は後続。

### 匠 (int43・からくり装置)
からくり仕掛け(必中)/煙玉(accDown全体)/毒煙(poison)/落とし穴(earth+転倒)/鉄球投擲/火炎放射器(全体)/拘束網(restraint)/高圧放水(全体水+転倒)。自爆人形/からくり兵(summon)/大発破/兵器解放(全体)/発明家(P) は後続。

### その他
全職キット化で「非キット職」概念が消えたため、該当テストを未習得帯 (Lv1) フォールバック検証に更新。

## 検証
- core 450 緑 (accDown の modifyHit・背水の陣の missingHpRatio 連動・3職のレベル習得・**全16職キット保有**を検証) /
  web build / typecheck (web+edge+core) 緑。**既存物理戦闘は modifyHit が空フックで挙動不変**。数値は sim 前提。
- **キット化 16/16 職完成**。残タスク: 召喚 (summon)・武器投げ・全体技のマルチ配線・各職の passive・sim 調整。

## Review

§1.5 3並列独立レビュー (実装/設計/体験)。**実装・体験は ★★★/★★ ゼロ、設計も ★★★ なし。キット⇄ステ合格** (冒険者luk34/芸術家luk26/匠int43 = 最強ステに攻撃技が乗る)。

- **実装**: ★★★/★★ なし。modifyHit が既存物理で完全 no-op (RNG非消費)・背水の scaleBy に穴なし・3職キット⇄ステ整合・テスト整合 (回帰隠蔽なし) を検証。★1 (accDown 0.2 の効き幅=sim)。
- **体験**: ★★★/★★/★ **ゼロ**。3職の役割 (逆転スカーミッシャー/空幻術デバッファー/罠キャスター) がソロで成立・背水の逆転設計・accDown の防御駆け引き・全16職の役割多様性に構造的破綻なしと明記。
- **設計**: ★★★ なし。modifyHit/scaleBy が §14 記述どおり。★★ 1件を PR 内対応 (commit e827f1b)。

### ★★/★ 対応 (PR 内)
- **全16職キット化で非キット fallback が dead code + 陳腐化コメント** (設計★★) → **JOB_KITS を Record<Archetype> (全16職必須) に**し dead 分岐を削除・型で「全職キット化」を保証。コメント更新。
- scaleBy の二重定義を共通型化する TODO 明記 (★)。

### 引き継ぎ (doc/comment で追跡済み・非ブロッカー)
summon (創造の絵筆/からくり兵)・武器投げ (#454)・random (秘境探索/傑作)・混乱 (confusion)・全体技のマルチ配線 (#453)・各職 passive・高Lv技に見合う endgame 敵 (#455)・sim 数値調整 (#456残)。

CI: web-ci pass / 本番 build pass。core 450緑 / typecheck (web+edge+core) 緑。**既存物理戦闘は挙動不変**。

---
**🎉 これで全16職の単体戦闘キットが完成 (#456 単体戦闘スコープ完了)。**
