### PR TITLE
各職 Lv30 innate パッシブ 7職実装 (#456)

### DIFF
--- a/packages/core/src/__tests__/passives.test.ts
+++ b/packages/core/src/__tests__/passives.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PASSIVES,
+  applyDodgeCalc,
+  applyPowerCalc,
+  applyCritCalc,
+  applyIncomingCalc,
+  applyOnHit,
+  type HookCtx,
+} from '../statuses.js';
+import { jobPassives, playerCombatant, type Combatant } from '../battle.js';
+
+function c(over: Partial<Combatant> = {}): Combatant {
+  return {
+    name: 'c',
+    maxHp: 100,
+    hp: 100,
+    maxMp: 10,
+    mp: 10,
+    atk: 20,
+    def: 10,
+    agi: 15,
+    int: 20,
+    luk: 10,
+    guarding: false,
+    parrying: false,
+    charging: false,
+    focus: 0,
+    statuses: [],
+    passives: [],
+    ...over,
+  };
+}
+const ctx = (rng = 0.5): HookCtx => ({ rng: () => rng, events: [] });
+
+describe('パッシブ (#456 各職 Lv30)', () => {
+  it('PASSIVES の全エントリで id がキーと一致', () => {
+    for (const key of Object.keys(PASSIVES)) {
+      expect(PASSIVES[key]!.id).toBe(key);
+    }
+  });
+
+  it('jobPassives: Lv30 到達で innate パッシブ1つ、Lv29 以下は空', () => {
+    expect(jobPassives('warrior', 30)).toEqual(['warrior-blademaster']);
+    expect(jobPassives('warrior', 29)).toEqual([]);
+    expect(jobPassives('mage', 30)).toEqual(['mage-barrier']);
+    expect(jobPassives('ninja', 30)).toEqual(['kubikari']);
+    // フック未実装の職 (慧眼/清き心/覇王 等) は Lv30 でもまだ空 (後続で追加)。
+    expect(jobPassives('sage', 30)).toEqual([]);
+    expect(jobPassives('paladin', 30)).toEqual([]);
+    expect(jobPassives('guardian', 30)).toEqual([]);
+  });
+
+  it('playerCombatant: 実装済み職は Lv30 で passives が入り、Lv29 では空', () => {
+    expect(playerCombatant('warrior', 30, 30, 'w').passives).toEqual(['warrior-blademaster']);
+    expect(playerCombatant('warrior', 29, 30, 'w').passives).toEqual([]);
+    expect(playerCombatant('captain', 30, 30, 'cap').passives).toEqual(['captain-command']);
+    // 未実装職は Lv30 でも空 (キット化と別軸)。
+    expect(playerCombatant('sage', 30, 30, 's').passives).toEqual([]);
+  });
+
+  // ── 各パッシブの効果 (dispatcher 経由) ──
+  it('魔力障壁 (mage-barrier): 被ダメ ×0.85', () => {
+    expect(applyIncomingCalc(1, c({ passives: ['mage-barrier'] }), ctx())).toBeCloseTo(0.85);
+  });
+
+  it('名将 (captain-command): 与ダメ ×1.1 かつ 被ダメ ×0.9', () => {
+    const cap = c({ passives: ['captain-command'] });
+    expect(applyPowerCalc(1, cap, ctx())).toBeCloseTo(1.1);
+    expect(applyIncomingCalc(1, cap, ctx())).toBeCloseTo(0.9);
+  });
+
+  it('全知/旅の勘: 回避を底上げ (上限 0.9)', () => {
+    expect(applyDodgeCalc(0.2, c({ passives: ['seer-omniscience'] }), ctx())).toBeCloseTo(0.35);
+    expect(applyDodgeCalc(0.2, c({ passives: ['explorer-instinct'] }), ctx())).toBeCloseTo(0.32);
+    expect(applyDodgeCalc(0.85, c({ passives: ['seer-omniscience'] }), ctx())).toBeCloseTo(0.9); // clamp
+  });
+
+  it('詩心 (poet-muse): 自己バフ中のみ 与ダメ ×1.25', () => {
+    const bare = c({ passives: ['poet-muse'] });
+    expect(applyPowerCalc(1, bare, ctx())).toBeCloseTo(1); // バフなし = 素通し
+    // hidden は powerCalc に触らない自己バフなので poet-muse の ×1.25 を単離できる
+    // (atkUp だと status 自身の ×1.3 と積算され 1.625 になる = パッシブとバフは正しく重畳)。
+    const buffed = c({ passives: ['poet-muse'], statuses: [{ id: 'hidden', turns: 3 }] });
+    expect(applyPowerCalc(1, buffed, ctx())).toBeCloseTo(1.25);
+  });
+
+  it('剣豪 (warrior-blademaster): rng<0.15 で会心へ引き上げ、既に会心なら維持', () => {
+    const w = c({ passives: ['warrior-blademaster'] });
+    expect(applyCritCalc(false, w, ctx(0.1))).toBe(true); // 確率的に会心
+    expect(applyCritCalc(false, w, ctx(0.9))).toBe(false); // 外れる
+    expect(applyCritCalc(true, w, ctx(0.9))).toBe(true); // 既に会心なら維持
+  });
+
+  it('首狩り (kubikari): 明確な格下 (非メタル) を低 rng で一撃、格上/メタル/等格は不発', () => {
+    const ninja = c({ passives: ['kubikari'], maxHp: 100, luk: 30 });
+    const weak = c({ name: 'z', maxHp: 40, luk: 5 }); // maxHp 40 <= 60 = 格下
+    expect(applyOnHit(ninja, weak, ctx(0.01))).toBe(true); // 低 rng で即死
+    expect(applyOnHit(ninja, weak, ctx(0.99))).toBe(false); // 高 rng で不発
+    const peer = c({ name: 'p', maxHp: 80 }); // 80 > 60 = 格下でない
+    expect(applyOnHit(ninja, peer, ctx(0.01))).toBe(false);
+    const metal = c({ name: 'm', maxHp: 30, resistAllMagic: true }); // メタルは即死無効
+    expect(applyOnHit(ninja, metal, ctx(0.01))).toBe(false);
+  });
+
+  it('パッシブなしの Combatant は全ディスパッチ no-op (回帰防止)', () => {
+    const bare = c();
+    expect(applyIncomingCalc(1, bare, ctx())).toBe(1);
+    expect(applyPowerCalc(1, bare, ctx())).toBe(1);
+    expect(applyDodgeCalc(0.2, bare, ctx())).toBe(0.2);
+    expect(applyCritCalc(false, bare, ctx(0.1))).toBe(false);
+    expect(applyOnHit(bare, c(), ctx(0.01))).toBe(false);
+  });
+});

