### PR TITLE
マルチ戦闘の敵個体 AI + 群れ生成 (#453 マルチ戦 PR1/3)

### DIFF
--- a/packages/core/src/__tests__/multi-combat.test.ts
+++ b/packages/core/src/__tests__/multi-combat.test.ts
@@ -55,4 +55,30 @@ describe('マルチ戦闘ターンループ (#453)', () => {
     expect(s.outcome).not.toBe('ongoing');
     if (s.outcome === 'win') expect(s.enemies!.every((e) => e.hp <= 0)).toBe(true);
   });
+
+  it('startBattle の extraEnemies で群れ (enemies[]・各敵 monsterId 保持・allies=[player])', () => {
+    const solo = startBattle('warrior', 8, 15, '勇者', 1, 5);
+    expect(solo.enemies).toBeUndefined(); // 従来ソロは enemies 未設定 (後方互換)
+    const pack = startBattle('warrior', 8, 15, '勇者', 1, 5, 0, undefined, { extraEnemies: 2 });
+    expect(pack.enemies).toHaveLength(3); // 主敵 + 追加2 = 3体
+    expect(pack.allies).toEqual([pack.player]);
+    for (const e of pack.enemies!) expect(typeof e.monsterId).toBe('string'); // 敵ごとに def id を保持
+    expect(pack.enemies![0]).toBe(pack.monster); // enemies[0]=主敵と同期
+  });
+
+  it('敵は個体ごとの ability で行動する — caster (night-raven) がマルチで魔法を撃つ (#453)', () => {
+    const spellName = 'かまいたち'; // night-raven の spell
+    let cast = false;
+    for (let seed = 0; seed < 40 && !cast; seed++) {
+      // 主敵を night-raven に固定 + 追加敵。プレイヤーは防御で長引かせ詠唱機会を稼ぐ。
+      let s = startBattle('warrior', 30, 30, '勇者', 3, seed, 0, undefined, { monsterId: 'night-raven', extraEnemies: 1 });
+      for (let i = 0; i < 30 && s.outcome === 'ongoing'; i++) {
+        s.player.hp = s.player.maxHp; // 倒し切らず長引かせる
+        for (const e of s.enemies!) e.mp = e.maxMp; // 敵 MP を戻して詠唱継続
+        s = resolveTurnMulti(s, 'guard');
+        if (s.lastEvents.some((ev) => ev.text.includes(spellName))) { cast = true; break; }
+      }
+    }
+    expect(cast).toBe(true); // マルチでも night-raven が ability (cast) を使った = 個体 AI が効いている
+  });
 });

--- a/packages/core/src/__tests__/multi-combat.test.ts
+++ b/packages/core/src/__tests__/multi-combat.test.ts
@@ -81,4 +81,34 @@ describe('マルチ戦闘ターンループ (#453)', () => {
     }
     expect(cast).toBe(true); // マルチでも night-raven が ability (cast) を使った = 個体 AI が効いている
   });
