### PR TITLE
装備ボーナスの二重加算を構造的に不可能にする (Closes #511)

### DIFF
--- a/apps/edge/src/battle-resolver.ts
+++ b/apps/edge/src/battle-resolver.ts
@@ -178,7 +178,7 @@ export async function sealEncounter(env: ResolverEnv, userDid: string, state: Ga
   // 戦闘ログの表示名は handle (DID ではなく)。startBattle の player 識別子に渡す。
   // 在庫は materials マップに一本化 (client と同じモデル)。やくそう=herb / そらのしずく=sky-dew。
   const battle = startBattle(archetype, jobLevel, playerLevel, handle, tier, monsterSeed, state.materials['herb'] ?? 0, { hp: state.carryHp, mp: state.carryMp }, {
-    baseStats, equipIds: state.gear, gear: state.gearSel, tonics: state.materials['sky-dew'] ?? 0, vitalsVariance: BATTLE_TUNING.monsterVitalsVariance,
+    baseStats, gear: state.gearSel, tonics: state.materials['sky-dew'] ?? 0, vitalsVariance: BATTLE_TUNING.monsterVitalsVariance,
   });
   const rewarded = state.power >= BATTLE_TUNING.powerCost;
   const pendingTurnSeed = (await entropyU32({ useKuda: true, apiKey: env.KUDA_API_KEY })).value;
@@ -298,7 +298,7 @@ export async function handleItem(env: ResolverEnv, userDid: string, item: 'herb'
   const matId = item === 'herb' ? 'herb' : 'sky-dew';
   if ((state.materials[matId] ?? 0) <= 0) throw new ResolverError(item === 'herb' ? 'やくそうを もっていない' : 'そらのしずくを もっていない', 400);
   const { archetype, baseStats, handle, jobXp, playerXp } = await readDiagnosis(userDid, ns, fetchImpl);
-  const c = playerCombatant(archetype, jobLevelFromXp(jobXp), playerLevelFromXp(playerXp), handle, baseStats, state.gear, state.gearSel);
+  const c = playerCombatant(archetype, jobLevelFromXp(jobXp), playerLevelFromXp(playerXp), handle, baseStats, undefined, state.gearSel);
   let healed = 0;
   const written = await readModifyWrite(env, userDid, (cur) => {
     const have = cur.materials[matId] ?? 0;
@@ -338,7 +338,7 @@ export async function handleSearch(env: ResolverEnv, userDid: string, token: str
   const rec = await readState(env, userDid);
   const state = rec?.state ?? (await migrateInitState(userDid, new Date(now * 1000).toISOString(), ns, fetchImpl));
   const { archetype, baseStats, handle, jobXp, playerXp } = await readDiagnosis(userDid, ns, fetchImpl);
-  const luk = playerCombatant(archetype, jobLevelFromXp(jobXp), playerLevelFromXp(playerXp), handle, baseStats, state.gear, state.gearSel).luk;
+  const luk = playerCombatant(archetype, jobLevelFromXp(jobXp), playerLevelFromXp(playerXp), handle, baseStats, undefined, state.gearSel).luk;
   const tier = tierForDanger(regionDanger(regionOf(x, y)));
   const found = rollSearch((await entropyU32({ useKuda: true, apiKey: env.KUDA_API_KEY })).value, luk, tier);
   if (!found) return { found: null, materials: state.materials };

--- a/apps/edge/src/game-state.ts
+++ b/apps/edge/src/game-state.ts
@@ -33,7 +33,10 @@ export interface GameState {
   jobXp: Record<string, number>;
   /** 素材インベントリ (item id → 個数)。 */
   materials: Record<string, number>;
-  /** 装備中の gear id。 */
+  /** @deprecated 装備中の gear id。**どこからも書き込まれない死んだフィールド** (emptyState が [] に
+   *  初期化するだけ)。装備の実効値は gearSel が単一の出所。**戦闘に渡さないこと** — gearSel と併せて
+   *  渡すと同じ装備が二重加算される経路だった (#511 で core 側も gear 優先に修正)。
+   *  既存 state との互換のためフィールド自体は残す。 */
   gear: string[];
   /** 装備中の個体 (強化値つき GearSelection)。client がミラー送信。戦闘の実効装備はこちら (#377)。 */
   gearSel?: GearSelection;

--- a/packages/core/src/__tests__/equipment.test.ts
+++ b/packages/core/src/__tests__/equipment.test.ts
@@ -123,6 +123,9 @@ describe('装備ボーナスの二重加算防止 (#511)', () => {
     // 両方渡しても gear のみと同値 (旧実装は a+b で二重に加算していた: def 15→17→19)
     expect(both.def).toBe(viaGear.def);
     expect(both.maxHp).toBe(viaGear.maxHp);
+    // 空の gear ({}) では equipIds が活きる (空判定を対称にしないと装備が黙って消える)
+    const emptyGear = playerCombatant('sage', 1, 1, 'x', undefined, [armor.id], {});
+    expect(emptyGear.def).toBe(viaIds.def);
     // playerStatsAt (丸め前) も同じ規則で解決する
     const bothRaw = playerStatsAt('sage', 1, 1, undefined, [armor.id], { armor: armor.id });
     const gearRaw = playerStatsAt('sage', 1, 1, undefined, undefined, { armor: armor.id });

--- a/packages/core/src/__tests__/equipment.test.ts
+++ b/packages/core/src/__tests__/equipment.test.ts
@@ -111,6 +111,26 @@ describe('gearBonusFromGear (スロット検証つき入口)', () => {
   });
 });
 
+describe('装備ボーナスの二重加算防止 (#511)', () => {
+  it('equipIds と gear を両方渡しても二重加算されない (gear 優先)', () => {
+    const armor = EQUIPMENT.find((e) => e.slot === 'armor' && (e.bonus.def ?? 0) > 0)!;
+    const none = playerCombatant('sage', 1, 1, 'x');
+    const viaIds = playerCombatant('sage', 1, 1, 'x', undefined, [armor.id]);
+    const viaGear = playerCombatant('sage', 1, 1, 'x', undefined, undefined, { armor: armor.id });
+    const both = playerCombatant('sage', 1, 1, 'x', undefined, [armor.id], { armor: armor.id });
+    expect(viaIds.def).toBeGreaterThan(none.def); // 単独ならボーナスが乗る
+    expect(viaGear.def).toBeGreaterThan(none.def);
+    // 両方渡しても gear のみと同値 (旧実装は a+b で二重に加算していた: def 15→17→19)
+    expect(both.def).toBe(viaGear.def);
+    expect(both.maxHp).toBe(viaGear.maxHp);
+    // playerStatsAt (丸め前) も同じ規則で解決する
+    const bothRaw = playerStatsAt('sage', 1, 1, undefined, [armor.id], { armor: armor.id });
+    const gearRaw = playerStatsAt('sage', 1, 1, undefined, undefined, { armor: armor.id });
+    expect(bothRaw.def).toBeCloseTo(gearRaw.def);
+    expect(bothRaw.maxHp).toBeCloseTo(gearRaw.maxHp);
+  });
+});
+
 describe('専用装備の弱点補完 (将軍)', () => {
   it('将軍の専用品は耐久複合で、フル装備の tier3 勝率が band に入る (≥55%)', async () => {
     const { BATTLE_TUNING, resolveTurn, startBattle } = await import('../battle.js');

--- a/packages/core/src/__tests__/equipment.test.ts
+++ b/packages/core/src/__tests__/equipment.test.ts
@@ -129,8 +129,12 @@ describe('装備ボーナスの二重加算防止 (#511)', () => {
     // playerStatsAt (丸め前) も同じ規則で解決する
     const bothRaw = playerStatsAt('sage', 1, 1, undefined, [armor.id], { armor: armor.id });
     const gearRaw = playerStatsAt('sage', 1, 1, undefined, undefined, { armor: armor.id });
-    expect(bothRaw.def).toBeCloseTo(gearRaw.def);
-    expect(bothRaw.maxHp).toBeCloseTo(gearRaw.maxHp);
+    const idsRaw = playerStatsAt('sage', 1, 1, undefined, [armor.id]);
+    expect(bothRaw.def).toBe(gearRaw.def); // 同一経路なので厳密一致 (toBeCloseTo だと微差を見逃す)
+    expect(bothRaw.maxHp).toBe(gearRaw.maxHp);
+    // 空 gear では equipIds が活きる (playerCombatant と同じ規則であることを raw 側でも固定)
+    const emptyRaw = playerStatsAt('sage', 1, 1, undefined, [armor.id], {});
+    expect(emptyRaw.def).toBe(idsRaw.def);
   });
 });
 

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -570,7 +570,9 @@ function fromStats(name: string, stats: StatArray, levelFactor: number, level: n
  * どちらも無ければ null (呼び出し側は加算をスキップ)。
  */
 function gearFlatBonus(archetype: Archetype, equipIds?: readonly string[], gear?: GearSelection): GearBonus | null {
-  if (gear) return gearBonusFromGear(archetype, gear);
+  // 「中身のある方」を採る。空の gear ({}) で equipIds を無視すると、両方渡した呼び出しで装備が
+  // 黙って消える (実測 def 17 → 15)。空判定を equipIds 側と対称にしてこの罠を構造的に潰す。
+  if (gear && Object.keys(gear).length > 0) return gearBonusFromGear(archetype, gear);
   if (equipIds && equipIds.length > 0) return gearBonus(archetype, equipIds);
   return null;
 }

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -17,7 +17,7 @@
 
 import type { Archetype, StatArray } from './types.js';
 import { JOBS_BY_ID } from './jobs.js';
-import { gearBonus, gearBonusFromGear, type GearSelection } from './equipment.js';
+import { gearBonus, gearBonusFromGear, type GearBonus, type GearSelection } from './equipment.js';
 import { SKILLS, runSkill, runSkillMulti } from './skills.js';
 import { elementMultiplier, type Element } from './elements.js';
 import { resolveTargets, type CombatSides } from './combat-target.js';
@@ -564,6 +564,18 @@ function fromStats(name: string, stats: StatArray, levelFactor: number, level: n
 }
 
 /**
+ * 装備の平坦ボーナスを 1 箇所で解決する (#511)。**gear (GearSelection) と equipIds が両方来たら
+ * gear を優先し equipIds は無視する** — 両方を加算すると同じ装備が二重に効くため (実測: def 15 →
+ * 単一 17 → 両方 19)。gear がアプリ本則 (強化値つき個体)、equipIds は sim 用の簡易形。
+ * どちらも無ければ null (呼び出し側は加算をスキップ)。
+ */
+function gearFlatBonus(archetype: Archetype, equipIds?: readonly string[], gear?: GearSelection): GearBonus | null {
+  if (gear) return gearBonusFromGear(archetype, gear);
+  if (equipIds && equipIds.length > 0) return gearBonus(archetype, equipIds);
+  return null;
+}
+
+/**
  * プレイヤーの戦闘値を導出。
  * 基底 = **ジョブ基準値と個人 rpgStats (プロフィールの 5 パラメータ、合計 100) の
  * ブレンド** (baseStatsPersonalWeight = 0.5)。個人値 100% は診断の min-max 正規化で
@@ -579,9 +591,10 @@ export function playerCombatant(
   playerLevel: number,
   displayName: string,
   baseStats?: StatArray,
-  /** 装備中の装備 id 列 (EQUIPMENT)。丸めの後に平坦加算 (docs/20)。sim 用の簡易形 */
+  /** 装備中の装備 id 列 (EQUIPMENT)。丸めの後に平坦加算 (docs/20)。sim 用の簡易形。
+   *  **gear を渡した場合は無視される** (下記 gearFlatBonus 参照 — 二重加算の防止)。 */
   equipIds?: readonly string[],
-  /** 装備中の個体 (強化値つき)。アプリ本則はこちら (gear/self の解決結果) */
+  /** 装備中の個体 (強化値つき)。アプリ本則はこちら (gear/self の解決結果)。equipIds より優先。 */
   gear?: GearSelection,
 ): Combatant {
   const t = BATTLE_TUNING;
@@ -603,17 +616,16 @@ export function playerCombatant(
   const flat = t.flatLevelGain * Math.max(0, playerLevel - 1);
   const grown: StatArray = [base[0] + flat, base[1] + flat, base[2] + flat, base[3] + flat, base[4] + flat];
   const c = fromStats(displayName, grown, factor, playerLevel);
-  if ((equipIds && equipIds.length > 0) || gear) {
+  const bonus = gearFlatBonus(archetype, equipIds, gear);
+  if (bonus) {
     // 装備はすべての導出 (ブレンド・成長・丸め) の後に平坦加算 — 低ステータス
     // ほど相対効果が大きく「装備で差をつける」が成立する (docs/20)
-    const a = equipIds && equipIds.length > 0 ? gearBonus(archetype, equipIds) : null;
-    const b = gear ? gearBonusFromGear(archetype, gear) : null;
-    c.atk += (a?.atk ?? 0) + (b?.atk ?? 0);
-    c.def += (a?.def ?? 0) + (b?.def ?? 0);
-    c.agi += (a?.agi ?? 0) + (b?.agi ?? 0);
-    c.int += (a?.int ?? 0) + (b?.int ?? 0);
-    c.luk += (a?.luk ?? 0) + (b?.luk ?? 0);
-    c.maxHp += (a?.maxHp ?? 0) + (b?.maxHp ?? 0);
+    c.atk += bonus.atk;
+    c.def += bonus.def;
+    c.agi += bonus.agi;
+    c.int += bonus.int;
+    c.luk += bonus.luk;
+    c.maxHp += bonus.maxHp;
     c.hp = c.maxHp;
   }
   c.passives = jobPassives(archetype, jobLevel); // ジョブ Lv30 の innate パッシブ
@@ -660,9 +672,9 @@ export function playerStatsAt(
   const factor = 1 + Math.max(0, jobLevel - 1) * t.jobLevelScale + Math.max(0, playerLevel - 1) * t.playerLevelScale;
   const flat = t.flatLevelGain * Math.max(0, playerLevel - 1);
   const g = (i: number) => (base[i]! + flat) * factor;
-  const a = equipIds && equipIds.length > 0 ? gearBonus(archetype, equipIds) : null;
-  const b = gear ? gearBonusFromGear(archetype, gear) : null;
-  const eq = (k: 'atk' | 'def' | 'agi' | 'int' | 'luk' | 'maxHp') => (a?.[k] ?? 0) + (b?.[k] ?? 0);
+  // 装備は gearFlatBonus で 1 箇所解決 (gear 優先・二重加算なし。#511)。playerCombatant と同じ規則。
+  const bonus = gearFlatBonus(archetype, equipIds, gear);
+  const eq = (k: 'atk' | 'def' | 'agi' | 'int' | 'luk' | 'maxHp') => bonus?.[k] ?? 0;
   return {
     atk: g(0) + eq('atk'),
     def: g(1) + eq('def'),


### PR DESCRIPTION
## 概要
`playerCombatant` / `playerStatsAt` は `equipIds` と `gear` を**両方**渡されると両方のボーナスを加算していた。edge は実際に両方渡していた。

Closes #511

## 実測 (賢者 + ar-cloth(def+2))
| 渡し方 | def |
|---|---|
| 装備なし | 15 |
| equipIds のみ | 17 |
| gear のみ | 17 |
| **両方 (= edge の渡し方)** | **19 ← 二重** |

## なぜ今まで実害が出ていなかったか
`GameState.gear: string[]` が `emptyState` 以外**どこからも書き込まれない死んだフィールド**のため `equipIds.length > 0` が常に false だった。**誰かが埋めた瞬間に戦闘だけ装備が二重に効く** (client 表示は単一なので発見しにくい)。

## 修正
- **core**: `gearFlatBonus(archetype, equipIds, gear)` を新設し装備解決を **1 箇所に集約**。**gear があれば equipIds を無視** (gear=アプリ本則の強化値つき個体、equipIds=sim 用の簡易形)。`playerCombatant` と `playerStatsAt` が同じ規則を共有 (旧実装は同じ加算ロジックを 2 箇所にコピペ = drift 源だった)。
- **edge**: 3 箇所から `state.gear` を外し `gearSel` を単一の出所に。
- `GameState.gear` を `@deprecated` + 「戦闘に渡さないこと」と明示 (既存 state 互換のため型は残す)。
- **回帰テスト**: 両方渡しても gear のみと同値、を `playerCombatant` / `playerStatsAt` 双方で固定。

## 検証
core **487緑** (新テスト含む) / edge 152緑 / web 346緑 / typecheck (core+edge+web) 緑。**実効挙動は不変** (dead field だったため)。

## Review

§1.5 実装レビュー。**★★★ ゼロ / ★★ 1件は PR 内で修正済み / ★ 4件**。

### ★★ 空 gear `{}` で装備が消える回帰 → commit 4f58315 で修正済み
初版 (`15a5faa`) の `if (gear)` は **`{}` も truthy** なので equipIds を捨てて 0 を返していた (実測 def 17 → 15)。

**レビューが裏取りした重要な事実**: `gearSel === {}` は例外経路ではなく**無装備プレイヤー全員の常態**。
- `gear.ts` の `selection` は `{}` 初期化、該当スロットが無ければキーを作らない
- `world.tsx` は `'null'` のときだけ送信を止めるので `'{}'` は**送る**
- `router.ts` は `{}` を受理 → `battle-resolver.ts` が `gearSel: {}` として格納

つまり初版のままマージしていたら、**#511 が警告していたのと同じクラスの潜在バグを新たに作り込む**ところだった。`Object.keys(gear).length > 0` で空判定を equipIds 側と対称化し、「中身のある方を採る」規則にして構造的に解消。回帰テストで固定。

### 同値性の検証 (レビューが実測)
| ケース | 旧 | 新 | |
|---|---|---|---|
| equipIds のみ | a | a | 同値 |
| gear のみ | b | b | 同値 |
| equipIds + 空 gear | a | a | 同値 (初版のみ 0 に壊れていた) |
| **equipIds + 非空 gear** | **a+b** | **b** | **意図した修正** |

### ★ 対応
- **playerStatsAt の空 gear テスト追加 / `toBeCloseTo`→`toBe` 厳密化** → PR 内対応 (最新 commit)
- edge に「state.gear を渡していない」ことを固定するテスト / `GameState.gear` を optional 化 → core 側が「非空優先」で構造的に守っているため見送り (必要なら別 issue)

### 検証済み (レビューが grep + git log -S で再確認)
`GameState.gear` への書き込みは `emptyState` の `gear: []` **のみ**。導入時 (M2) 以降一度も追加されていない → edge の変更は**実データ上 strict no-op**。sim スクリプト・debug-battle-sim を含む**全 caller が影響なし**。

CI: web-ci pass。core 487緑 / edge 152緑 / web 346緑 / typecheck 緑。
