### PR TITLE
模擬戦にマルチ戦モード — 群れの操作感を dev で確認 (#453 PR3a)

### DIFF
--- a/apps/web/src/components/debug-battle-sim.tsx
+++ b/apps/web/src/components/debug-battle-sim.tsx
@@ -267,7 +267,7 @@ export function DebugBattleSim() {
             const multi = (duel.enemies?.length ?? 1) > 1;
             const targeted = multi && !dead && liveTarget(duel) === i;
             return (
-              <div key={i} style={{ display: 'flex', alignItems: 'center', gap: '0.4em', opacity: dead ? 0.4 : 1 }}>
+              <div key={i} style={{ display: 'flex', alignItems: 'center', gap: '0.4em', opacity: dead ? 0.4 : 1, background: targeted ? 'rgba(211,51,51,0.12)' : undefined, borderRadius: 3 }}>
                 {multi && !dead && (
                   <button
                     onClick={() => setTargetIndex(i)}

--- a/apps/web/src/components/debug-battle-sim.tsx
+++ b/apps/web/src/components/debug-battle-sim.tsx
@@ -11,6 +11,7 @@ import {
   isPureHealSkill,
   jobDisplayName,
   resolveTurn,
+  resolveTurnMulti,
   runAutoBattle,
   skillMpCostOf,
   startBattle,
@@ -77,6 +78,9 @@ export function DebugBattleSim() {
   const [trials, setTrials] = useState(300);
   const [batch, setBatch] = useState<BatchResult | null>(null);
   const [duel, setDuel] = useState<BattleState | null>(null);
+  // #453 マルチ戦: 追加の敵数 (0=ソロ, 1〜2 で計 2〜3 体) と単体技のターゲット (敵 index)。
+  const [extraEnemies, setExtraEnemies] = useState(0);
+  const [targetIndex, setTargetIndex] = useState(0);
 
   const enemy = MONSTERS_BY_ID[enemyId]!;
   const gear = useMemo<GearSelection>(
@@ -86,7 +90,8 @@ export function DebugBattleSim() {
 
   /** 1 戦を開始 (variance を指定)。tier は敵に付随 (monsterId 固定なので抽選はされない)。
    *  入力は clampInt で NaN/範囲外を潰してから渡す。 */
-  const start = (seed: number, variance: number): BattleState =>
+  // extra = 追加の敵数。バッチ (runAutoBattle) は 1v1 専用なので 0 固定で呼ぶ (群れ統計は未対応)。
+  const start = (seed: number, variance: number, extra = clampInt(extraEnemies, 0, 0, 2)): BattleState =>
     startBattle(
       job,
       clampInt(jobLv, 1, 1, 50),
@@ -96,7 +101,7 @@ export function DebugBattleSim() {
       seed,
       clampInt(herbs, 0, 0, WORLD_HERB_MAX),
       undefined,
-      { monsterId: enemyId, gear, tonics: clampInt(tonics, 0, 0, WORLD_TONIC_MAX), vitalsVariance: variance },
+      { monsterId: enemyId, gear, tonics: clampInt(tonics, 0, 0, WORLD_TONIC_MAX), vitalsVariance: variance, extraEnemies: extra },
     );
 
   const runBatch = () => {
@@ -107,7 +112,7 @@ export function DebugBattleSim() {
     let turnSum = 0;
     let hpPctSum = 0;
     for (let seed = 0; seed < n; seed++) {
-      const end = runAutoBattle(start(seed, BATTLE_TUNING.monsterVitalsVariance)); // world と同じ分散
+      const end = runAutoBattle(start(seed, BATTLE_TUNING.monsterVitalsVariance, 0)); // 1v1 統計 (群れは未対応)
       turnSum += end.turn;
       if (end.outcome === 'win') {
         wins++;
@@ -138,14 +143,26 @@ export function DebugBattleSim() {
   const freshSeed = () => Date.now();
   const startDuel = () => {
     setBatch(null);
+    setTargetIndex(0);
     // 初期 seed は固定でよい: monsterId 固定 + variance 0 なので敵ステータスは seed 非依存で一定
     // (summonMonster を通らず monsterCombatant の jitter も効かない)。戦闘中の乱数だけ下で新鮮に。
     setDuel(start(1, 0));
   };
+  // #453: 群れ (enemies が複数) なら resolveTurnMulti + targetIndex、それ以外は 1v1 resolveTurn。
+  const isMultiDuel = (s: BattleState) => (s.enemies?.length ?? 0) > 1;
+  // 狙う敵が倒れていたら生存する先頭に寄せる (単体技の空振りを避ける)。
+  const liveTarget = (s: BattleState) => {
+    const es = s.enemies ?? [s.monster];
+    if ((es[targetIndex]?.hp ?? 0) > 0) return targetIndex;
+    const i = es.findIndex((e) => e.hp > 0);
+    return i >= 0 ? i : 0;
+  };
+  const step = (s: BattleState, cmd: Command, skillIndex: number): BattleState =>
+    isMultiDuel(s) ? resolveTurnMulti(s, cmd, freshSeed(), skillIndex, liveTarget(s)) : resolveTurn(s, cmd, freshSeed(), skillIndex);
   const duelCmd = (cmd: Command, skillIndex = 0) =>
-    setDuel((s) => (s && s.outcome === 'ongoing' ? resolveTurn(s, cmd, freshSeed(), skillIndex) : s));
+    setDuel((s) => (s && s.outcome === 'ongoing' ? step(s, cmd, skillIndex) : s));
   const duelAuto = () =>
-    setDuel((s) => (s && s.outcome === 'ongoing' ? resolveTurn(s, autoBattleCommand(s), freshSeed()) : s));
+    setDuel((s) => (s && s.outcome === 'ongoing' ? step(s, autoBattleCommand(s), 0) : s));
 
   const pct = (x: number) => `${Math.round(x * 100)}%`;
 
@@ -203,6 +220,13 @@ export function DebugBattleSim() {
             <input type="number" min={0} max={WORLD_TONIC_MAX} value={tonics} onChange={(e) => setTonics(Number(e.target.value))} style={{ width: '3em' }} />
           </span>
         </label>
+        <label>追加の敵 (#453 群れ・1戦のみ)
+          <select value={extraEnemies} onChange={(e) => setExtraEnemies(Number(e.target.value))} style={{ width: '100%' }}>
+            <option value={0}>0 (ソロ 1 体)</option>
+            <option value={1}>+1 (計 2 体)</option>
+            <option value={2}>+2 (計 3 体)</option>
+          </select>
+        </label>
       </div>
 
       <div style={{ display: 'flex', gap: '0.5em', alignItems: 'center', marginTop: '0.6em', flexWrap: 'wrap' }}>
@@ -231,9 +255,35 @@ export function DebugBattleSim() {
       {/* 1 戦プレイ (本番同様の per-turn 乱数) */}
       {duel && (
         <div className="dq-window" style={{ marginTop: '0.6em', fontSize: '0.82em', padding: '0.6em 0.8em' }}>
-          <div style={{ fontWeight: 700 }}>{`${jobDisplayName(job)} vs ${duel.monster.name}`}</div>
+          <div style={{ fontWeight: 700 }}>
+            {`${jobDisplayName(job)} vs `}
+            {(duel.enemies ?? [duel.monster]).map((e) => e.name).join('・')}
+            {(duel.enemies?.length ?? 1) > 1 ? ` (${duel.enemies!.length}体)` : ''}
+          </div>
           <div>じぶん HP {duel.player.hp}/{duel.player.maxHp} · MP {duel.player.mp}/{duel.player.maxMp} · やくそう{duel.herbs} しずく{duel.tonics}</div>
-          <div>てき HP {duel.monster.hp}/{duel.monster.maxHp}{duel.monster.charging ? ' · ⚡ため中' : ''}</div>
+          {/* 敵は複数対応: 各敵の HP + ⚡ため中。群れでは単体技の「狙う」対象を選ぶ (生存敵のみ)。 */}
+          {(duel.enemies ?? [duel.monster]).map((e, i) => {
+            const dead = e.hp <= 0;
+            const multi = (duel.enemies?.length ?? 1) > 1;
+            const targeted = multi && !dead && liveTarget(duel) === i;
+            return (
+              <div key={i} style={{ display: 'flex', alignItems: 'center', gap: '0.4em', opacity: dead ? 0.4 : 1 }}>
+                {multi && !dead && (
+                  <button
+                    onClick={() => setTargetIndex(i)}
+                    title="この敵を単体技/たたかうの対象にする"
+                    style={{ fontSize: '0.75em', padding: '0 0.4em', border: targeted ? '2px solid var(--color-accent, #d33)' : '1px solid #999', borderRadius: 3 }}
+                  >
+                    {targeted ? '◉狙う' : '狙う'}
+                  </button>
+                )}
+                <span>
+                  てき{multi ? i + 1 : ''} {e.name} HP {Math.max(0, e.hp)}/{e.maxHp}
+                  {e.charging ? ' · ⚡ため中' : ''}{dead ? ' · ✕' : ''}
+                </span>
+              </div>
+            );
+          })}
           <div style={{ margin: '0.3em 0', minHeight: '2.4em', color: 'var(--color-muted)' }}>
             {duel.lastEvents.map((ev, i) => (<div key={i}>{ev.text}</div>))}
           </div>


### PR DESCRIPTION
## 概要
マルチ戦 UI の前段。まず管理者デバッグ模擬戦 (/spirit) で群れの操作感 (複数敵表示・ターゲット選択) を固める (オーナー判断: 先に安全な dev ツールで UX を詰めてから live 経路へ)。**client のみ・live 経路 (world/edge) は一切触らない**。

## 実装
- **「追加の敵 (0/+1/+2)」** を追加。1戦プレイで `startBattle` の `extraEnemies` に渡し計 2〜3 体の群れを組む。
- 1戦プレイの解決を group 対応: `enemies` が複数なら `resolveTurnMulti` (+ targetIndex)、それ以外は従来 `resolveTurn` (1v1 挙動不変)。狙う敵が倒れていたら生存先頭に寄せる (単体技の空振り回避)。
- **敵表示を複数対応**: 各敵の HP・⚡ため中・✕(撃破)、群れでは **「狙う」で単体技/たたかうの対象を選ぶ** (生存敵のみ・現在対象は ◉)。
- バッチ (runAutoBattle=1v1 専用) は `extraEnemies=0` 固定で 1v1 統計のまま (群れ統計は未対応と明示)。

## 段階投入
- ✅ PR1 (core・merged) / ✅ PR2 (edge・merged): マルチ戦エンジン + サーバー解決 (dormant)。
- **PR3a (これ)**: dev 模擬戦でマルチ戦を**遊べる化** — 操作感/ターゲット選択 UX の確認用。live 不変。
- PR3b: world UI (複数敵表示 + ターゲット選択) + sealEncounter 群れ生成 (#502)。**§3 実機検証**。

## 確認のお願い (dev)
dev マージ後、**/spirit の管理者「模擬戦」→「追加の敵」で +1/+2 → 1戦プレイ**で:
- 複数敵の HP・ため中・撃破が見やすいか
- 「狙う」で単体技のターゲットを選ぶ操作が分かりやすいか
- 全体技 (bard ディスコード等) が全敵に効くか
を触って、world UI (PR3b) に持っていく UX を決めたいです。

## 検証
- web **346 緑** / typecheck 緑。**live 経路 (world/edge) は不変** (デバッグツールのみ)。

## Review

§1.5 レビュー (dev ツールだがロジック=マルチ解決/ターゲット選択が絡むため 実装 + UX)。**両方 ★★★/★★ ゼロ・マージ可**。

### 実装レビュー: ★★★/★★ ゼロ・★ 3件
typecheck 緑。**1v1 不変性** (extraEnemies=0 で従来 resolveTurn・バッチ extra=0 固定)・liveTarget の演算子優先順位・範囲外/全滅フォールバック・非null ガード・**React クロージャ (毎レンダー再生成で最新 targetIndex)** すべて正しいと確認。★ = duelAuto の multi 注記 / liveTarget 二度呼び / start デフォルト引数の可読性 (任意)。

### UX レビュー: ★★★ ゼロ・★★ 2件 (PR3b 申し送り)・★ 3件
エンジンの全体/単体振り分けに UI が乗る設計は正しい (単体技は targetIndex・全体技は runSkillMulti が自前)。liveTarget の表示⇄着弾一致・敵名の「てき1/てき2」番号付け・撃破の opacity+✕ すべて妥当。ソロ時に番号/狙うボタンを出さない条件分岐も後方互換に配慮。

### ★★/★ 対応
- **PR3b (live world UI) の UX 要件** (UX★★): 全体/単体技の視覚区別 / 対象撃破時のカーソル移動を明示 / モバイルは「たたかう・とくぎ選択後に敵タップ」の2段方式 / 選択行ハイライト / 撃破敵フェード → **issue #505 に記録** (この PR3a で型は成立・live 移植時に追加)。
- **選択行の背景ハイライト** (UX★) → **PR 内試作** (commit c32cd0b)。
- 実装 ★ (duelAuto 注記等) → 任意・dev ツールの割り切りとして許容。

## 確認のお願い (dev マージ後)
**/spirit の管理者「模擬戦」→「追加の敵 +1/+2」→ 1戦プレイ**で群れの操作感 (複数敵表示・「狙う」ターゲット選択・全体技が全敵に効くか) を触ってください。ここで得た UX を PR3b (live world UI・#505) に反映します。

CI: web-ci pass。web 346緑 / typecheck 緑。**live 経路 (world/edge) は不変** (デバッグツールのみ)。
