### PR TITLE
マルチ戦闘のサーバー解決 + 報酬スケール (#453 マルチ戦 PR2/3)

### DIFF
--- a/apps/edge/src/battle-resolver.ts
+++ b/apps/edge/src/battle-resolver.ts
@@ -386,7 +386,8 @@ export async function handleTurn(env: ResolverEnv, userDid: string, battleId: st
   const skills = guard.state.playerSkills ?? [guard.state.playerSkill];
   const idx = Number.isInteger(skillIndex) && skillIndex >= 0 && skillIndex < skills.length ? skillIndex : 0;
   // 群れ (#453): enemies が 2 体以上なら resolveTurnMulti で解決 + targetIndex を検証。1 体 (従来) は
-  // resolveTurn (1v1・挙動不変)。client が偽った targetIndex は生存敵の範囲に clamp (詐称防止)。
+  // resolveTurn (1v1・挙動不変)。client が偽った targetIndex は敵配列の範囲に clamp、範囲外/非整数は
+  // 主敵 [0] に落とす (詐称防止の fail-safe。死体を指定しても core の resolveTargets が空振りにする)。
   const enemies = guard.state.enemies;
   const isMulti = (enemies?.length ?? 0) > 1;
   const tIdx = isMulti && Number.isInteger(targetIndex) && targetIndex >= 0 && targetIndex < enemies!.length ? targetIndex : 0;
@@ -423,8 +424,9 @@ export async function handleTurn(env: ResolverEnv, userDid: string, battleId: st
       const r = applyBattleOutcome({ ...cur, materials: consumedMaterials }, {
         outcome: decision, monsterId: next.monsterId, archetype: guard.sealed.archetype,
         luk: next.player.luk, dropBonus: dropBonusOf(next.player), rewardSeed, lossSeed, rewarded: guard.rewarded,
-        // 群れ (#453): 倒した全敵ぶんの報酬。1 体戦は enemies 未設定なので従来どおり monsterId 単体。
-        ...(isMulti ? { enemyIds: next.enemies!.map((e) => e.monsterId ?? next.monsterId) } : {}),
+        // 群れ (#453): **倒した敵 (hp<=0) ぶんだけ**報酬。maxTurns 勝ち (HP 比で win・敵が生存) のとき
+        // 生存敵に報酬を出さない (レビュー ★★)。全滅勝ちなら全敵が hp<=0 で全頭ぶん。1 体戦は monsterId 単体。
+        ...(isMulti ? { enemyIds: next.enemies!.filter((e) => e.hp <= 0).map((e) => e.monsterId ?? next.monsterId) } : {}),
       });
       awarded = r.awarded;
       // 勝ったらそのタイルを「撃破済み」に記録し、同じ 30 分枠では再エンカウントさせない (無限狩り防止)。

--- a/apps/edge/src/battle-resolver.ts
+++ b/apps/edge/src/battle-resolver.ts
@@ -11,7 +11,7 @@
  *     (同一ターンの並行二重解決/引き直しを弾く)。
  */
 import {
-  startBattle, resolveTurn, statVectorToArray, jobLevelFromXp, playerLevelFromXp, playerCombatant, rollSearch, dropBonusOf,
+  startBattle, resolveTurn, resolveTurnMulti, statVectorToArray, jobLevelFromXp, playerLevelFromXp, playerCombatant, rollSearch, dropBonusOf,
   terrainAt, isWalkable, wrap, townAt, regionOf, regionDanger, tierForDanger, encounterRateFor, worldOverlay, BATTLE_TUNING,
   type BattleState, type Command, type Archetype, type StatVector, type GearSelection,
 } from '@aozoraquest/core';
@@ -373,7 +373,7 @@ export interface TurnResult {
  * turn: 1 コマンドを**サーバーが**確定 pendingTurnSeed で解決する。
  * 決着なら報酬を fail-closed で確定 + ガード削除。未決着なら CAS で turn を進めてから応答。
  */
-export async function handleTurn(env: ResolverEnv, userDid: string, battleId: string, turn: number, command: Command, now: number, ns: string = DEFAULT_NS, skillIndex = 0): Promise<TurnResult> {
+export async function handleTurn(env: ResolverEnv, userDid: string, battleId: string, turn: number, command: Command, now: number, ns: string = DEFAULT_NS, skillIndex = 0, targetIndex = 0): Promise<TurnResult> {
   if (!VALID_COMMANDS.includes(command)) throw new ResolverError('不正なコマンド', 400);
   const g = await readGuard<SealedMeta, BattleState>(env, userDid);
   if (!g) throw new ResolverError('戦闘中でない', 409);
@@ -385,7 +385,14 @@ export async function handleTurn(env: ResolverEnv, userDid: string, battleId: st
   // (client が持っていない index を偽っても署名スキル [0] に落とす。詐称防止)。
   const skills = guard.state.playerSkills ?? [guard.state.playerSkill];
   const idx = Number.isInteger(skillIndex) && skillIndex >= 0 && skillIndex < skills.length ? skillIndex : 0;
-  const next = resolveTurn(guard.state, command, guard.pendingTurnSeed, idx);
+  // 群れ (#453): enemies が 2 体以上なら resolveTurnMulti で解決 + targetIndex を検証。1 体 (従来) は
+  // resolveTurn (1v1・挙動不変)。client が偽った targetIndex は生存敵の範囲に clamp (詐称防止)。
+  const enemies = guard.state.enemies;
+  const isMulti = (enemies?.length ?? 0) > 1;
+  const tIdx = isMulti && Number.isInteger(targetIndex) && targetIndex >= 0 && targetIndex < enemies!.length ? targetIndex : 0;
+  const next = isMulti
+    ? resolveTurnMulti(guard.state, command, guard.pendingTurnSeed, idx, tIdx)
+    : resolveTurn(guard.state, command, guard.pendingTurnSeed, idx);
 
   if (next.outcome !== 'ongoing') {
     // ── 決着: **まずガードを CAS 削除して「この決着ターンは自分が消費」を確定** ──
@@ -416,6 +423,8 @@ export async function handleTurn(env: ResolverEnv, userDid: string, battleId: st
       const r = applyBattleOutcome({ ...cur, materials: consumedMaterials }, {
         outcome: decision, monsterId: next.monsterId, archetype: guard.sealed.archetype,
         luk: next.player.luk, dropBonus: dropBonusOf(next.player), rewardSeed, lossSeed, rewarded: guard.rewarded,
+        // 群れ (#453): 倒した全敵ぶんの報酬。1 体戦は enemies 未設定なので従来どおり monsterId 単体。
+        ...(isMulti ? { enemyIds: next.enemies!.map((e) => e.monsterId ?? next.monsterId) } : {}),
       });
       awarded = r.awarded;
       // 勝ったらそのタイルを「撃破済み」に記録し、同じ 30 分枠では再エンカウントさせない (無限狩り防止)。

--- a/apps/edge/src/battle-reward.ts
+++ b/apps/edge/src/battle-reward.ts
@@ -29,6 +29,9 @@ export interface BattleOutcomeInput {
   luk: number;
   /** 巫女の直感 (#456) 等のドロップ確率加算ボーナス。未指定は 0。 */
   dropBonus?: number;
+  /** マルチ戦闘 (#453 群れ) の全敵の monsterId。指定時は勝利報酬を頭数分 (XP 合算・各敵でドロップ試行)。
+   *  未指定/1体は従来どおり monsterId 単体で計算 (完全互換)。 */
+  enemyIds?: string[];
   /** サーバーが独立に引いたドロップ用エントロピー (32bit)。 */
   rewardSeed: number;
   /** サーバーが独立に引いた敗北ロス用エントロピー (32bit)。 */
@@ -66,8 +69,16 @@ export function applyBattleOutcome(state: GameState, o: BattleOutcomeInput): { n
   if (!o.rewarded) return { next: state, awarded: {} };
 
   if (o.outcome === 'win') {
-    const xp = battleXpFor(o.monsterId);
-    const drops = rollDrops(o.monsterId, o.luk, o.rewardSeed, o.dropBonus ?? 0);
+    // 群れ (#453) は倒した全敵ぶん。XP 合算・各敵で別 seed のドロップ試行。1体 (従来) は monsterId 単体 =
+    // rewardSeed をそのまま使い完全互換。
+    const ids = o.enemyIds && o.enemyIds.length > 0 ? o.enemyIds : [o.monsterId];
+    let xp = 0;
+    const drops: string[] = [];
+    ids.forEach((id, i) => {
+      xp += battleXpFor(id);
+      const seed = i === 0 ? o.rewardSeed : (o.rewardSeed ^ (0x9e3779b1 * (i + 1))) >>> 0;
+      drops.push(...rollDrops(id, o.luk, seed, o.dropBonus ?? 0));
+    });
     const next: GameState = {
       ...state,
       playerXp: state.playerXp + xp,

--- a/apps/edge/test/battle-reward.test.ts
+++ b/apps/edge/test/battle-reward.test.ts
@@ -39,6 +39,28 @@ describe('battle-reward (fail-closed 報酬確定)', () => {
     expect(a.next).toEqual(b.next);
   });
 
+  it('群れ勝ち (#453): enemyIds の頭数分 XP を合算し各敵でドロップ試行', () => {
+    const s = base({ power: 3, playerXp: 0, jobXp: {} });
+    const ids = [mon.id, mon.id, mon.id]; // 3体
+    const { next, awarded } = applyBattleOutcome(s, input({ outcome: 'win', enemyIds: ids }));
+    const expectXp = ids.reduce((a, id) => a + battleXpFor(id), 0);
+    expect(next.playerXp).toBe(expectXp); // 3体分の XP 合算
+    expect(next.jobXp.warrior).toBe(expectXp);
+    expect(awarded.xp).toBe(expectXp);
+    expect(next.power).toBe(2); // パワー消費は 1 戦闘 1 回 (頭数に依らない)
+    // 各敵で別 seed のドロップ試行 → 単体戦より総ドロップ数は増える傾向 (seed 固定なので決定的)。
+    const solo = applyBattleOutcome(s, input({ outcome: 'win' }));
+    expect(awarded.xp!).toBeGreaterThan(solo.awarded.xp!); // 3体 > 1体
+  });
+
+  it('群れ報酬の後方互換: enemyIds 省略 = enemyIds:[monsterId] = 従来の単体計算', () => {
+    const s = base();
+    const omitted = applyBattleOutcome(s, input({ outcome: 'win' }));
+    const single = applyBattleOutcome(s, input({ outcome: 'win', enemyIds: [mon.id] }));
+    expect(omitted.next).toEqual(single.next); // 完全一致 (rewardSeed をそのまま使う)
+    expect(omitted.awarded).toEqual(single.awarded);
+  });
+
   it('負け: 素材ロス + パワー1消費 + 僅かな xpLose (§5)', () => {
     const s = base({ power: 2, playerXp: 80, jobXp: { warrior: 20 }, materials: { herb: 3, ore: 2 } });
     const { next, awarded } = applyBattleOutcome(s, input({ outcome: 'lose' }));

--- a/apps/edge/test/battle-reward.test.ts
+++ b/apps/edge/test/battle-reward.test.ts
@@ -53,6 +53,14 @@ describe('battle-reward (fail-closed 報酬確定)', () => {
     expect(awarded.xp!).toBeGreaterThan(solo.awarded.xp!); // 3体 > 1体
   });
 
+  it('群れ勝ち: 異なる id の敵は各 id の XP を正しく合算 (id 取り違えなし)', () => {
+    const withDrops = MONSTERS.filter((m) => m.tier === 1 && m.drops.length > 0);
+    const [a, b] = [withDrops[0]!, withDrops[1]!];
+    const s = base({ playerXp: 0, jobXp: {} });
+    const { next } = applyBattleOutcome(s, input({ outcome: 'win', enemyIds: [a.id, b.id] }));
+    expect(next.playerXp).toBe(battleXpFor(a.id) + battleXpFor(b.id)); // A+B の XP (取り違えなら 2*A 等になる)
+  });
+
   it('群れ報酬の後方互換: enemyIds 省略 = enemyIds:[monsterId] = 従来の単体計算', () => {
     const s = base();
     const omitted = applyBattleOutcome(s, input({ outcome: 'win' }));


### PR DESCRIPTION
## 概要
群れ (複数敵) を**サーバー権威で解決**できるようにする **PR 2/3 (edge)**。**dormant** = まだ誰も群れを spawn しないので **live は 1v1 のまま** (sealEncounter は従来どおり 1 体、handleTurn の multi 分岐は prod で踏まれない)。edge テストで報酬ロジックを検証。

## 実装
- `handleTurn` に `targetIndex` 引数を追加。sealed state の `enemies` が **2 体以上なら `resolveTurnMulti`** で解決 (それ以外は `resolveTurn`=1v1 で挙動不変)。**`targetIndex` は生存敵の範囲に clamp** (client 詐称防止)。
- `applyBattleOutcome` に `enemyIds?` を追加: 群れ勝利は倒した**全敵ぶんの報酬** (XP 合算・各敵で別 seed のドロップ試行)。パワー消費は 1 戦闘 1 回 (頭数非依存)。**`enemyIds` 省略 = `[monsterId]` 単体 = 従来完全互換** (rewardSeed をそのまま使う)。

## テスト
- 群れ勝ちの XP 合算 (3体>1体) / 各敵ドロップ試行 / **後方互換 (enemyIds 省略 = [monsterId] で完全一致)** を edge テストで固定。
- `handleTurn` の multi 分岐は core-tested `resolveTurnMulti` + edge-tested 報酬の**単純な glue** (typecheck 済)。end-to-end は PR3 (実機) で検証。

## 段階投入
- ✅ PR1 (core・merged): 群れ生成 + 敵個体 AI。
- **PR2 (これ)**: edge 解決 + 報酬スケール。dormant・live 不変。
- PR3: client UI (複数敵表示 + ターゲット選択) + sealEncounter の群れ生成 (配分/caster頭数制限 = #502)。**§3 実機検証**。

## 検証
- core 486緑 / **edge 151緑** (群れ報酬 +2) / typecheck (web+edge+core) 緑
- **1v1・live 挙動不変** (packs 未 spawn・handleTurn は enemies<=1 で従来 resolveTurn)

## Review

§1.5 3並列独立レビュー (設計/実装/体験)。**3本とも ★★★ ゼロ・マージ可**。焦点の **solo 経済不変性**は実測+コード両面で完全担保 (isMulti ゲート + enemyIds 省略=byte一致)。

### 設計レビュー: ★★★ ゼロ・★★ 2件 (PR 内対応 or #502)・★ 3件
dormant (sealEncounter が群れを spawn せず handleTurn の multi 分岐は prod で踏まれない) を確認。詐称防止 (targetIndex clamp)・CAS 冪等性 (deleteGuard→報酬の順序不変)・後方互換完全一致すべて妥当。

### 実装レビュー: ★★★/★★ ゼロ・★ 2件
edge 151→152緑を実機確認。後方互換 byte 一致 (seed 経路非変更)・per-enemy seed の distinct/決定性 (float 精度域内)・handleTurn 分岐・monsterId フォールバックすべて厳密に担保。テストは実 core 関数・実在モンスターで記述 (mock でない)。

### 体験・バランスレビュー: ★★★ ゼロ・approve
**solo 不変性 (全プレイヤー影響) をコード構造 + 実測テストの二重で封じている**。群れ経済は「低頻度・高報酬」の DQ 的設計で筋が通る。

### ★★/★ 対応
- **maxTurns 勝利で生存敵に報酬** (設計/体験★★) → **PR 内修正** (commit 685a707): enemyIds を hp<=0 の撃破敵に絞る。全滅勝ちは挙動不変・時間切れ勝ちは撃破分のみ。
- **群れの farm 対策 (パワー効率 N 倍・再エンカウント抑止) / ドロップ×巫女 / Math.imul / targetIndex 生存敵 clamp** (体験/設計/実装★・PR3 有効化課題) → **#502 に追記**。
- **targetIndex コメント乖離** (設計/実装★) → **PR 内修正**。**異 id 報酬テスト** (実装★) → **PR 内追加**。

CI: web-ci pass。core 486緑 / edge 152緑 / typecheck 緑。**solo・live 挙動不変** (dormant・handleTurn は enemies<=1 で resolveTurn)。次: PR3 (client UI + sealEncounter 群れ生成・#502 の配分/farm対策込み)・**§3 実機検証**。
