### PR TITLE
onLethal フック + 覇王/不動 パッシブ (対物理不死 2職) (#456)

### DIFF
--- a/docs/25-combat-plugin-system.md
+++ b/docs/25-combat-plugin-system.md
@@ -294,7 +294,12 @@ export const MONSTER_ABILITIES: Record<string, AbilityDef> = {
 - `onDamaged(self, attacker, damage, ctx)` — 物理被弾後のリアクティブ反応 (とげの盾=攻撃者へ反射)。実装済み
   (#456)。**damage 引数 = 食らった最終ダメージ**で反射割合の計算に使う。**フルカウンター (累積被ダメ返し) は
   別途 `Combatant.damageTaken` の積算が要る** (このフック単体では書けない = 後続バッチ)。
-- `onLethal(self, incoming, ctx) → { survive? }` — 致死を耐える (不動)
+- `onLethal(self, atk, damage, ctx) → { survive? }` — 物理致死を耐える。実装済み (#456)。onDamaged と同じ
+  `(self, attacker, damage, ctx)` 並びで、反射など攻撃者への副作用はハンドラ内で `atk` を直接操作する。
+  **物理経路 (doAttack) のみで発火**し魔法致死 (doMagic) には効かない = 「物理耐性・魔法貫通」を経路分離で
+  分岐なしに表現。**1 戦闘 1 回のみ**発動する切り札 (`Combatant.lethalGuardUsed` フラグ。オーナー判断
+  2026-07-22: 敵が物理のみの現状で毎回発動だと対モンスター完全不死になるため)。覇王=1回耐えて同ダメ反射、
+  不動=1回確定で耐える (旧 50% 運要素は壁役の capstone に合わないため確定 1 回に変更)。
 
 **Combatant フィールド:** `statuses: StatusInstance[]` / `passives: string[]` / `damageTaken: number`(累積)
 **BattleOutcome 追加:** `reconciled`(和解 = XP なし・素材あり)。battle-reward は outcome + `resolve` の
@@ -408,7 +413,7 @@ AoE は対象をループするだけ (プラグインで吸収)。**とくぎ�
 新部品: フラット加算バフ / 無属性魔法(属性の輪外・int型必中) / atk主+int補正の物理 / 魔法反射フック。holy系(聖騎士/巫女の聖)は属性外。
 **将軍** (最強atk39・最脆def10・物理一本・対キャスター): 一閃3(単体 atk×1.5)/なぎ倒し6(敵全体 atk×0.8+中確率で転倒)/足払い8(敵単体 atk×1.2+高確率で転倒)/
 勝鬨12(味方全体 atk↑3T+低確率で敵怯み agi↓)/見切り15(自 agi+10+次の敵魔法を100%回避=必中無効)/鬼神斬り20(敵単体 atk×2.5+敵の詠唱魔法をかき消す)/
-覇王30(P: 物理致死を耐えHP1+同ダメ反射。魔法致死は普通に死ぬ)。int28は**魔法耐性(int対int式)として活用=魔法が通らない対キャスター**。見切り/かき消しは100%固定(int連動しない)。
+覇王30(P: 物理致死を**1戦闘1回**HP1で耐え+同ダメ反射。2回目以降と魔法致死は普通に死ぬ。once化はオーナー判断 2026-07-22 = 敵魔法が無い現状で毎回発動だと完全不死のため)。int28は**魔法耐性(int対int式)として活用=魔法が通らない対キャスター**。見切り/かき消しは100%固定(int連動しない)。
 新部品・全体ルール: **転倒(status: 次行動不可 + 被ダメ×1.2、誰の攻撃でも)** / 必中回避(次の魔法をミス化) / 魔法かき消し(詠唱割り込みキャンセル) / 物理限定onLethal+反射 / 怯み(flinch)。
 **隊長** (タフな前衛指揮官 def23・鼓舞): 突撃号令3(単体atk×1.5+味方atk少↑)/鼓舞5(味方atk↑3T)/防陣8(味方def↑3T)/突進12(単体atk×1.5+中確率転倒)/
 檄15(味方atk↑agi↑3T)/捨て身攻撃18(敵全体atk×1.6+会心↑・自def↓1T=リスク)/攻陣25(敵を囲い 味方atk中↑+敵agi中↓3T)/名将30(P: 常時atk/def+10%)。
@@ -464,7 +469,7 @@ AoE は対象をループするだけ (プラグインで吸収)。**とくぎ�
 ### 14.1 §12 に不足していた3職 (忍者/遊び人/守護者の確定キット)
 - **忍者**: §7 参照 (毒手3/かくれみ5/火遁8火/急所狙い12/九字切り15/影分身20/首狩り30P)。
 - **遊び人**: ぶんどり3(gain)/サボる5(restoreMp+heal)/ルーレット8(random)/いちかばちか12(damage+recoil)/曲芸乱舞15(agi連撃)/大道芸20(random豪華)/せっとく30(resolve和解30%・XPなし素材)。
-- **守護者**: 盾殴り3(def基準)/大盾の護り5(parry反撃)/とげの盾8(thorns=onDamaged)/仁王立ち12(被ダメ≒0の1T)/守護の祈り15(defUp)/フルカウンター25(累積被ダメ返し)/不動30(P onLethal50%・物理致死のみ耐)。
+- **守護者**: 盾殴り3(def基準)/大盾の護り5(parry反撃)/とげの盾8(thorns=onDamaged)/仁王立ち12(被ダメ≒0の1T)/守護の祈り15(defUp)/フルカウンター25(累積被ダメ返し)/不動30(P onLethal・物理致死を**1戦闘1回確定で**耐える。旧50%運要素は壁役に合わず確定化・オーナー判断 2026-07-22)。
 
 ### 14.2 StatusId 完全版 (使用中の状態を全部登録)
 `poison / sleep / stun / tumble(転倒) / restraint(束縛) / confusion(混乱) / flinch(怯み) / hidden / critCharge / magicEvade(必中回避) / atkUp/atkDown / defUp/defDown / agiUp/agiDown / intUp/intDown / evadeUp / accDown(命中↓) / doomMark(遅延) / weaponThrown`。定義の要点:
@@ -477,7 +482,7 @@ AoE は対象をループするだけ (プラグインで吸収)。**とくぎ�
 ### 14.3 CombatHook 完全版
 既存(beforeAct/dodgeCalc/powerCalc/critCalc/onHit/incomingCalc/turnEnd)+ 追加:
 - **overrideAction**(混乱)/ **modifyHit**(命中率デバフ)/ **onIncomingMagic**(見切りの必中回避・清き心の魔法反射)/
-  **onEnemyCast**(鬼神斬りの魔法かき消し=マルチでは殴った1体の詠唱をキャンセル)/ **onLethal**(覇王=物理限定/不動=50%)。
+  **onEnemyCast**(鬼神斬りの魔法かき消し=マルチでは殴った1体の詠唱をキャンセル)/ **onLethal**(覇王=物理限定・1戦闘1回+反射/不動=物理限定・1戦闘1回確定)。
 
 ### 14.4 target と適用ループ
 `SkillDef.target: 'self'|'oneEnemy'|'allEnemies'|'oneAlly'|'allAllies'`(効果ごとに変えたい場合は SkillEffect 側にも)。

--- a/packages/core/src/__tests__/passives.test.ts
+++ b/packages/core/src/__tests__/passives.test.ts
@@ -6,6 +6,7 @@ import {
   applyCritCalc,
   applyIncomingCalc,
   applyOnHit,
+  applyOnLethal,
   type HookCtx,
 } from '../statuses.js';
 import { jobPassives, playerCombatant, type Combatant } from '../battle.js';
@@ -45,10 +46,12 @@ describe('パッシブ (#456 各職 Lv30)', () => {
     expect(jobPassives('warrior', 29)).toEqual([]);
     expect(jobPassives('mage', 30)).toEqual(['mage-barrier']);
     expect(jobPassives('ninja', 30)).toEqual(['kubikari']);
-    // フック未実装の職 (慧眼/清き心/覇王 等) は Lv30 でもまだ空 (後続で追加)。
+    expect(jobPassives('shogun', 30)).toEqual(['shogun-overlord']);
+    expect(jobPassives('guardian', 30)).toEqual(['guardian-immovable']);
+    // フック未実装の職 (慧眼/清き心/審美眼/発明家/非戦闘) は Lv30 でもまだ空 (後続 #483)。
     expect(jobPassives('sage', 30)).toEqual([]);
     expect(jobPassives('paladin', 30)).toEqual([]);
-    expect(jobPassives('guardian', 30)).toEqual([]);
+    expect(jobPassives('artist', 30)).toEqual([]);
   });
 
   it('playerCombatant: 実装済み職は Lv30 で passives が入り、Lv29 では空', () => {
@@ -107,6 +110,32 @@ describe('パッシブ (#456 各職 Lv30)', () => {
     expect(applyOnHit(ninja, metal, ctx(0.01))).toBe(false);
   });
 
+  it('覇王 (shogun-overlord): 物理致死をHP1で耐え、受けた分を攻撃者へ反射', () => {
+    const shogun = c({ passives: ['shogun-overlord'], name: '将軍' });
+    const atk = c({ name: '敵', hp: 100 });
+    const ev = ctx();
+    expect(applyOnLethal(shogun, atk, 30, ev)).toBe(true); // 生存
+    expect(atk.hp).toBe(70); // 30 反射
+    expect(ev.events.some((e) => e.text.includes('反射'))).toBe(true);
+  });
+
+  it('不動 (guardian-immovable): 物理致死を 50% で耐える (反射なし)', () => {
+    const g = c({ passives: ['guardian-immovable'], name: '守護者' });
+    const atk = c({ name: '敵', hp: 100 });
+    expect(applyOnLethal(g, atk, 40, ctx(0.3))).toBe(true); // rng<0.5 = 耐える
+    expect(atk.hp).toBe(100); // 反射なし
+    expect(applyOnLethal(g, atk, 40, ctx(0.7))).toBe(false); // rng>=0.5 = 死ぬ
+  });
+
+  it('onLethal: パッシブなしは survive せず (通常どおり死ぬ)', () => {
+    expect(applyOnLethal(c(), c(), 50, ctx())).toBe(false);
+  });
+
+  it('playerCombatant: 将軍/守護者 Lv30 で onLethal パッシブが入る', () => {
+    expect(playerCombatant('shogun', 30, 30, 'sh').passives).toEqual(['shogun-overlord']);
+    expect(playerCombatant('guardian', 30, 30, 'gd').passives).toEqual(['guardian-immovable']);
+  });
+
   it('パッシブなしの Combatant は全ディスパッチ no-op (回帰防止)', () => {
     const bare = c();
     expect(applyIncomingCalc(1, bare, ctx())).toBe(1);
@@ -114,5 +143,6 @@ describe('パッシブ (#456 各職 Lv30)', () => {
     expect(applyDodgeCalc(0.2, bare, ctx())).toBe(0.2);
     expect(applyCritCalc(false, bare, ctx(0.1))).toBe(false);
     expect(applyOnHit(bare, c(), ctx(0.01))).toBe(false);
+    expect(applyOnLethal(bare, c(), 50, ctx())).toBe(false);
   });
 });

--- a/packages/core/src/__tests__/passives.test.ts
+++ b/packages/core/src/__tests__/passives.test.ts
@@ -110,29 +110,45 @@ describe('パッシブ (#456 各職 Lv30)', () => {
     expect(applyOnHit(ninja, metal, ctx(0.01))).toBe(false);
   });
 
-  it('覇王 (shogun-overlord): 物理致死をHP1で耐え、受けた分を攻撃者へ反射', () => {
+  it('覇王 (shogun-overlord): 物理致死をHP1で耐え反射、ただし 1 戦闘 1 回だけ (2 回目は死ぬ)', () => {
     const shogun = c({ passives: ['shogun-overlord'], name: '将軍' });
     const atk = c({ name: '敵', hp: 100 });
     const ev = ctx();
-    expect(applyOnLethal(shogun, atk, 30, ev)).toBe(true); // 生存
+    expect(applyOnLethal(shogun, atk, 30, ev)).toBe(true); // 初回: 生存
     expect(atk.hp).toBe(70); // 30 反射
+    expect(shogun.lethalGuardUsed).toBe(true); // 発動済みフラグ
     expect(ev.events.some((e) => e.text.includes('反射'))).toBe(true);
+    // 2 回目の物理致死は耐えられない (切り札は 1 回)。反射も起きない。
+    const atk2 = c({ name: '敵2', hp: 100 });
+    expect(applyOnLethal(shogun, atk2, 30, ctx())).toBe(false);
+    expect(atk2.hp).toBe(100);
   });
 
-  it('不動 (guardian-immovable): 物理致死を 50% で耐える (反射なし)', () => {
+  it('不動 (guardian-immovable): 物理致死を 1 回だけ確定で耐える (反射なし・運要素なし・2 回目は死ぬ)', () => {
     const g = c({ passives: ['guardian-immovable'], name: '守護者' });
     const atk = c({ name: '敵', hp: 100 });
-    expect(applyOnLethal(g, atk, 40, ctx(0.3))).toBe(true); // rng<0.5 = 耐える
+    expect(applyOnLethal(g, atk, 40, ctx(0.99))).toBe(true); // rng に依らず確定で耐える
     expect(atk.hp).toBe(100); // 反射なし
-    expect(applyOnLethal(g, atk, 40, ctx(0.7))).toBe(false); // rng>=0.5 = 死ぬ
+    expect(g.lethalGuardUsed).toBe(true);
+    expect(applyOnLethal(g, atk, 40, ctx(0.01))).toBe(false); // 2 回目は死ぬ
+  });
+
+  it('onLethal: オーバーキル (残HP<<ダメージ) でも survive すれば HP1 固定 (呼び出し側 battle.ts で hp=1)', () => {
+    // applyOnLethal 自体は survive 可否のみ返す。ダメージ量に依らず初回は耐える (HP1 化は doAttack 側)。
+    const shogun = c({ passives: ['shogun-overlord'], hp: 10, name: '将軍' });
+    const atk = c({ name: '敵', hp: 500 });
+    expect(applyOnLethal(shogun, atk, 9999, ctx())).toBe(true); // 超過ダメージでも初回は耐える
+    expect(atk.hp).toBe(0); // 9999 反射で攻撃者は即死 (Math.max(0,...))
   });
 
   it('onLethal: パッシブなしは survive せず (通常どおり死ぬ)', () => {
     expect(applyOnLethal(c(), c(), 50, ctx())).toBe(false);
   });
 
-  it('playerCombatant: 将軍/守護者 Lv30 で onLethal パッシブが入る', () => {
-    expect(playerCombatant('shogun', 30, 30, 'sh').passives).toEqual(['shogun-overlord']);
+  it('playerCombatant: 将軍/守護者 Lv30 で onLethal パッシブが入り、切り札は毎戦闘 未使用から始まる', () => {
+    const sh = playerCombatant('shogun', 30, 30, 'sh');
+    expect(sh.passives).toEqual(['shogun-overlord']);
+    expect(sh.lethalGuardUsed).toBeUndefined(); // 新しい戦闘 = 未発動 (once-per-battle のリセット)
     expect(playerCombatant('guardian', 30, 30, 'gd').passives).toEqual(['guardian-immovable']);
   });
 

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -402,7 +402,8 @@ export function skillsForJob(archetype: Archetype, jobLevel: number): JobSkill[]
 }
 
 /** ジョブ innate パッシブ (docs/25 §12 の各職 Lv30)。PASSIVES のキー。習得 jobLevel は一律 30。
- *  フック実装済みの7職のみ (onLethal/onIncomingMagic/属性シナジー/非戦闘 待ちの9職は後続)。 */
+ *  フック実装済みの9職 (基本7職 + onLethal で覇王/不動)。onIncomingMagic/属性シナジー/対象状態参照/
+ *  MP割引/非戦闘 待ちの残職は後続 (#483)。 */
 const JOB_PASSIVES: Partial<Record<Archetype, string>> = {
   warrior: 'warrior-blademaster', // 剣豪: 会心率↑
   mage: 'mage-barrier', // 魔力障壁: 常時被ダメ軽減
@@ -507,6 +508,9 @@ export interface Combatant {
   element?: Element;
   /** すべての魔法を無効化 (メタル系。#455)。true だと fixedDamage/doMagic が最小 1。 */
   resistAllMagic?: boolean;
+  /** onLethal (覇王/不動) を戦闘中に発動済みか (#456)。物理致死を耐える切り札は 1 戦闘 1 回のみ。
+   *  playerCombatant で毎戦闘 undefined から始まり、初回発動でハンドラが true にする。 */
+  lethalGuardUsed?: boolean;
 }
 
 function fromStats(name: string, stats: StatArray, levelFactor: number, level: number): Combatant {

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -31,6 +31,7 @@ import {
   applyCritCalc,
   applyIncomingCalc,
   applyOnHit,
+  applyOnLethal,
   applyOnDamaged,
   applyModifyHit,
   tickStatuses,
@@ -410,6 +411,8 @@ const JOB_PASSIVES: Partial<Record<Archetype, string>> = {
   seer: 'seer-omniscience', // 全知: 常時回避↑
   explorer: 'explorer-instinct', // 旅の勘: 回避↑
   poet: 'poet-muse', // 詩心: 自己バフ中 与ダメ↑
+  shogun: 'shogun-overlord', // 覇王: 物理致死をHP1で耐え+反射
+  guardian: 'guardian-immovable', // 不動: 物理致死を50%で耐える
 };
 
 /** その jobLevel 時点で有効なパッシブ id 列。Lv30 到達で innate パッシブが1つ有効になる。 */
@@ -1161,7 +1164,13 @@ function doAttack(
   // 丸めの後にも最低 1 を保証 (guardReduction で 0.5 に落ちて round(0) になる境界対策)。
   // minDamage を将来 0 等に変える場合、この行のハード 1 も一緒に見直すこと (二重下限の注意)。
   const final = Math.max(1, Math.round(dmg));
-  defender.hp = Math.max(0, defender.hp - final);
+  // 物理致死の直前に onLethal フック (覇王/不動) を確認。survive なら HP1 で耐える (反射等は
+  // ハンドラ内で処理済み)。魔法致死は doMagic を通るためここには来ず、耐えられず死ぬ (§12)。
+  if (defender.hp - final <= 0 && applyOnLethal(defender, attacker, final, defCtx)) {
+    defender.hp = 1;
+  } else {
+    defender.hp = Math.max(0, defender.hp - final);
+  }
   const fatal = defender.hp === 0;
   // 被弾で解ける状態 (かくれみ解除・眠り起床)。none なら no-op。
   if (!fatal) clearHitStatuses(defender);

--- a/packages/core/src/statuses.ts
+++ b/packages/core/src/statuses.ts
@@ -294,23 +294,28 @@ export const PASSIVES: Record<string, PassiveDef> = {
     name: '詩心',
     powerCalc: (power, c) => (hasSelfBuff(c) ? power * 1.25 : power),
   },
-  // 将軍 覇王: 物理致死をHP1で耐え、受けた分を攻撃者へ反射 (§12 Lv30)。魔法致死は doAttack を通らない
-  // ため耐えられず普通に死ぬ (int28 の魔法耐性で対キャスターを補う設計)。対物理ほぼ不死の看板。
+  // 将軍 覇王: 物理致死をHP1で耐え、受けた分を攻撃者へ反射 (§12 Lv30)。**1 戦闘 1 回だけ**の切り札
+  // (オーナー判断 2026-07-22: 毎回発動だと敵が物理のみの現状で対モンスター完全不死になるため)。魔法致死は
+  // doAttack を通らず耐えられない (int28 の魔法耐性で対キャスターを補う設計)。2 回目以降の物理致死は普通に死ぬ。
   'shogun-overlord': {
     id: 'shogun-overlord',
     name: '覇王',
     onLethal(self, atk, damage, ctx) {
+      if (self.lethalGuardUsed) return; // 発動済み: 2 回目の物理致死は耐えられない
+      self.lethalGuardUsed = true;
       atk.hp = Math.max(0, atk.hp - damage); // 同ダメージ反射
       ctx.events.push({ actor: ctx.actor ?? 'player', text: `${self.name}は 覇王の意地で耐えた! ${atk.name}に ${damage} 反射!`, damage });
       return { survive: true };
     },
   },
-  // 守護者 不動: 物理致死を 50% でHP1耐え (§12 Lv30)。反射はなし。魔法致死は覇王同様に死ぬ。
+  // 守護者 不動: 物理致死を **1 戦闘 1 回だけ確定で** HP1 耐える (§12 Lv30。オーナー判断 2026-07-22: 壁役の
+  // capstone に 50% 運要素は噛み合わないため確定 1 回に。once-per-battle で対モンスター完全不死も防ぐ)。反射なし。
   'guardian-immovable': {
     id: 'guardian-immovable',
     name: '不動',
     onLethal(self, _atk, _damage, ctx) {
-      if (ctx.rng() >= 0.5) return; // 50% は耐えられず死ぬ
+      if (self.lethalGuardUsed) return; // 発動済み: 2 回目の物理致死は耐えられない
+      self.lethalGuardUsed = true;
       ctx.events.push({ actor: ctx.actor ?? 'player', text: `${self.name}は 不動の構えで持ちこたえた!` });
       return { survive: true };
     },
@@ -415,7 +420,8 @@ export function applyOnDamaged(c: Combatant, atk: Combatant, damage: number, ctx
 }
 
 /** 物理致死の直前: 被弾側のフック (覇王/不動) を回し、いずれかが survive を返したら true (HP1 生存)。
- *  反射等の攻撃者への副作用はハンドラ内で atk を操作する (ここでは生存可否だけ集約)。 */
+ *  反射等の攻撃者への副作用はハンドラ内で atk を操作する (ここでは生存可否だけ集約)。複数の onLethal
+ *  が共存する場合は全ハンドラが走る (副作用も全部発火) — 現状 1 職 1 パッシブなので単一発火。 */
 export function applyOnLethal(c: Combatant, atk: Combatant, damage: number, ctx: HookCtx): boolean {
   let survive = false;
   for (const { def, inst } of hooksOf(c)) {

--- a/packages/core/src/statuses.ts
+++ b/packages/core/src/statuses.ts
@@ -79,6 +79,9 @@ export interface CombatHook {
   incomingCalc?(power: number, c: Combatant, ctx: HookCtx): number;
   /** 物理被弾後 (c=被弾側)。とげの盾: 攻撃者 atk へ反射。damage=食らった最終ダメージ。 */
   onDamaged?(c: Combatant, atk: Combatant, damage: number, ctx: HookCtx): void;
+  /** 物理致死の直前 (c=倒れかけている側)。survive=true で HP1 生存 (覇王/不動)。魔法致死には効かない
+   *  (doAttack の物理経路からのみ呼ばれる)。反射など攻撃者への副作用はハンドラ内で atk を直接操作。 */
+  onLethal?(c: Combatant, atk: Combatant, damage: number, ctx: HookCtx): { survive?: boolean } | void;
   /** ターン終了。毒ダメージ等。 */
   turnEnd?(c: Combatant, ctx: HookCtx): void;
 }
@@ -233,9 +236,9 @@ function boostDodge(dodge: number, bonus: number): number {
 
 /**
  * パッシブレジストリ (ジョブ innate な常時フック。docs/25 §12 の各職 Lv30)。エンジンは
- * hooksOf でこれを状態異常と同じフック点に流すだけ (専用分岐なし)。フック実装済みの7職を
- * ここで登録。onLethal (覇王/不動)・onIncomingMagic (清き心)・属性シナジー (慧眼)・対象状態参照
- * (審美眼)・MP消費割引 (発明家)・非戦闘 (巫女の直感/名演) は追加フック待ちで #456 の後続に残す。
+ * hooksOf でこれを状態異常と同じフック点に流すだけ (専用分岐なし)。フック実装済みの9職を
+ * ここで登録 (基本7職 + onLethal 追加で覇王/不動)。onIncomingMagic (清き心)・属性シナジー (慧眼)・
+ * 対象状態参照 (審美眼)・MP消費割引 (発明家)・非戦闘 (巫女の直感/名演) は追加フック待ちで後続 (#483)。
  */
 export const PASSIVES: Record<string, PassiveDef> = {
   // 忍者 首狩り: 自分より明確に弱い敵 (メタル除く) を luk 補正つき低確率で一撃 (§7/§12 Lv30)。
@@ -290,6 +293,27 @@ export const PASSIVES: Record<string, PassiveDef> = {
     id: 'poet-muse',
     name: '詩心',
     powerCalc: (power, c) => (hasSelfBuff(c) ? power * 1.25 : power),
+  },
+  // 将軍 覇王: 物理致死をHP1で耐え、受けた分を攻撃者へ反射 (§12 Lv30)。魔法致死は doAttack を通らない
+  // ため耐えられず普通に死ぬ (int28 の魔法耐性で対キャスターを補う設計)。対物理ほぼ不死の看板。
+  'shogun-overlord': {
+    id: 'shogun-overlord',
+    name: '覇王',
+    onLethal(self, atk, damage, ctx) {
+      atk.hp = Math.max(0, atk.hp - damage); // 同ダメージ反射
+      ctx.events.push({ actor: ctx.actor ?? 'player', text: `${self.name}は 覇王の意地で耐えた! ${atk.name}に ${damage} 反射!`, damage });
+      return { survive: true };
+    },
+  },
+  // 守護者 不動: 物理致死を 50% でHP1耐え (§12 Lv30)。反射はなし。魔法致死は覇王同様に死ぬ。
+  'guardian-immovable': {
+    id: 'guardian-immovable',
+    name: '不動',
+    onLethal(self, _atk, _damage, ctx) {
+      if (ctx.rng() >= 0.5) return; // 50% は耐えられず死ぬ
+      ctx.events.push({ actor: ctx.actor ?? 'player', text: `${self.name}は 不動の構えで持ちこたえた!` });
+      return { survive: true };
+    },
   },
 };
 
@@ -388,6 +412,16 @@ export function applyIncomingCalc(base: number, c: Combatant, ctx: HookCtx): num
 /** 物理被弾後: 被弾側のフック (とげの盾) を回す (攻撃者へ反射など)。 */
 export function applyOnDamaged(c: Combatant, atk: Combatant, damage: number, ctx: HookCtx): void {
   for (const { def, inst } of hooksOf(c)) def.onDamaged?.(c, atk, damage, ctxFor(ctx, inst));
+}
+
+/** 物理致死の直前: 被弾側のフック (覇王/不動) を回し、いずれかが survive を返したら true (HP1 生存)。
+ *  反射等の攻撃者への副作用はハンドラ内で atk を操作する (ここでは生存可否だけ集約)。 */
+export function applyOnLethal(c: Combatant, atk: Combatant, damage: number, ctx: HookCtx): boolean {
+  let survive = false;
+  for (const { def, inst } of hooksOf(c)) {
+    if (def.onLethal?.(c, atk, damage, ctxFor(ctx, inst))?.survive) survive = true;
+  }
+  return survive;
 }
 
 /** 命中時: いずれかのパッシブ/状態が即死を返したら true。 */


### PR DESCRIPTION
## 概要
Lv30 パッシブ capstone の続き (#482 の7職に続く)。追加フック **onLethal** を実装し、将軍/守護者の看板「対物理不死」パッシブを配線した。これで **Lv30 パッシブ実装済みは 9/16 職**。

## 実装
- `CombatHook` に `onLethal(c, atk, damage, ctx) → {survive?}` を追加。`applyOnLethal` が被弾側フックを回し survive を集約 (反射等の攻撃者への副作用はハンドラ内で `atk` を直接操作 = thorns と同じ data-driven idiom)。
- `doAttack` の物理致死直前 (hp を 0 にする前) に `applyOnLethal` を挿入。survive なら **HP1 で耐える**。
- **魔法致死は `doMagic` を通るため onLethal に到達せず普通に死ぬ** — §12「物理のみ耐える／魔法致死は死ぬ」を**経路分離で if 分岐なしに表現**。

| 職 | パッシブ | 効果 |
|---|---|---|
| 将軍 | 覇王 | 物理致死をHP1で耐え、受けた分を攻撃者へ反射。対物理ほぼ不死・魔法に弱い (int28 の魔法耐性で対キャスターを補う設計) |
| 守護者 | 不動 | 物理致死を 50% (ctx.rng) でHP1耐え。反射なし |

## サーバー権威との整合
edge の `battle-resolver` が `resolveTurn → doAttack` で同じ物理経路を replay するため、onLethal はサーバー権威戦闘でも一致 (不動の `ctx.rng()` も seeded 決定性)。

## バランス設計 (docs/25 §509 の balance watch)
覇王/不動は「対物理ほぼ不死」を意図した看板パッシブ。**カウンターは魔法** (魔法致死は onLethal を通らず貫通) として明確に用意されている。数値 (不動 50%) は sim 前提の暫定値。

## 検証
- core **464 緑** (applyOnLethal の覇王反射・不動 50%・no-op を明示テスト)
- edge 149 緑 / typecheck (web+edge+core) 緑
- 既存戦闘は挙動不変 (onLethal は Lv30 到達の将軍/守護者のみ・致死時のみ発火)

## 後続
onIncomingMagic (清き心)・属性シナジー (慧眼)・対象状態参照 (審美眼)・MP割引 (発明家)・非戦闘 (巫女/名演) は #483。

## Review

§1.5 3並列独立レビュー (設計/実装/体験)。**設計・実装は ★★★ ゼロ・マージ可**、体験が **★★★ 1件** を検出 → オーナー判断で対応済み。

### 設計レビュー: ★★★ ゼロ・マージ可
物理経路 (doAttack) のみに onLethal を挿し魔法致死 (doMagic) には挿さない = 「物理耐性・魔法貫通」を分岐なしに表現、を doMagic 実コードで裏取り。survive→fatal=false の後続整合・反射 idiom (thorns と同型)・サーバー権威決定性すべて健全。★★ = doc signature 乖離 (対応済)・parry 死体殴り (先行課題 #486)。

### 実装レビュー: ★★★ ゼロ・マージ可
no-op / RNG 決定性 / doMagic 非通過 / sealed state 往復すべて実機確認。★★ = parry 死体殴り (#486)・複数回 lethal テスト欠落 (#486)。★ = オーバーキル境界テスト (対応済)。

### 体験・バランスレビュー: ★★★ 1件 (対応必須)
**★★★ 覇王のカウンター (魔法致死) が world に存在せず対モンスター完全不死**。敵は 100% 物理 (doMagic は player 専用・charger/healer/fleer は物理/自己回復/逃走のみ)。毎ターン無条件で物理致死を耐える覇王将軍が敗北する経路が無い。あわせて ★★ 反射過剰 (高火力敵ほど自滅) / ★★ 不動 50% がタンク capstone として運ゲー。

### ★★★/★★ 対応 (commit 06a3105) — オーナー判断 2026-07-22「戦闘中1回だけ」
`Combatant.lethalGuardUsed` を追加し onLethal を **1 戦闘 1 回の切り札**に:
- **覇王**: 1 回だけ HP1 で耐え同ダメ反射 → 2 回目以降の物理致死・魔法致死は死ぬ。DQ アストロン的切り札。
- **不動**: 旧 50% 運要素を廃し **1 回確定で**耐える (壁役の名に相応しい確実さ)。
- これ 1 つで ★★★ (完全不死)・★★ (反射が毎回でなく 1 回に)・★★ (不動運ゲー解消) を一括解決。playerCombatant で毎戦闘リセット、edge は sealed state で round-trip。

### 後続 issue
- #486: 反射で死んだ敵への見切り反撃ログ (★★・thorns にも既存の先行課題) / onLethal メッセージ順序 (★) / 複数回 lethal テスト (★)。
- #483: 残 onIncomingMagic (清き心)・属性シナジー (慧眼)・対象状態参照 (審美眼)・MP割引 (発明家)・非戦闘 (巫女/名演)。

CI: web-ci pass 予定。core 465緑 / edge 149緑 / typecheck (web+edge+core) 緑。**既存戦闘は挙動不変** (onLethal は Lv30 将軍/守護者の致死時のみ)。
