### PR TITLE
敵の魔法 (caster ability) — 対物理型の弱点=魔法を成立させる (#456)

### DIFF
--- a/docs/25-combat-plugin-system.md
+++ b/docs/25-combat-plugin-system.md
@@ -212,9 +212,10 @@ export const MONSTER_ABILITIES: Record<string, AbilityDef> = {
 
 **caster (#456)**: `MonsterDef.spell { name, element?, min, max, intScale? }` を持つ敵が MP を消費して
 `doMagic` で def 無視の属性魔撃を撃つ。**対物理型 (覇王/不動) の弱点=魔法を成立させる要**の content で、
-魔法致死は `onLethal` を通らないため覇王将軍も魔法では死ぬ (§14.6)。聖騎士の清き心 (魔法反射) もこれで
-意味を持つ。初期投入は night-raven (tier3・かまいたち/wind) の 1 体・控えめな数値 (def 無視は def タンクに
-刺さるため)。full 配置・数値・int 対 int 軽減は #479 sim 待ち。
+魔法致死は `onLethal` を通らないため覇王将軍も魔法では死ぬ (§14.6)。聖騎士の清き心 (魔法反射) は**後続
+(#483) で `onIncomingMagic` を配線すればこの経路に乗る**前提が整う (本 PR 時点では清き心は未実装)。初期投入は
+night-raven (tier3・かまいたち/wind) の 1 体・控えめな数値 (def 無視は def タンクに刺さるため)。full 配置・
+数値・int 対 int 軽減 (低 def の支援職に過剰に刺さらない配分) は #479 sim 待ち。
 
 ---
 

--- a/docs/25-combat-plugin-system.md
+++ b/docs/25-combat-plugin-system.md
@@ -205,9 +205,16 @@ export const MONSTER_ABILITIES: Record<string, AbilityDef> = {
   charger: { id: 'charger', decideAction: /* ため予告→解放 */ },
   healer:  { id: 'healer',  decideAction: /* 低HPで回復 */ },
   fleer:   { id: 'fleer',   decideAction: /* 毎ターン逃走判定 */ },
+  caster:  { id: 'caster',  decideAction: /* MPあるうちは def無視の属性魔撃 */ }, // #456
 };
 ```
 `monsterCommand` は `MONSTER_ABILITIES[def.ability]?.decideAction(...)` を呼ぶだけ (switch なし)。
+
+**caster (#456)**: `MonsterDef.spell { name, element?, min, max, intScale? }` を持つ敵が MP を消費して
+`doMagic` で def 無視の属性魔撃を撃つ。**対物理型 (覇王/不動) の弱点=魔法を成立させる要**の content で、
+魔法致死は `onLethal` を通らないため覇王将軍も魔法では死ぬ (§14.6)。聖騎士の清き心 (魔法反射) もこれで
+意味を持つ。初期投入は night-raven (tier3・かまいたち/wind) の 1 体・控えめな数値 (def 無視は def タンクに
+刺さるため)。full 配置・数値・int 対 int 軽減は #479 sim 待ち。
 
 ---
 

--- a/packages/core/src/__tests__/enemy-magic.test.ts
+++ b/packages/core/src/__tests__/enemy-magic.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { startBattle, resolveTurn, MONSTERS_BY_ID, type BattleState } from '../index.js';
+
+/** night-raven (tier3 caster) が出る戦闘を探す。 */
+function findRavenBattle(job: 'warrior' | 'shogun', jobLv: number, plLv: number): BattleState | null {
+  for (let seed = 0; seed < 120; seed++) {
+    const s = startBattle(job, jobLv, plLv, 'x', 3, seed, 0, undefined, { monsterId: 'night-raven' });
+    if (s.monsterId === 'night-raven') return s;
+  }
+  return null;
+}
+
+describe('敵の魔法 (caster ability #456)', () => {
+  it('caster 型の敵が存在し spell を持つ (対物理型の弱点=魔法を成立させる)', () => {
+    const casters = Object.values(MONSTERS_BY_ID).filter((m) => m.ability === 'caster');
+    expect(casters.length).toBeGreaterThanOrEqual(1);
+    for (const c of casters) {
+      expect(c.spell, c.id).toBeTruthy();
+      expect(typeof c.spell!.name).toBe('string');
+      expect(c.spell!.max).toBeGreaterThanOrEqual(c.spell!.min);
+    }
+  });
+
+  it('caster は MP を消費して def 無視の属性魔撃を撃つ (プレイヤーが被弾)', () => {
+    const s0 = findRavenBattle('warrior', 8, 12);
+    expect(s0).not.toBeNull();
+    let s = s0!;
+    const spellName = MONSTERS_BY_ID['night-raven']!.spell!.name;
+    // 高 def の壁を作り「魔法は def を無視して通る」ことを見る (物理は 1 に沈むが魔法は通る)。
+    s.player.def = 999;
+    let cast = false;
+    for (let i = 0; i < 40 && s.outcome === 'ongoing'; i++) {
+      const mpBefore = s.monster.mp;
+      const hpBefore = s.player.hp;
+      s = resolveTurn(s, 'guard'); // プレイヤーは防御に徹して長引かせる
+      if (s.lastEvents.some((e) => e.text.includes(spellName))) {
+        cast = true;
+        expect(s.monster.mp).toBeLessThan(mpBefore); // MP 消費
+        expect(s.player.hp).toBeLessThan(hpBefore); // 高 def でも魔法は通る (def 無視)
+        break;
+      }
+    }
+    expect(cast).toBe(true);
+  });
+
+  it('覇王 (将軍 Lv30) は物理致死は耐えるが、魔法致死では死ぬ (設計どおりの弱点)', () => {
+    const s0 = findRavenBattle('shogun', 30, 30);
+    expect(s0).not.toBeNull();
+    let s = s0!;
+    expect(s.player.passives).toContain('shogun-overlord'); // 覇王を持っている
+    const spellName = MONSTERS_BY_ID['night-raven']!.spell!.name;
+    // 毎ターン HP1・覇王未使用に固定してガードで受ける。覇王は物理致死を毎回耐える (once はリセット) ので、
+    // **敗北するのは魔法致死のときだけ**。physicalSaved で「物理は耐えた」実績も確認する。
+    let physicalSaved = false;
+    let magicKilled = false;
+    for (let i = 0; i < 120 && s.outcome === 'ongoing'; i++) {
+      s.player.hp = 1;
+      s.player.lethalGuardUsed = false; // 覇王を常に使える状態に (物理は毎回耐えるはず)
+      s = resolveTurn(s, 'guard');
+      const magic = s.lastEvents.some((e) => e.text.includes(spellName));
+      if (s.outcome === 'lose') {
+        expect(magic).toBe(true); // 敗北したなら必ず魔法致死 (物理では覇王が耐えるので死なない)
+        magicKilled = true;
+        break;
+      }
+      // 生存 (HP1 に固定し直される前) = 物理を覇王で耐えた or 魔法を回避
+      if (!magic && s.player.hp >= 1) physicalSaved = true;
+    }
+    expect(magicKilled).toBe(true); // 魔法致死で覇王将軍が敗北した = 魔法は覇王を貫く
+    expect(physicalSaved).toBe(true); // 物理致死は覇王で耐えた = 物理耐性は健在
+  });
+});

--- a/packages/core/src/__tests__/enemy-magic.test.ts
+++ b/packages/core/src/__tests__/enemy-magic.test.ts
@@ -63,8 +63,12 @@ describe('敵の魔法 (caster ability #456)', () => {
         magicKilled = true;
         break;
       }
-      // 生存 (HP1 に固定し直される前) = 物理を覇王で耐えた or 魔法を回避
-      if (!magic && s.player.hp >= 1) physicalSaved = true;
+      // 敵が実際に物理ダメージを与えた (spell でない monster ダメージイベント) のに HP1 で生存 =
+      // 物理致死を覇王が耐えた実績 (guard 空振り/回避ターンでは true にしない = 厳密化)。
+      const physHit = s.lastEvents.some(
+        (e) => e.actor === 'monster' && typeof e.damage === 'number' && !e.text.includes(spellName),
+      );
+      if (!magic && physHit && s.outcome === 'ongoing') physicalSaved = true;
     }
     expect(magicKilled).toBe(true); // 魔法致死で覇王将軍が敗北した = 魔法は覇王を貫く
     expect(physicalSaved).toBe(true); // 物理致死は覇王で耐えた = 物理耐性は健在

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -762,12 +762,13 @@ export interface MonsterDef {
    *  'healer' = 低 HP でたまに自己回復 (削り切る前に倒す読み合い)。
    *  'fleer' = 毎ターン逃走を試みる (はぐれメタル型。倒す前に逃げられると報酬ゼロ)。
    *  'caster' = たまに魔法を撃つ (def 無視の属性魔撃。#456: 対物理型の看板 覇王/不動 の弱点=魔法を
-   *    成立させ、聖騎士の清き心を活かす。要 spell 定義)。 */
+   *    成立させ、後続 (#483) の清き心 (魔法反射) の前提にもなる。要 spell 定義)。 */
   ability?: 'charger' | 'healer' | 'fleer' | 'caster';
   /** healer の回復技名 (省略時デフォルト)。 */
   healName?: string;
   /** caster の魔法 (#456)。def 無視・属性つきの int スケール魔撃。ダメージ = min〜max + int*intScale。
-   *  魔法致死は onLethal を通らない (物理耐性の覇王/不動 も魔法では死ぬ = 設計どおりの弱点)。 */
+   *  魔法致死は onLethal を通らない (物理耐性の覇王/不動 も魔法では死ぬ = 設計どおりの弱点)。
+   *  データ規約: min <= max (span 負を避ける)。caster の攻撃ラベルは skillName でなくこの name を使う。 */
   spell?: { name: string; element?: Element; min: number; max: number; intScale?: number };
   /** 防御属性 (#455 / docs/25 §1)。被弾時の属性相性に使う。未指定 = 無属性 (常に等倍)。
    *  キャスターが弱点を突く駆け引きの導線 (賢者/魔法使いの属性撃ち分けが機能する)。 */
@@ -1317,11 +1318,13 @@ const MONSTER_ABILITIES: Record<string, AbilityDef> = {
     },
   },
   // caster: MP があるうちは高確率で def 無視の属性魔撃を撃つ (#456)。対物理型 (覇王/不動) の弱点=魔法を
-  // 成立させ、int 職の魔法耐性・聖騎士の魔法反射 (清き心) に意味を与える。MP 切れで通常攻撃に落ちる。
+  // 成立させる (int 職の魔法耐性・聖騎士の魔法反射=清き心 は後続 #483 の前提)。MP 切れで通常攻撃に落ちる。
   caster: {
     id: 'caster',
     decideAction: ({ state, r, t, canGuard, monsterDef }) => {
       if (monsterDef?.spell && state.monster.mp >= t.monsterCastMpCost && r < t.casterCastChance) return 'cast';
+      // guard バンドは charger/healer (+0.15) よりやや狭い +0.1 — caster は攻撃寄りに保ち、魔法を撃てない
+      // (MP 枯渇) ターンも殴りに来る威圧感を残すため (守りに籠らせない)。
       if (canGuard && r < t.casterCastChance + 0.1) return 'guard';
       return 'attack';
     },
@@ -1549,7 +1552,7 @@ export function resolveTurn(prev: BattleState, command: Command, turnSeed?: numb
         events.push({ actor: 'monster', text: `${state.monster.name}は にげだした!` });
       } else if (mCommand === 'cast') {
         // caster の属性魔撃 (MP 消費)。def 無視・int スケール。onLethal を通らないので物理耐性の
-        // 覇王/不動 も魔法致死では死ぬ (設計どおりの弱点)。清き心 (魔法反射) はここで効く。
+        // 覇王/不動 も魔法致死では死ぬ (設計どおりの弱点)。清き心 (魔法反射) は後続 #483 でこの経路に乗る。
         const spell = MONSTERS_BY_ID[state.monsterId]?.spell;
         if (spell) {
           state.monster.mp = Math.max(0, state.monster.mp - BATTLE_TUNING.monsterCastMpCost);

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -111,6 +111,11 @@ export const BATTLE_TUNING = {
   healerLowHpRatio: 0.55,
   healerHealChance: 0.5,
   healerHealRatio: 0.14,
+  /** caster が魔法を撃つ確率 (MP があるとき毎ターン判定)。残りは通常攻撃。数値は sim 前提の暫定値
+   *  (def 無視の魔法は def タンクに刺さるため、初期投入は控えめ。full 調整は #479 sim)。 */
+  casterCastChance: 0.3,
+  /** caster の魔法 MP コスト。 */
+  monsterCastMpCost: 6,
   /** モンスターの特技 MP コスト。MP は int から算出 (fromStats) 済み。ため/回復を
    *  MP 制にすることで「int の高い敵ほど特技を多用でき、尽きたら通常攻撃に落ちる」
    *  = MP を削り切る/尽きるのを待つ読み合いを作る (オーナー提案 2026-07-18)。 */
@@ -755,10 +760,15 @@ export interface MonsterDef {
    *  未指定 = plain (通常攻撃 + 低 HP でたまに防御)。
    *  'charger' = 1 ターン ため → 強攻撃 (予告を防御する読み合い。全体の ~20%)。
    *  'healer' = 低 HP でたまに自己回復 (削り切る前に倒す読み合い)。
-   *  'fleer' = 毎ターン逃走を試みる (はぐれメタル型。倒す前に逃げられると報酬ゼロ)。 */
-  ability?: 'charger' | 'healer' | 'fleer';
+   *  'fleer' = 毎ターン逃走を試みる (はぐれメタル型。倒す前に逃げられると報酬ゼロ)。
+   *  'caster' = たまに魔法を撃つ (def 無視の属性魔撃。#456: 対物理型の看板 覇王/不動 の弱点=魔法を
+   *    成立させ、聖騎士の清き心を活かす。要 spell 定義)。 */
+  ability?: 'charger' | 'healer' | 'fleer' | 'caster';
   /** healer の回復技名 (省略時デフォルト)。 */
   healName?: string;
+  /** caster の魔法 (#456)。def 無視・属性つきの int スケール魔撃。ダメージ = min〜max + int*intScale。
+   *  魔法致死は onLethal を通らない (物理耐性の覇王/不動 も魔法では死ぬ = 設計どおりの弱点)。 */
+  spell?: { name: string; element?: Element; min: number; max: number; intScale?: number };
   /** 防御属性 (#455 / docs/25 §1)。被弾時の属性相性に使う。未指定 = 無属性 (常に等倍)。
    *  キャスターが弱点を突く駆け引きの導線 (賢者/魔法使いの属性撃ち分けが機能する)。 */
   element?: Element;
@@ -814,7 +824,7 @@ export const MONSTERS: readonly MonsterDef[] = [
   { id: 'will-o-wisp', element: 'fire', name: 'あおい鬼火', species: 'wisp', tier: 2, stats: [18, 12, 24, 34, 12], hp: 24, xp: 52, drops: [{ item: 'wisp-ember', chance: 0.5 }, { item: 'sky-dew', chance: 0.35 }], intro: 'ゆらゆらとこちらを見ている。', ability: 'healer', healName: 'いやしのゆらめき' },
   { id: 'river-serpent', element: 'water', name: 'かわながれ大蛇', species: 'serpent', tier: 2, stats: [42, 18, 22, 10, 10], hp: 22, xp: 42, drops: [{ item: 'serpent-scale', chance: 0.5 }, { item: 'herb', chance: 0.2 }], intro: '水面から鎌首をもたげた。', skillName: 'まきつき' },
   // tier3: 真剣勝負。xp 62〜96
-  { id: 'night-raven', element: 'wind', name: 'よるのおおガラス', species: 'raven', tier: 3, stats: [48, 14, 34, 16, 14], hp: 24, xp: 62, drops: [{ item: 'raven-feather', chance: 0.45 }, { item: 'sky-dew', chance: 0.3 }, { item: 'sky-feather', chance: 0.25 }], intro: '月を背に静かに舞い降りた。', skillName: 'かまいたち' },
+  { id: 'night-raven', element: 'wind', name: 'よるのおおガラス', species: 'raven', tier: 3, stats: [48, 14, 34, 16, 14], hp: 24, xp: 62, drops: [{ item: 'raven-feather', chance: 0.45 }, { item: 'sky-dew', chance: 0.3 }, { item: 'sky-feather', chance: 0.25 }], intro: '月を背に静かに舞い降りた。', ability: 'caster', spell: { name: 'かまいたち', element: 'wind', min: 4, max: 8, intScale: 0.1 } },
   { id: 'blue-oni', element: 'water', name: 'あおおに', species: 'oni', tier: 3, stats: [66, 28, 12, 8, 12], hp: 30, xp: 78, drops: [{ item: 'oni-horn', chance: 0.45 }], intro: '金棒を担いで笑っている。', skillName: 'かなぼうふりまわし', ability: 'charger' },
   { id: 'sky-dragon', element: 'void', name: 'そらのりゅう', species: 'dragon', tier: 3, stats: [58, 24, 18, 26, 10], hp: 30, xp: 96, drops: [{ item: 'dragon-fang', chance: 0.4 }], intro: '雲を裂いて姿を現した!', ability: 'healer', healName: 'りゅうの いこい' },
 ];
@@ -1266,7 +1276,7 @@ function doMagic(
 
 /** モンスターの行動選択 (tier が高いほど賢い)。 */
 /** モンスターの行動。'charge' = ため宣言、'heal' = 自己回復 (プレイヤーの Command とは別)。 */
-type MonsterAction = 'attack' | 'guard' | 'charge' | 'heal' | 'flee';
+type MonsterAction = 'attack' | 'guard' | 'charge' | 'heal' | 'flee' | 'cast';
 
 /** モンスター能力プラグイン (#452 / docs/25 §5)。行動 AI を ability id → データ定義に置き、
  *  monsterCommand の if 分岐を排す。null を返すと通常判定 (plain) にフォールバック。 */
@@ -1303,6 +1313,16 @@ const MONSTER_ABILITIES: Record<string, AbilityDef> = {
     decideAction: ({ state, r, t, hpRatio, canGuard }) => {
       if (state.monster.mp >= t.monsterHealMpCost && hpRatio < t.healerLowHpRatio && r < t.healerHealChance) return 'heal';
       if (canGuard && r < t.healerHealChance + 0.15) return 'guard';
+      return 'attack';
+    },
+  },
+  // caster: MP があるうちは高確率で def 無視の属性魔撃を撃つ (#456)。対物理型 (覇王/不動) の弱点=魔法を
+  // 成立させ、int 職の魔法耐性・聖騎士の魔法反射 (清き心) に意味を与える。MP 切れで通常攻撃に落ちる。
+  caster: {
+    id: 'caster',
+    decideAction: ({ state, r, t, canGuard, monsterDef }) => {
+      if (monsterDef?.spell && state.monster.mp >= t.monsterCastMpCost && r < t.casterCastChance) return 'cast';
+      if (canGuard && r < t.casterCastChance + 0.1) return 'guard';
       return 'attack';
     },
   },
@@ -1527,6 +1547,22 @@ export function resolveTurn(prev: BattleState, command: Command, turnSeed?: numb
         // はぐれメタル型: 逃走成功 → 即決着 (報酬なし)。倒せなかった悔しさを残す。
         state.outcome = 'monster-fled';
         events.push({ actor: 'monster', text: `${state.monster.name}は にげだした!` });
+      } else if (mCommand === 'cast') {
+        // caster の属性魔撃 (MP 消費)。def 無視・int スケール。onLethal を通らないので物理耐性の
+        // 覇王/不動 も魔法致死では死ぬ (設計どおりの弱点)。清き心 (魔法反射) はここで効く。
+        const spell = MONSTERS_BY_ID[state.monsterId]?.spell;
+        if (spell) {
+          state.monster.mp = Math.max(0, state.monster.mp - BATTLE_TUNING.monsterCastMpCost);
+          const span = spell.max - spell.min;
+          const amount = spell.min + Math.floor(rng() * (span + 1)) + Math.round(state.monster.int * (spell.intScale ?? 0));
+          doMagic(state.monster, state.player, rng, events, 'monster', {
+            amount,
+            ...(spell.element ? { element: spell.element } : {}),
+            label: spell.name,
+          });
+        } else {
+          doAttack(state.monster, state.player, rng, events, 'monster');
+        }
       } else if (mCommand === 'attack') {
         doAttack(state.monster, state.player, rng, events, 'monster');
       }


### PR DESCRIPTION
## 概要
覇王/不動 (対物理ほぼ不死) の唯一のカウンター「魔法致死」が world に存在しなかった問題 (#485 で判明・docs §509 balance-watch) を解消する **content**。敵が def 無視の属性魔撃を撃てるようにした。これで **①覇王が本来の弱点=魔法を持つ、②聖騎士の清き心 (魔法反射) が意味を持つ (#483 で実装可能に)、③戦闘に魔法という新たな脅威** が加わる。

## 実装
- `MonsterAction` に `'cast'` / `MonsterDef` に `spell { name, element?, min, max, intScale? }` / `ability: 'caster'` を追加。
- `MONSTER_ABILITIES.caster`: MP があるうちは `casterCastChance` で魔法、切れたら通常攻撃 (既存 charger/healer と同じデータ駆動 AI・**専用分岐なし**)。`resolveTurn` の monster act に `'cast' → doMagic` 分岐。
- **魔法致死は `doMagic` を通り `onLethal` を通らないため、覇王将軍も魔法では死ぬ** (§14.6 の設計どおりの弱点)。

## バランス方針 (保守的な初期投入)
- **night-raven (tier3・かまいたち/wind) の 1 体のみ**・控えめな数値 (min4-8 + int×0.1・発動30%)。
- def 無視の魔法は def タンクに刺さるため、既存の **tier1/tier2 バランス (序盤 win-rate テスト) を崩さない tier3 限定**に。
- **重要**: tier3 の def タンク (warrior/guardian) 5/8 の 0% 勝率は enemy magic 由来ではなく、night-raven を除外しても 0% の **既存の underleveled 競合帯** (probe で確認)。本 PR は非回帰。
- full 配置・数値調整・**int 対 int 軽減 (§12「int対int式」)** は #479 sim 待ち。

## 検証
- core **475 緑** — caster 存在/spell/MP消費/**def無視 (高 def でも魔法は通る)**/**覇王将軍が物理致死は耐え魔法致死で死ぬ** を統合テストで固定
- edge 149 緑 / typecheck (web+edge+core) 緑。edge は resolveTurn を replay するため敵魔法もサーバー権威で一致
- 既存の全モンスター行動 (charger/healer/fleer/plain) は挙動不変

## 後続 (#483/#479)
清き心 (聖騎士・魔法反射) は onIncomingMagic フック + この敵魔法で実装可能に。魔法の full 配置・int 軽減・数値調整は sim (#479)。

## Review

§1.5 3並列独立レビュー (設計/実装/体験)。**3本とも ★★★ ゼロ・マージ可**。体験レビューは win-rate を実測して評価。

### 設計レビュー: ★★★/★★ ... ★★ 1件・★ 3件
核心 (魔法致死が onLethal を迂回 → 覇王が魔法で死ぬ) が正しく実装・実バトルでテスト済みと裏取り。caster が既存 charger/healer と同じデータ駆動 AI パターン (専用分岐なし)、決定性・既存不変性も合格。

### 実装レビュー: ★★★/★★ ゼロ・★ 1件
core 475緑を実機確認。**決定性が airtight** (edge/client 同一 core resolveTurn + turnRng がターン毎に新規シード = 'cast'/'attack' の rng 消費差は後続ターンに波及しない)、MP 境界・amount 計算・回帰すべて健全。

### 体験・バランスレビュー: ★★★ ゼロ・マージ可 (win-rate 実測)
night-raven 強制 400 seed で魔法あり/なし比較。**PR の主張「tier3 def タンク 0% は魔法由来でなく既存 underleveled 帯」を裏取り** (Lv8 -1pt=ノイズ)。魔法の実効は Lv10-14 の過渡帯 -4〜-12pt で新規の壁は作らない。数値 6-10・30% は MP 制約 (17/6=2-3発) で自己制限=実効~8%、「バーストして息切れ」の良設計。

### ★★/★ 対応
- **未実装の清き心 (魔法反射) を「効く」と断定していた doc/コメント** (設計★★/体験★★) → **PR 内修正** (commit 8930ac4): 「後続 #483 で配線すればこの経路に乗る」へ (no-overselling / self-contained)。
- **def 無視魔法が低 def 支援職に過刺さり (bard Lv30 -20pt) / int 対 int 軽減未実装 / ぼうぎょ非適用** (体験★★・★) → **issue #495** (sim フェーズ #479。tier3 1体・控えめ数値で被害限定・新規 0% 壁なし)。
- **覇王テスト physicalSaved の厳密化** (実装★) → PR 内対応。
- **caster guard バンド +0.1 の理由 / spell min<=max データ規約** (設計★) → PR 内注記。

CI: web-ci pass。core 475緑 (caster 存在/MP消費/**def無視**/**覇王が物理耐え魔法で死ぬ**を実バトルで検証) / edge 149緑 / typecheck 緑。**既存の全モンスター行動 (charger/healer/fleer/plain) は挙動不変**。
