### PR TITLE
発明家 (匠) パッシブ — とくぎ MP 消費 30% 引き (#456)

### DIFF
--- a/apps/web/src/components/debug-battle-sim.tsx
+++ b/apps/web/src/components/debug-battle-sim.tsx
@@ -12,6 +12,7 @@ import {
   jobDisplayName,
   resolveTurn,
   runAutoBattle,
+  skillMpCostOf,
   startBattle,
   type Archetype,
   type BattleState,
@@ -246,7 +247,7 @@ export function DebugBattleSim() {
                 <button
                   key={i}
                   onClick={() => duelCmd('skill', i)}
-                  disabled={duel.player.mp < BATTLE_TUNING.skillMpCost || (isPureHealSkill(sk.kind) && duel.player.hp >= duel.player.maxHp)}
+                  disabled={duel.player.mp < skillMpCostOf(duel.player) || (isPureHealSkill(sk.kind) && duel.player.hp >= duel.player.maxHp)}
                   style={{ fontSize: '0.85em', padding: '0.2em 0.5em' }}
                 >
                   {sk.name}

--- a/apps/web/src/components/world-battle-controls.tsx
+++ b/apps/web/src/components/world-battle-controls.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import type { BattleState, Command } from '@aozoraquest/core';
-import { BATTLE_TUNING, MONSTERS_BY_ID, isPureHealSkill } from '@aozoraquest/core';
+import { MONSTERS_BY_ID, isPureHealSkill, skillMpCostOf } from '@aozoraquest/core';
 import { MonsterSvg } from './monster-svg';
 import { HpBar, TypedLines } from './battle-view';
 
@@ -51,7 +51,8 @@ export function WorldBattleControls({
   useEffect(() => {
     if (phase !== 'input') { setItemMenu(false); setSkillMenu(false); }
   }, [phase]);
-  const lowMp = state.player.mp < BATTLE_TUNING.skillMpCost;
+  const skillCost = skillMpCostOf(state.player); // 発明家 (匠) の MP 割引を反映
+  const lowMp = state.player.mp < skillCost;
   // デプロイ跨ぎの旧 sealed state は playerSkills が無いことがある → 署名スキル 1 個にフォールバック。
   const skills = state.playerSkills ?? [state.playerSkill];
   const multiSkill = skills.length > 1;
@@ -96,7 +97,7 @@ export function WorldBattleControls({
                   {skills.map((sk, i) => (
                     <DqRow
                       key={i}
-                      label={`${sk.name} (MP${BATTLE_TUNING.skillMpCost})`}
+                      label={`${sk.name} (MP${skillCost})`}
                       onClick={() => { setSkillMenu(false); onCommand('skill', i); }}
                       // 純回復技は満タンなら無意味 → 無効化 (キット技も効果ベースで判定)
                       disabled={busy || lowMp || (isPureHealSkill(sk.kind) && state.player.hp >= state.player.maxHp)}

--- a/packages/core/src/__tests__/passives.test.ts
+++ b/packages/core/src/__tests__/passives.test.ts
@@ -13,7 +13,7 @@ import {
   applyStatusDurationBonus,
   type HookCtx,
 } from '../statuses.js';
-import { jobPassives, playerCombatant, type Combatant } from '../battle.js';
+import { jobPassives, playerCombatant, skillMpCostOf, startBattle, resolveTurn, BATTLE_TUNING, type Combatant } from '../battle.js';
 import { runSkill, type SkillContext, type SkillDef } from '../skills.js';
 
 function c(over: Partial<Combatant> = {}): Combatant {
@@ -56,17 +56,18 @@ describe('パッシブ (#456 各職 Lv30)', () => {
     expect(jobPassives('sage', 30)).toEqual(['sage-insight']);
     expect(jobPassives('artist', 30)).toEqual(['artist-aesthete']);
     expect(jobPassives('paladin', 30)).toEqual(['paladin-purity']);
-    // フック未実装の職 (発明家=MP割引/巫女=非戦闘) は Lv30 でもまだ空 (後続 #483)。
-    expect(jobPassives('fighter', 30)).toEqual([]);
+    expect(jobPassives('fighter', 30)).toEqual(['fighter-inventor']);
+    // 残 巫女 (ドロップ↑=drop 配線待ち) は Lv30 でもまだ空 (後続 #483)。遊び人は Lv30 パッシブ無し。
     expect(jobPassives('miko', 30)).toEqual([]);
+    expect(jobPassives('performer', 30)).toEqual([]);
   });
 
   it('playerCombatant: 実装済み職は Lv30 で passives が入り、Lv29 では空', () => {
     expect(playerCombatant('warrior', 30, 30, 'w').passives).toEqual(['warrior-blademaster']);
     expect(playerCombatant('warrior', 29, 30, 'w').passives).toEqual([]);
     expect(playerCombatant('captain', 30, 30, 'cap').passives).toEqual(['captain-command']);
-    // 未実装職は Lv30 でも空 (発明家=MP割引/巫女=非戦闘)。キット化とは別軸。
-    expect(playerCombatant('fighter', 30, 30, 'f').passives).toEqual([]);
+    // 未実装職は Lv30 でも空 (巫女=ドロップ配線待ち)。キット化とは別軸。
+    expect(playerCombatant('miko', 30, 30, 'mk').passives).toEqual([]);
   });
 
   // ── 各パッシブの効果 (dispatcher 経由) ──
@@ -169,6 +170,30 @@ describe('パッシブ (#456 各職 Lv30)', () => {
 
   it('playerCombatant: 聖騎士 Lv30 で清き心が入る', () => {
     expect(playerCombatant('paladin', 30, 30, 'pl').passives).toEqual(['paladin-purity']);
+  });
+
+  it('発明家 (fighter-inventor): とくぎ MP コストを 30% 引き (skillMpCostOf)', () => {
+    const base = BATTLE_TUNING.skillMpCost; // 4
+    expect(skillMpCostOf(c())).toBe(base); // パッシブなし = 素通し (4)
+    expect(skillMpCostOf(c({ passives: ['fighter-inventor'] }))).toBe(Math.max(1, Math.round(base * 0.7))); // 3
+    expect(playerCombatant('fighter', 30, 30, 'fi').passives).toEqual(['fighter-inventor']);
+  });
+
+  it('発明家: resolveTurn の実 MP 消費が割引される (統合)', () => {
+    // 匠 Lv30 vs 非割引職で同条件のとくぎ 1 発の MP 消費を比較。
+    const cast = (job: 'fighter' | 'mage'): number => {
+      const s = startBattle(job, 30, 30, 'x', 1, 3, 0, undefined, { monsterId: 'sky-slime' });
+      const before = s.player.mp;
+      const idx = 0;
+      const n = resolveTurn(s, 'skill', undefined, idx);
+      // とくぎが撃てた (MP 不足フォールバックでない) ことを確認しつつ消費量を返す
+      return before - n.player.mp;
+    };
+    const fighterCost = cast('fighter'); // 発明家 = 3
+    const mageCost = cast('mage'); // 割引なし = 4
+    expect(mageCost).toBe(BATTLE_TUNING.skillMpCost);
+    expect(fighterCost).toBe(Math.max(1, Math.round(BATTLE_TUNING.skillMpCost * 0.7)));
+    expect(fighterCost).toBeLessThan(mageCost);
   });
 
   it('慧眼 (sage-insight): 弱点 (相性倍率>=1.5) のみ ×1.25 増幅、等倍/耐性/空 1.2 は素通し', () => {

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -1826,14 +1826,14 @@ export function resolveTurnMulti(
  *  MP 不足かつしずく → しずく / MP 足りれば特技 / それ以外 たたかう。
  *  scripts/sim-battle-balance.ts と /spirit 模擬戦シミュレータで共有する。 */
 export function autoBattleCommand(s: BattleState): Command {
-  const t = BATTLE_TUNING;
   const isParry = s.playerSkill.kind === 'parry';
   const p = s.player;
-  if (s.monster.charging) return isParry && p.mp >= t.skillMpCost ? 'skill' : 'guard';
+  const skillCost = skillMpCostOf(p); // 発明家 (匠) の割引を実消費と揃える (sim 判断が過小評価しないよう)
+  if (s.monster.charging) return isParry && p.mp >= skillCost ? 'skill' : 'guard';
   if (s.herbs > 0 && p.hp < p.maxHp * 0.45) return 'herb';
   // 見切り (parry) 職は特技を撃たない → MP 回復しても無駄なので しずくを飲まない。
-  if (!isParry && s.tonics > 0 && p.mp < t.skillMpCost && p.maxMp >= t.skillMpCost * 2) return 'tonic';
-  if (!isParry && p.mp >= t.skillMpCost) return 'skill';
+  if (!isParry && s.tonics > 0 && p.mp < skillCost && p.maxMp >= skillCost * 2) return 'tonic';
+  if (!isParry && p.mp >= skillCost) return 'skill';
   return 'attack';
 }
 

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -33,6 +33,7 @@ import {
   applyOnHit,
   applyOnLethal,
   applyOnIncomingMagic,
+  mpCostFactorOf,
   applyElementBonus,
   applyTargetBonus,
   applyOnDamaged,
@@ -410,8 +411,9 @@ export function skillsForJob(archetype: Archetype, jobLevel: number): JobSkill[]
 }
 
 /** ジョブ innate パッシブ (docs/25 §12 の各職 Lv30)。PASSIVES のキー。習得 jobLevel は一律 30。
- *  フック実装済みの13職 (基本7職 + onLethal 覇王/不動 + elementBonus 慧眼 + targetBonus 審美眼 +
- *  statusDurationBonus 名演 + onIncomingMagic 清き心)。MP割引 (発明家)/非戦闘 (巫女の直感) は後続 (#483)。 */
+ *  実装済みの14職 (基本7職 + onLethal 覇王/不動 + elementBonus 慧眼 + targetBonus 審美眼 +
+ *  statusDurationBonus 名演 + onIncomingMagic 清き心 + mpCostFactor 発明家)。残 巫女の直感 (ドロップ↑=drop
+ *  reward 経路の配線が要る + MP off) は #483。performer(遊び人)は Lv30=せっとくでパッシブ無し。 */
 const JOB_PASSIVES: Partial<Record<Archetype, string>> = {
   warrior: 'warrior-blademaster', // 剣豪: 会心率↑
   mage: 'mage-barrier', // 魔力障壁: 常時被ダメ軽減
@@ -426,12 +428,18 @@ const JOB_PASSIVES: Partial<Record<Archetype, string>> = {
   artist: 'artist-aesthete', // 審美眼: 状態異常の敵に与ダメ↑
   bard: 'bard-encore', // 名演: 自分の歌 (状態) の効果ターン+1
   paladin: 'paladin-purity', // 清き心: 低確率で魔法反射
+  fighter: 'fighter-inventor', // 発明家: とくぎ MP 消費 30% 引き
 };
 
 /** その jobLevel 時点で有効なパッシブ id 列。Lv30 到達で innate パッシブが1つ有効になる。 */
 export function jobPassives(archetype: Archetype, jobLevel: number): string[] {
   const pid = JOB_PASSIVES[archetype];
   return pid && jobLevel >= 30 ? [pid] : [];
+}
+
+/** c のとくぎ MP コスト (発明家/巫女の直感の割引を反映)。最低 1。 */
+export function skillMpCostOf(c: Combatant): number {
+  return Math.max(1, Math.round(BATTLE_TUNING.skillMpCost * mpCostFactorOf(c)));
 }
 
 /** MP 回復のジョブ特性 (オーナー提案 2026-07-17「MP 回復はジョブの特別な要素に。
@@ -1439,8 +1447,9 @@ export function resolveTurn(prev: BattleState, command: Command, turnSeed?: numb
   // (UI は disabled にする前提。エンジン側の防御的措置で、ターンを無駄にしない)。
   const t = BATTLE_TUNING;
   let cmd: Command = command;
-  if (command === 'skill' && state.player.mp < t.skillMpCost) {
-    events.push({ actor: 'player', text: `MP が足りない! (${state.player.mp}/${t.skillMpCost})` });
+  const skillCost = skillMpCostOf(state.player); // 発明家/巫女の MP 割引を反映
+  if (command === 'skill' && state.player.mp < skillCost) {
+    events.push({ actor: 'player', text: `MP が足りない! (${state.player.mp}/${skillCost})` });
     cmd = 'attack';
   } else if (command === 'herb' && state.herbs <= 0) {
     events.push({ actor: 'player', text: 'やくそうを持っていない!' });
@@ -1450,7 +1459,7 @@ export function resolveTurn(prev: BattleState, command: Command, turnSeed?: numb
     cmd = 'attack';
   }
   if (cmd === 'skill') {
-    state.player.mp -= t.skillMpCost;
+    state.player.mp -= skillCost;
   }
 
   // ── にげる: 成功したら即離脱 (敵は行動しない)。失敗はターンを失い敵の行動を受ける。 ──
@@ -1667,8 +1676,9 @@ export function resolveTurnMulti(
 
   // ── コマンド実効化 (ソロと同じ防御的措置) ──
   let cmd: Command = command;
-  if (command === 'skill' && player.mp < t.skillMpCost) {
-    events.push({ actor: 'player', text: `MP が足りない! (${player.mp}/${t.skillMpCost})` });
+  const skillCost = skillMpCostOf(player); // 発明家/巫女の MP 割引を反映
+  if (command === 'skill' && player.mp < skillCost) {
+    events.push({ actor: 'player', text: `MP が足りない! (${player.mp}/${skillCost})` });
     cmd = 'attack';
   } else if (command === 'herb' && state.herbs <= 0) {
     events.push({ actor: 'player', text: 'やくそうを持っていない!' });
@@ -1677,7 +1687,7 @@ export function resolveTurnMulti(
     events.push({ actor: 'player', text: 'そらのしずくを持っていない!' });
     cmd = 'attack';
   }
-  if (cmd === 'skill') player.mp -= t.skillMpCost;
+  if (cmd === 'skill') player.mp -= skillCost;
 
   // 防御宣言 (行動順に依存しない)
   if (cmd === 'guard') {

--- a/packages/core/src/statuses.ts
+++ b/packages/core/src/statuses.ts
@@ -111,10 +111,20 @@ export interface StatusDef extends CombatHook {
   wakeOnHit?: boolean;
 }
 
-/** パッシブ = ジョブ innate な常時フック (turns なし)。 */
+/** パッシブ = ジョブ innate な常時フック (turns なし)。CombatHook に加え、戦闘ライフサイクル外の
+ *  非フック効果 (MP コスト割引など) はメタデータフィールドで表す (発明家/巫女の直感)。 */
 export interface PassiveDef extends CombatHook {
   id: string;
   name: string;
+  /** とくぎ MP コストの倍率 (発明家/巫女の直感)。0.7 なら 30% 引き。複数パッシブは乗算。 */
+  mpCostFactor?: number;
+}
+
+/** c の全パッシブの mpCostFactor を掛け合わせた倍率 (none は 1)。発明家/巫女の MP 割引。 */
+export function mpCostFactorOf(c: Combatant): number {
+  let f = 1;
+  for (const pid of c.passives ?? []) f *= PASSIVES[pid]?.mpCostFactor ?? 1;
+  return f;
 }
 
 function blockedActing(c: Combatant, ctx: HookCtx, label: string): { block?: boolean } {
@@ -264,9 +274,9 @@ function boostDodge(dodge: number, bonus: number): number {
 
 /**
  * パッシブレジストリ (ジョブ innate な常時フック。docs/25 §12 の各職 Lv30)。エンジンは
- * hooksOf でこれを状態異常と同じフック点に流すだけ (専用分岐なし)。フック実装済みの13職を
- * ここで登録 (基本7職 + onLethal 覇王/不動 + elementBonus 慧眼 + targetBonus 審美眼 + statusDurationBonus 名演
- * + onIncomingMagic 清き心)。MP消費割引 (発明家)・非戦闘 (巫女の直感) は後続 (#483)。
+ * hooksOf でこれを状態異常と同じフック点に流すだけ (専用分岐なし)。実装済みの14職を登録 (基本7職 +
+ * onLethal 覇王/不動 + elementBonus 慧眼 + targetBonus 審美眼 + statusDurationBonus 名演 + onIncomingMagic
+ * 清き心 + mpCostFactor 発明家)。残 巫女の直感 (ドロップ↑=drop reward 配線 + MP off) は後続 (#483)。
  */
 export const PASSIVES: Record<string, PassiveDef> = {
   // 忍者 首狩り: 自分より明確に弱い敵 (メタル除く) を luk 補正つき低確率で一撃 (§7/§12 Lv30)。
@@ -375,6 +385,13 @@ export const PASSIVES: Record<string, PassiveDef> = {
     id: 'artist-aesthete',
     name: '審美眼',
     targetBonus: (mult, _c, target) => (hasAilment(target) ? mult * 1.3 : mult),
+  },
+  // 匠 発明家: とくぎの MP 消費 30% 引き (§12 Lv30)。int43 の罠/装置キャスターが手数を伸ばす。フックでなく
+  // mpCostFactor メタデータで表す (MP コストは戦闘ライフサイクルのフック点でなく resolveTurn の消費計算)。
+  'fighter-inventor': {
+    id: 'fighter-inventor',
+    name: '発明家',
+    mpCostFactor: 0.7,
   },
   // 吟遊詩人 名演: 自分がかける歌 (状態異常) の効果ターン +1 (§12 Lv30)。吟遊詩人のキットは味方バフ
   // (プレリュード/スケルツォ/ラプソディ) と敵デバフ (ディスコード/ララバイ) の「歌」中心なので、全ての歌が

--- a/scripts/sim-all-jobs.ts
+++ b/scripts/sim-all-jobs.ts
@@ -3,7 +3,7 @@
  * 目標帯: 装備なし tier3 = 挑戦的 (概ね 45-65%) / フル装備 = 快適だが自明でない (80-92%)。
  * 実行: pnpm exec tsx scripts/sim-all-jobs.ts
  */
-import { ARCHETYPES, BATTLE_TUNING, EQUIPMENT_BY_ID, canEquip, resolveTurn, startBattle, type Archetype, type Command } from '../packages/core/src/index.js';
+import { ARCHETYPES, BATTLE_TUNING, EQUIPMENT_BY_ID, canEquip, resolveTurn, skillMpCostOf, startBattle, type Archetype, type Command } from '../packages/core/src/index.js';
 
 const play = (job: Archetype, jobLv: number, plLv: number, tier: 1 | 2 | 3, seed: number, equip: string[]): string => {
   let s = startBattle(job, jobLv, plLv, 'x', tier, seed, BATTLE_TUNING.herbCarryMax, undefined, { tonics: BATTLE_TUNING.tonicCarryMax, equipIds: equip });
@@ -12,12 +12,13 @@ const play = (job: Archetype, jobLv: number, plLv: number, tier: 1 | 2 | 3, seed
     const p = s.player;
     // 見切りジョブは能動的に見切る (通常攻撃も反撃で捌く = 最適プレイ)。他は
     // ため予告に防御 / HP 危険で薬草 / MP 足りれば特技。
+    const skillCost = skillMpCostOf(p); // 発明家 (匠) の割引を実消費と揃える
     const cmd: Command =
       s.herbs > 0 && p.hp < p.maxHp * 0.4 ? 'herb'
-      : isParry && p.mp >= BATTLE_TUNING.skillMpCost ? 'skill'
+      : isParry && p.mp >= skillCost ? 'skill'
       : s.monster.charging ? 'guard'
-      : s.tonics > 0 && p.mp < BATTLE_TUNING.skillMpCost && p.maxMp - p.mp >= 6 ? 'tonic'
-      : !isParry && p.mp >= BATTLE_TUNING.skillMpCost ? 'skill'
+      : s.tonics > 0 && p.mp < skillCost && p.maxMp - p.mp >= 6 ? 'tonic'
+      : !isParry && p.mp >= skillCost ? 'skill'
       : 'attack';
     s = resolveTurn(s, cmd);
   }


### PR DESCRIPTION
## 概要
Lv30 パッシブの続き。**発明家 (匠)** を実装。実装済みは **14/15 職** (残 巫女の直感=ドロップ配線待ち・#483)。MP コストは戦闘ライフサイクルのフック点でなく `resolveTurn` の消費計算なので、CombatHook でなく `PassiveDef` のメタデータ (`mpCostFactor`) で表す。

## 実装
- `PassiveDef` に `mpCostFactor?: number` を追加 + `mpCostFactorOf(c)` (全パッシブ乗算)。`skillMpCostOf(c) = round(skillMpCost × factor)` min 1。
- **発明家 (匠)**: `mpCostFactor 0.7` (4→3 MP)。int43 の罠/装置キャスターが手数を伸ばす。
- `resolveTurn` / `resolveTurnMulti` の MP 不足判定・消費を `skillMpCostOf(player)` に統一 (割引が両経路で効く)。
- **web UI** (world-battle-controls / debug-battle-sim) の MP コスト表示・可否判定も `skillMpCostOf` に統一 (発明家の割引が UI に反映。**割引なし職は従来と同値 = 挙動不変**)。

## 設計方針
- 首狩り/慧眼同様データ駆動 (専用分岐なし)。MP は非戦闘フック点なので**メタデータで表現** (CombatHook 濫用を避ける)。
- edge は `resolveTurn` を replay するためサーバー権威で一致。

## ⚠️ 要 device 確認 (§3)
web UI (world-battle-controls) を触るため、**匠 Lv30 で戦闘 UI のとくぎコストが「MP3」表示になり、MP3 で撃てる**ことを dev 実機で確認してください。割引なし職 (mage 等) は従来どおり MP4 表示。

## 検証
- core **480 緑** (dispatcher `skillMpCostOf` + **resolveTurn 経由で匠の実 MP 消費が 3・mage が 4** の統合テスト)
- typecheck (web+edge+core) 緑

## 数値
割引 0.7 (30%) は sim 前提の暫定値 (#479)。MP は int43 職では潤沢なため影響は控えめ。

## Review

§1.5 3並列独立レビュー (設計/実装/体験・UI ロジックのため 3 並列維持)。**3本とも ★★★ ゼロ・マージ可**。

### 設計レビュー: ★★★ ゼロ・★★ 1件 (PR 内対応済)・★ 2件
**MP割引を CombatHook でなく PassiveDef メタデータ (mpCostFactor) で表す判断は正しい** (MP コストは戦闘ライフサイクルのフック点でなく resolveTurn の消費計算 = フック化する方が §4 違反)。TDZ なし・責務分担 (mpCostFactorOf=statuses / skillMpCostOf=battle) 適切。★★ = autoBattleCommand の生コスト。

### 実装レビュー: ★★★ ゼロ・★★ 1件 (PR 内対応済)
core 480緑を実機確認。TDZ/回帰/判定と消費の一貫性/round境界/web UI 一致/edge すべて健全。★★ = autoBattleCommand。

### 体験・バランスレビュー: ★★★ ゼロ・マージ可 (条件つき)
役割整合正しい (匠 int43 罠キャスターの手数バフ)。実測で **現 flat-MP tuning では実効価値ほぼゼロ** (匠 maxMp71・23発/戦・MP枯渇0) だが、**空パッシブより mpCostFactor 先行配線が良い** (per-skill MP 実装で自動的に活きる) とマージ許容。

### ★★/★ 対応
- **autoBattleCommand が生 skillMpCost で判定 → 割引が auto/sim/模擬戦で無効・sim が過小評価** (設計/実装/体験★★・共通指摘) → **PR 内修正** (commit 3b2f174): autoBattleCommand 3箇所 + sim-all-jobs.ts を skillMpCostOf に統一。表示・実消費・AI・sim の四者一致。
- **発明家が現状ほぼ無価値 (flat MP)** (体験★★) → **issue #498** (per-skill MP コスト実装 + 再 sim)。**暫定的な先行実装であることを本 PR に明記** (#498 で真価)。
- **巫女 defer 理由 / mpCostFactor 乗算下限** (設計/体験★) → コミット/issue #498 に記録。

## ⚠️ 現状の位置づけ (暫定先行実装)
**発明家は現 flat-MP tuning では体感効果が小さい**。§12 想定の per-skill MP コスト (英雄叙事詩 MP30 等) が入ると重い技を回す局面で 30%off が効き真価が出る (#498)。機構 (mpCostFactor) は per-skill 実装で自動的に活きる先行配線。

## ⚠️ 要 device 確認 (§3)
web UI を触るため、**匠 Lv30 で戦闘 UI のとくぎコストが「MP3」表示・MP3 で撃てる**ことを dev 実機で確認してください (割引なし職は MP4)。

CI: web-ci pass (e2e 込み)。core 480緑 / typecheck (web+edge+core) 緑。**割引なし職は skillMpCostOf が従来値 = 既存戦闘は挙動不変**。
