### PR TITLE
管理者が自分のジョブを即変更 (キット/パッシブ確認用)

### DIFF
--- a/apps/web/src/components/admin/job-change-admin.tsx
+++ b/apps/web/src/components/admin/job-change-admin.tsx
@@ -11,8 +11,9 @@ import { adminSetJob } from '@/lib/post-processor';
  *
  * confirmJobChange と同じく**本人の PDS (analysis/self) を本人トークンで書く**ので、サーバー権威の
  * 詐称にならない (通常プレイヤーも再診断で自分の archetype を書き換える)。表示ゲートは admin-dashboard
- * の `WORLD_PREVIEW_ENABLED && isAdminDid`。次の戦闘から新ジョブが適用される (進行中の戦闘ガードは
- * sealed.archetype で封印済みなので、切替後に新ジョブで戦うには一度戦闘を終える or リセットが要る)。
+ * の `WORLD_PREVIEW_ENABLED && isAdminDid`。**次の戦闘から新ジョブが適用される** (edge は戦闘開始時に
+ * analysis の archetype を読んでガードに封じるため、進行中の戦闘は旧ジョブのまま・切替後に新ジョブで
+ * 戦うには一度戦闘を終える)。
  */
 export function JobChangeAdmin({ agent, did }: { agent: Agent; did: string }) {
   const [current, setCurrent] = useState<{ archetype: Archetype; jobLevel: number } | null>(null);
@@ -64,7 +65,15 @@ export function JobChangeAdmin({ agent, did }: { agent: Agent; did: string }) {
         </select>
         <label>
           Lv
-          <input type="number" min={1} max={50} value={level} onChange={(e) => setLevel(Number(e.target.value))} disabled={busy} style={{ width: '3.5em', marginLeft: '0.3em' }} />
+          <input
+            type="number"
+            min={1}
+            max={50}
+            value={level}
+            onChange={(e) => { const n = Number(e.target.value); setLevel(Number.isFinite(n) ? n : 1); }}
+            disabled={busy}
+            style={{ width: '3.5em', marginLeft: '0.3em' }}
+          />
         </label>
         <button type="button" disabled={busy} onClick={() => void apply()} style={{ padding: '0.2em 0.7em' }}>
           {busy ? '変更中…' : 'このジョブに変更'}

--- a/apps/web/src/components/admin/job-change-admin.tsx
+++ b/apps/web/src/components/admin/job-change-admin.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react';
+import type { Agent } from '@atproto/api';
+import { ARCHETYPES, jobDisplayName, jobLevelFromXp, type Archetype, type DiagnosisResult } from '@aozoraquest/core';
+import { COL } from '@/lib/collections';
+import { getRecord } from '@/lib/atproto';
+import { adminSetJob } from '@/lib/post-processor';
+
+/**
+ * 管理者用 (dev): 自分のジョブ (archetype) と現職レベルを即座に切り替える。
+ * 各ジョブのキット / Lv30 パッシブを実プレイで確かめる用途 (#456)。
+ *
+ * confirmJobChange と同じく**本人の PDS (analysis/self) を本人トークンで書く**ので、サーバー権威の
+ * 詐称にならない (通常プレイヤーも再診断で自分の archetype を書き換える)。表示ゲートは admin-dashboard
+ * の `WORLD_PREVIEW_ENABLED && isAdminDid`。次の戦闘から新ジョブが適用される (進行中の戦闘ガードは
+ * sealed.archetype で封印済みなので、切替後に新ジョブで戦うには一度戦闘を終える or リセットが要る)。
+ */
+export function JobChangeAdmin({ agent, did }: { agent: Agent; did: string }) {
+  const [current, setCurrent] = useState<{ archetype: Archetype; jobLevel: number } | null>(null);
+  const [pick, setPick] = useState<Archetype>('warrior');
+  const [level, setLevel] = useState(30); // 既定 30 = Lv30 パッシブをすぐ試せる
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getRecord<DiagnosisResult>(agent, did, COL.analysis, 'self')
+      .then((a) => {
+        if (cancelled || !a) return;
+        const jl = jobLevelFromXp(a.jobLevel?.xp ?? 0);
+        setCurrent({ archetype: a.archetype, jobLevel: jl });
+        setPick(a.archetype);
+      })
+      .catch((e) => console.warn('admin job load failed', e));
+    return () => { cancelled = true; };
+  }, [agent, did]);
+
+  const apply = async () => {
+    setBusy(true);
+    setMsg(null);
+    try {
+      const next = await adminSetJob(agent, did, pick, level);
+      if (!next) { setMsg('診断レコードが無い (先に診断が要る)'); return; }
+      const jl = jobLevelFromXp(next.jobLevel?.xp ?? 0);
+      setCurrent({ archetype: next.archetype, jobLevel: jl });
+      setMsg(`${jobDisplayName(next.archetype)} Lv${jl} に変更した`);
+    } catch (e) {
+      console.warn('admin job change failed', e);
+      setMsg('変更に失敗した (コンソール参照)');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <section style={{ marginTop: '2em' }}>
+      <h3 style={{ fontSize: '0.95em' }}>ジョブ変更 (自分・テスト)</h3>
+      <p style={{ fontSize: '0.8em', color: 'var(--color-muted)', marginBottom: '0.5em' }}>
+        自分のジョブとレベルを即切替 (キット / Lv30 パッシブ確認用)。次の戦闘から反映。
+        {current && <> 現在: <b>{jobDisplayName(current.archetype)}</b> Lv{current.jobLevel}</>}
+      </p>
+      <div style={{ display: 'inline-flex', gap: '0.5em', alignItems: 'center', flexWrap: 'wrap', fontSize: '0.85em' }}>
+        <select value={pick} onChange={(e) => setPick(e.target.value as Archetype)} disabled={busy}>
+          {ARCHETYPES.map((a) => (<option key={a} value={a}>{jobDisplayName(a)}</option>))}
+        </select>
+        <label>
+          Lv
+          <input type="number" min={1} max={50} value={level} onChange={(e) => setLevel(Number(e.target.value))} disabled={busy} style={{ width: '3.5em', marginLeft: '0.3em' }} />
+        </label>
+        <button type="button" disabled={busy} onClick={() => void apply()} style={{ padding: '0.2em 0.7em' }}>
+          {busy ? '変更中…' : 'このジョブに変更'}
+        </button>
+        {msg && <span style={{ color: 'var(--color-muted)' }}>{msg}</span>}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/admin/job-change-admin.tsx
+++ b/apps/web/src/components/admin/job-change-admin.tsx
@@ -43,7 +43,7 @@ export function JobChangeAdmin({ agent, did }: { agent: Agent; did: string }) {
       if (!next) { setMsg('診断レコードが無い (先に診断が要る)'); return; }
       const jl = jobLevelFromXp(next.jobLevel?.xp ?? 0);
       setCurrent({ archetype: next.archetype, jobLevel: jl });
-      setMsg(`${jobDisplayName(next.archetype)} Lv${jl} に変更した`);
+      setMsg(`${jobDisplayName(next.archetype)} Lv${jl} に変更 (戦闘中なら次戦から)`);
     } catch (e) {
       console.warn('admin job change failed', e);
       setMsg('変更に失敗した (コンソール参照)');

--- a/apps/web/src/lib/post-processor.ts
+++ b/apps/web/src/lib/post-processor.ts
@@ -355,11 +355,12 @@ export async function confirmJobChange(agent: Agent, did: string, newArchetype: 
 
 /**
  * 管理者用: 自分のジョブを即座に任意の archetype + jobLevel に切り替える (dev の /admin から)。
- * confirmJobChange と同じく本人の PDS (analysis/self) を本人トークンで書く = サーバー権威の詐称に
- * ならない (通常プレイヤーも再診断で自分の archetype を書き換える)。各ジョブのキット/パッシブ
- * (特に Lv30) を実プレイで確かめるため、jobLevel を目標レベルの XP しきい値で直接セットする。
- * playerLevel (個人累積) は維持。pending 転職候補はクリア。反映は次の戦闘から (edge が戦闘開始時に
- * analysis の archetype を読む — 進行中の戦闘は旧ジョブのまま)。
+ * confirmJobChange と同じく本人の PDS (analysis/self) を本人トークンで書く。**新しい攻撃面は増やさない**:
+ * edge は戦闘開始時に本人 analysis の archetype/jobLevel.xp を**無検証で権威値として読む** (battle-resolver.ts /
+ * docs/21 §6-4 の既知の未解決事項。真の偽造対策は M4)。よって本人が任意 Lv を書ける状態は元々あり
+ * (zeroAnalysisXp や直接 putRecord で到達可能)、この関数はその同経路に UI を付けただけ。各ジョブの
+ * キット/パッシブ (特に Lv30) を実プレイで確かめるため jobLevel を目標レベルの XP しきい値で直接セットする。
+ * playerLevel (個人累積) は維持。pending 転職候補はクリア。反映は次の戦闘から (進行中の戦闘は旧ジョブのまま)。
  */
 export async function adminSetJob(agent: Agent, did: string, newArchetype: Archetype, targetJobLevel: number): Promise<DiagnosisResult | null> {
   const analysis = await getRecord<DiagnosisResult>(agent, did, COL.analysis, 'self');

--- a/apps/web/src/lib/post-processor.ts
+++ b/apps/web/src/lib/post-processor.ts
@@ -358,7 +358,8 @@ export async function confirmJobChange(agent: Agent, did: string, newArchetype: 
  * confirmJobChange と同じく本人の PDS (analysis/self) を本人トークンで書く = サーバー権威の詐称に
  * ならない (通常プレイヤーも再診断で自分の archetype を書き換える)。各ジョブのキット/パッシブ
  * (特に Lv30) を実プレイで確かめるため、jobLevel を目標レベルの XP しきい値で直接セットする。
- * playerLevel (個人累積) は維持。pending 転職候補はクリア。
+ * playerLevel (個人累積) は維持。pending 転職候補はクリア。反映は次の戦闘から (edge が戦闘開始時に
+ * analysis の archetype を読む — 進行中の戦闘は旧ジョブのまま)。
  */
 export async function adminSetJob(agent: Agent, did: string, newArchetype: Archetype, targetJobLevel: number): Promise<DiagnosisResult | null> {
   const analysis = await getRecord<DiagnosisResult>(agent, did, COL.analysis, 'self');

--- a/apps/web/src/lib/post-processor.ts
+++ b/apps/web/src/lib/post-processor.ts
@@ -23,6 +23,7 @@ import {
   DAILY_BONUS_DAY_MARGIN_FACTOR,
   DEFAULT_QUEST_TEMPLATES,
   JOB_CHANGE_STREAK_THRESHOLD as CORE_JOB_CHANGE_STREAK_THRESHOLD,
+  JOB_XP_CURVE,
   XP_REWARDS,
   cognitiveToRpg,
   determineArchetype,
@@ -345,6 +346,32 @@ export async function confirmJobChange(agent: Agent, did: string, newArchetype: 
     ...analysis,
     archetype: newArchetype,
     jobLevel: { archetype: newArchetype, xp: 0, joinedAt: now },
+  };
+  delete (next as Partial<DiagnosisResult>).pendingArchetype;
+  delete (next as Partial<DiagnosisResult>).pendingArchetypeStreak;
+  await putRecord(agent, COL.analysis, 'self', next);
+  return next;
+}
+
+/**
+ * 管理者用: 自分のジョブを即座に任意の archetype + jobLevel に切り替える (dev の /admin から)。
+ * confirmJobChange と同じく本人の PDS (analysis/self) を本人トークンで書く = サーバー権威の詐称に
+ * ならない (通常プレイヤーも再診断で自分の archetype を書き換える)。各ジョブのキット/パッシブ
+ * (特に Lv30) を実プレイで確かめるため、jobLevel を目標レベルの XP しきい値で直接セットする。
+ * playerLevel (個人累積) は維持。pending 転職候補はクリア。
+ */
+export async function adminSetJob(agent: Agent, did: string, newArchetype: Archetype, targetJobLevel: number): Promise<DiagnosisResult | null> {
+  const analysis = await getRecord<DiagnosisResult>(agent, did, COL.analysis, 'self');
+  if (!analysis) return null;
+  const maxLv = JOB_XP_CURVE[JOB_XP_CURVE.length - 1]?.[0] ?? 50;
+  const lv = Math.max(1, Math.min(maxLv, Math.floor(targetJobLevel)));
+  // 目標 LV の XP しきい値 (JOB_XP_CURVE)。LV1 は 0。jobLevelFromXp(xp) がこの LV を返す最小 XP。
+  const xp = JOB_XP_CURVE.find((e) => e[0] === lv)?.[1] ?? 0;
+  const now = new Date().toISOString();
+  const next: DiagnosisResult = {
+    ...analysis,
+    archetype: newArchetype,
+    jobLevel: { archetype: newArchetype, xp, joinedAt: now },
   };
   delete (next as Partial<DiagnosisResult>).pendingArchetype;
   delete (next as Partial<DiagnosisResult>).pendingArchetypeStreak;

--- a/apps/web/src/routes/admin-dashboard.tsx
+++ b/apps/web/src/routes/admin-dashboard.tsx
@@ -6,6 +6,7 @@ import { serverOAuthConfigured } from '@/lib/server-oauth';
 import { ServerOAuthAdmin } from '@/components/admin/server-oauth-admin';
 import { WorldResetAdmin } from '@/components/admin/world-reset-admin';
 import { PowerGrantAdmin } from '@/components/admin/power-grant-admin';
+import { JobChangeAdmin } from '@/components/admin/job-change-admin';
 import { DebugBattleSim } from '@/components/debug-battle-sim';
 
 /**
@@ -115,6 +116,7 @@ export function AdminDashboard() {
         <>
           {serverOAuthConfigured && <ServerOAuthAdmin agent={agent} />}
           {devTools && <PowerGrantAdmin agent={agent} did={did} />}
+          {devTools && <JobChangeAdmin agent={agent} did={did} />}
           {devTools && <WorldResetAdmin agent={agent} did={did} />}
           {devTools && <DebugBattleSim />}
         </>


### PR DESCRIPTION
## 概要
管理者が **/admin から自分のジョブ (archetype) と現職レベルを即座に切り替え**られるようにする。全16職キット + 全15職 Lv30 パッシブ (#456) が揃ったので、各職を実 world で触って確認する手段 (再診断=投稿を積んで転職確定、を待たずに試せる)。

## 実装
- `post-processor` に `adminSetJob(agent, did, archetype, targetJobLevel)` を追加。**`confirmJobChange` と同じく本人の PDS (analysis/self) を本人トークンで書く** = サーバー権威の詐称にならない (通常プレイヤーも再診断で自分の archetype を書き換える)。`jobLevel` は目標レベルの XP しきい値 (`JOB_XP_CURVE`) で直接セットし、Lv30 パッシブをすぐ試せる。playerLevel は維持・pending 転職候補はクリア。
- `JobChangeAdmin` コンポーネント (16職ドロップダウン + Lv 入力 default 30 + 変更ボタン・現職表示つき)。
- admin-dashboard の devTools ツール群に追加 (`WORLD_PREVIEW_ENABLED && isAdminDid` の表示ゲート)。

## セキュリティ (自分の PDS 書き込みなので追加認可不要)
- 変えるのは**管理者自身の archetype** で、書き込みは**本人トークンで本人の PDS** へ。通常プレイヤーの `confirmJobChange` と同じ経路。他人の書き換えではないので、admin-dashboard の注記「実データ CRUD の書き込みは edge で権限検証」に抵触しない (これは他人書き換えの話)。
- 表示ゲートは既存の `WORLD_PREVIEW_ENABLED (dev 限定) && isAdminDid`。

## 反映タイミング
次の戦闘から新ジョブが適用される (進行中の戦闘ガードは `sealed.archetype` で封印済みなので、切替後に新ジョブで戦うには一度戦闘を終える)。

## 検証
- xp↔level 往復が厳密 (Lv30→xp15225→Lv30 を probe で確認) = 目標レベルにぴったり着地
- web **346 緑** / typecheck 緑
- **要 dev 実機確認 (§3)**: /admin → 「ジョブ変更 (自分・テスト)」で職+Lv を選び変更 → world で戦闘 → 選んだ職のキット/パッシブが出るか

## Review

§1.5 レビュー (ロジック=PDS 書き込み/レベル換算が絡むため 実装 + 設計)。**両方 ★★★/★★(要 in-PR) ゼロ・マージ可**。

### 実装レビュー: ★★★/★★ ゼロ・★ 2件 (PR 内対応)
confirmJobChange と完全同型 (pending* delete・スプレッド・putRecord)、**xp↔Lv 厳密対応** (JOB_XP_CURVE のしきい値 → jobLevelFromXp が目標 Lv を返す)、他フィールド保持 (rpgStats/playerLevel/card)、maxLv=50 clamp、診断前 null 処理、admin ゲート一貫すべて確認。★ = Lv 入力 NaN ガード・実在しない `sealed.archetype` コメント → **PR 内修正**。

### 設計レビュー: ★★★ ゼロ・★★ 1件 (PR 内対応)・★ 柔軟
**核心「自分の PDS 書き込みだからサーバー認可不要」は正しいと edge 実コードで裏付け**: battle-resolver が本人 analysis の archetype/jobLevel.xp を**無検証で権威読み** (docs/21 §6-4 の既知課題・真の対策は M4)。よって**一般ユーザーも本人トークンで同じ状態に到達でき (zeroAnalysisXp 前例)、この PR は新しい攻撃面を追加しない**。admin-dashboard の注記 (共有データ CRUD の話) にも非抵触。jobLevel を目標 Lv しきい値にする (confirmJobChange の Lv1 と別) のもテスト用途として妥当。

### ★★/★ 対応 (PR 内)
- **コメント「詐称にならない」が「サーバー検証済み」と誤読されうる** (設計★★) → edge 無検証読み前提 (docs/21 §6-4・M4) を明記し「新しい攻撃面なし」に精緻化 (commit 5bc0356)。no-overselling / self-contained。
- **Lv 入力 NaN ガード** (実装★) → 明示的に Lv1 フォールバック (commit 5c8172a)。
- **実在しない sealed.archetype コメント** (実装★) → edge が戦闘開始時に archetype を読む実挙動に修正。
- **進行中戦闘の注意を UI に** (設計★) → 変更後 msg に「(戦闘中なら次戦から)」追記。

## ⚠️ 要 dev 実機確認 (§3)
**/admin → 「ジョブ変更 (自分・テスト)」で職 + Lv を選び変更 → world で戦闘** → 選んだ職のキット/パッシブ (Lv30 なら覇王/慧眼等) が出るか確認してください。

CI: web-ci pass。web 346緑 / typecheck 緑。**書き込みは本人の PDS (analysis/self) のみ・edge の権威モデルは不変**。
