### PR TITLE
statusDurationBonus フック + 名演 (吟遊詩人) パッシブ (#456)

### DIFF
--- a/packages/core/src/__tests__/passives.test.ts
+++ b/packages/core/src/__tests__/passives.test.ts
@@ -9,9 +9,11 @@ import {
   applyOnLethal,
   applyElementBonus,
   applyTargetBonus,
+  applyStatusDurationBonus,
   type HookCtx,
 } from '../statuses.js';
 import { jobPassives, playerCombatant, type Combatant } from '../battle.js';
+import { runSkill, type SkillContext, type SkillDef } from '../skills.js';
 
 function c(over: Partial<Combatant> = {}): Combatant {
   return {
@@ -180,6 +182,40 @@ describe('パッシブ (#456 各職 Lv30)', () => {
 
   it('playerCombatant: 芸術家 Lv30 で審美眼が入る', () => {
     expect(playerCombatant('artist', 30, 30, 'ar').passives).toEqual(['artist-aesthete']);
+  });
+
+  it('名演 (bard-encore): 付与する状態の持続を +1 ターン (バフ・デバフどちらの歌も)', () => {
+    const bard = c({ passives: ['bard-encore'] });
+    expect(applyStatusDurationBonus(3, bard, ctx())).toBe(4); // 味方バフ (プレリュード等) の歌
+    expect(applyStatusDurationBonus(1, bard, ctx())).toBe(2); // 短い歌も +1
+    expect(applyStatusDurationBonus(3, c(), ctx())).toBe(3); // パッシブなしは no-op
+  });
+
+  it('playerCombatant: 吟遊詩人 Lv30 で名演が入る', () => {
+    expect(playerCombatant('bard', 30, 30, 'bd').passives).toEqual(['bard-encore']);
+  });
+
+  it('名演: runSkill 経由で実際に付与される状態の turns が +1 される (統合)', () => {
+    const song: SkillDef = { id: 'song', effects: [{ kind: 'status', status: 'atkDown', target: 'enemy', turns: 3 }] };
+    const mkCtx = (attacker: Combatant, defender: Combatant): SkillContext => ({
+      attacker,
+      defender,
+      rng: () => 0.5,
+      events: [],
+      skillName: 'テストの歌',
+      engine: {
+        doAttack: (_a, d) => ({ hit: d.hp > 0, damage: 5, fatal: false, crit: false }),
+        doMagic: (_a, d) => ({ hit: d.hp > 0, damage: 5, fatal: false, crit: false }),
+      },
+    });
+    // 名演あり: atkDown が turns 4 で付く。
+    const enemy1 = c({ name: '敵' });
+    runSkill(song, mkCtx(c({ passives: ['bard-encore'] }), enemy1));
+    expect(enemy1.statuses?.find((s) => s.id === 'atkDown')?.turns).toBe(4);
+    // 名演なし: 従来どおり turns 3。
+    const enemy2 = c({ name: '敵' });
+    runSkill(song, mkCtx(c(), enemy2));
+    expect(enemy2.statuses?.find((s) => s.id === 'atkDown')?.turns).toBe(3);
   });
 
   it('playerCombatant: 将軍/守護者 Lv30 で onLethal パッシブが入り、切り札は毎戦闘 未使用から始まる', () => {

--- a/packages/core/src/__tests__/passives.test.ts
+++ b/packages/core/src/__tests__/passives.test.ts
@@ -216,6 +216,18 @@ describe('パッシブ (#456 各職 Lv30)', () => {
     const enemy2 = c({ name: '敵' });
     runSkill(song, mkCtx(c(), enemy2));
     expect(enemy2.statuses?.find((s) => s.id === 'atkDown')?.turns).toBe(3);
+
+    // 自己バフの歌 (target:'self' → attacker に付与) にも名演が乗る。
+    const selfSong: SkillDef = { id: 'self', effects: [{ kind: 'status', status: 'atkUp', target: 'self', turns: 3 }] };
+    const singer = c({ passives: ['bard-encore'], name: '詩人' });
+    runSkill(selfSong, mkCtx(singer, c({ name: '敵' })));
+    expect(singer.statuses?.find((s) => s.id === 'atkUp')?.turns).toBe(4);
+
+    // restack refresh は max 挙動: 名演(4)の後に名演なし(3)を重ねても 4 が維持され短縮されない。
+    const enemy3 = c({ name: '敵' });
+    runSkill(song, mkCtx(c({ passives: ['bard-encore'] }), enemy3)); // 4
+    runSkill(song, mkCtx(c(), enemy3)); // 3 を重ねる → max(4,3)=4
+    expect(enemy3.statuses?.find((s) => s.id === 'atkDown')?.turns).toBe(4);
   });
 
   it('playerCombatant: 将軍/守護者 Lv30 で onLethal パッシブが入り、切り札は毎戦闘 未使用から始まる', () => {

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -404,8 +404,8 @@ export function skillsForJob(archetype: Archetype, jobLevel: number): JobSkill[]
 }
 
 /** ジョブ innate パッシブ (docs/25 §12 の各職 Lv30)。PASSIVES のキー。習得 jobLevel は一律 30。
- *  フック実装済みの11職 (基本7職 + onLethal 覇王/不動 + elementBonus 慧眼 + targetBonus 審美眼)。
- *  onIncomingMagic (清き心・敵魔法が無いと inert のため保留)/MP割引 (発明家)/非戦闘 (巫女/名演) は後続 (#483)。 */
+ *  フック実装済みの12職 (基本7職 + onLethal 覇王/不動 + elementBonus 慧眼 + targetBonus 審美眼 +
+ *  statusDurationBonus 名演)。onIncomingMagic (清き心・敵魔法が無いと inert)/MP割引 (発明家)/非戦闘 (巫女) は後続 (#483)。 */
 const JOB_PASSIVES: Partial<Record<Archetype, string>> = {
   warrior: 'warrior-blademaster', // 剣豪: 会心率↑
   mage: 'mage-barrier', // 魔力障壁: 常時被ダメ軽減
@@ -418,6 +418,7 @@ const JOB_PASSIVES: Partial<Record<Archetype, string>> = {
   guardian: 'guardian-immovable', // 不動: 物理致死を1回確定で耐える
   sage: 'sage-insight', // 慧眼: 弱点属性で追加ダメ
   artist: 'artist-aesthete', // 審美眼: 状態異常の敵に与ダメ↑
+  bard: 'bard-encore', // 名演: 自分の歌 (状態) の効果ターン+1
 };
 
 /** その jobLevel 時点で有効なパッシブ id 列。Lv30 到達で innate パッシブが1つ有効になる。 */

--- a/packages/core/src/skills.ts
+++ b/packages/core/src/skills.ts
@@ -11,7 +11,15 @@
  */
 
 import type { Combatant, TurnEvent, AttackOptions, AttackResult } from './battle.js';
-import { applyStatus, statusApplyText, DEFAULT_STATUS_TURNS, AILMENT_IDS, type StatusId } from './statuses.js';
+import {
+  applyStatus,
+  statusApplyText,
+  applyStatusDurationBonus,
+  DEFAULT_STATUS_TURNS,
+  AILMENT_IDS,
+  type StatusId,
+  type HookCtx,
+} from './statuses.js';
 import type { Element } from './elements.js';
 import { resolveTargets, type SkillTarget, type CombatSides } from './combat-target.js';
 
@@ -240,9 +248,12 @@ const statusHandler: EffectHandler = (effect, ctx) => {
     effect.magnitude !== undefined || effect.magIntBonus !== undefined
       ? (effect.magnitude ?? 0) + (effect.magIntBonus ? Math.round(attacker.int * effect.magIntBonus) : 0)
       : undefined;
+  // 名演 (吟遊詩人): 付与する側 (attacker) の持続延長パッシブを適用 (none なら素通し)。歌の効果 +1 ターン。
+  const hookCtx: HookCtx = { rng, events, actor };
+  const turns = applyStatusDurationBonus(effect.turns ?? DEFAULT_STATUS_TURNS, attacker, hookCtx);
   applyStatus(target, {
     id: effect.status,
-    turns: effect.turns ?? DEFAULT_STATUS_TURNS,
+    turns,
     ...(mag !== undefined ? { magnitude: mag } : {}),
   });
   // 付与を告知 (無告知だとプレイヤーが状態変化を認識できない。レビュー ★★)。

--- a/packages/core/src/statuses.ts
+++ b/packages/core/src/statuses.ts
@@ -364,6 +364,8 @@ export const PASSIVES: Record<string, PassiveDef> = {
   // 吟遊詩人 名演: 自分がかける歌 (状態異常) の効果ターン +1 (§12 Lv30)。吟遊詩人のキットは味方バフ
   // (プレリュード/スケルツォ/ラプソディ) と敵デバフ (ディスコード/ララバイ) の「歌」中心なので、全ての歌が
   // 1 ターン長く続く support の要。バフ・デバフどちらの歌にも乗る (どちらも吟遊詩人の「歌の効果」)。
+  // 注: 付与する側 (attacker) スコープなので、現キットに無い doomMark 等を将来 bard に持たせると炸裂も
+  // 1 ターン遅れる (弱体化方向)。現状 bard キットに doomMark はなく inert。
   'bard-encore': {
     id: 'bard-encore',
     name: '名演',
@@ -483,7 +485,8 @@ export function applyTargetBonus(mult: number, c: Combatant, target: Combatant, 
   return v;
 }
 
-/** 付与する状態の持続ターン補正 (c=付与する側)。名演など。none なら入力そのまま。 */
+/** 付与する状態の持続ターン補正 (c=付与する側)。名演など。none なら入力そのまま。ctx は現状の名演では
+ *  未使用だが、将来「確率で +2」等の rng 連動 encore を書けるよう他フックと同じく通している。 */
 export function applyStatusDurationBonus(turns: number, c: Combatant, ctx: HookCtx): number {
   let v = turns;
   for (const { def, inst } of hooksOf(c)) v = def.statusDurationBonus?.(v, c, ctxFor(ctx, inst)) ?? v;

--- a/packages/core/src/statuses.ts
+++ b/packages/core/src/statuses.ts
@@ -73,6 +73,8 @@ export interface CombatHook {
   elementBonus?(mult: number, c: Combatant, ctx: HookCtx): number;
   /** 対象の状態に応じた与ダメ倍率補正 (c=攻撃側, target=被弾側)。審美眼: 状態異常の敵に与ダメ↑。 */
   targetBonus?(mult: number, c: Combatant, target: Combatant, ctx: HookCtx): number;
+  /** 付与する状態異常の持続ターン補正 (c=付与する側)。名演: 自分がかける歌 (状態) の効果ターン+1。 */
+  statusDurationBonus?(turns: number, c: Combatant, ctx: HookCtx): number;
   /** 命中補正 (c=攻撃側)。accDown: hitBonus を下げて当てにくく。 */
   modifyHit?(hitBonus: number, c: Combatant, ctx: HookCtx): number;
   /** 会心の可否 (c=攻撃側)。九字切り=確定会心。 */
@@ -259,9 +261,9 @@ function boostDodge(dodge: number, bonus: number): number {
 
 /**
  * パッシブレジストリ (ジョブ innate な常時フック。docs/25 §12 の各職 Lv30)。エンジンは
- * hooksOf でこれを状態異常と同じフック点に流すだけ (専用分岐なし)。フック実装済みの11職を
- * ここで登録 (基本7職 + onLethal で覇王/不動 + elementBonus で慧眼 + targetBonus で審美眼)。
- * onIncomingMagic (清き心・敵魔法待ちで inert)・MP消費割引 (発明家)・非戦闘 (巫女の直感/名演) は後続 (#483)。
+ * hooksOf でこれを状態異常と同じフック点に流すだけ (専用分岐なし)。フック実装済みの12職を
+ * ここで登録 (基本7職 + onLethal 覇王/不動 + elementBonus 慧眼 + targetBonus 審美眼 + statusDurationBonus 名演)。
+ * onIncomingMagic (清き心・敵魔法待ちで inert)・MP消費割引 (発明家)・非戦闘 (巫女の直感) は後続 (#483)。
  */
 export const PASSIVES: Record<string, PassiveDef> = {
   // 忍者 首狩り: 自分より明確に弱い敵 (メタル除く) を luk 補正つき低確率で一撃 (§7/§12 Lv30)。
@@ -358,6 +360,14 @@ export const PASSIVES: Record<string, PassiveDef> = {
     id: 'artist-aesthete',
     name: '審美眼',
     targetBonus: (mult, _c, target) => (hasAilment(target) ? mult * 1.3 : mult),
+  },
+  // 吟遊詩人 名演: 自分がかける歌 (状態異常) の効果ターン +1 (§12 Lv30)。吟遊詩人のキットは味方バフ
+  // (プレリュード/スケルツォ/ラプソディ) と敵デバフ (ディスコード/ララバイ) の「歌」中心なので、全ての歌が
+  // 1 ターン長く続く support の要。バフ・デバフどちらの歌にも乗る (どちらも吟遊詩人の「歌の効果」)。
+  'bard-encore': {
+    id: 'bard-encore',
+    name: '名演',
+    statusDurationBonus: (turns) => turns + 1,
   },
 };
 
@@ -470,6 +480,13 @@ export function applyElementBonus(mult: number, c: Combatant, ctx: HookCtx): num
 export function applyTargetBonus(mult: number, c: Combatant, target: Combatant, ctx: HookCtx): number {
   let v = mult;
   for (const { def, inst } of hooksOf(c)) v = def.targetBonus?.(v, c, target, ctxFor(ctx, inst)) ?? v;
+  return v;
+}
+
+/** 付与する状態の持続ターン補正 (c=付与する側)。名演など。none なら入力そのまま。 */
+export function applyStatusDurationBonus(turns: number, c: Combatant, ctx: HookCtx): number {
+  let v = turns;
+  for (const { def, inst } of hooksOf(c)) v = def.statusDurationBonus?.(v, c, ctxFor(ctx, inst)) ?? v;
   return v;
 }
 


### PR DESCRIPTION
## 概要
Lv30 パッシブ capstone の続き (#482/#485/#487/#489 に続く)。追加フック **statusDurationBonus** を実装し、吟遊詩人の **名演** を配線した。これで **Lv30 パッシブ実装済みは 12/16 職**。

## 実装
- `CombatHook` に `statusDurationBonus(turns, c, ctx) → turns` を追加。`applyStatusDurationBonus` が**付与する側 (attacker)** のフックを回し状態の持続ターンを補正。skills.ts の `statusHandler` が `applyStatus` の直前で適用 (これまでの doAttack/doMagic ダメージ系フックと**別軸の新経路**)。
- **名演 (吟遊詩人)**: 自分がかける歌 (状態異常) の効果ターン **+1**。吟遊詩人のキットは味方バフ (プレリュード/スケルツォ/ラプソディ) と敵デバフ (ディスコード/ララバイ) の「歌」中心なので、**全ての歌が 1 ターン長く続く** support の要。バフ・デバフどちらの歌にも乗る。

## 設計方針
- 首狩り/慧眼/審美眼同様「専用分岐を作らず汎用フックに載せる」(docs/25 §4)。
- 吟遊詩人はキットの大半が turns:3 の状態付与技 = 純 support 職。名演は「歌を長く効かせる」ことで支援を強化する、役割にぴったりの capstone (キット⇄役割整合)。

## サーバー権威との整合
edge も同じ `resolveTurn → playerSkillAction → runSkillMulti → statusHandler` を replay し、`playerCombatant` が Lv30 bard に名演を再導出するため一致。

## 検証
- core **472 緑** (dispatcher 単体 + **runSkill 経由の統合テスト**: 名演ありで atkDown が turns 4・なしで 3)
- edge 149 緑 / typecheck (web+edge+core) 緑
- 名演なしは `applyStatusDurationBonus` 素通し = **既存戦闘は挙動不変**

## 後続 (#483)
onIncomingMagic (清き心・敵魔法待ちで inert)・MP割引 (発明家)・非戦闘 (巫女の直感)。

## Review

§1.5 3並列独立レビュー (設計/実装/体験)。**3本とも ★★★/★★ ゼロ・マージ可**。名演⇄吟遊詩人 (support 職) の整合をキット照合で確認 (7歌中5つが status ベースで全て +1・fixedDamage の2つは正しく除外)。

### 設計レビュー: ★★★/★★ ゼロ・★ 2件
applyStatusDurationBonus が elementBonus/targetBonus とバイト単位で同じ reduce idiom = §4 忠実 (専用分岐ゼロ)。SkillContext→HookCtx 橋渡し・attacker スコープ (付与する側の名演で延長)・バフ+デバフ両対応・fresh 相互作用 (turns 確定後に fresh 畳み)・サーバー権威一致すべて裏取り。

### 実装レビュー: ★★★/★★ ゼロ・★ 3件
core 472緑を実機確認。no-op/決定性 (rng 非消費純関数)/HookCtx 構築/restack (max で二重加算なし)/多段効果 (effect 単位で +1) すべて合格。

### 体験・バランスレビュー: ★★★ ゼロ・マージ可
名演は吟遊詩人の全「歌」に実効しソロでも成立 (allAllies→self)。空パッシブでない。support 特化 capstone として役割強化。

### ★★/★ 対応
- **ララバイ sleep 4T の対ボス拘束 / 歌 refresh 連打の永続化** (体験★★・sim 課題) → **issue #493** (機構は健全・数値は sim 宿題)。
- **self バフ/restack-max の統合テスト** (設計/実装★) → **PR 内対応** (commit 3b46f13): self 歌 turns 4・名演4→なし3 重ねで 4 維持を固定。
- **doomMark 相互作用の注記 / applyStatusDurationBonus の ctx 用途注記** (実装/設計★) → **PR 内対応** (コメント)。

CI: web-ci pass。core 472緑 (dispatcher + runSkill 統合) / edge 149緑 / typecheck (web+edge+core) 緑。**名演なしは applyStatusDurationBonus 素通し = 既存戦闘は挙動不変**。