+
+  it('敵の charger がマルチで「ため」→ 強攻撃を放つ (#453 個体 AI)', () => {
+    let charged = false;
+    for (let seed = 0; seed < 40 && !charged; seed++) {
+      // moss-golem (charger)。プレイヤーは防御で長引かせる。
+      let s = startBattle('warrior', 30, 30, '勇者', 2, seed, 0, undefined, { monsterId: 'moss-golem', extraEnemies: 1 });
+      for (let i = 0; i < 20 && s.outcome === 'ongoing'; i++) {
+        s.player.hp = s.player.maxHp;
+        for (const e of s.enemies!) e.mp = e.maxMp;
+        s = resolveTurnMulti(s, 'guard');
+        if (s.lastEvents.some((ev) => ev.text.includes('力をためている'))) { charged = true; break; }
+      }
+    }
+    expect(charged).toBe(true); // マルチでも charger が ため宣言 = per-enemy AI (multiEnemyAct)
+  });
+
+  it('敵の healer がマルチで自己回復する (#453 個体 AI)', () => {
+    let healed = false;
+    for (let seed = 0; seed < 40 && !healed; seed++) {
+      // sky-dragon (healer)。低 HP に固定して回復判定を誘発。
+      let s = startBattle('warrior', 30, 30, '勇者', 3, seed, 0, undefined, { monsterId: 'sky-dragon', extraEnemies: 1 });
+      for (let i = 0; i < 20 && s.outcome === 'ongoing'; i++) {
+        s.player.hp = s.player.maxHp;
+        for (const e of s.enemies!) { e.hp = Math.max(1, Math.floor(e.maxHp * 0.2)); e.mp = e.maxMp; }
+        s = resolveTurnMulti(s, 'guard');
+        if (s.lastEvents.some((ev) => ev.text.includes('回復'))) { healed = true; break; }
+      }
+    }
+    expect(healed).toBe(true); // マルチでも healer が自己回復 = per-enemy AI
+  });
 });

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -1737,8 +1737,7 @@ export function resolveTurnMulti(
   const state: BattleState = { ...prev, turn: prev.turn + 1, allies, enemies, player: allies[0]!, monster: enemies[0]!, lastEvents: [] };
   const sides: CombatSides = { allies, enemies };
   const player = allies[0]!;
-  // ぼうぎょは 1 ターン限り。前ターンから copy された guarding をリセットし、このターンの宣言/AI で立て直す。
-  for (const c of [...allies, ...enemies]) c.guarding = false;
+  // ぼうぎょは 1 ターン限り: copyCombatant が guarding:false でコピーするので、このターンの宣言/AI で立て直す。
   const isAlly = (c: Combatant) => allies.includes(c);
   const events: TurnEvent[] = [];
   const rng = turnSeed === undefined ? turnRng(state.seed, state.turn) : createRng(turnSeed >>> 0);

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -532,6 +532,9 @@ export interface Combatant {
   /** onLethal (覇王/不動) を戦闘中に発動済みか (#456)。物理致死を耐える切り札は 1 戦闘 1 回のみ。
    *  playerCombatant で毎戦闘 undefined から始まり、初回発動でハンドラが true にする。 */
   lethalGuardUsed?: boolean;
+  /** モンスター個体の def id (#453 マルチ戦闘で敵ごとに ability/spell を引くため)。プレイヤー/召喚は未設定。
+   *  monsterCombatant が def.id を載せる。1v1 では state.monsterId と一致する。 */
+  monsterId?: string;
 }
 
 function fromStats(name: string, stats: StatArray, levelFactor: number, level: number): Combatant {
@@ -970,6 +973,7 @@ export function monsterCombatant(def: MonsterDef, variance: number, rng: () => n
   // 属性・魔法耐性 (#455)。属性相性はキャスターの弱点突き、resistAllMagic はメタルの魔法無効。
   if (def.element !== undefined) c.element = def.element;
   if (def.resistAllMagic) c.resistAllMagic = true;
+  c.monsterId = def.id; // マルチ戦闘で敵個体ごとに ability/spell を引く (#453)
   return c;
 }
 
@@ -1062,6 +1066,9 @@ export function startBattle(
     /** 出現を tier 抽選せず**この id のモンスターに固定**する (模擬戦シミュレータ用)。
      *  未知 id は無視して従来どおり tier 抽選。 */
     monsterId?: string;
+    /** 追加の敵数 (#453 マルチ戦闘: 群れ)。0=ソロ (従来・enemies 未設定)、1〜2 で計 2〜3 体。
+     *  各追加敵は同 tier から別 seed で抽選し monsterId を保持。allies=[player]・enemies=[主敵, …追加] を設定。 */
+    extraEnemies?: number;
   },
 ): BattleState {
   const player = playerCombatant(archetype, jobLevel, playerLevel, displayName, extras?.baseStats, extras?.equipIds, extras?.gear);
@@ -1077,12 +1084,24 @@ export function startBattle(
     ? { def: forced, combatant: monsterCombatant(forced, variance, createRng((seed ^ 0x2a9f) >>> 0)) }
     : summonMonster(tier, playerLevel, seed, jobLevel, extras?.affinity, variance);
   const gains = mpGainsFor(archetype);
+  // #453 群れ: 追加の敵を別 seed で抽選 (最大 +2 = 計 3 体)。0 のとき enemies 未設定 = 従来ソロ。
+  const extraCount = Math.max(0, Math.min(2, Math.floor(extras?.extraEnemies ?? 0)));
+  const enemies: Combatant[] = [combatant];
+  for (let i = 0; i < extraCount; i++) {
+    const es = (seed ^ (0x9e3779b1 * (i + 1))) >>> 0;
+    enemies.push(
+      forced
+        ? monsterCombatant(forced, variance, createRng((es ^ 0x2a9f) >>> 0))
+        : summonMonster(tier, playerLevel, es, jobLevel, extras?.affinity, variance).combatant,
+    );
+  }
   return {
     seed,
     turn: 0,
     player,
     monster: combatant,
     monsterId: def.id,
+    ...(extraCount > 0 ? { allies: [player], enemies } : {}),
     playerSkill: skillForJob(archetype),
     playerSkills: skillsForJob(archetype, jobLevel),
     outcome: 'ongoing',
@@ -1300,6 +1319,8 @@ type MonsterAction = 'attack' | 'guard' | 'charge' | 'heal' | 'flee' | 'cast';
  *  monsterCommand の if 分岐を排す。null を返すと通常判定 (plain) にフォールバック。 */
 interface AbilityDecisionCtx {
   state: BattleState;
+  /** 行動する敵個体 (#453: マルチ戦闘で敵ごとに判断。1v1 では state.monster と同じ)。 */
+  monster: Combatant;
   /** そのターンの単一乱数 (全 ability で共有 = 決定性維持)。 */
   r: number;
   t: typeof BATTLE_TUNING;
@@ -1319,8 +1340,8 @@ const MONSTER_ABILITIES: Record<string, AbilityDef> = {
   // charger: 1 ターン ため → 強攻撃 (予告を防御する読み合い。全体の ~20%)
   charger: {
     id: 'charger',
-    decideAction: ({ state, r, t, canGuard }) => {
-      if (state.monster.mp >= t.monsterChargeMpCost && r < t.chargerChargeChance) return 'charge';
+    decideAction: ({ monster, r, t, canGuard }) => {
+      if (monster.mp >= t.monsterChargeMpCost && r < t.chargerChargeChance) return 'charge';
       if (canGuard && r < t.chargerChargeChance + 0.15) return 'guard';
       return 'attack';
     },
@@ -1328,8 +1349,8 @@ const MONSTER_ABILITIES: Record<string, AbilityDef> = {
   // healer: 低 HP でたまに自己回復 (削り切る前に倒す読み合い)
   healer: {
     id: 'healer',
-    decideAction: ({ state, r, t, hpRatio, canGuard }) => {
-      if (state.monster.mp >= t.monsterHealMpCost && hpRatio < t.healerLowHpRatio && r < t.healerHealChance) return 'heal';
+    decideAction: ({ monster, r, t, hpRatio, canGuard }) => {
+      if (monster.mp >= t.monsterHealMpCost && hpRatio < t.healerLowHpRatio && r < t.healerHealChance) return 'heal';
       if (canGuard && r < t.healerHealChance + 0.15) return 'guard';
       return 'attack';
     },
@@ -1338,8 +1359,8 @@ const MONSTER_ABILITIES: Record<string, AbilityDef> = {
   // 成立させる (int 職の魔法耐性・聖騎士の魔法反射=清き心 は後続 #483 の前提)。MP 切れで通常攻撃に落ちる。
   caster: {
     id: 'caster',
-    decideAction: ({ state, r, t, canGuard, monsterDef }) => {
-      if (monsterDef?.spell && state.monster.mp >= t.monsterCastMpCost && r < t.casterCastChance) return 'cast';
+    decideAction: ({ monster, r, t, canGuard, monsterDef }) => {
+      if (monsterDef?.spell && monster.mp >= t.monsterCastMpCost && r < t.casterCastChance) return 'cast';
       // guard バンドは charger/healer (+0.15) よりやや狭い +0.1 — caster は攻撃寄りに保ち、魔法を撃てない
       // (MP 枯渇) ターンも殴りに来る威圧感を残すため (守りに籠らせない)。
       if (canGuard && r < t.casterCastChance + 0.1) return 'guard';
@@ -1363,16 +1384,17 @@ const MONSTER_ABILITIES: Record<string, AbilityDef> = {
 /** モンスターの行動を能力 (ability) で決める (オーナー要望 2026-07-18: ため攻撃は
  *  一部 (~20%) に限定し、回復する敵などバリエーションで戦略性を出す)。
  *  #452: if 分岐でなく MONSTER_ABILITIES レジストリ引き (プラグイン化)。 */
-function monsterCommand(state: BattleState, rng: () => number): MonsterAction {
-  const def = MONSTERS_BY_ID[state.monsterId];
+function monsterCommand(monster: Combatant, state: BattleState, rng: () => number): MonsterAction {
+  // 敵個体の monsterId で def を引く (#453: マルチ戦闘は敵ごとに別 def。1v1 は state.monsterId と一致)。
+  const def = MONSTERS_BY_ID[monster.monsterId ?? state.monsterId];
   const t = BATTLE_TUNING;
   const r = rng();
-  const hpRatio = state.monster.hp / state.monster.maxHp;
+  const hpRatio = monster.hp / monster.maxHp;
   // 低 HP でたまに身を固める (charger のため中は別処理なのでここでは除外)
-  const canGuard = (def?.tier ?? 1) >= 2 && hpRatio < 0.35 && !state.monster.charging;
+  const canGuard = (def?.tier ?? 1) >= 2 && hpRatio < 0.35 && !monster.charging;
 
   const ability = def?.ability ? MONSTER_ABILITIES[def.ability] : undefined;
-  const action = ability?.decideAction({ state, r, t, hpRatio, canGuard, monsterDef: def });
+  const action = ability?.decideAction({ state, monster, r, t, hpRatio, canGuard, monsterDef: def });
   if (action) return action;
 
   // plain (ability 無し / null): 通常攻撃 + 低 HP でたまに防御
@@ -1441,7 +1463,7 @@ export function resolveTurn(prev: BattleState, command: Command, turnSeed?: numb
   const events: TurnEvent[] = [];
   // 外部供給 seed があればそれで (サーバー権威: 先読み不可)、無ければ seed 由来 (決定的)。
   const rng = turnSeed === undefined ? turnRng(state.seed, state.turn) : createRng(turnSeed >>> 0);
-  const mCommand = monsterCommand(state, rng);
+  const mCommand = monsterCommand(state.monster, state, rng);
 
   // ── コマンドの実効化 ──
   // MP 不足の特技 / 在庫切れのやくそうは「たたかう」にフォールバック
@@ -1645,12 +1667,59 @@ function randomLiving(arr: readonly Combatant[], rng: () => number): Combatant |
   return living.length ? living[Math.floor(rng() * living.length)] : undefined;
 }
 
+/** マルチ戦闘での敵1体の行動 (#453)。1v1 の monster act と同じ ability (charger/healer/caster) を、
+ *  敵個体の monsterId で引いて実行する。ターゲットはランダムな生存味方 (挑発/かばうは後続)。
+ *  flee は集団戦では意味が薄いので通常攻撃に退避する。 */
+function multiEnemyAct(enemy: Combatant, allies: Combatant[], state: BattleState, rng: () => number, events: TurnEvent[]): void {
+  const t = BATTLE_TUNING;
+  const def = MONSTERS_BY_ID[enemy.monsterId ?? state.monsterId];
+  // ため中なら宣言どおり強攻撃を解放 (mCommand は無視)。
+  if (enemy.charging) {
+    enemy.charging = false;
+    const target = randomLiving(allies, rng);
+    if (target) doAttack(enemy, target, rng, events, 'monster', { power: t.chargedPower, hitBonus: -0.05, label: def?.skillName ?? 'つよいこうげき' });
+    return;
+  }
+  const action = monsterCommand(enemy, state, rng);
+  if (action === 'guard') {
+    enemy.guarding = true; // 被ダメ軽減の宣言 (turn 頭で全体リセット済み)
+    return;
+  }
+  if (action === 'charge') {
+    enemy.mp = Math.max(0, enemy.mp - t.monsterChargeMpCost);
+    enemy.charging = true;
+    events.push({ actor: 'monster', text: `${enemy.name}は力をためている…!` });
+    return;
+  }
+  if (action === 'heal') {
+    enemy.mp = Math.max(0, enemy.mp - t.monsterHealMpCost);
+    const healed = Math.round(enemy.maxHp * t.healerHealRatio);
+    const before = enemy.hp;
+    enemy.hp = Math.min(enemy.maxHp, enemy.hp + healed);
+    events.push({ actor: 'monster', text: `${enemy.name}は${def?.healName ?? 'きずをいやす'}! HP が ${enemy.hp - before} 回復。` });
+    return;
+  }
+  if (action === 'cast' && def?.spell) {
+    enemy.mp = Math.max(0, enemy.mp - t.monsterCastMpCost);
+    const spell = def.spell;
+    const span = spell.max - spell.min;
+    const amount = spell.min + Math.floor(rng() * (span + 1)) + Math.round(enemy.int * (spell.intScale ?? 0));
+    const target = randomLiving(allies, rng);
+    if (target) doMagic(enemy, target, rng, events, 'monster', { amount, ...(spell.element ? { element: spell.element } : {}), label: spell.name });
+    return;
+  }
+  // attack / flee (集団戦は通常攻撃に退避) / spell 未定義の cast。
+  const target = randomLiving(allies, rng);
+  if (target) doAttack(enemy, target, rng, events, 'monster');
+}
+
 /**
  * マルチ戦闘のターン解決 (#453 / docs/25 §14.8)。**allies[] vs enemies[]** を全員 agi+乱数で
  * 並べ、順に行動させる。ソロ用 resolveTurn とは**別経路** (1v1 は一切変更しない)。
  *
  * 現ブロックの AI: プレイヤーは command + skillIndex + targetIndex、召喚/NPC 味方はランダムな敵へ
- * 通常攻撃、敵はランダムな味方へ通常攻撃 (敵の charge/heal ability・挑発/かばうは後続ブロック)。
+ * 通常攻撃、敵は個体ごとの ability (charger/healer/caster) でランダムな味方へ行動 (#453。挑発/かばう・
+ * 味方 autoBattle は後続)。
  */
 export function resolveTurnMulti(
   prev: BattleState,
@@ -1668,6 +1737,8 @@ export function resolveTurnMulti(
   const state: BattleState = { ...prev, turn: prev.turn + 1, allies, enemies, player: allies[0]!, monster: enemies[0]!, lastEvents: [] };
   const sides: CombatSides = { allies, enemies };
   const player = allies[0]!;
+  // ぼうぎょは 1 ターン限り。前ターンから copy された guarding をリセットし、このターンの宣言/AI で立て直す。
+  for (const c of [...allies, ...enemies]) c.guarding = false;
   const isAlly = (c: Combatant) => allies.includes(c);
   const events: TurnEvent[] = [];
   const rng = turnSeed === undefined ? turnRng(state.seed, state.turn) : createRng(turnSeed >>> 0);
@@ -1773,9 +1844,8 @@ export function resolveTurnMulti(
       const target = randomLiving(enemies, rng);
       if (target) doAttack(actor, target, rng, events, 'player');
     } else {
-      // 敵: ランダムな味方へ通常攻撃 (charge/heal ability は後続ブロック)
-      const target = randomLiving(allies, rng);
-      if (target) doAttack(actor, target, rng, events, 'monster');
+      // 敵: 個体ごとの ability (charger/healer/caster) で行動 (#453)。
+      multiEnemyAct(actor, allies, state, rng, events);
     }
 
     if (consumed.length && actor.statuses) actor.statuses = actor.statuses.filter((s) => !consumed.includes(s));


### PR DESCRIPTION
## 概要
マルチ戦 UI (複数敵 vs プレイヤー) を実際に遊べるようにする段階投入の **PR 1/3 (core 基盤)**。エンジン (`resolveTurnMulti`) は #453 で作ったが、**敵が通常攻撃しかせず**、複数敵を生成する経路も無かった。本 PR は **core のみ・live 挙動を一切変えない** (まだ誰も群れを spawn せず、prod は resolveTurn=1v1 のまま)。

## 実装
- `Combatant.monsterId?` を追加 (`monsterCombatant` が `def.id` を載せる)。マルチで敵個体ごとに ability/spell を引くため。1v1 では `state.monsterId` と一致。
- `AbilityDecisionCtx` / `monsterCommand` を**敵個体 (`monster: Combatant`) 引数に refactor** (`state.monster` 直参照を廃し per-enemy 化)。**1v1 は `monsterCommand(state.monster, …)` で完全に挙動不変**。
- `resolveTurnMulti` の敵行動を `multiEnemyAct` に置換: 個体の `monsterId` で ability (charger ため / healer 自己回復 / caster 魔法) を引いて実行。ランダムな生存味方を狙う。flee は集団戦で通常攻撃に退避。ぼうぎょはターン頭で全体リセット。
- `startBattle` に `extraEnemies?` を追加: 群れ (最大 +2 = 計3体) を別 seed で抽選し `allies=[player]`・`enemies=[…]` を設定。**0 (従来) は enemies 未設定 = ソロ完全互換**。

## 段階投入
- **PR 1 (これ)**: core 基盤 (群れ生成 + 敵個体 AI)。live 不変。
- PR 2: edge (群れ遭遇 + `handleTurn` が multi を `resolveTurnMulti` で解決 + 報酬スケール)。
- PR 3: client UI (複数敵表示 + ターゲット選択)。**§3 実機検証が要る**。

## 検証
- core **484 緑** (群れ生成で enemies[]・各敵 monsterId 保持・allies=[player] / **敵個体 caster=night-raven がマルチで魔法を撃つ統合テスト** = per-enemy AI が効いている)
- edge 149 緑 / typecheck (web+edge+core) 緑
- **1v1 (resolveTurn) は一切変更なし・挙動不変** (ability refactor は monsterCommand(state.monster) で同値)

## Review

§1.5 3並列独立レビュー (設計/実装/体験)。**3本とも ★★★/★★(要 in-PR) ゼロ・マージ可**。焦点の 1v1 回帰は無しと構造的に確認、体験は群れ勝率を実測。

### 設計レビュー: ★★★ ゼロ・★★ 1件 (issue)・★ 3件
1v1 不変性を構造的に保証 (`state.monster.monsterId === state.monsterId`・旧 state は `?? state.monsterId` フォールバック)。**prod に群れ spawn 経路が無いことを grep で二重確認 = live 不変**。★★ = 1v1 act と multiEnemyAct の二重管理 drift → **#501**。

### 実装レビュー: ★★★/★★ ゼロ・★ 3件
core 484緑を実機確認。1v1 完全非破壊 (battle.test 93 緑)・決定性 (seed 派生・rng 順序)・参照同期・monsterId 伝播 (copyCombatant)・guard リセット順序すべて正しい。

### 体験・バランスレビュー: ★★★ ゼロ・approve (群れ勝率を実測)
AoE 職 (bard/miko) は pack3 をほぼ無傷制圧・単体特化 warrior は格上 pack3 で 0〜28% = **全体技の存在意義が数値で成立**。tier1×3 は理不尽でない。★★ 2件 (mage は単体技で群れに弱い / caster×3 はボス級) は全て PR2 (edge) 設計要件 → **#502 に実測つきで起票**。

### ★★/★ 対応
- **1v1/multi ロジック二重管理 (drift)** (設計★★) → **#501**。
- **群れ遭遇配分・caster頭数制限・報酬スケール・mage AoE** (体験★★・PR2 設計) → **#502** (実測つき)。
- **冗長 guarding リセット行** (設計/体験★) → **PR 内除去** (commit 6741e90)。
- **multi の charger/healer 直接テスト** (実装★・drift 防止) → **PR 内追加** (commit 6741e90)。
- heal-0 イベント / fleer が群れで通常攻撃退避 / multiEnemyAct guard 無告知 (実装/設計★) → 1v1 踏襲 or PR3 UI で揃える (issue 追跡)。

CI: web-ci pass。core 8 (multi-combat) 緑 / 全 484+ 緑 / edge 149緑 / typecheck 緑。**1v1 (resolveTurn) は一切変更なし・live 挙動不変** (prod は群れを spawn せず resolveTurn=1v1 のまま)。次: PR2 (edge #502) → PR3 (client UI・§3 実機検証)。
