### PR TITLE
巫女の直感 (巫女) パッシブ — 全15職 Lv30 パッシブ完成 (#456)

### DIFF
--- a/apps/edge/src/battle-resolver.ts
+++ b/apps/edge/src/battle-resolver.ts
@@ -11,7 +11,7 @@
  *     (同一ターンの並行二重解決/引き直しを弾く)。
  */
 import {
-  startBattle, resolveTurn, statVectorToArray, jobLevelFromXp, playerLevelFromXp, playerCombatant, rollSearch,
+  startBattle, resolveTurn, statVectorToArray, jobLevelFromXp, playerLevelFromXp, playerCombatant, rollSearch, dropBonusOf,
   terrainAt, isWalkable, wrap, townAt, regionOf, regionDanger, tierForDanger, encounterRateFor, worldOverlay, BATTLE_TUNING,
   type BattleState, type Command, type Archetype, type StatVector, type GearSelection,
 } from '@aozoraquest/core';
@@ -415,7 +415,7 @@ export async function handleTurn(env: ResolverEnv, userDid: string, battleId: st
       setCount('sky-dew', next.tonics ?? 0);
       const r = applyBattleOutcome({ ...cur, materials: consumedMaterials }, {
         outcome: decision, monsterId: next.monsterId, archetype: guard.sealed.archetype,
-        luk: next.player.luk, rewardSeed, lossSeed, rewarded: guard.rewarded,
+        luk: next.player.luk, dropBonus: dropBonusOf(next.player), rewardSeed, lossSeed, rewarded: guard.rewarded,
       });
       awarded = r.awarded;
       // 勝ったらそのタイルを「撃破済み」に記録し、同じ 30 分枠では再エンカウントさせない (無限狩り防止)。

--- a/apps/edge/src/battle-reward.ts
+++ b/apps/edge/src/battle-reward.ts
@@ -27,6 +27,8 @@ export interface BattleOutcomeInput {
   archetype: string;
   /** ドロップ/敗北ロスの luk ボーナス。 */
   luk: number;
+  /** 巫女の直感 (#456) 等のドロップ確率加算ボーナス。未指定は 0。 */
+  dropBonus?: number;
   /** サーバーが独立に引いたドロップ用エントロピー (32bit)。 */
   rewardSeed: number;
   /** サーバーが独立に引いた敗北ロス用エントロピー (32bit)。 */
@@ -65,7 +67,7 @@ export function applyBattleOutcome(state: GameState, o: BattleOutcomeInput): { n
 
   if (o.outcome === 'win') {
     const xp = battleXpFor(o.monsterId);
-    const drops = rollDrops(o.monsterId, o.luk, o.rewardSeed);
+    const drops = rollDrops(o.monsterId, o.luk, o.rewardSeed, o.dropBonus ?? 0);
     const next: GameState = {
       ...state,
       playerXp: state.playerXp + xp,

--- a/docs/25-combat-plugin-system.md
+++ b/docs/25-combat-plugin-system.md
@@ -163,8 +163,10 @@ export interface StatusDef extends CombatHook {
   immuneIf?(c: Combatant): boolean;   // 毒無効・睡眠耐性
   clearOnAct?: boolean; clearOnHit?: boolean; wakeOnHit?: boolean;
 }
-// パッシブ = ジョブ innate な常時フック (turns なし)
-export interface PassiveDef extends CombatHook { id: string; name: string }
+// パッシブ = ジョブ innate な常時フック (turns なし)。加えて、戦闘ライフサイクルのフック点でない
+// 非戦闘効果は**メタデータフィールド**で表す: mpCostFactor (発明家/巫女=とくぎMP割引・resolveTurn で乗算)、
+// dropBonus (巫女=ドロップ↑・rollDrops で加算)。フック点でないものを無理にフック化しない (#456)。
+export interface PassiveDef extends CombatHook { id: string; name: string; mpCostFactor?: number; dropBonus?: number }
 
 export const STATUS_REGISTRY: Record<StatusId, StatusDef> = { /* poison/sleep/hidden/critCharge/… */ };
 export const PASSIVES: Record<string, PassiveDef> = {

--- a/packages/core/src/__tests__/passives.test.ts
+++ b/packages/core/src/__tests__/passives.test.ts
@@ -13,7 +13,8 @@ import {
   applyStatusDurationBonus,
   type HookCtx,
 } from '../statuses.js';
-import { jobPassives, playerCombatant, skillMpCostOf, startBattle, resolveTurn, BATTLE_TUNING, type Combatant } from '../battle.js';
+import { jobPassives, playerCombatant, skillMpCostOf, rollDrops, startBattle, resolveTurn, BATTLE_TUNING, type Combatant } from '../battle.js';
+import { dropBonusOf } from '../statuses.js';
 import { runSkill, type SkillContext, type SkillDef } from '../skills.js';
 
 function c(over: Partial<Combatant> = {}): Combatant {
@@ -57,8 +58,8 @@ describe('パッシブ (#456 各職 Lv30)', () => {
     expect(jobPassives('artist', 30)).toEqual(['artist-aesthete']);
     expect(jobPassives('paladin', 30)).toEqual(['paladin-purity']);
     expect(jobPassives('fighter', 30)).toEqual(['fighter-inventor']);
-    // 残 巫女 (ドロップ↑=drop 配線待ち) は Lv30 でもまだ空 (後続 #483)。遊び人は Lv30 パッシブ無し。
-    expect(jobPassives('miko', 30)).toEqual([]);
+    expect(jobPassives('miko', 30)).toEqual(['miko-intuition']);
+    // 遊び人は Lv30=せっとく(resolve スキル)でパッシブ無し。
     expect(jobPassives('performer', 30)).toEqual([]);
   });
 
@@ -66,8 +67,9 @@ describe('パッシブ (#456 各職 Lv30)', () => {
     expect(playerCombatant('warrior', 30, 30, 'w').passives).toEqual(['warrior-blademaster']);
     expect(playerCombatant('warrior', 29, 30, 'w').passives).toEqual([]);
     expect(playerCombatant('captain', 30, 30, 'cap').passives).toEqual(['captain-command']);
-    // 未実装職は Lv30 でも空 (巫女=ドロップ配線待ち)。キット化とは別軸。
-    expect(playerCombatant('miko', 30, 30, 'mk').passives).toEqual([]);
+    expect(playerCombatant('miko', 30, 30, 'mk').passives).toEqual(['miko-intuition']);
+    // 遊び人は Lv30 パッシブ無し (せっとく=resolve スキル)。
+    expect(playerCombatant('performer', 30, 30, 'pf').passives).toEqual([]);
   });
 
   // ── 各パッシブの効果 (dispatcher 経由) ──
@@ -194,6 +196,29 @@ describe('パッシブ (#456 各職 Lv30)', () => {
     expect(mageCost).toBe(BATTLE_TUNING.skillMpCost);
     expect(fighterCost).toBe(Math.max(1, Math.round(BATTLE_TUNING.skillMpCost * 0.7)));
     expect(fighterCost).toBeLessThan(mageCost);
+  });
+
+  it('巫女の直感 (miko-intuition): MP 割引 (0.7) + ドロップ加算 (0.1) の複合パッシブ', () => {
+    const miko = c({ passives: ['miko-intuition'] });
+    expect(skillMpCostOf(miko)).toBe(Math.max(1, Math.round(BATTLE_TUNING.skillMpCost * 0.7))); // MP off
+    expect(dropBonusOf(miko)).toBeCloseTo(0.1); // ドロップ↑
+    expect(dropBonusOf(c())).toBe(0); // パッシブなしは 0
+    const mk = playerCombatant('miko', 30, 30, 'mk');
+    expect(mk.passives).toEqual(['miko-intuition']);
+    expect(dropBonusOf(mk)).toBeCloseTo(0.1);
+  });
+
+  it('rollDrops: dropBonus (巫女の直感) がドロップ確率を上げる (統合)', () => {
+    // 同 seed 群で dropBonus あり/なしのドロップ総数を比較 → 巫女の方が多い。
+    let base = 0;
+    let boosted = 0;
+    for (let seed = 0; seed < 200; seed++) {
+      base += rollDrops('moss-golem', 0, seed, 0).length;
+      boosted += rollDrops('moss-golem', 0, seed, 0.1).length;
+    }
+    expect(boosted).toBeGreaterThan(base); // dropBonus で総ドロップ数が増える
+    // dropBonus なしは従来と完全一致 (回帰なし)。
+    expect(rollDrops('moss-golem', 5, 42)).toEqual(rollDrops('moss-golem', 5, 42, 0));
   });
 
   it('慧眼 (sage-insight): 弱点 (相性倍率>=1.5) のみ ×1.25 増幅、等倍/耐性/空 1.2 は素通し', () => {

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -411,9 +411,9 @@ export function skillsForJob(archetype: Archetype, jobLevel: number): JobSkill[]
 }
 
 /** ジョブ innate パッシブ (docs/25 §12 の各職 Lv30)。PASSIVES のキー。習得 jobLevel は一律 30。
- *  実装済みの14職 (基本7職 + onLethal 覇王/不動 + elementBonus 慧眼 + targetBonus 審美眼 +
- *  statusDurationBonus 名演 + onIncomingMagic 清き心 + mpCostFactor 発明家)。残 巫女の直感 (ドロップ↑=drop
- *  reward 経路の配線が要る + MP off) は #483。performer(遊び人)は Lv30=せっとくでパッシブ無し。 */
+ *  **Lv30 パッシブを持つ全15職を実装済み** (基本7職 + onLethal 覇王/不動 + elementBonus 慧眼 +
+ *  targetBonus 審美眼 + statusDurationBonus 名演 + onIncomingMagic 清き心 + mpCostFactor 発明家/巫女 +
+ *  dropBonus 巫女)。performer(遊び人)は Lv30=せっとく(resolve スキル)でパッシブ無し = 全職キット化完了。 */
 const JOB_PASSIVES: Partial<Record<Archetype, string>> = {
   warrior: 'warrior-blademaster', // 剣豪: 会心率↑
   mage: 'mage-barrier', // 魔力障壁: 常時被ダメ軽減
@@ -429,6 +429,7 @@ const JOB_PASSIVES: Partial<Record<Archetype, string>> = {
   bard: 'bard-encore', // 名演: 自分の歌 (状態) の効果ターン+1
   paladin: 'paladin-purity', // 清き心: 低確率で魔法反射
   fighter: 'fighter-inventor', // 発明家: とくぎ MP 消費 30% 引き
+  miko: 'miko-intuition', // 巫女の直感: ドロップ↑ + MP 消費 30% 引き
 };
 
 /** その jobLevel 時点で有効なパッシブ id 列。Lv30 到達で innate パッシブが1つ有効になる。 */
@@ -1862,14 +1863,15 @@ export function rollDefeatLoss(materials: Record<string, number>, luk: number, s
   return lost;
 }
 
-/** 勝利時のドロップ判定。luk で上振れ。決定的 (seed 依存)。 */
-export function rollDrops(monsterId: string, luk: number, seed: number): string[] {
+/** 勝利時のドロップ判定。luk で上振れ。決定的 (seed 依存)。dropBonus = 巫女の直感の加算 (#456)。 */
+export function rollDrops(monsterId: string, luk: number, seed: number, dropBonus = 0): string[] {
   const def = MONSTERS_BY_ID[monsterId];
   if (!def) return [];
   const rng = createRng((seed ^ 0x2545f491) >>> 0);
   const out: string[] = [];
   for (const d of def.drops) {
-    const chance = Math.min(0.95, d.chance + luk * BATTLE_TUNING.dropLukScale);
+    // luk ボーナス + 巫女の直感 dropBonus を合算し 0.95 で clamp。
+    const chance = Math.min(0.95, d.chance + luk * BATTLE_TUNING.dropLukScale + dropBonus);
     if (rng() < chance) out.push(d.item);
   }
   return out;

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -1870,7 +1870,9 @@ export function rollDrops(monsterId: string, luk: number, seed: number, dropBonu
   const rng = createRng((seed ^ 0x2545f491) >>> 0);
   const out: string[] = [];
   for (const d of def.drops) {
-    // luk ボーナス + 巫女の直感 dropBonus を合算し 0.95 で clamp。
+    // luk ボーナス + 巫女の直感 dropBonus を合算し 0.95 で clamp。dropBonus は luk 補正と天井 (0.95) を
+    // **共有**するので、高 luk 職 (巫女=luk37) では既にドロップ率が高い素材で +0.1 の限界効用が逓減する
+    // (青天井を防ぐ意図的な設計。数値は sim 前提の暫定値)。
     const chance = Math.min(0.95, d.chance + luk * BATTLE_TUNING.dropLukScale + dropBonus);
     if (rng() < chance) out.push(d.item);
   }

--- a/packages/core/src/statuses.ts
+++ b/packages/core/src/statuses.ts
@@ -118,6 +118,8 @@ export interface PassiveDef extends CombatHook {
   name: string;
   /** とくぎ MP コストの倍率 (発明家/巫女の直感)。0.7 なら 30% 引き。複数パッシブは乗算。 */
   mpCostFactor?: number;
+  /** ドロップ確率への加算ボーナス (巫女の直感)。0.1 なら各ドロップの確率 +0.1 (上限は rollDrops 側で clamp)。 */
+  dropBonus?: number;
 }
 
 /** c の全パッシブの mpCostFactor を掛け合わせた倍率 (none は 1)。発明家/巫女の MP 割引。 */
@@ -125,6 +127,13 @@ export function mpCostFactorOf(c: Combatant): number {
   let f = 1;
   for (const pid of c.passives ?? []) f *= PASSIVES[pid]?.mpCostFactor ?? 1;
   return f;
+}
+
+/** c の全パッシブの dropBonus を合算 (none は 0)。巫女の直感のドロップ↑。 */
+export function dropBonusOf(c: Combatant): number {
+  let b = 0;
+  for (const pid of c.passives ?? []) b += PASSIVES[pid]?.dropBonus ?? 0;
+  return b;
 }
 
 function blockedActing(c: Combatant, ctx: HookCtx, label: string): { block?: boolean } {
@@ -274,9 +283,9 @@ function boostDodge(dodge: number, bonus: number): number {
 
 /**
  * パッシブレジストリ (ジョブ innate な常時フック。docs/25 §12 の各職 Lv30)。エンジンは
- * hooksOf でこれを状態異常と同じフック点に流すだけ (専用分岐なし)。実装済みの14職を登録 (基本7職 +
- * onLethal 覇王/不動 + elementBonus 慧眼 + targetBonus 審美眼 + statusDurationBonus 名演 + onIncomingMagic
- * 清き心 + mpCostFactor 発明家)。残 巫女の直感 (ドロップ↑=drop reward 配線 + MP off) は後続 (#483)。
+ * hooksOf でこれを状態異常と同じフック点に流すだけ (専用分岐なし)。**Lv30 パッシブを持つ全15職を実装済み**
+ * (基本7職 + onLethal 覇王/不動 + elementBonus 慧眼 + targetBonus 審美眼 + statusDurationBonus 名演 +
+ * onIncomingMagic 清き心 + mpCostFactor 発明家/巫女 + dropBonus 巫女)。遊び人の Lv30 はせっとくでパッシブ無し。
  */
 export const PASSIVES: Record<string, PassiveDef> = {
   // 忍者 首狩り: 自分より明確に弱い敵 (メタル除く) を luk 補正つき低確率で一撃 (§7/§12 Lv30)。
@@ -392,6 +401,14 @@ export const PASSIVES: Record<string, PassiveDef> = {
     id: 'fighter-inventor',
     name: '発明家',
     mpCostFactor: 0.7,
+  },
+  // 巫女 巫女の直感: ドロップ↑ + とくぎ MP 消費 30% 引き (§12 Lv30)。回復/浄化の支援職が素材集めと手数を
+  // 支える。どちらも戦闘フック点でない非戦闘/報酬メタデータ (mpCostFactor は resolveTurn・dropBonus は rollDrops)。
+  'miko-intuition': {
+    id: 'miko-intuition',
+    name: '巫女の直感',
+    mpCostFactor: 0.7,
+    dropBonus: 0.1,
   },
   // 吟遊詩人 名演: 自分がかける歌 (状態異常) の効果ターン +1 (§12 Lv30)。吟遊詩人のキットは味方バフ
   // (プレリュード/スケルツォ/ラプソディ) と敵デバフ (ディスコード/ララバイ) の「歌」中心なので、全ての歌が


### PR DESCRIPTION
## 概要
**最後の Lv30 パッシブ**。巫女の直感 (ドロップ↑ + とくぎ MP 消費30%引き) を実装。これで **Lv30 パッシブを持つ全15職が完成** (遊び人の Lv30 はせっとく=resolve スキルでパッシブ無し)。

## 実装
- `PassiveDef` に `dropBonus?: number` 追加 + `dropBonusOf(c)` (全パッシブ合算)。`rollDrops` に `dropBonus` 引数 (luk ボーナスと合算し 0.95 clamp)。
- **巫女の直感**: `mpCostFactor 0.7` (#497 の発明家と同基盤) + `dropBonus 0.1`。回復/浄化の支援職が素材集めと手数を支える。
- **edge**: `BattleOutcomeInput` に `dropBonus` 追加。`battle-resolver` が `next.player.passives` から `dropBonusOf` で算出して渡す (**sealed player Combatant が既にパッシブを持つので jobLevel 追加配線は不要**)。
- **MP off の UI 表示は #497 の skillMpCostOf 汎用化で自動反映** (巫女も対象)。ドロップは server 権威 (rollDrops は edge のみ) なので **web 変更なし**。

## 設計方針
- 発明家/慧眼同様データ駆動 (専用分岐なし)。MP/ドロップは戦闘ライフサイクルのフック点でないので**メタデータで表現** (mpCostFactor / dropBonus)。

## 検証
- core **482 緑** (dispatcher `dropBonusOf`/`skillMpCostOf` + **rollDrops の dropBonus でドロップ数が増える統合テスト**・dropBonus なしは従来と完全一致=回帰なし)
- edge 149 緑 / typecheck (web+edge+core) 緑

## 数値
0.7 (MP) / 0.1 (drop) は sim 前提の暫定値 (#498 per-skill MP / #479 sim)。

## 🎉 マイルストーン
これで **全16職の確定キット + Lv30 パッシブ全15職** が揃い、docs/25 戦闘プラグインシステムの単体戦闘スコープが完成。

## Review

§1.5 3並列独立レビュー (設計/実装/体験)。**3本とも ★★★/★★(要 in-PR) ゼロ・マージ可**。体験は drop 経済を実測。

### 設計レビュー: ★★★/★★ ゼロ・★ 3件
dropBonus を mpCostFactor と同格の非戦闘メタデータで表す設計 = §4 方針の対称拡張 (専用分岐なし)。**edge の配線 (dropBonusOf(next.player)) が権威 Combatant の単一出所を尊重しクリーン** (jobLevel 再導出不要)。純粋関数性・決定性 (dropBonus は chance 加算のみで rng 消費不変)・後方互換すべて妥当。

### 実装レビュー: ★★★/★★ ゼロ・★ 2件
core 482緑を実機確認。回帰 (dropBonus=0 が従来と完全一致)・決定性・サーバー権威 (web は rollDrops 非呼び出し)・clamp・複合パッシブ・TDZ すべて健全。

### 体験・バランスレビュー: ★★★ ゼロ・マージ可 (drop 経済を実測)
**ドロップ +0.1 = 素材収集 +18〜25%** (体感できるが乱獲でない)。レア 0.12→0.33 で 0.95 clamp が効き**経済破壊なし**。**MP off は巫女 (maxMp31) では有効** — 発明家 (匠 maxMp71 で無価値) と違い支援職の手数が実際に増える。役割 (支援・収集) と噛み合う。

### ★★/★ 対応
- **flat MP モデルが §12 の per-skill 高コスト支援技を表現せず 0.7x が過小評価** (体験★★・PR 外) → **#498 に申し送り済** (発明家と同根)。
- **docs §4 に非戦闘メタデータ (mpCostFactor/dropBonus) を明記 / dropBonus の luk-clamp 共有コメント** (設計★) → **PR 内対応**。
- 複合 capstone の派手さ / luk37 二重取り / edge end-to-end drop テスト (体験/実装★) → 役割的に正解・sim 前提の暫定値・配線は目視+core 契約でカバー、issue 不要レベル。

CI: web-ci pass。core 482緑 (dropBonusOf/skillMpCostOf 複合 + rollDrops dropBonus 統合・回帰なし) / edge 149緑 / typecheck 緑。**既存プレイヤーのドロップ・MP は挙動不変** (dropBonus=0 / mpCostFactor=1)。

---
**🎉 これで全16職の確定キット + Lv30 パッシブ全15職が揃い、docs/25 戦闘プラグインの単体戦闘スコープが完成。**
