### PR TITLE
targetBonus フック + 審美眼 (芸術家) パッシブ (#456)

### DIFF
--- a/docs/25-combat-plugin-system.md
+++ b/docs/25-combat-plugin-system.md
@@ -300,6 +300,10 @@ export const MONSTER_ABILITIES: Record<string, AbilityDef> = {
   分岐なしに表現。**1 戦闘 1 回のみ**発動する切り札 (`Combatant.lethalGuardUsed` フラグ。オーナー判断
   2026-07-22: 敵が物理のみの現状で毎回発動だと対モンスター完全不死になるため)。覇王=1回耐えて同ダメ反射、
   不動=1回確定で耐える (旧 50% 運要素は壁役の capstone に合わないため確定 1 回に変更)。
+- `targetBonus(mult, c, target, ctx) → mult` — 対象の状態に応じた与ダメ倍率補正 (c=攻撃側/target=被弾側)。
+  実装済み (#456)。審美眼 (芸術家): 状態異常 (AILMENT_IDS) の敵に与ダメ **×1.3** (sim 調整前提の暫定値)。
+  基準 1 に対する乗数を返し doAttack/doMagic 双方で dmg に乗算。芸術家の fixedDamage は doMagic を通るので
+  実効。会心↑ (必中 fixedDamage に乗らない)・良素材↑ (非戦闘) は §12 の残部分で別途 (#483)。
 - `elementBonus(mult, c, ctx) → mult` — 属性相性倍率の補正 (c=攻撃側)。実装済み (#456)。慧眼 (賢者): 弱点
   (mult>=1.5) を突いたとき **×1.25 増幅** (1.5→1.875)。1.25 の根拠 = 弱点を突く能動プレイへの報酬。大賢者
   の一撃 (×2.5) と合わせても過剰にならない範囲で、閾値 1.5/倍率 1.25 とも sim 調整余地を残す暫定値。

--- a/packages/core/src/__tests__/passives.test.ts
+++ b/packages/core/src/__tests__/passives.test.ts
@@ -8,6 +8,7 @@ import {
   applyOnHit,
   applyOnLethal,
   applyElementBonus,
+  applyTargetBonus,
   type HookCtx,
 } from '../statuses.js';
 import { jobPassives, playerCombatant, type Combatant } from '../battle.js';
@@ -50,9 +51,10 @@ describe('パッシブ (#456 各職 Lv30)', () => {
     expect(jobPassives('shogun', 30)).toEqual(['shogun-overlord']);
     expect(jobPassives('guardian', 30)).toEqual(['guardian-immovable']);
     expect(jobPassives('sage', 30)).toEqual(['sage-insight']);
-    // フック未実装/inert の職 (清き心=敵魔法待ち/審美眼/発明家/非戦闘) は Lv30 でもまだ空 (後続 #483)。
+    expect(jobPassives('artist', 30)).toEqual(['artist-aesthete']);
+    // フック未実装/inert の職 (清き心=敵魔法待ち/発明家/非戦闘) は Lv30 でもまだ空 (後続 #483)。
     expect(jobPassives('paladin', 30)).toEqual([]);
-    expect(jobPassives('artist', 30)).toEqual([]);
+    expect(jobPassives('miko', 30)).toEqual([]);
   });
 
   it('playerCombatant: 実装済み職は Lv30 で passives が入り、Lv29 では空', () => {
@@ -157,6 +159,24 @@ describe('パッシブ (#456 各職 Lv30)', () => {
 
   it('playerCombatant: 賢者 Lv30 で慧眼が入る', () => {
     expect(playerCombatant('sage', 30, 30, 'sg').passives).toEqual(['sage-insight']);
+  });
+
+  it('審美眼 (artist-aesthete): 状態異常の敵に与ダメ ×1.3、無傷の敵は素通し', () => {
+    const artist = c({ passives: ['artist-aesthete'] });
+    const healthy = c({ name: '敵', statuses: [] });
+    const poisoned = c({ name: '毒敵', statuses: [{ id: 'poison', turns: 3, magnitude: 5 }] });
+    const dazed = c({ name: '幻惑敵', statuses: [{ id: 'accDown', turns: 3 }] }); // 芸術家が撒くデバフ
+    expect(applyTargetBonus(1, artist, healthy, ctx())).toBeCloseTo(1); // 無傷 = 素通し
+    expect(applyTargetBonus(1, artist, poisoned, ctx())).toBeCloseTo(1.3); // 状態異常 = 増幅
+    expect(applyTargetBonus(1, artist, dazed, ctx())).toBeCloseTo(1.3);
+    // バフ (atkUp) しか持たない敵は「状態異常」ではないので素通し。
+    const buffed = c({ name: 'バフ敵', statuses: [{ id: 'atkUp', turns: 3 }] });
+    expect(applyTargetBonus(1, artist, buffed, ctx())).toBeCloseTo(1);
+    expect(applyTargetBonus(1, c(), poisoned, ctx())).toBeCloseTo(1); // パッシブなしは no-op
+  });
+
+  it('playerCombatant: 芸術家 Lv30 で審美眼が入る', () => {
+    expect(playerCombatant('artist', 30, 30, 'ar').passives).toEqual(['artist-aesthete']);
   });
 
   it('playerCombatant: 将軍/守護者 Lv30 で onLethal パッシブが入り、切り札は毎戦闘 未使用から始まる', () => {

--- a/packages/core/src/__tests__/passives.test.ts
+++ b/packages/core/src/__tests__/passives.test.ts
@@ -172,6 +172,9 @@ describe('パッシブ (#456 各職 Lv30)', () => {
     // バフ (atkUp) しか持たない敵は「状態異常」ではないので素通し。
     const buffed = c({ name: 'バフ敵', statuses: [{ id: 'atkUp', turns: 3 }] });
     expect(applyTargetBonus(1, artist, buffed, ctx())).toBeCloseTo(1);
+    // バフ+状態異常の混在敵 (バフ持ちに芸術家がデバフを足した実戦形) は状態異常があるので発火。
+    const mixed = c({ name: '混在敵', statuses: [{ id: 'atkUp', turns: 3 }, { id: 'poison', turns: 3, magnitude: 5 }] });
+    expect(applyTargetBonus(1, artist, mixed, ctx())).toBeCloseTo(1.3);
     expect(applyTargetBonus(1, c(), poisoned, ctx())).toBeCloseTo(1); // パッシブなしは no-op
   });
 

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -33,6 +33,7 @@ import {
   applyOnHit,
   applyOnLethal,
   applyElementBonus,
+  applyTargetBonus,
   applyOnDamaged,
   applyModifyHit,
   tickStatuses,
@@ -403,8 +404,8 @@ export function skillsForJob(archetype: Archetype, jobLevel: number): JobSkill[]
 }
 
 /** ジョブ innate パッシブ (docs/25 §12 の各職 Lv30)。PASSIVES のキー。習得 jobLevel は一律 30。
- *  フック実装済みの10職 (基本7職 + onLethal で覇王/不動 + elementBonus で慧眼)。onIncomingMagic (清き心・
- *  敵魔法が無いと inert のため保留)/対象状態参照 (審美眼)/MP割引 (発明家)/非戦闘 (巫女/名演) は後続 (#483)。 */
+ *  フック実装済みの11職 (基本7職 + onLethal 覇王/不動 + elementBonus 慧眼 + targetBonus 審美眼)。
+ *  onIncomingMagic (清き心・敵魔法が無いと inert のため保留)/MP割引 (発明家)/非戦闘 (巫女/名演) は後続 (#483)。 */
 const JOB_PASSIVES: Partial<Record<Archetype, string>> = {
   warrior: 'warrior-blademaster', // 剣豪: 会心率↑
   mage: 'mage-barrier', // 魔力障壁: 常時被ダメ軽減
@@ -416,6 +417,7 @@ const JOB_PASSIVES: Partial<Record<Archetype, string>> = {
   shogun: 'shogun-overlord', // 覇王: 物理致死をHP1で耐え+反射 (1戦闘1回)
   guardian: 'guardian-immovable', // 不動: 物理致死を1回確定で耐える
   sage: 'sage-insight', // 慧眼: 弱点属性で追加ダメ
+  artist: 'artist-aesthete', // 審美眼: 状態異常の敵に与ダメ↑
 };
 
 /** その jobLevel 時点で有効なパッシブ id 列。Lv30 到達で innate パッシブが1つ有効になる。 */
@@ -1166,6 +1168,8 @@ function doAttack(
   // 属性相性 (#452 §1): 攻撃属性 × 防御属性。両者 undefined (無属性) なら ×1 = 従来挙動。
   // モンスター/装備への属性付与は #455/#456 で配線。慧眼 (賢者) は弱点時さらに増幅 (none なら素通し)。
   dmg *= applyElementBonus(elementMultiplier(opts.element, defender.element), attacker, atkCtx);
+  // 対象状態シナジー: 審美眼 (芸術家) は状態異常の敵に与ダメ↑ (none なら素通し)。
+  dmg *= applyTargetBonus(1, attacker, defender, atkCtx);
 
   // 丸めの後にも最低 1 を保証 (guardReduction で 0.5 に落ちて round(0) になる境界対策)。
   // minDamage を将来 0 等に変える場合、この行のハード 1 も一緒に見直すこと (二重下限の注意)。
@@ -1232,6 +1236,7 @@ function doMagic(
   // 属性相性 (無属性は ×1)。慧眼 (賢者) は弱点時さらに増幅 (none なら素通し)。
   const eMult = applyElementBonus(elementMultiplier(opts.element, defender.element), attacker, atkCtx);
   dmg *= eMult;
+  dmg *= applyTargetBonus(1, attacker, defender, atkCtx); // 審美眼: 状態異常の敵に与ダメ↑ (none 素通し)
   dmg *= applyIncomingCalc(1, defender, defCtx); // defUp/defDown/転倒
   // メタル系の魔法無効 (#455 / DQ 準拠): def 無視の魔法でも最小 1 に抑える (会心物理でしか倒せない)。
   const final = defender.resistAllMagic ? 1 : Math.max(1, Math.round(dmg));

--- a/packages/core/src/skills.ts
+++ b/packages/core/src/skills.ts
@@ -11,7 +11,7 @@
  */
 
 import type { Combatant, TurnEvent, AttackOptions, AttackResult } from './battle.js';
-import { applyStatus, statusApplyText, DEFAULT_STATUS_TURNS, type StatusId } from './statuses.js';
+import { applyStatus, statusApplyText, DEFAULT_STATUS_TURNS, AILMENT_IDS, type StatusId } from './statuses.js';
 import type { Element } from './elements.js';
 import { resolveTargets, type SkillTarget, type CombatSides } from './combat-target.js';
 
@@ -252,21 +252,9 @@ const statusHandler: EffectHandler = (effect, ctx) => {
 /** 自己バフとして数える状態 (感情爆発の buffCount)。積み重ねてダメージに変換する。 */
 const BUFF_STATUSES: ReadonlySet<StatusId> = new Set<StatusId>(['atkUp', 'defUp', 'agiUp']);
 
-/** デバフ (浄化 cleanse で除去する状態)。バフ (atk/def/agiUp) は残す。
- *  **注意**: StatusId に新しいデバフ (confusion/flinch/accDown/doomMark/intDown 等) を足したら、
- *  ここにも追記すること (型では検出できない。将来 BUFF/DEBUFF を StatusId 側の1テーブルに寄せたい)。 */
-const DEBUFF_STATUSES: ReadonlySet<StatusId> = new Set<StatusId>([
-  'poison',
-  'sleep',
-  'stun',
-  'tumble',
-  'restraint',
-  'atkDown',
-  'defDown',
-  'agiDown',
-  'doomMark',
-  'accDown',
-]);
+/** デバフ (浄化 cleanse で除去する状態)。負の状態異常の正準集合は statuses.ts の AILMENT_IDS に一本化
+ *  (審美眼の「状態異常の敵」判定と同概念)。新デバフを足すときは AILMENT_IDS 側に追記する。 */
+const DEBUFF_STATUSES = AILMENT_IDS;
 
 /** 使用者の自己バフ数 (scaleBy: 'buffCount' 用)。 */
 function countBuffs(c: Combatant): number {

--- a/packages/core/src/statuses.ts
+++ b/packages/core/src/statuses.ts
@@ -465,7 +465,8 @@ export function applyElementBonus(mult: number, c: Combatant, ctx: HookCtx): num
   return v;
 }
 
-/** 対象の状態に応じた与ダメ倍率補正 (c=攻撃側, target=被弾側)。審美眼など。none なら入力そのまま。 */
+/** 対象の状態に応じた与ダメ倍率補正 (c=攻撃側, target=被弾側)。審美眼など。基準 1 に対する乗数を返す
+ *  (属性倍率とは独立した別軸なので基点 1 から始め、呼び出し側が dmg に乗算する)。none なら入力そのまま。 */
 export function applyTargetBonus(mult: number, c: Combatant, target: Combatant, ctx: HookCtx): number {
   let v = mult;
   for (const { def, inst } of hooksOf(c)) v = def.targetBonus?.(v, c, target, ctxFor(ctx, inst)) ?? v;

--- a/packages/core/src/statuses.ts
+++ b/packages/core/src/statuses.ts
@@ -71,6 +71,8 @@ export interface CombatHook {
   powerCalc?(power: number, c: Combatant, ctx: HookCtx): number;
   /** 属性相性倍率の補正 (c=攻撃側)。慧眼: 弱点 (mult>=1.5) を突いたときさらに増幅。mult=現在の属性倍率。 */
   elementBonus?(mult: number, c: Combatant, ctx: HookCtx): number;
+  /** 対象の状態に応じた与ダメ倍率補正 (c=攻撃側, target=被弾側)。審美眼: 状態異常の敵に与ダメ↑。 */
+  targetBonus?(mult: number, c: Combatant, target: Combatant, ctx: HookCtx): number;
   /** 命中補正 (c=攻撃側)。accDown: hitBonus を下げて当てにくく。 */
   modifyHit?(hitBonus: number, c: Combatant, ctx: HookCtx): number;
   /** 会心の可否 (c=攻撃側)。九字切り=確定会心。 */
@@ -226,6 +228,25 @@ function hasSelfBuff(c: Combatant): boolean {
   return (c.statuses ?? []).some((s) => SELF_BUFF_IDS.has(s.id));
 }
 
+/** 負の状態異常 (デバフ/弱体) の正準集合。浄化 (cleanse) が除去する対象であり、審美眼が「状態異常の敵」
+ *  と判定する対象でもある = 同じ概念なので単一の出所とする (skills.ts はこれを import して使う)。 */
+export const AILMENT_IDS: ReadonlySet<StatusId> = new Set<StatusId>([
+  'poison',
+  'sleep',
+  'stun',
+  'tumble',
+  'restraint',
+  'atkDown',
+  'defDown',
+  'agiDown',
+  'doomMark',
+  'accDown',
+]);
+/** c が何らかの状態異常 (ailment) を負っているか (審美眼の「状態異常の敵」判定)。 */
+function hasAilment(c: Combatant): boolean {
+  return (c.statuses ?? []).some((s) => AILMENT_IDS.has(s.id));
+}
+
 /** 回避パッシブ (全知/旅の勘) の実効回避上限。通常の dodgeMax(0.32) は回避職の identity として超える
  *  が、ここで頭打ちにして「絶対に当たらない」化を防ぐ (レビュー ★★: かくれみ 0.75 と積んで 0.9 化する
  *  懸念への対処)。数値は sim 前提の暫定値。 */
@@ -238,9 +259,9 @@ function boostDodge(dodge: number, bonus: number): number {
 
 /**
  * パッシブレジストリ (ジョブ innate な常時フック。docs/25 §12 の各職 Lv30)。エンジンは
- * hooksOf でこれを状態異常と同じフック点に流すだけ (専用分岐なし)。フック実装済みの9職を
- * ここで登録 (基本7職 + onLethal 追加で覇王/不動)。onIncomingMagic (清き心)・属性シナジー (慧眼)・
- * 対象状態参照 (審美眼)・MP消費割引 (発明家)・非戦闘 (巫女の直感/名演) は追加フック待ちで後続 (#483)。
+ * hooksOf でこれを状態異常と同じフック点に流すだけ (専用分岐なし)。フック実装済みの11職を
+ * ここで登録 (基本7職 + onLethal で覇王/不動 + elementBonus で慧眼 + targetBonus で審美眼)。
+ * onIncomingMagic (清き心・敵魔法待ちで inert)・MP消費割引 (発明家)・非戦闘 (巫女の直感/名演) は後続 (#483)。
  */
 export const PASSIVES: Record<string, PassiveDef> = {
   // 忍者 首狩り: 自分より明確に弱い敵 (メタル除く) を luk 補正つき低確率で一撃 (§7/§12 Lv30)。
@@ -329,6 +350,14 @@ export const PASSIVES: Record<string, PassiveDef> = {
     id: 'sage-insight',
     name: '慧眼',
     elementBonus: (mult) => (mult >= 1.5 ? mult * 1.25 : mult),
+  },
+  // 芸術家 審美眼: 状態異常の敵に与ダメ↑ (§12 Lv30 の与ダメ部分。会心↑は必中 fixedDamage の芸術家キットに
+  // 乗らず・良素材↑は非戦闘のため別途)。芸術家は幻惑/毒煙/拘束網で敵を弱らせる debuffer なので、自分で
+  // 撒いた状態異常を突いて追撃する『崩してから仕留める』シナジー。fixedDamage は doMagic を通るので両経路で効く。
+  'artist-aesthete': {
+    id: 'artist-aesthete',
+    name: '審美眼',
+    targetBonus: (mult, _c, target) => (hasAilment(target) ? mult * 1.3 : mult),
   },
 };
 
@@ -433,6 +462,13 @@ export function applyOnDamaged(c: Combatant, atk: Combatant, damage: number, ctx
 export function applyElementBonus(mult: number, c: Combatant, ctx: HookCtx): number {
   let v = mult;
   for (const { def, inst } of hooksOf(c)) v = def.elementBonus?.(v, c, ctxFor(ctx, inst)) ?? v;
+  return v;
+}
+
+/** 対象の状態に応じた与ダメ倍率補正 (c=攻撃側, target=被弾側)。審美眼など。none なら入力そのまま。 */
+export function applyTargetBonus(mult: number, c: Combatant, target: Combatant, ctx: HookCtx): number {
+  let v = mult;
+  for (const { def, inst } of hooksOf(c)) v = def.targetBonus?.(v, c, target, ctxFor(ctx, inst)) ?? v;
   return v;
 }
 


### PR DESCRIPTION
## 概要
Lv30 パッシブ capstone の続き (#482/#485/#487 に続く)。追加フック **targetBonus** を実装し、芸術家の **審美眼** を配線した。これで **Lv30 パッシブ実装済みは 11/16 職**。

## 実装
- `CombatHook` に `targetBonus(mult, c, target, ctx) → mult` を追加。`applyTargetBonus` が攻撃側フックを回し、**被弾側 (target) の状態を見て**与ダメ倍率を補正。doAttack/doMagic 双方の属性補正の直後で発火。
- **審美眼 (芸術家)**: 状態異常の敵に与ダメ **×1.3**。芸術家は幻惑/毒煙/拘束網の debuffer なので「**自分で崩してから仕留める**」シナジー。芸術家の攻撃は fixedDamage だが `engine.doMagic` を通る (skills.ts) ので両経路で効く。
- **負の状態異常の正準集合を `AILMENT_IDS` (statuses.ts) に一本化**。審美眼の「状態異常の敵」判定と cleanse の除去対象は同概念なので、skills.ts の `DEBUFF_STATUSES` はこれを参照するだけにして**二重管理・drift を解消**。

## 設計方針
- 首狩り/慧眼同様「専用分岐を作らず汎用フックに載せる」(docs/25 §4)。
- 既存の状態異常システムを活かし、debuffer 職に「崩しへの報酬」を与えて状態異常を撒く動機を強める。int43 の罠/幻術キャスターという芸術家の性格に一致 (キット⇄ステ整合)。

## スコープ外 (§12 残部分)
- 会心↑: 芸術家の攻撃は必中 fixedDamage で会心が乗らないため、芸術家キットには実効せず保留。
- 良素材↑: 非戦闘 (素材ドロップ) のため別軸。
- 清き心 (聖騎士・魔法反射): 敵魔法が無いと inert のため保留。
- いずれも #483。

## 検証
- core **469 緑** (審美眼の状態異常敵×1.3・無傷/バフのみ敵は素通し・no-op を明示テスト。AILMENT_IDS 一本化で cleanse テストも緑維持)
- edge 149 緑 / typecheck (web+edge+core) 緑
- 審美眼なしは `applyTargetBonus` 素通し = **既存戦闘は挙動不変**

## Review

§1.5 3並列独立レビュー (設計/実装/体験)。**3本とも ★★★/★★ ゼロ・マージ可**。事前懸念の「芸術家のキットで発火しない空パッシブ」は、キット照合で杞憂と確認 (幻惑の色/目くらまし/原色の刃 が accDown/atkDown=AILMENT_IDS を撒き、火力技は doMagic 経由で ×1.3 が乗る = 崩してから仕留めるシナジーが実キットで成立)。

### 設計レビュー: ★★★/★★ ゼロ・★ 3件
targetBonus は applyElementBonus の完全ミラー (target 1つ増やしただけ・専用分岐ゼロ = §4 忠実)。AILMENT_IDS 単一出所化は cleanse とデバフ判定が真に同概念・依存方向正しく循環なし・cleanse 挙動 1バイトも不変。会心↑ (fixedDamage に構造的に乗らない)/良素材↑ (非戦闘) 保留の線引きも正しいと裏取り。

### 実装レビュー: ★★★/★★ ゼロ・★ 2件
core 469緑を実機確認。AILMENT_IDS refactor の等価性 (同一10 ids・順序同一・循環 import なし)・no-op/決定性 (純関数)・メタル (resistAllMagic で final=1 固定・審美眼増幅も無効化)・引数順序すべて合格。

### 体験・バランスレビュー: ★★★ ゼロ・マージ可
審美眼⇄芸術家 (幻術デバッファー) が実キットで噛み合う。×1.3 はセットアップ1ターンのコストを踏まえ過剰でなく、むしろやや弱め側 (sim 待ち)。マルチ戦で全体デバフ職として輝く設計。

### ★★/★ 対応
- **StatusId polarity 1テーブル化** (設計/実装★★: buff 側の単一出所化が未達・AILMENT_IDS の網羅を型で守れない) → **issue #490**。
- **芸術家 §12 残要素** (体験★★: だまし討ち/混乱 confusion 未実装・会心↑/良素材↑ 追跡) → **issue #491**。
- **審美眼増幅の混在敵テスト** (実装★) → **PR 内対応** (commit 1172868)。
- **1.3 の暫定値記録 / applyTargetBonus JSDoc / targetBonus の docs 記載** (設計★) → **PR 内対応** (docs §14.3 + JSDoc、feedback_comments に従い値の理由は docs/commit へ)。

CI: web-ci pass。core 469緑 / edge 149緑 / typecheck (web+edge+core) 緑。**審美眼なしは applyTargetBonus 素通し = 既存戦闘は挙動不変**。おまけで AILMENT_IDS 単一出所化により skills.ts の二重管理を1つ解消。
