### PR TITLE
成長式を growthOf に一本化する (Closes #520)

### DIFF
--- a/packages/core/src/__tests__/growth-formula.test.ts
+++ b/packages/core/src/__tests__/growth-formula.test.ts
@@ -49,7 +49,10 @@ describe('成長式の一貫性 (#520)', () => {
     expect(hasFraction).toBe(true);
   });
 
-  it('MP の式は mpBase + かしこさ × mpIntScale (丸めを挟まない)', () => {
+  it('MP の式は mpBase + かしこさ × mpIntScale (丸めを挟まない。装備ボーナス適用**前**の素の値基準)', () => {
+    // 装備で かしこさ が上がっても さいだいMP は増えない (杖の int ボーナスは MP に乗らない)。
+    // これは #520 以前からの挙動で、ここで検証しているのは素の値の式のみ。装備込みのケースを
+    // 足すと落ちるので注意 (仕様として妥当かは別途 #525)。
     const t = BATTLE_TUNING;
     for (const j of JOBS) {
       for (const lv of [1, 13, 37]) {

--- a/packages/core/src/__tests__/growth-formula.test.ts
+++ b/packages/core/src/__tests__/growth-formula.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { playerCombatant, playerStatsAt, JOBS, BATTLE_TUNING, type StatArray } from '../index.js';
+
+/**
+ * `growthOf` に一本化した後 (#520) も、`playerCombatant` と `playerStatsAt` が
+ * **丸め以外は同一**であることを固定する。
+ *
+ * リファクタ時に `playerStatsAt.maxMp` の丸め基準だけ変えてしまい、レベルアップ演出の
+ * MP 表示が 95% のケースで変わる (720 ケースでは MP 行が消える) 事故を起こした。
+ * 既存の同期テストは `Math.round(raw) === combatant` しか見ないため**原理的に検出できない**
+ * ので、生値そのものの不変条件をここで押さえる。
+ */
+describe('成長式の一貫性 (#520)', () => {
+  const PROFILES: (StatArray | undefined)[] = [
+    undefined,
+    [20, 20, 20, 20, 20],
+    [60, 10, 10, 10, 10],
+    [10, 10, 10, 60, 10],
+    [23, 17, 31, 13, 16], // 端数が出るプロフィール (丸めの境界を踏ませる)
+    [7, 41, 3, 29, 20],
+  ];
+
+  it('playerStatsAt の生値を丸めると playerCombatant に一致する (全16職 × Lv1〜50 × 6 プロフィール)', () => {
+    for (const j of JOBS) {
+      for (let lv = 1; lv <= 50; lv++) {
+        for (const p of PROFILES) {
+          const c = playerCombatant(j.id, lv, 1, 'x', p);
+          const raw = playerStatsAt(j.id, lv, 1, p);
+          const at = `${j.id} Lv${lv}`;
+          expect(Math.round(raw.atk), `${at} atk`).toBe(c.atk);
+          expect(Math.round(raw.def), `${at} def`).toBe(c.def);
+          expect(Math.round(raw.agi), `${at} agi`).toBe(c.agi);
+          expect(Math.round(raw.int), `${at} int`).toBe(c.int);
+          expect(Math.round(raw.luk), `${at} luk`).toBe(c.luk);
+          expect(Math.round(raw.maxHp), `${at} maxHp`).toBe(c.maxHp);
+          expect(Math.round(raw.maxMp), `${at} maxMp`).toBe(c.maxMp);
+        }
+      }
+    }
+  });
+
+  it('playerStatsAt.maxMp は **生値** を返す = 上昇量が整数に量子化されない', () => {
+    // この関数の存在理由が「上昇量を小数 1 桁で見せる」ことなので、MP だけ丸めた整数を
+    // 基準にすると「毎レベル +1.5」が「+2 / +1」とガタつき、0 になった行は表示から消える。
+    // 少なくとも 1 つの職・レベルで小数部を持つことを確かめれば、量子化への退行を検出できる。
+    const hasFraction = JOBS.some((j) =>
+      [1, 5, 10, 20].some((lv) => playerStatsAt(j.id, lv, 1).maxMp % 1 !== 0),
+    );
+    expect(hasFraction).toBe(true);
+  });
+
+  it('MP の式は mpBase + かしこさ × mpIntScale (丸めを挟まない)', () => {
+    const t = BATTLE_TUNING;
+    for (const j of JOBS) {
+      for (const lv of [1, 13, 37]) {
+        const raw = playerStatsAt(j.id, lv, 1);
+        expect(raw.maxMp, `${j.id} Lv${lv}`).toBeCloseTo(t.mpBase + raw.int * t.mpIntScale, 10);
+      }
+    }
+  });
+});

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -643,17 +643,19 @@ function growthOf(archetype: Archetype, jobLevel: number, baseStats?: StatArray)
   const lv = Math.max(0, jobLevel - 1);
   const gr = t.statBase + t.statGrow * lv;
   const dr = t.defBase + t.defGrow * lv;
+  /** 5 ステータスの生値。**まもり (index 1) だけ statFloor 無し・def 系統の伸び率** — 守備は
+   *  防具が主役という設計を下駄で薄めないため (docs/19 §6.4.5)。 */
+  const stat = (i: 0 | 1 | 2 | 3 | 4): number => (i === 1 ? base[i]! * dr : t.statFloor + base[i]! * gr);
   return {
-    /** 5 ステータスの生値。**まもり (index 1) だけ statFloor 無し・def 系統の伸び率** — 守備は
-     *  防具が主役という設計を下駄で薄めないため (docs/19 §6.4.5)。 */
-    stat: (i: 0 | 1 | 2 | 3 | 4): number => (i === 1 ? base[i]! * dr : t.statFloor + base[i]! * gr),
+    stat,
     /** たいりょく。**丸めた値**を返す — ステータス画面に出す たいりょく が HP を説明できる
      *  必要があるため (「たいりょく 4」なのに HP 13 では表示の意味が無い)。 */
     vit: Math.round(JOBS_BY_ID[archetype].vit * gr),
-    /** MP の**生値**。丸めるかどうかは呼び出し側が決める (playerCombatant だけが丸める)。
-     *  基準を helper 内に固定してあるので、`round(playerStatsAt.maxMp) === playerCombatant.maxMp`
-     *  が `mpIntScale` の値に依らず構造的に成立する。 */
-    maxMp: (): number => t.mpBase + (t.statFloor + base[3]! * gr) * t.mpIntScale,
+    /** MP の**生値** (装備ボーナス適用**前**の素の かしこさ 基準)。丸めるかどうかは呼び出し側が
+     *  決める (playerCombatant だけが丸める)。`stat(3)` をそのまま使うので式は 1 つしかなく、
+     *  `round(playerStatsAt.maxMp) === playerCombatant.maxMp` が `mpIntScale` の値に依らず
+     *  構造的に成立する。 */
+    maxMp: (): number => t.mpBase + stat(3) * t.mpIntScale,
   };
 }
 
@@ -695,7 +697,7 @@ export function playerCombatant(
     displayName,
     grown,
     Math.round(t.hpBase + g.vit * t.hpVitScale),
-    Math.round(g.maxMp()),
+    Math.round(g.maxMp()), // grown[3] を使うと mpIntScale 非整数時に playerStatsAt と割れる
     g.vit,
   );
   const bonus = gearFlatBonus(archetype, equipIds, gear);

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -616,16 +616,6 @@ function gearFlatBonus(archetype: Archetype, equipIds?: readonly string[], gear?
 }
 
 /**
- * プレイヤーの戦闘値を導出。
- * 基底 = **ジョブ基準値と個人 rpgStats (プロフィールの 5 パラメータ、合計 100) の
- * ブレンド** (baseStatsPersonalWeight = 0.5)。個人値 100% は診断の min-max 正規化で
- * 極端ビルドが常態化し勝率が 0〜100% に割れるため (issue #279)。未診断は
- * ジョブ基準値のみ。
- * レベル補正 = 平坦加算 (+flatLevelGain × (playerLv−1)、レベル係数の乗算前に加算) の
- * 後に乗算 (jobLv/playerLv の levelScale)。W4 のサーバー権威化ではこの関数を
- * Worker 側で同じ入力 (analysis レコード) から再導出する。
- */
-/**
  * 成長式の**単一の出所** (#520)。`playerCombatant` (丸めて Combatant にする) と
  * `playerStatsAt` (丸めずに上昇量表示に使う) の両方がこれを使う。
  *
@@ -656,15 +646,27 @@ function growthOf(archetype: Archetype, jobLevel: number, baseStats?: StatArray)
   return {
     /** 5 ステータスの生値。**まもり (index 1) だけ statFloor 無し・def 系統の伸び率** — 守備は
      *  防具が主役という設計を下駄で薄めないため (docs/19 §6.4.5)。 */
-    stat: (i: number): number => (i === 1 ? base[i]! * dr : t.statFloor + base[i]! * gr),
+    stat: (i: 0 | 1 | 2 | 3 | 4): number => (i === 1 ? base[i]! * dr : t.statFloor + base[i]! * gr),
     /** たいりょく。**丸めた値**を返す — ステータス画面に出す たいりょく が HP を説明できる
      *  必要があるため (「たいりょく 4」なのに HP 13 では表示の意味が無い)。 */
     vit: Math.round(JOBS_BY_ID[archetype].vit * gr),
-    /** MP。`intValue` の基準 (丸め済み / 生値) は呼び出し側が決める。 */
-    maxMp: (intValue: number): number => t.mpBase + intValue * t.mpIntScale,
+    /** MP の**生値**。丸めるかどうかは呼び出し側が決める (playerCombatant だけが丸める)。
+     *  基準を helper 内に固定してあるので、`round(playerStatsAt.maxMp) === playerCombatant.maxMp`
+     *  が `mpIntScale` の値に依らず構造的に成立する。 */
+    maxMp: (): number => t.mpBase + (t.statFloor + base[3]! * gr) * t.mpIntScale,
   };
 }
 
+/**
+ * プレイヤーの戦闘値を導出。
+ * 基底 = **ジョブ基準値と個人 rpgStats (プロフィールの 5 パラメータ、合計 100) の
+ * ブレンド** (baseStatsPersonalWeight = 0.5)。個人値 100% は診断の min-max 正規化で
+ * 極端ビルドが常態化し勝率が 0〜100% に割れるため (issue #279)。未診断は
+ * ジョブ基準値のみ。
+ * レベル補正は `growthOf` が持つ (**ジョブ Lv のみ**。旧 flatLevelGain / levelScale による
+ * プレイヤー Lv 追従は #507 で撤廃済み)。W4 のサーバー権威化ではこの関数を
+ * Worker 側で同じ入力 (analysis レコード) から再導出する。
+ */
 export function playerCombatant(
   archetype: Archetype,
   jobLevel: number,
@@ -686,13 +688,14 @@ export function playerCombatant(
     Math.round(g.stat(0)), Math.round(g.stat(1)), Math.round(g.stat(2)),
     Math.round(g.stat(3)), Math.round(g.stat(4)),
   ];
-  // HP は たいりょく の 2 倍 (DQ 準拠)、MP は かしこさ から。**どちらも丸めた整数を基準にする**
-  // — 画面に出す たいりょく / かしこさ が HP / MP を説明できる必要があるため。
+  // HP は たいりょく の 2 倍 (DQ 準拠)、MP は かしこさ から。**HP だけ丸めた たいりょく を
+  // 基準にする** — 画面に出す たいりょく が HP を説明できる必要があるため (「たいりょく 4」
+  // なのに HP 13 では表示の意味が無い)。MP は生値から丸めるので playerStatsAt と厳密に一致する。
   const c = makeCombatant(
     displayName,
     grown,
     Math.round(t.hpBase + g.vit * t.hpVitScale),
-    Math.round(g.maxMp(grown[3])),
+    Math.round(g.maxMp()),
     g.vit,
   );
   const bonus = gearFlatBonus(archetype, equipIds, gear);
@@ -750,10 +753,12 @@ export function playerStatsAt(
     agi: g.stat(2) + eq('agi'),
     int: g.stat(3) + eq('int'),
     luk: g.stat(4) + eq('luk'),
-    // HP/MP は playerCombatant と同じく **丸めた たいりょく / かしこさ** を基準にする。
-    // ここだけ生値を使うと「丸めの点まで同期している」不変条件が mpIntScale 次第で崩れる。
+    // HP は playerCombatant と同じく丸めた たいりょく 基準 (画面表示との整合)。
+    // MP は生値のまま — この関数の存在理由が「上昇量を小数 1 桁で見せる」ことなので、
+    // ここで整数に量子化すると「毎レベル +1.5」が「+2 / +1」とガタつき、表示から MP 行が
+    // 消えるケースも出る (レビューで実測 4,464/4,704 ケースが変化)。
     maxHp: t.hpBase + g.vit * t.hpVitScale + eq('maxHp'),
-    maxMp: g.maxMp(Math.round(g.stat(3))),
+    maxMp: g.maxMp(),
   };
 }
 

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -625,18 +625,17 @@ function gearFlatBonus(archetype: Archetype, equipIds?: readonly string[], gear?
  * 後に乗算 (jobLv/playerLv の levelScale)。W4 のサーバー権威化ではこの関数を
  * Worker 側で同じ入力 (analysis レコード) から再導出する。
  */
-export function playerCombatant(
-  archetype: Archetype,
-  jobLevel: number,
-  playerLevel: number,
-  displayName: string,
-  baseStats?: StatArray,
-  /** 装備中の装備 id 列 (EQUIPMENT)。丸めの後に平坦加算 (docs/20)。sim 用の簡易形。
-   *  **gear を渡した場合は無視される** (下記 gearFlatBonus 参照 — 二重加算の防止)。 */
-  equipIds?: readonly string[],
-  /** 装備中の個体 (強化値つき)。アプリ本則はこちら (gear/self の解決結果)。equipIds より優先。 */
-  gear?: GearSelection,
-): Combatant {
+/**
+ * 成長式の**単一の出所** (#520)。`playerCombatant` (丸めて Combatant にする) と
+ * `playerStatsAt` (丸めずに上昇量表示に使う) の両方がこれを使う。
+ *
+ * 以前は同じ規則を 2 箇所で別々に書いており (配列リテラルの index1 別扱い / `i === 1` の三項)、
+ * 片方だけ直す事故が実際に起きた (#518 の実装中に playerStatsAt 側へ statFloor を入れ忘れ、
+ * 「丸めの点まで同期している」テストが検出)。表現を 1 つにして構造的に防ぐ。
+ *
+ * 式の意味は docs/19-overworld.md §6.4.5 を参照。
+ */
+function growthOf(archetype: Archetype, jobLevel: number, baseStats?: StatArray) {
   const t = BATTLE_TUNING;
   const job = JOBS_BY_ID[archetype].stats;
   // 個人 rpgStats はジョブ基準値とブレンドして使う (baseStatsPersonalWeight)。
@@ -651,28 +650,50 @@ export function playerCombatant(
         job[4] + (baseStats[4] - job[4]) * w,
       ]
     : job;
-  // **成長軸はジョブ Lv のみ** (#507)。プレイヤー Lv 由来の倍率・平坦加算は撤廃した
-  // (同じ Lv1 賢者がプレイヤー Lv で HP 20→65 に変わる = 「その職の強さ」が定まらなかった)。
-  void playerLevel; // 引数は呼び出し文脈として残す (強さには使わない。#507)
-  // #518: 比率 (合計 100 の職プロファイル) を **伸び率** に掛ける。まもりだけ伸びを抑え防具を主役に。
   const lv = Math.max(0, jobLevel - 1);
   const gr = t.statBase + t.statGrow * lv;
   const dr = t.defBase + t.defGrow * lv;
-  const f = t.statFloor;
+  return {
+    /** 5 ステータスの生値。**まもり (index 1) だけ statFloor 無し・def 系統の伸び率** — 守備は
+     *  防具が主役という設計を下駄で薄めないため (docs/19 §6.4.5)。 */
+    stat: (i: number): number => (i === 1 ? base[i]! * dr : t.statFloor + base[i]! * gr),
+    /** たいりょく。**丸めた値**を返す — ステータス画面に出す たいりょく が HP を説明できる
+     *  必要があるため (「たいりょく 4」なのに HP 13 では表示の意味が無い)。 */
+    vit: Math.round(JOBS_BY_ID[archetype].vit * gr),
+    /** MP。`intValue` の基準 (丸め済み / 生値) は呼び出し側が決める。 */
+    maxMp: (intValue: number): number => t.mpBase + intValue * t.mpIntScale,
+  };
+}
+
+export function playerCombatant(
+  archetype: Archetype,
+  jobLevel: number,
+  playerLevel: number,
+  displayName: string,
+  baseStats?: StatArray,
+  /** 装備中の装備 id 列 (EQUIPMENT)。丸めの後に平坦加算 (docs/20)。sim 用の簡易形。
+   *  **gear を渡した場合は無視される** (下記 gearFlatBonus 参照 — 二重加算の防止)。 */
+  equipIds?: readonly string[],
+  /** 装備中の個体 (強化値つき)。アプリ本則はこちら (gear/self の解決結果)。equipIds より優先。 */
+  gear?: GearSelection,
+): Combatant {
+  const t = BATTLE_TUNING;
+  // **成長軸はジョブ Lv のみ** (#507)。プレイヤー Lv 由来の倍率・平坦加算は撤廃した
+  // (同じ Lv1 賢者がプレイヤー Lv で HP 20→65 に変わる = 「その職の強さ」が定まらなかった)。
+  void playerLevel; // 引数は呼び出し文脈として残す (強さには使わない。#507)
+  const g = growthOf(archetype, jobLevel, baseStats);
   const grown: StatArray = [
-    Math.round(f + base[0] * gr), Math.round(base[1] * dr), Math.round(f + base[2] * gr),
-    Math.round(f + base[3] * gr), Math.round(f + base[4] * gr),
+    Math.round(g.stat(0)), Math.round(g.stat(1)), Math.round(g.stat(2)),
+    Math.round(g.stat(3)), Math.round(g.stat(4)),
   ];
-  // たいりょくも同じ式で伸び、その 2 倍が HP (DQ 準拠)。MP は かしこさ から。
-  // **丸めた vit から HP を出す**: ステータス画面に出す たいりょく が HP を正しく説明できないと
-  // (「たいりょく 4 なのに HP が 6+4*2=14 でなく 13」) 表示する意味がない。
-  const vit = Math.round(JOBS_BY_ID[archetype].vit * gr);
+  // HP は たいりょく の 2 倍 (DQ 準拠)、MP は かしこさ から。**どちらも丸めた整数を基準にする**
+  // — 画面に出す たいりょく / かしこさ が HP / MP を説明できる必要があるため。
   const c = makeCombatant(
     displayName,
     grown,
-    Math.round(t.hpBase + vit * t.hpVitScale),
-    Math.round(t.mpBase + grown[3] * t.mpIntScale),
-    vit,
+    Math.round(t.hpBase + g.vit * t.hpVitScale),
+    Math.round(g.maxMp(grown[3])),
+    g.vit,
   );
   const bonus = gearFlatBonus(archetype, equipIds, gear);
   if (bonus) {
@@ -716,39 +737,23 @@ export function playerStatsAt(
   gear?: GearSelection,
 ): CombatStatsRaw {
   const t = BATTLE_TUNING;
-  const job = JOBS_BY_ID[archetype].stats;
-  const w = t.baseStatsPersonalWeight;
-  const base: StatArray = baseStats
-    ? [
-        job[0] + (baseStats[0] - job[0]) * w,
-        job[1] + (baseStats[1] - job[1]) * w,
-        job[2] + (baseStats[2] - job[2]) * w,
-        job[3] + (baseStats[3] - job[3]) * w,
-        job[4] + (baseStats[4] - job[4]) * w,
-      ]
-    : job;
-  // playerCombatant と同じ規則: 成長はジョブ Lv のみ (#507)。
-  void playerLevel;
-  // playerCombatant と同じ式 (#518)。丸める前の生値を返す (レベルアップの上昇量表示用)。
-  const lv = Math.max(0, jobLevel - 1);
-  const gr = t.statBase + t.statGrow * lv;
-  const dr = t.defBase + t.defGrow * lv;
-  const g = (i: number) => (i === 1 ? base[i]! * dr : t.statFloor + base[i]! * gr);
+  // playerCombatant と**同じ growthOf** を使う (#520)。違うのは丸めるかどうかだけで、
+  // ここは丸める前の生値を返す (レベルアップの上昇量を小数 1 桁で見せるため)。
+  void playerLevel; // 成長はジョブ Lv のみ (#507)
+  const g = growthOf(archetype, jobLevel, baseStats);
   // 装備は gearFlatBonus で 1 箇所解決 (gear 優先・二重加算なし。#511)。playerCombatant と同じ規則。
   const bonus = gearFlatBonus(archetype, equipIds, gear);
   const eq = (k: 'atk' | 'def' | 'agi' | 'int' | 'luk' | 'maxHp') => bonus?.[k] ?? 0;
   return {
-    atk: g(0) + eq('atk'),
-    def: g(1) + eq('def'),
-    agi: g(2) + eq('agi'),
-    int: g(3) + eq('int'),
-    luk: g(4) + eq('luk'),
-    maxHp: t.hpBase + Math.round(JOBS_BY_ID[archetype].vit * gr) * t.hpVitScale + eq('maxHp'),
-    // g() は statFloor 込み。playerCombatant は丸めた int から出すが、mpIntScale が整数かつ
-    // mpBase が整数の間は round(mpBase + round(x)) === round(mpBase + x) で一致する
-    // (「playerStatsAt は playerCombatant と丸めの点まで同期している」テストが固定)。
-    // **mpIntScale を非整数にするならこの一致が崩れるので両方を丸め済み int 基準に揃えること。**
-    maxMp: t.mpBase + g(3) * t.mpIntScale,
+    atk: g.stat(0) + eq('atk'),
+    def: g.stat(1) + eq('def'),
+    agi: g.stat(2) + eq('agi'),
+    int: g.stat(3) + eq('int'),
+    luk: g.stat(4) + eq('luk'),
+    // HP/MP は playerCombatant と同じく **丸めた たいりょく / かしこさ** を基準にする。
+    // ここだけ生値を使うと「丸めの点まで同期している」不変条件が mpIntScale 次第で崩れる。
+    maxHp: t.hpBase + g.vit * t.hpVitScale + eq('maxHp'),
+    maxMp: g.maxMp(Math.round(g.stat(3))),
   };
 }
 


### PR DESCRIPTION
## なぜ

`playerCombatant` (丸めて Combatant を作る) と `playerStatsAt` (丸めずにレベルアップの
上昇量表示に使う) が、**同じ成長規則を別々の書き方で 2 回**表現していた:

- 個人 rpgStats とジョブ基準値のブレンド — 5 行の同一コードが両方に
- 伸び率 (`statBase + statGrow × (Lv−1)` / def だけ `defBase + defGrow × (Lv−1)`)
- **まもり だけ statFloor を掛けない例外** — 配列リテラルの index1 別扱い vs `i === 1` の三項
- たいりょく → HP の導出

片方だけ直す事故が**実際に起きている**。#518 の実装中に playerStatsAt 側へ statFloor を
入れ忘れ、「playerStatsAt は playerCombatant と丸めの点まで同期している」テストが検出した。
表現が 1 つなら起こらない類の事故なので構造で潰す。

## 何をしたか

`growthOf(archetype, jobLevel, baseStats)` に集約し、両者はここから

- `stat(i)` — 5 ステータスの生値 (まもりの例外もここに 1 回だけ書く)
- `vit` — 丸めた たいりょく (画面表示と HP の両方がこれを基準にする)
- `maxMp(intValue)` — MP の式

を受け取る。違いは「丸めるかどうか」だけになった。

あわせて **maxMp の丸め基準も揃えた**。従来 playerCombatant は丸めた かしこさ から、
playerStatsAt は生値から MP を出しており、`mpIntScale` が整数の間だけ結果が一致する
状態だった (#517 ではコメントで注意書きするに留めていた)。両方を丸め済み整数基準に
統一したので、係数を変えても一致が崩れない。

## 検証

**挙動は変えていない**。期待値の変更は 1 件も無く、core 498 / web 346 / edge 152 すべて緑。
`-55 行 / +60 行` で、増分はほぼ helper の doc-comment。

Closes #520

## Review

### ★★★ 「挙動は変えていない」という当初の主張は**偽**だった → `7fc9d96` で修正

レビュアーが dev の式をテスト内にベタ書き再実装して突き合わせた結果、
`playerStatsAt.maxMp` を生値基準から「丸めた かしこさ」基準に変えてしまっており、
唯一の利用者である `levelUpGains` の出力が広範囲に変わっていた:

- 全16職 × Lv N→N+1 × プロフィール 6 種 = **4,704 ケース中 4,464 (95%) で表示が変化**
- うち **720 ケースは delta が 0 になり「さいだいMP」行が演出から消える**
- 「毎レベル +1.5」が「+2 / +1 / +2 …」とガタつく

`playerStatsAt` の存在理由は「上昇量は小数なので丸めた Combatant の差分では 0 か 1 しか
出ない」ことなのに、MP についてそれを自ら破っていた。**既存 498 テストは
`Math.round(raw.maxMp) === c.maxMp` しか見ないので原理的に検出できない空白域**だった。

**修正**: 丸めの基準を helper 内に固定し (`maxMp()` は常に生値)、丸めは
`playerCombatant` 側の 1 箇所だけにした。これで目的の不変条件
(`round(playerStatsAt) === playerCombatant`) が `mpIntScale` に依らず**構造的に**成立し、
かつ dev と完全に同じ数値になる。

**再検証 (今度は実測で)**: dev の式との突き合わせで
**playerCombatant 38,400 項目 / playerStatsAt 33,600 項目 / levelUpGains 4,704 ケースが
すべて一致**。全16職 × Lv1〜50 × プロフィール 6 種 (端数が出るものを含む)。

空白域を塞ぐため `growth-formula.test.ts` を新設 (3 ケース)。

### ★★ 2件 → `7fc9d96` で対応

- `growthOf` の JSDoc を `playerCombatant` の JSDoc と関数定義の**間**に挿入したため、
  公開 API である `playerCombatant` の doc がホバーから消えていた → 順序を修正
- その doc に #507 で撤廃済みの `flatLevelGain` / `levelScale` の記述が残っていた → 更新

### ★ 2件 → `7fc9d96` で対応

- `growthOf` の戻り値で raw/rounded が混在 (★★★ の温床だった) → maxMp を生値に固定
- `stat(i)` の引数型を `0|1|2|3|4` に絞り、範囲外アクセスで NaN になる経路を潰した

### 問題なしと確認された観点

`playerCombatant` の数値は**当初から完全に挙動不変** (9,600 ケースで差分 0)。
ホットパスのアロケーション懸念なし (`playerCombatant` は戦闘開始時 1 回のみで、
ターンループ内では呼ばれない)。まもり (index 1) の例外の可読性は改善と評価。

