### PR TITLE
onIncomingMagic フック + 清き心 (聖騎士) パッシブ (#456)

### DIFF
--- a/docs/25-combat-plugin-system.md
+++ b/docs/25-combat-plugin-system.md
@@ -212,10 +212,10 @@ export const MONSTER_ABILITIES: Record<string, AbilityDef> = {
 
 **caster (#456)**: `MonsterDef.spell { name, element?, min, max, intScale? }` を持つ敵が MP を消費して
 `doMagic` で def 無視の属性魔撃を撃つ。**対物理型 (覇王/不動) の弱点=魔法を成立させる要**の content で、
-魔法致死は `onLethal` を通らないため覇王将軍も魔法では死ぬ (§14.6)。聖騎士の清き心 (魔法反射) は**後続
-(#483) で `onIncomingMagic` を配線すればこの経路に乗る**前提が整う (本 PR 時点では清き心は未実装)。初期投入は
+魔法致死は `onLethal` を通らないため覇王将軍も魔法では死ぬ (§14.6)。聖騎士の清き心 (魔法反射) は
+`doMagic` の `onIncomingMagic` フックで発火する (#456 で配線済み・下記フック一覧参照)。初期投入は
 night-raven (tier3・かまいたち/wind) の 1 体・控えめな数値 (def 無視は def タンクに刺さるため)。full 配置・
-数値・int 対 int 軽減 (低 def の支援職に過剰に刺さらない配分) は #479 sim 待ち。
+数値・int 対 int 軽減 (低 def の支援職に過剰に刺さらない配分)、清き心が体感できるだけの敵魔法量は #479/#495 sim 待ち。
 
 ---
 
@@ -311,7 +311,8 @@ night-raven (tier3・かまいたち/wind) の 1 体・控えめな数値 (def �
 - `onIncomingMagic(self, atk, damage, ctx) → { reflect? }` — 魔法被弾の直前 (self=被弾側/atk=術者)。実装済み
   (#456)。reflect=true で被弾 0 に無効化 (術者への反射などはハンドラ内で atk を操作。onLethal と同じ idiom)。
   **魔法経路 (doMagic) のみで発火**。清き心 (聖騎士): 低確率 (25%・暫定) で敵魔法を術者へ跳ね返す。見切りの
-  必中回避 (魔法をミス化) も将来このフックに乗せられる (§14.6)。
+  必中回避 (魔法をミス化) も将来このフックに乗せられる (§14.6)。**保有時のみ `ctx.rng()` を 1 消費**する条件消費
+  フック — 非保有の被弾は素通しで rng を引かないため既存 seed の再現性を壊さない (rng 条件消費フックの初例)。
 - `targetBonus(mult, c, target, ctx) → mult` — 対象の状態に応じた与ダメ倍率補正 (c=攻撃側/target=被弾側)。
   実装済み (#456)。審美眼 (芸術家): 状態異常 (AILMENT_IDS) の敵に与ダメ **×1.3** (sim 調整前提の暫定値)。
   基準 1 に対する乗数を返し doAttack/doMagic 双方で dmg に乗算。芸術家の fixedDamage は doMagic を通るので

--- a/docs/25-combat-plugin-system.md
+++ b/docs/25-combat-plugin-system.md
@@ -308,6 +308,10 @@ night-raven (tier3・かまいたち/wind) の 1 体・控えめな数値 (def �
   分岐なしに表現。**1 戦闘 1 回のみ**発動する切り札 (`Combatant.lethalGuardUsed` フラグ。オーナー判断
   2026-07-22: 敵が物理のみの現状で毎回発動だと対モンスター完全不死になるため)。覇王=1回耐えて同ダメ反射、
   不動=1回確定で耐える (旧 50% 運要素は壁役の capstone に合わないため確定 1 回に変更)。
+- `onIncomingMagic(self, atk, damage, ctx) → { reflect? }` — 魔法被弾の直前 (self=被弾側/atk=術者)。実装済み
+  (#456)。reflect=true で被弾 0 に無効化 (術者への反射などはハンドラ内で atk を操作。onLethal と同じ idiom)。
+  **魔法経路 (doMagic) のみで発火**。清き心 (聖騎士): 低確率 (25%・暫定) で敵魔法を術者へ跳ね返す。見切りの
+  必中回避 (魔法をミス化) も将来このフックに乗せられる (§14.6)。
 - `targetBonus(mult, c, target, ctx) → mult` — 対象の状態に応じた与ダメ倍率補正 (c=攻撃側/target=被弾側)。
   実装済み (#456)。審美眼 (芸術家): 状態異常 (AILMENT_IDS) の敵に与ダメ **×1.3** (sim 調整前提の暫定値)。
   基準 1 に対する乗数を返し doAttack/doMagic 双方で dmg に乗算。芸術家の fixedDamage は doMagic を通るので

--- a/packages/core/src/__tests__/enemy-magic.test.ts
+++ b/packages/core/src/__tests__/enemy-magic.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { startBattle, resolveTurn, MONSTERS_BY_ID, type BattleState } from '../index.js';
 
 /** night-raven (tier3 caster) が出る戦闘を探す。 */
-function findRavenBattle(job: 'warrior' | 'shogun', jobLv: number, plLv: number): BattleState | null {
+function findRavenBattle(job: 'warrior' | 'shogun' | 'paladin', jobLv: number, plLv: number): BattleState | null {
   for (let seed = 0; seed < 120; seed++) {
     const s = startBattle(job, jobLv, plLv, 'x', 3, seed, 0, undefined, { monsterId: 'night-raven' });
     if (s.monsterId === 'night-raven') return s;
@@ -72,5 +72,26 @@ describe('敵の魔法 (caster ability #456)', () => {
     }
     expect(magicKilled).toBe(true); // 魔法致死で覇王将軍が敗北した = 魔法は覇王を貫く
     expect(physicalSaved).toBe(true); // 物理致死は覇王で耐えた = 物理耐性は健在
+  });
+
+  it('清き心 (聖騎士 Lv30) は敵魔法を実戦で反射する (敵魔法 content との統合)', () => {
+    const spellName = MONSTERS_BY_ID['night-raven']!.spell!.name;
+    // 複数 seed × 多ターンで、清き心の反射 (25%) × 敵の詠唱 が少なくとも 1 回起きることを確認。
+    // 聖騎士の HP を毎ターン満タンに戻して戦闘を長引かせ、詠唱機会を稼ぐ。
+    let reflected = false;
+    for (let seed = 0; seed < 20 && !reflected; seed++) {
+      let s = startBattle('paladin', 30, 30, 'x', 3, seed, 0, undefined, { monsterId: 'night-raven' });
+      expect(s.player.passives).toContain('paladin-purity');
+      for (let i = 0; i < 60 && s.outcome === 'ongoing'; i++) {
+        s.player.hp = s.player.maxHp; // 倒し切らず長引かせる (詠唱機会を稼ぐ)
+        s.monster.mp = s.monster.maxMp; // 敵 MP も戻して詠唱を続けさせる
+        s = resolveTurn(s, 'guard');
+        if (s.lastEvents.some((e) => e.text.includes('はね返した'))) {
+          reflected = true;
+          break;
+        }
+      }
+    }
+    expect(reflected).toBe(true); // 敵魔法を清き心で反射した = onIncomingMagic 経路が実戦で発火
   });
 });

--- a/packages/core/src/__tests__/passives.test.ts
+++ b/packages/core/src/__tests__/passives.test.ts
@@ -7,6 +7,7 @@ import {
   applyIncomingCalc,
   applyOnHit,
   applyOnLethal,
+  applyOnIncomingMagic,
   applyElementBonus,
   applyTargetBonus,
   applyStatusDurationBonus,
@@ -54,8 +55,9 @@ describe('パッシブ (#456 各職 Lv30)', () => {
     expect(jobPassives('guardian', 30)).toEqual(['guardian-immovable']);
     expect(jobPassives('sage', 30)).toEqual(['sage-insight']);
     expect(jobPassives('artist', 30)).toEqual(['artist-aesthete']);
-    // フック未実装/inert の職 (清き心=敵魔法待ち/発明家/非戦闘) は Lv30 でもまだ空 (後続 #483)。
-    expect(jobPassives('paladin', 30)).toEqual([]);
+    expect(jobPassives('paladin', 30)).toEqual(['paladin-purity']);
+    // フック未実装の職 (発明家=MP割引/巫女=非戦闘) は Lv30 でもまだ空 (後続 #483)。
+    expect(jobPassives('fighter', 30)).toEqual([]);
     expect(jobPassives('miko', 30)).toEqual([]);
   });
 
@@ -63,8 +65,8 @@ describe('パッシブ (#456 各職 Lv30)', () => {
     expect(playerCombatant('warrior', 30, 30, 'w').passives).toEqual(['warrior-blademaster']);
     expect(playerCombatant('warrior', 29, 30, 'w').passives).toEqual([]);
     expect(playerCombatant('captain', 30, 30, 'cap').passives).toEqual(['captain-command']);
-    // 未実装/inert 職は Lv30 でも空 (清き心=敵魔法待ち)。キット化とは別軸。
-    expect(playerCombatant('paladin', 30, 30, 'p').passives).toEqual([]);
+    // 未実装職は Lv30 でも空 (発明家=MP割引/巫女=非戦闘)。キット化とは別軸。
+    expect(playerCombatant('fighter', 30, 30, 'f').passives).toEqual([]);
   });
 
   // ── 各パッシブの効果 (dispatcher 経由) ──
@@ -148,6 +150,25 @@ describe('パッシブ (#456 各職 Lv30)', () => {
 
   it('onLethal: パッシブなしは survive せず (通常どおり死ぬ)', () => {
     expect(applyOnLethal(c(), c(), 50, ctx())).toBe(false);
+  });
+
+  it('清き心 (paladin-purity): rng<0.25 で魔法反射 (被弾側フック・術者へ跳ね返し)', () => {
+    const pal = c({ passives: ['paladin-purity'], name: '聖騎士' });
+    const caster = c({ name: '術者', hp: 100 });
+    const ev = ctx(0.1);
+    expect(applyOnIncomingMagic(pal, caster, 30, ev)).toBe(true); // 反射成立
+    expect(caster.hp).toBe(70); // 30 跳ね返し
+    expect(ev.events.some((e) => e.text.includes('はね返した'))).toBe(true);
+    // rng>=0.25 は反射せず通常被弾。
+    const caster2 = c({ name: '術者2', hp: 100 });
+    expect(applyOnIncomingMagic(c({ passives: ['paladin-purity'] }), caster2, 30, ctx(0.5))).toBe(false);
+    expect(caster2.hp).toBe(100);
+    // パッシブなしは no-op。
+    expect(applyOnIncomingMagic(c(), caster2, 30, ctx(0.1))).toBe(false);
+  });
+
+  it('playerCombatant: 聖騎士 Lv30 で清き心が入る', () => {
+    expect(playerCombatant('paladin', 30, 30, 'pl').passives).toEqual(['paladin-purity']);
   });
 
   it('慧眼 (sage-insight): 弱点 (相性倍率>=1.5) のみ ×1.25 増幅、等倍/耐性/空 1.2 は素通し', () => {

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -32,6 +32,7 @@ import {
   applyIncomingCalc,
   applyOnHit,
   applyOnLethal,
+  applyOnIncomingMagic,
   applyElementBonus,
   applyTargetBonus,
   applyOnDamaged,
@@ -409,8 +410,8 @@ export function skillsForJob(archetype: Archetype, jobLevel: number): JobSkill[]
 }
 
 /** ジョブ innate パッシブ (docs/25 §12 の各職 Lv30)。PASSIVES のキー。習得 jobLevel は一律 30。
- *  フック実装済みの12職 (基本7職 + onLethal 覇王/不動 + elementBonus 慧眼 + targetBonus 審美眼 +
- *  statusDurationBonus 名演)。onIncomingMagic (清き心・敵魔法が無いと inert)/MP割引 (発明家)/非戦闘 (巫女) は後続 (#483)。 */
+ *  フック実装済みの13職 (基本7職 + onLethal 覇王/不動 + elementBonus 慧眼 + targetBonus 審美眼 +
+ *  statusDurationBonus 名演 + onIncomingMagic 清き心)。MP割引 (発明家)/非戦闘 (巫女の直感) は後続 (#483)。 */
 const JOB_PASSIVES: Partial<Record<Archetype, string>> = {
   warrior: 'warrior-blademaster', // 剣豪: 会心率↑
   mage: 'mage-barrier', // 魔力障壁: 常時被ダメ軽減
@@ -424,6 +425,7 @@ const JOB_PASSIVES: Partial<Record<Archetype, string>> = {
   sage: 'sage-insight', // 慧眼: 弱点属性で追加ダメ
   artist: 'artist-aesthete', // 審美眼: 状態異常の敵に与ダメ↑
   bard: 'bard-encore', // 名演: 自分の歌 (状態) の効果ターン+1
+  paladin: 'paladin-purity', // 清き心: 低確率で魔法反射
 };
 
 /** その jobLevel 時点で有効なパッシブ id 列。Lv30 到達で innate パッシブが1つ有効になる。 */
@@ -1252,6 +1254,10 @@ function doMagic(
   dmg *= applyIncomingCalc(1, defender, defCtx); // defUp/defDown/転倒
   // メタル系の魔法無効 (#455 / DQ 準拠): def 無視の魔法でも最小 1 に抑える (会心物理でしか倒せない)。
   const final = defender.resistAllMagic ? 1 : Math.max(1, Math.round(dmg));
+  // 清き心 (聖騎士): 低確率で魔法反射 (被弾側フック)。reflect なら被弾 0・術者へ跳ね返し済み (ハンドラ内)。
+  if (!defender.resistAllMagic && applyOnIncomingMagic(defender, attacker, final, defCtx)) {
+    return { hit: true, damage: 0, fatal: false, crit: false };
+  }
   defender.hp = Math.max(0, defender.hp - final);
   const fatal = defender.hp === 0;
   if (!fatal) clearHitStatuses(defender); // 被弾で解ける状態 (かくれみ/眠り)

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -1255,6 +1255,8 @@ function doMagic(
   // メタル系の魔法無効 (#455 / DQ 準拠): def 無視の魔法でも最小 1 に抑える (会心物理でしか倒せない)。
   const final = defender.resistAllMagic ? 1 : Math.max(1, Math.round(dmg));
   // 清き心 (聖騎士): 低確率で魔法反射 (被弾側フック)。reflect なら被弾 0・術者へ跳ね返し済み (ハンドラ内)。
+  // 被弾 0 なので clearHitStatuses (かくれみ/眠り解除) も弱点告知も出さないのが正 (被弾していない扱い)。
+  // 将来の見切り (魔法ミス化=回避) も同じ「被弾 0」結果なので、必要なら返り値に nullify を足して分岐する。
   if (!defender.resistAllMagic && applyOnIncomingMagic(defender, attacker, final, defCtx)) {
     return { hit: true, damage: 0, fatal: false, crit: false };
   }
@@ -1558,7 +1560,7 @@ export function resolveTurn(prev: BattleState, command: Command, turnSeed?: numb
         events.push({ actor: 'monster', text: `${state.monster.name}は にげだした!` });
       } else if (mCommand === 'cast') {
         // caster の属性魔撃 (MP 消費)。def 無視・int スケール。onLethal を通らないので物理耐性の
-        // 覇王/不動 も魔法致死では死ぬ (設計どおりの弱点)。清き心 (魔法反射) は後続 #483 でこの経路に乗る。
+        // 覇王/不動 も魔法致死では死ぬ (設計どおりの弱点)。聖騎士の清き心 (魔法反射) はこの doMagic 内で発火する。
         const spell = MONSTERS_BY_ID[state.monsterId]?.spell;
         if (spell) {
           state.monster.mp = Math.max(0, state.monster.mp - BATTLE_TUNING.monsterCastMpCost);

--- a/packages/core/src/statuses.ts
+++ b/packages/core/src/statuses.ts
@@ -88,6 +88,9 @@ export interface CombatHook {
   /** 物理致死の直前 (c=倒れかけている側)。survive=true で HP1 生存 (覇王/不動)。魔法致死には効かない
    *  (doAttack の物理経路からのみ呼ばれる)。反射など攻撃者への副作用はハンドラ内で atk を直接操作。 */
   onLethal?(c: Combatant, atk: Combatant, damage: number, ctx: HookCtx): { survive?: boolean } | void;
+  /** 魔法被弾の直前 (c=被弾側/atk=術者)。reflect=true で被弾を無効化 (攻撃者への反射などはハンドラ内で
+   *  atk を操作)。清き心: 低確率で魔法反射。doMagic の魔法経路からのみ呼ばれる。 */
+  onIncomingMagic?(c: Combatant, atk: Combatant, damage: number, ctx: HookCtx): { reflect?: boolean } | void;
   /** ターン終了。毒ダメージ等。 */
   turnEnd?(c: Combatant, ctx: HookCtx): void;
 }
@@ -261,9 +264,9 @@ function boostDodge(dodge: number, bonus: number): number {
 
 /**
  * パッシブレジストリ (ジョブ innate な常時フック。docs/25 §12 の各職 Lv30)。エンジンは
- * hooksOf でこれを状態異常と同じフック点に流すだけ (専用分岐なし)。フック実装済みの12職を
- * ここで登録 (基本7職 + onLethal 覇王/不動 + elementBonus 慧眼 + targetBonus 審美眼 + statusDurationBonus 名演)。
- * onIncomingMagic (清き心・敵魔法待ちで inert)・MP消費割引 (発明家)・非戦闘 (巫女の直感) は後続 (#483)。
+ * hooksOf でこれを状態異常と同じフック点に流すだけ (専用分岐なし)。フック実装済みの13職を
+ * ここで登録 (基本7職 + onLethal 覇王/不動 + elementBonus 慧眼 + targetBonus 審美眼 + statusDurationBonus 名演
+ * + onIncomingMagic 清き心)。MP消費割引 (発明家)・非戦闘 (巫女の直感) は後続 (#483)。
  */
 export const PASSIVES: Record<string, PassiveDef> = {
   // 忍者 首狩り: 自分より明確に弱い敵 (メタル除く) を luk 補正つき低確率で一撃 (§7/§12 Lv30)。
@@ -343,6 +346,18 @@ export const PASSIVES: Record<string, PassiveDef> = {
       self.lethalGuardUsed = true;
       ctx.events.push({ actor: ctx.actor ?? 'player', text: `${self.name}は 不動の構えで持ちこたえた!` });
       return { survive: true };
+    },
+  },
+  // 聖騎士 清き心: 低確率 (25%) で魔法をはね返す (§12 Lv30)。敵魔法 (#456 caster) の登場で意味を持つ。
+  // 反射時は被弾 0 で術者へ同ダメージ (覇王の反射と同じ idiom)。数値は sim 前提の暫定値 (#495)。
+  'paladin-purity': {
+    id: 'paladin-purity',
+    name: '清き心',
+    onIncomingMagic(self, atk, damage, ctx) {
+      if (ctx.rng() >= 0.25) return; // 75% は通常どおり被弾
+      atk.hp = Math.max(0, atk.hp - damage);
+      ctx.events.push({ actor: ctx.actor ?? 'player', text: `${self.name}は 清き心で魔法をはね返した! ${atk.name}に ${damage}!`, damage });
+      return { reflect: true };
     },
   },
   // 賢者 慧眼: 弱点属性 (相性倍率 >=1.5) を突いたときさらに与ダメ↑ (§12 Lv30)。int40 の属性キャスターが
@@ -502,6 +517,16 @@ export function applyOnLethal(c: Combatant, atk: Combatant, damage: number, ctx:
     if (def.onLethal?.(c, atk, damage, ctxFor(ctx, inst))?.survive) survive = true;
   }
   return survive;
+}
+
+/** 魔法被弾の直前: 被弾側のフック (清き心) を回し、いずれかが reflect を返したら true (被弾を無効化)。
+ *  反射など攻撃者への副作用はハンドラ内で atk を操作する (覇王 onLethal と同じ idiom)。 */
+export function applyOnIncomingMagic(c: Combatant, atk: Combatant, damage: number, ctx: HookCtx): boolean {
+  let reflect = false;
+  for (const { def, inst } of hooksOf(c)) {
+    if (def.onIncomingMagic?.(c, atk, damage, ctxFor(ctx, inst))?.reflect) reflect = true;
+  }
+  return reflect;
 }
 
 /** 命中時: いずれかのパッシブ/状態が即死を返したら true。 */

--- a/packages/core/src/statuses.ts
+++ b/packages/core/src/statuses.ts
@@ -356,7 +356,7 @@ export const PASSIVES: Record<string, PassiveDef> = {
     onIncomingMagic(self, atk, damage, ctx) {
       if (ctx.rng() >= 0.25) return; // 75% は通常どおり被弾
       atk.hp = Math.max(0, atk.hp - damage);
-      ctx.events.push({ actor: ctx.actor ?? 'player', text: `${self.name}は 清き心で魔法をはね返した! ${atk.name}に ${damage}!`, damage });
+      ctx.events.push({ actor: ctx.actor ?? 'player', text: `${self.name}は 清き心で魔法をはね返した! ${atk.name}に ${damage} のダメージ!`, damage });
       return { reflect: true };
     },
   },


### PR DESCRIPTION
## 概要
敵魔法 (#494) の登場で inert だった **清き心** が実装可能に。追加フック **onIncomingMagic** を実装し聖騎士の清き心を配線した。これで **Lv30 パッシブ実装済みは 13/15 職** (残 発明家=MP割引 / 巫女の直感=非戦闘・#483)。

## 実装
- `CombatHook` に `onIncomingMagic(c, atk, damage, ctx) → { reflect? }` を追加。`applyOnIncomingMagic` が被弾側フックを回し reflect を集約 (反射など術者への副作用はハンドラ内で `atk` を操作 = 覇王 onLethal と同じ idiom)。
- `doMagic` の被弾直前に挿入。reflect なら**被弾 0**・術者へ跳ね返し済み。**魔法経路のみで発火**。
- **清き心 (聖騎士)**: 低確率 (25%・暫定) で敵魔法を術者へ同ダメージ反射。

## 依存順を守った実装
敵魔法 (caster) が無いと発火しないため、**#494 (敵魔法 content) の後に配線** = content と機構の依存順を守った。これで #483 で残していた「清き心 (onIncomingMagic)」が閉じる。見切りの必中回避 (魔法ミス化) も将来このフックに乗せられる (§14.6)。

## サーバー権威との整合
edge は `doMagic` を replay するためサーバー権威で一致。清き心の `ctx.rng()` も seeded 決定的。

## 検証
- core **478 緑** — dispatcher (反射25%/非反射/no-op) + **聖騎士 Lv30 が敵魔法 (night-raven) を実戦で反射する統合テスト** (onIncomingMagic 経路が end-to-end で発火)
- edge 149 緑 / typecheck (web+edge+core) 緑
- 清き心なしは `applyOnIncomingMagic` 素通し = **既存戦闘は挙動不変**

## 数値
反射率 25% は sim 前提の暫定値 (#495 の魔法 sim で調整)。

## Review

§1.5 3並列独立レビュー (設計/実装/体験)。**3本とも ★★★/★★(実装) ゼロ・マージ可**。

### 設計レビュー: ★★★ ゼロ・★★ 2件 (PR 内対応済)・★ 3件
onIncomingMagic が onLethal の完全な写像 (被弾側フック・reflect 集約・副作用はハンドラ内) = §4 忠実。doMagic 挿入位置・メタル順序・依存順 (content→機構)・サーバー権威一致すべて健全。★★ = 前 PR #494 で「清き心は後続 #483 で乗る」と書いた doc/コメントがこの PR で stale化 (自己矛盾) → **PR 内修正** (commit 61532be)。

### 実装レビュー: ★★★/★★ ゼロ・★ 2件
core 478緑を実機確認。決定性 (清き心保有時のみ rng 条件消費・非保有は素通し)・reflect 副作用 (反射キルは act ガード+勝敗判定で安全)・メタル順序・回帰・統合テストのフレーク性 (seeded 決定的・5連実行不変) すべて問題なし。

### 体験・バランスレビュー: ★★★ ゼロ・マージ可 (条件つき)
役割整合良好 (魔力障壁=常時軽減 vs 清き心=低確率反射 で棲み分け明確)、テストは本物のエンジン経路。★★ = **清き心は現状ほぼ inert** (night-raven のみ・実測 ~0.36 反射/戦・reflectKills=0)。機構は正しい土台だが現リリースでは capstone 体感が薄い → PR 内修正は不要、**#495 に実効化を申し送り**。

### ★★/★ 対応
- **stale化した「後続 #483」doc/コメント** (設計★★) → **PR 内修正** (commit 61532be): doc §14.6 + battle.ts コメントを「配線済み・doMagic で発火」へ。
- **清き心が現状 inert** (体験★★) → **#495 に申し送り済** (敵魔法拡充 + 反射が意味を持つダメージ帯)。**Lv30 報酬が現状体感薄いことを隠さず記録** (no-overselling)。
- reflect の状態解除/告知スキップ注記・rng 条件消費の doc 明記・反射イベント文体統一 (実装/設計★) → **PR 内対応**。
- reflect/nullify の返り値語彙の将来分割 (設計★) → 見切り実装 PR 送り。

CI: web-ci pass。core 478緑 (dispatcher + **聖騎士 Lv30 が敵魔法を実戦で反射する統合テスト**) / edge 149緑 / typecheck 緑。**清き心なしは applyOnIncomingMagic 素通し = 既存戦闘は挙動不変**。
