### PR TITLE
elementBonus フック + 慧眼 (賢者) パッシブ (#456)

### DIFF
--- a/docs/25-combat-plugin-system.md
+++ b/docs/25-combat-plugin-system.md
@@ -300,8 +300,11 @@ export const MONSTER_ABILITIES: Record<string, AbilityDef> = {
   分岐なしに表現。**1 戦闘 1 回のみ**発動する切り札 (`Combatant.lethalGuardUsed` フラグ。オーナー判断
   2026-07-22: 敵が物理のみの現状で毎回発動だと対モンスター完全不死になるため)。覇王=1回耐えて同ダメ反射、
   不動=1回確定で耐える (旧 50% 運要素は壁役の capstone に合わないため確定 1 回に変更)。
-- `elementBonus(mult, self, ctx) → mult` — 属性相性倍率の補正 (self=攻撃側)。実装済み (#456)。慧眼 (賢者):
-  弱点 (mult>=1.5) を突いたとき ×1.25 増幅。doAttack/doMagic 双方の属性倍率適用点で発火。none なら素通し。
+- `elementBonus(mult, c, ctx) → mult` — 属性相性倍率の補正 (c=攻撃側)。実装済み (#456)。慧眼 (賢者): 弱点
+  (mult>=1.5) を突いたとき **×1.25 増幅** (1.5→1.875)。1.25 の根拠 = 弱点を突く能動プレイへの報酬。大賢者
+  の一撃 (×2.5) と合わせても過剰にならない範囲で、閾値 1.5/倍率 1.25 とも sim 調整余地を残す暫定値。
+  doAttack/doMagic 双方の属性倍率適用点で発火。none なら素通し。**告知テキストは増幅時も共通の「弱点を突
+  いた!」のまま** (賢者専用の別演出は出さず、跳ねる数値で実感させる = 情報量を増やさない方針)。
 
 **Combatant フィールド:** `statuses: StatusInstance[]` / `passives: string[]` / `damageTaken: number`(累積)
 **BattleOutcome 追加:** `reconciled`(和解 = XP なし・素材あり)。battle-reward は outcome + `resolve` の

--- a/docs/25-combat-plugin-system.md
+++ b/docs/25-combat-plugin-system.md
@@ -300,6 +300,8 @@ export const MONSTER_ABILITIES: Record<string, AbilityDef> = {
   分岐なしに表現。**1 戦闘 1 回のみ**発動する切り札 (`Combatant.lethalGuardUsed` フラグ。オーナー判断
   2026-07-22: 敵が物理のみの現状で毎回発動だと対モンスター完全不死になるため)。覇王=1回耐えて同ダメ反射、
   不動=1回確定で耐える (旧 50% 運要素は壁役の capstone に合わないため確定 1 回に変更)。
+- `elementBonus(mult, self, ctx) → mult` — 属性相性倍率の補正 (self=攻撃側)。実装済み (#456)。慧眼 (賢者):
+  弱点 (mult>=1.5) を突いたとき ×1.25 増幅。doAttack/doMagic 双方の属性倍率適用点で発火。none なら素通し。
 
 **Combatant フィールド:** `statuses: StatusInstance[]` / `passives: string[]` / `damageTaken: number`(累積)
 **BattleOutcome 追加:** `reconciled`(和解 = XP なし・素材あり)。battle-reward は outcome + `resolve` の

--- a/packages/core/src/__tests__/passives.test.ts
+++ b/packages/core/src/__tests__/passives.test.ts
@@ -7,6 +7,7 @@ import {
   applyIncomingCalc,
   applyOnHit,
   applyOnLethal,
+  applyElementBonus,
   type HookCtx,
 } from '../statuses.js';
 import { jobPassives, playerCombatant, type Combatant } from '../battle.js';
@@ -48,8 +49,8 @@ describe('パッシブ (#456 各職 Lv30)', () => {
     expect(jobPassives('ninja', 30)).toEqual(['kubikari']);
     expect(jobPassives('shogun', 30)).toEqual(['shogun-overlord']);
     expect(jobPassives('guardian', 30)).toEqual(['guardian-immovable']);
-    // フック未実装の職 (慧眼/清き心/審美眼/発明家/非戦闘) は Lv30 でもまだ空 (後続 #483)。
-    expect(jobPassives('sage', 30)).toEqual([]);
+    expect(jobPassives('sage', 30)).toEqual(['sage-insight']);
+    // フック未実装/inert の職 (清き心=敵魔法待ち/審美眼/発明家/非戦闘) は Lv30 でもまだ空 (後続 #483)。
     expect(jobPassives('paladin', 30)).toEqual([]);
     expect(jobPassives('artist', 30)).toEqual([]);
   });
@@ -58,8 +59,8 @@ describe('パッシブ (#456 各職 Lv30)', () => {
     expect(playerCombatant('warrior', 30, 30, 'w').passives).toEqual(['warrior-blademaster']);
     expect(playerCombatant('warrior', 29, 30, 'w').passives).toEqual([]);
     expect(playerCombatant('captain', 30, 30, 'cap').passives).toEqual(['captain-command']);
-    // 未実装職は Lv30 でも空 (キット化と別軸)。
-    expect(playerCombatant('sage', 30, 30, 's').passives).toEqual([]);
+    // 未実装/inert 職は Lv30 でも空 (清き心=敵魔法待ち)。キット化とは別軸。
+    expect(playerCombatant('paladin', 30, 30, 'p').passives).toEqual([]);
   });
 
   // ── 各パッシブの効果 (dispatcher 経由) ──
@@ -143,6 +144,19 @@ describe('パッシブ (#456 各職 Lv30)', () => {
 
   it('onLethal: パッシブなしは survive せず (通常どおり死ぬ)', () => {
     expect(applyOnLethal(c(), c(), 50, ctx())).toBe(false);
+  });
+
+  it('慧眼 (sage-insight): 弱点 (相性倍率>=1.5) のみ ×1.25 増幅、等倍/耐性/空 1.2 は素通し', () => {
+    const sage = c({ passives: ['sage-insight'] });
+    expect(applyElementBonus(1.5, sage, ctx())).toBeCloseTo(1.875); // 弱点 → さらに増幅
+    expect(applyElementBonus(1.0, sage, ctx())).toBeCloseTo(1.0); // 等倍は素通し
+    expect(applyElementBonus(0.5, sage, ctx())).toBeCloseTo(0.5); // 耐性は素通し (弱点でない)
+    expect(applyElementBonus(1.2, sage, ctx())).toBeCloseTo(1.2); // 空の普遍優位は「弱点」でない
+    expect(applyElementBonus(1.5, c(), ctx())).toBeCloseTo(1.5); // パッシブなしは no-op
+  });
+
+  it('playerCombatant: 賢者 Lv30 で慧眼が入る', () => {
+    expect(playerCombatant('sage', 30, 30, 'sg').passives).toEqual(['sage-insight']);
   });
 
   it('playerCombatant: 将軍/守護者 Lv30 で onLethal パッシブが入り、切り札は毎戦闘 未使用から始まる', () => {

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -32,6 +32,7 @@ import {
   applyIncomingCalc,
   applyOnHit,
   applyOnLethal,
+  applyElementBonus,
   applyOnDamaged,
   applyModifyHit,
   tickStatuses,
@@ -402,8 +403,8 @@ export function skillsForJob(archetype: Archetype, jobLevel: number): JobSkill[]
 }
 
 /** ジョブ innate パッシブ (docs/25 §12 の各職 Lv30)。PASSIVES のキー。習得 jobLevel は一律 30。
- *  フック実装済みの9職 (基本7職 + onLethal で覇王/不動)。onIncomingMagic/属性シナジー/対象状態参照/
- *  MP割引/非戦闘 待ちの残職は後続 (#483)。 */
+ *  フック実装済みの10職 (基本7職 + onLethal で覇王/不動 + elementBonus で慧眼)。onIncomingMagic (清き心・
+ *  敵魔法が無いと inert のため保留)/対象状態参照 (審美眼)/MP割引 (発明家)/非戦闘 (巫女/名演) は後続 (#483)。 */
 const JOB_PASSIVES: Partial<Record<Archetype, string>> = {
   warrior: 'warrior-blademaster', // 剣豪: 会心率↑
   mage: 'mage-barrier', // 魔力障壁: 常時被ダメ軽減
@@ -412,8 +413,9 @@ const JOB_PASSIVES: Partial<Record<Archetype, string>> = {
   seer: 'seer-omniscience', // 全知: 常時回避↑
   explorer: 'explorer-instinct', // 旅の勘: 回避↑
   poet: 'poet-muse', // 詩心: 自己バフ中 与ダメ↑
-  shogun: 'shogun-overlord', // 覇王: 物理致死をHP1で耐え+反射
-  guardian: 'guardian-immovable', // 不動: 物理致死を50%で耐える
+  shogun: 'shogun-overlord', // 覇王: 物理致死をHP1で耐え+反射 (1戦闘1回)
+  guardian: 'guardian-immovable', // 不動: 物理致死を1回確定で耐える
+  sage: 'sage-insight', // 慧眼: 弱点属性で追加ダメ
 };
 
 /** その jobLevel 時点で有効なパッシブ id 列。Lv30 到達で innate パッシブが1つ有効になる。 */
@@ -1162,8 +1164,8 @@ function doAttack(
   // 被ダメバフ (defUp/defDown/転倒)。none なら ×1。
   dmg *= applyIncomingCalc(1, defender, defCtx);
   // 属性相性 (#452 §1): 攻撃属性 × 防御属性。両者 undefined (無属性) なら ×1 = 従来挙動。
-  // モンスター/装備への属性付与は #455/#456 で配線。現状は常に ×1 (behavior-preserving)。
-  dmg *= elementMultiplier(opts.element, defender.element);
+  // モンスター/装備への属性付与は #455/#456 で配線。慧眼 (賢者) は弱点時さらに増幅 (none なら素通し)。
+  dmg *= applyElementBonus(elementMultiplier(opts.element, defender.element), attacker, atkCtx);
 
   // 丸めの後にも最低 1 を保証 (guardReduction で 0.5 に落ちて round(0) になる境界対策)。
   // minDamage を将来 0 等に変える場合、この行のハード 1 も一緒に見直すこと (二重下限の注意)。
@@ -1225,8 +1227,10 @@ function doMagic(
   const label = opts.label ? `${attacker.name}の${opts.label}!` : `${attacker.name}の魔法!`;
   const defenderSide: 'player' | 'monster' = actor === 'player' ? 'monster' : 'player';
   const defCtx: HookCtx = { rng, events, actor: defenderSide };
+  const atkCtx: HookCtx = { rng, events, actor };
   let dmg = opts.amount;
-  const eMult = elementMultiplier(opts.element, defender.element); // 属性相性 (無属性は ×1)
+  // 属性相性 (無属性は ×1)。慧眼 (賢者) は弱点時さらに増幅 (none なら素通し)。
+  const eMult = applyElementBonus(elementMultiplier(opts.element, defender.element), attacker, atkCtx);
   dmg *= eMult;
   dmg *= applyIncomingCalc(1, defender, defCtx); // defUp/defDown/転倒
   // メタル系の魔法無効 (#455 / DQ 準拠): def 無視の魔法でも最小 1 に抑える (会心物理でしか倒せない)。

--- a/packages/core/src/statuses.ts
+++ b/packages/core/src/statuses.ts
@@ -69,6 +69,8 @@ export interface CombatHook {
   dodgeCalc?(dodge: number, c: Combatant, ctx: HookCtx): number;
   /** 攻撃威力の倍率補正 (c=攻撃側)。atkUp/atkDown。 */
   powerCalc?(power: number, c: Combatant, ctx: HookCtx): number;
+  /** 属性相性倍率の補正 (c=攻撃側)。慧眼: 弱点 (mult>=1.5) を突いたときさらに増幅。mult=現在の属性倍率。 */
+  elementBonus?(mult: number, c: Combatant, ctx: HookCtx): number;
   /** 命中補正 (c=攻撃側)。accDown: hitBonus を下げて当てにくく。 */
   modifyHit?(hitBonus: number, c: Combatant, ctx: HookCtx): number;
   /** 会心の可否 (c=攻撃側)。九字切り=確定会心。 */
@@ -320,6 +322,14 @@ export const PASSIVES: Record<string, PassiveDef> = {
       return { survive: true };
     },
   },
+  // 賢者 慧眼: 弱点属性 (相性倍率 >=1.5) を突いたときさらに与ダメ↑ (§12 Lv30)。int40 の属性キャスターが
+  // 属性の輪 (§1) を読み切って弱点を的確に突く知恵の職。空 (void ×1.2) の普遍的優位は「弱点」ではないので
+  // 対象外 (>=1.5 のみ)。等倍/耐性時は素通し = 弱点を突けたときだけのご褒美。
+  'sage-insight': {
+    id: 'sage-insight',
+    name: '慧眼',
+    elementBonus: (mult) => (mult >= 1.5 ? mult * 1.25 : mult),
+  },
 };
 
 /** 状態付与時の告知テキスト (対象名の後に続ける)。プレイヤーが状態変化を認識できるように
@@ -417,6 +427,13 @@ export function applyIncomingCalc(base: number, c: Combatant, ctx: HookCtx): num
 /** 物理被弾後: 被弾側のフック (とげの盾) を回す (攻撃者へ反射など)。 */
 export function applyOnDamaged(c: Combatant, atk: Combatant, damage: number, ctx: HookCtx): void {
   for (const { def, inst } of hooksOf(c)) def.onDamaged?.(c, atk, damage, ctxFor(ctx, inst));
+}
+
+/** 属性相性倍率の補正 (c=攻撃側)。慧眼など。none なら入力そのまま。 */
+export function applyElementBonus(mult: number, c: Combatant, ctx: HookCtx): number {
+  let v = mult;
+  for (const { def, inst } of hooksOf(c)) v = def.elementBonus?.(v, c, ctxFor(ctx, inst)) ?? v;
+  return v;
 }
 
 /** 物理致死の直前: 被弾側のフック (覇王/不動) を回し、いずれかが survive を返したら true (HP1 生存)。


### PR DESCRIPTION
## 概要
Lv30 パッシブ capstone の続き (#482 の7職・#485 の覇王/不動 に続く)。追加フック **elementBonus** を実装し、賢者の **慧眼** を配線した。これで **Lv30 パッシブ実装済みは 10/16 職**。

## 実装
- `CombatHook` に `elementBonus(mult, c, ctx) → mult` を追加。`applyElementBonus` が攻撃側フックを回し属性相性倍率を変換。**doAttack (物理) / doMagic (魔法) 双方**の属性倍率適用点で発火 (どちらも属性を持つため両対応)。
- **慧眼 (賢者)**: 弱点 (相性倍率 >=1.5) を突いたとき **×1.25 増幅**。空 (void ×1.2) の普遍優位は「弱点」でないので対象外、等倍/耐性も素通し = 弱点を的確に突けたときだけのご褒美。

## 設計方針
- 首狩り/onLethal 同様「専用分岐を作らず汎用フックに載せる」(docs/25 §4)。
- 既に配線済みの属性の輪 (#452 §1・#455 でモンスターに water/fire/earth/wind/void/metal を付与済み) を活かし、**弱点突きに報酬を与えて属性戦術を意味あるものにする**。int40 の属性キャスターが属性の輪を読み切る知恵の職、という賢者の性格に一致 (キット⇄ステ整合)。

## 清き心 (聖騎士) を保留する理由
§12 の残パッシブのうち **清き心 (魔法反射) は敵魔法 (doMagic 経由の敵行動) が world に無いため現状 inert** (覇王のカウンター不在と同根)。inert なパッシブを足しても「完成」にならないので #483 / 敵魔法実装 (#455) 後に回す。

## 検証
- core **467 緑** (慧眼の弱点増幅・等倍/耐性/void 素通し・no-op を明示テスト)
- typecheck (web+edge+core) 緑
- 慧眼なしは `applyElementBonus` 素通し = **既存戦闘は挙動不変**。edge (resolveTurn→doAttack/doMagic) も同経路で一致

## 後続 (#483)
onIncomingMagic (清き心・敵魔法待ち)・対象状態参照 (審美眼)・MP割引 (発明家)・非戦闘 (巫女の直感/名演)。

## Review

§1.5 3並列独立レビュー (設計/実装/体験)。**3本とも ★★★/★★ ゼロ・マージ可**。事前に懸念した「賢者のキットで慧眼が発火しない空回り」は、確定キット (§12) 照合で杞憂と確認 (賢者は火/土/水/風の全4元素技を持つ全属性キャスターで、常に弱点を突ける = キット⇄パッシブ整合が強い)。

### 設計レビュー: ★★★/★★ ゼロ・★ 3件
applyElementBonus が既存 applyPowerCalc/applyIncomingCalc と一字一句同じ `?? v` 素通しパターン = 専用分岐ゼロ (§4 忠実)。doAttack/doMagic 両挿し・doMagic の atkCtx 新設・弱点線引き (void 1.2 除外)・フィードバック閾値・サーバー一致・no-op すべて設計意図に忠実と裏取り。

### 実装レビュー: ★★★/★★ ゼロ・★ 2件
core 467緑を実機確認。no-op/回帰・doMagic atkCtx 方向・フィードバック相互作用・メタル (resistAllMagic で final=1 固定・慧眼で破れない)・決定性 (純関数・rng 非消費) すべて安全。diff 4ファイル48行・ロジック追加は最小。

### 体験・バランスレビュー: ★★★ ゼロ・マージ可 (approve)
賢者=全5属性・弱点を突く知恵の職に慧眼 (弱点特化) は完全整合。メタル弱者の性格も二重に保持 (resistAllMagic + メタル無属性)。×1.25 は能動プレイへの報酬として過剰でなく、他職 capstone と比べ突出しない。清き心を敵魔法待ちで保留した判断も妥当。

### ★ 対応 (commit 76f88c4)
- **慧眼増幅時のフィードバック演出の設計意図** (設計★★) → docs/25 §14.3 に「告知は共通・数値差で実感」を記録。
- **1.25 の根拠** (設計★) → docs §14.3 に明記 (feedback_comments に従いソースでなく docs へ)。
- **elementBonus 引数名 self→c** (設計/体験★) → docs を実装に統一。
- **統合テスト (resolveTurn 経由の慧眼実ダメージ検証)** (実装★) → オーバーキル+rng順序でフレーク化しやすいため **issue #488** に。dispatcher 単体テストが math を担保・配線は両レビュー済みで非ブロッカー。

CI: web-ci pass。core 467緑 / typecheck (web+edge+core) 緑。**慧眼なしは applyElementBonus 素通し = 既存戦闘は挙動不変**。