--- a/packages/core/src/__tests__/passives.test.ts
+++ b/packages/core/src/__tests__/passives.test.ts
@@ -70,10 +70,14 @@ describe('パッシブ (#456 各職 Lv30)', () => {
     expect(applyIncomingCalc(1, cap, ctx())).toBeCloseTo(0.9);
   });
 
-  it('全知/旅の勘: 回避を底上げ (上限 0.9)', () => {
+  it('全知/旅の勘: 回避を底上げ (通常上限 0.32 は超えるが EVASION_PASSIVE_CAP 0.55 で頭打ち)', () => {
+    // 通常帯: dodgeMax(0.32) を超えて底上げ = 回避職の identity。
     expect(applyDodgeCalc(0.2, c({ passives: ['seer-omniscience'] }), ctx())).toBeCloseTo(0.35);
     expect(applyDodgeCalc(0.2, c({ passives: ['explorer-instinct'] }), ctx())).toBeCloseTo(0.32);
-    expect(applyDodgeCalc(0.85, c({ passives: ['seer-omniscience'] }), ctx())).toBeCloseTo(0.9); // clamp
+    // cap 帯: 0.45 + 0.15 = 0.6 → 0.55 で頭打ち (絶対回避化を防ぐ)。
+    expect(applyDodgeCalc(0.45, c({ passives: ['seer-omniscience'] }), ctx())).toBeCloseTo(0.55);
+    // 既に cap 超の高回避 (将来のかくれみ 0.75 等) はパッシブで下げない (max 保護)。
+    expect(applyDodgeCalc(0.75, c({ passives: ['seer-omniscience'] }), ctx())).toBeCloseTo(0.75);
   });
 
   it('詩心 (poet-muse): 自己バフ中のみ 与ダメ ×1.25', () => {

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -400,6 +400,24 @@ export function skillsForJob(archetype: Archetype, jobLevel: number): JobSkill[]
   return learned.length ? learned : [skillForJob(archetype)];
 }
 
+/** ジョブ innate パッシブ (docs/25 §12 の各職 Lv30)。PASSIVES のキー。習得 jobLevel は一律 30。
+ *  フック実装済みの7職のみ (onLethal/onIncomingMagic/属性シナジー/非戦闘 待ちの9職は後続)。 */
+const JOB_PASSIVES: Partial<Record<Archetype, string>> = {
+  warrior: 'warrior-blademaster', // 剣豪: 会心率↑
+  mage: 'mage-barrier', // 魔力障壁: 常時被ダメ軽減
+  ninja: 'kubikari', // 首狩り: 格下を一撃
+  captain: 'captain-command', // 名将: 常時 atk/def+10%
+  seer: 'seer-omniscience', // 全知: 常時回避↑
+  explorer: 'explorer-instinct', // 旅の勘: 回避↑
+  poet: 'poet-muse', // 詩心: 自己バフ中 与ダメ↑
+};
+
+/** その jobLevel 時点で有効なパッシブ id 列。Lv30 到達で innate パッシブが1つ有効になる。 */
+export function jobPassives(archetype: Archetype, jobLevel: number): string[] {
+  const pid = JOB_PASSIVES[archetype];
+  return pid && jobLevel >= 30 ? [pid] : [];
+}
+
 /** MP 回復のジョブ特性 (オーナー提案 2026-07-17「MP 回復はジョブの特別な要素に。
  *  強化して初期で弱いジョブに付ける。能力がジョブに合っているかも大事」)。
  *  **戦闘中に MP が回復するのは特性を持つジョブだけ** (全員一律の基本回復は
@@ -567,6 +585,7 @@ export function playerCombatant(
     c.maxHp += (a?.maxHp ?? 0) + (b?.maxHp ?? 0);
     c.hp = c.maxHp;
   }
+  c.passives = jobPassives(archetype, jobLevel); // ジョブ Lv30 の innate パッシブ
   return c;
 }
 

--- a/packages/core/src/statuses.ts
+++ b/packages/core/src/statuses.ts
@@ -206,8 +206,77 @@ export const STATUS_REGISTRY: Record<StatusId, StatusDef> = {
   },
 };
 
-/** パッシブレジストリ (ジョブ innate)。#456 で首狩り等を追加。今は枠だけ。 */
-export const PASSIVES: Record<string, PassiveDef> = {};
+/** 自己バフとみなす状態異常 (詩心の「自己バフ中 与ダメ↑」判定用)。 */
+const SELF_BUFF_IDS: ReadonlySet<StatusId> = new Set<StatusId>([
+  'atkUp',
+  'defUp',
+  'agiUp',
+  'critCharge',
+  'hidden',
+  'ironWall',
+  'thorns',
+]);
+function hasSelfBuff(c: Combatant): boolean {
+  return (c.statuses ?? []).some((s) => SELF_BUFF_IDS.has(s.id));
+}
+
+/**
+ * パッシブレジストリ (ジョブ innate な常時フック。docs/25 §12 の各職 Lv30)。エンジンは
+ * hooksOf でこれを状態異常と同じフック点に流すだけ (専用分岐なし)。フック実装済みの7職を
+ * ここで登録。onLethal (覇王/不動)・onIncomingMagic (清き心)・属性シナジー (慧眼)・対象状態参照
+ * (審美眼)・MP消費割引 (発明家)・非戦闘 (巫女の直感/名演) は追加フック待ちで #456 の後続に残す。
+ */
+export const PASSIVES: Record<string, PassiveDef> = {
+  // 忍者 首狩り: 自分より明確に弱い敵 (メタル除く) を luk 補正つき低確率で一撃 (§7/§12 Lv30)。
+  // isWeaker は maxHp 比で判定 (中ボス/敵は maxHp が高く成立しない = 事故ワンパン防止)。
+  kubikari: {
+    id: 'kubikari',
+    name: '首狩り',
+    onHit(atk, def, ctx) {
+      if (def.resistAllMagic) return; // メタル系は即死無効 (高防御ザコの存在意義)
+      if (def.maxHp > atk.maxHp * 0.6) return; // 明確に格下でなければ発動しない
+      const chance = Math.min(0.35, Math.max(0.05, 0.2 + (atk.luk - def.luk) * 0.004));
+      if (ctx.rng() < chance) return { instakill: true };
+    },
+  },
+  // 魔法使い 魔力障壁: 常時被ダメ軽減 (§12「常時10-20%軽減」→ ×0.85)。脆い大砲の生存補助。
+  'mage-barrier': {
+    id: 'mage-barrier',
+    name: '魔力障壁',
+    incomingCalc: (power) => power * 0.85,
+  },
+  // 戦士 剣豪: 会心率↑ (§12 Lv30)。critCalc は bool なので rng で確率的に会心へ引き上げる。
+  'warrior-blademaster': {
+    id: 'warrior-blademaster',
+    name: '剣豪',
+    critCalc: (willCrit, _c, ctx) => willCrit || ctx.rng() < 0.15,
+  },
+  // 隊長 名将: 常時 atk/def +10% (§12 Lv30)。攻撃は powerCalc ×1.1、被弾は incomingCalc ×0.9。
+  'captain-command': {
+    id: 'captain-command',
+    name: '名将',
+    powerCalc: (power) => power * 1.1,
+    incomingCalc: (power) => power * 0.9,
+  },
+  // 予言者 全知: 常時回避↑ (§12 Lv30)。低 agi を補い「当たらなければどうということはない」型。
+  'seer-omniscience': {
+    id: 'seer-omniscience',
+    name: '全知',
+    dodgeCalc: (dodge) => Math.min(0.9, dodge + 0.15),
+  },
+  // 冒険者 旅の勘: 回避↑ (§12 Lv30 の戦闘部分。ドロップ↑/逃走↑は非戦闘のため別途)。
+  'explorer-instinct': {
+    id: 'explorer-instinct',
+    name: '旅の勘',
+    dodgeCalc: (dodge) => Math.min(0.9, dodge + 0.12),
+  },
+  // 詩人 詩心: 自己バフ中 与ダメ↑ (§12 Lv30)。バフ orbiter 型の詩人が撃つときだけ乗る。
+  'poet-muse': {
+    id: 'poet-muse',
+    name: '詩心',
+    powerCalc: (power, c) => (hasSelfBuff(c) ? power * 1.25 : power),
+  },
+};
 
 /** 状態付与時の告知テキスト (対象名の後に続ける)。プレイヤーが状態変化を認識できるように
  *  (無告知だと忍者のかくれみ/九字切り等が「何も起きていない」ように見える。レビュー ★★)。 */

--- a/packages/core/src/statuses.ts
+++ b/packages/core/src/statuses.ts
@@ -206,18 +206,29 @@ export const STATUS_REGISTRY: Record<StatusId, StatusDef> = {
   },
 };
 
-/** 自己バフとみなす状態異常 (詩心の「自己バフ中 与ダメ↑」判定用)。 */
+/** 自己バフとみなす状態異常 (詩心の「自己バフ中 与ダメ↑」判定用)。「自分を強化した状態」= 攻撃/
+ *  守備/素早さ up・会心チャージ・隠密のみ。守護スタンス系 (thorns=とげの盾 / ironWall=仁王立ち) は
+ *  守護者の防御姿勢であって「盛って撃つ」詩人の自己強化とは概念が別なので**含めない** (将来マルチで
+ *  他職の状態が混ざったときの誤発火も避ける。レビュー ★)。デバフ (atkDown 等) は当然含めない。 */
 const SELF_BUFF_IDS: ReadonlySet<StatusId> = new Set<StatusId>([
   'atkUp',
   'defUp',
   'agiUp',
   'critCharge',
   'hidden',
-  'ironWall',
-  'thorns',
 ]);
 function hasSelfBuff(c: Combatant): boolean {
   return (c.statuses ?? []).some((s) => SELF_BUFF_IDS.has(s.id));
+}
+
+/** 回避パッシブ (全知/旅の勘) の実効回避上限。通常の dodgeMax(0.32) は回避職の identity として超える
+ *  が、ここで頭打ちにして「絶対に当たらない」化を防ぐ (レビュー ★★: かくれみ 0.75 と積んで 0.9 化する
+ *  懸念への対処)。数値は sim 前提の暫定値。 */
+const EVASION_PASSIVE_CAP = 0.55;
+/** 回避を bonus ぶん底上げするが EVASION_PASSIVE_CAP を超えさせない。ただし既に cap 超の高回避は
+ *  下げない (max 保護: パッシブが既存の高回避状態を弱めてはならない)。 */
+function boostDodge(dodge: number, bonus: number): number {
+  return Math.max(dodge, Math.min(EVASION_PASSIVE_CAP, dodge + bonus));
 }
 
 /**
@@ -246,6 +257,8 @@ export const PASSIVES: Record<string, PassiveDef> = {
     incomingCalc: (power) => power * 0.85,
   },
   // 戦士 剣豪: 会心率↑ (§12 Lv30)。critCalc は bool なので rng で確率的に会心へ引き上げる。
+  // 注: base 会心が外れたときだけ ctx.rng() を追加 1 消費する (短絡評価)。剣豪持ちの戦士は同 seed でも
+  // 乱数系列が変わるが、client/edge とも同じ playerCombatant でパッシブを再導出するため replay は一致。
   'warrior-blademaster': {
     id: 'warrior-blademaster',
     name: '剣豪',
@@ -259,16 +272,18 @@ export const PASSIVES: Record<string, PassiveDef> = {
     incomingCalc: (power) => power * 0.9,
   },
   // 予言者 全知: 常時回避↑ (§12 Lv30)。低 agi を補い「当たらなければどうということはない」型。
+  // 回避職の identity として通常の回避上限 (dodgeMax=0.32) は意図的に超えるが、EVASION_PASSIVE_CAP
+  // で頭打ちにし「絶対当たらない」化は防ぐ。既に上限超の高回避 (将来のかくれみ等) は下げない (max 保護)。
   'seer-omniscience': {
     id: 'seer-omniscience',
     name: '全知',
-    dodgeCalc: (dodge) => Math.min(0.9, dodge + 0.15),
+    dodgeCalc: (dodge) => boostDodge(dodge, 0.15),
   },
   // 冒険者 旅の勘: 回避↑ (§12 Lv30 の戦闘部分。ドロップ↑/逃走↑は非戦闘のため別途)。
   'explorer-instinct': {
     id: 'explorer-instinct',
     name: '旅の勘',
-    dodgeCalc: (dodge) => Math.min(0.9, dodge + 0.12),
+    dodgeCalc: (dodge) => boostDodge(dodge, 0.12),
   },
   // 詩人 詩心: 自己バフ中 与ダメ↑ (§12 Lv30)。バフ orbiter 型の詩人が撃つときだけ乗る。
   'poet-muse': {


### PR DESCRIPTION
## 概要
全16職キット化 (#481) に続く **Lv30 capstone**。docs/25 §12 の各職 Lv30 innate パッシブのうち、**既存フックで表現できる7職**を実装した。プラグイン基盤 (PASSIVES レジストリ + hooksOf) は #452 で配線済みだったが登録も populate も無かった枠を埋める。

## 実装 (既存フックのみ・専用分岐ゼロ)
| 職 | パッシブ | フック | 効果 |
|---|---|---|---|
| 忍者 | 首狩り | onHit | 明確な格下 (maxHp比・非メタル) を luk 補正つき 5〜35% で一撃。中ボス/メタルは不発 |
| 魔法使い | 魔力障壁 | incomingCalc ×0.85 | 脆い大砲の常時被ダメ軽減 |
| 戦士 | 剣豪 | critCalc | rng で会心率↑ (既会心は維持) |
| 隊長 | 名将 | powerCalc ×1.1 + incomingCalc ×0.9 | 常時 atk/def +10% |
| 予言者 | 全知 | dodgeCalc +0.15 (上限0.9) | 常時回避↑ |
| 冒険者 | 旅の勘 | dodgeCalc +0.12 (上限0.9) | 回避↑ (ドロップ/逃走は非戦闘のため別途) |
| 詩人 | 詩心 | powerCalc ×1.25 (自己バフ時のみ) | バフ orbiter 時に与ダメ↑ |

配線: `playerCombatant` が `jobPassives(archetype, jobLevel)` で `player.passives` を設定 (Lv30 到達で1つ有効)。エンジンは `hooksOf` が状態異常と同じフック点に流すだけ (docs/25 §4 の汎用フック方針。首狩り専用 onKillCheck は作らない — オーナー方針 2026-07-22)。

## 後続 (追加フック待ち・§12 の残9職)
覇王/不動 (**onLethal**)・清き心 (**onIncomingMagic**)・慧眼 (属性シナジー)・審美眼 (対象状態参照)・発明家 (MP消費割引)・巫女の直感/名演 (非戦闘)。これらは #453 系の追加フックが要るため本 PR スコープ外。

## サーバー権威との整合
edge の `battle-resolver.ts` が同じ `playerCombatant` でプレイヤーを再導出するため、**パッシブはサーバー権威戦闘の replay でも一致**する (追加配線不要)。

## 検証
- core **460 緑** (パッシブなし Combatant は全ディスパッチ no-op = 回帰なしを明示テスト)
- web / edge typecheck 緑
- 既存戦闘は挙動不変 (パッシブは Lv30 到達職のみに付く純増分)

## Review

§1.5 3並列独立レビュー (設計/実装/体験)。**3本とも ★★★・★★ の「マージ不可」はゼロ**。実装は no-op 保証/RNG 決定性/sealed state 往復を実機確認、設計は §4 汎用フック方針への忠実さと後続9職の線引きを spec と1対1で検証、体験は首狩り即死・名将常時倍率を実数で「役割の範囲内」と確認。

### 実装レビュー: ★★★/★★ ゼロ・★ 3件
no-op / RNG 決定性 (剣豪短絡評価・首狩り条件消費) / sealed state 往復 / テスト網羅すべて穴なし。★ は resistAllMagic のメタル転用 (コメント済)・SELF_BUFF_IDS がやや広め・Lv30 ハードコード。

### 設計レビュー: ★★★/★★ ゼロ・★ 3件
専用分岐を足さず hooksOf に載せる §4 方針を忠実遵守。後続9職 (覇王/不動=onLethal, 清き心=onIncomingMagic, 慧眼=属性シナジー, 審美眼=対象状態参照, 発明家=MP割引, 巫女/名演=非戦闘) は §14.3 追加フック待ちと**1対1で追跡可能**=サボりでないと評価。Record/Partial の非対称も `JOB_MP_TRAITS` 先例に沿い妥当。★ は剣豪 rng 注記・§14.7 cap・UI 露出。

### 体験・バランスレビュー: ★★★ ゼロ・★★ 2件・★ 4件
役割を壊す機構なし。首狩りは実数で tier1/2 掃討+tier3 低HP個体まで (青おに/そらのりゅう=41 は閾値超で不発、ボスは maxHp 高く確実に不発=事故防止機能)。発動率 20-35% が忍者 luk 型と整合。

### ★★/★ 対応 (commit cd06d43)
- **★★ 回避パッシブが dodgeMax(0.32) の外で加算** (体験) → `EVASION_PASSIVE_CAP=0.55` で頭打ちにする `boostDodge` 導入。回避職 identity として 0.32 は意図的に超えるが絶対回避化は防ぐ。既存高回避は max 保護で下げない。**PR 内対応**。
- **★★ 威力/被ダメの ×2 頭打ち (§14.7) 未実装** (体験) → dev 既存の基盤欠落・本 PR の回帰でない。パッシブは cap 前提で数値設計済み → **issue #484 に切り出し** (マージ非ブロック)。
- **★ SELF_BUFF_IDS の thorns/ironWall** (実装/体験) → 守護スタンス系を除外し詩人の自己強化のみに絞り、将来マルチの誤発火を防止。**PR 内対応**。
- **★ 剣豪の追加 rng 消費** (設計/実装) → replay 一致の根拠つきコメントを追記。**PR 内対応**。
- **★ UI 可視化 / 残9職 Lv30 パッシブ** → **issue #483** (UI は device 検証要・§13 の UI phase でまとめる)。
- **★ その他** (resistAllMagic 転用・Lv30 ハードコード) → コメント記録で許容 (実害なし)。

CI: web-ci pass / 本番 build pass。core 460緑 / typecheck (web+edge+core) 緑。**既存戦闘は挙動不変** (パッシブは Lv30 到達職のみの純増分)。
