### PR TITLE
保存した地図が消える不具合と、エディタの操作性

### DIFF
--- a/apps/web/src/components/admin/tile-art-editor.tsx
+++ b/apps/web/src/components/admin/tile-art-editor.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useRef, useState } from 'react';
+import { TERRAIN_TILES } from '@/components/world-tiles';
 import {
   BASE_PALETTE,
   TERRAIN_COLORS,
@@ -37,15 +38,19 @@ export function TileArtEditor() {
   const [size, setSize] = useState<number>(16);
   // **初期表示も代表色の下敷きから始める。** emptyTileArt だと全画素が透明で、
   // 開いた瞬間は市松模様しか出ず「壊れている」ように見える (実機で確認)。
-  const [art, setArt] = useState<TileArt>(() => tileArtFor(BASE_PALETTE[0]!) ?? seedFromColor(BASE_PALETTE[0]!, 16));
+  // 描いた絵があればそれ、無ければ**透明から**。下敷き (既存 SVG) をなぞる前提なので、
+  // 代表色で塗りつぶすと下敷きが見えなくなる。パレットには代表色を入れておく。
+  const [art, setArt] = useState<TileArt>(() => tileArtFor(BASE_PALETTE[0]!) ?? blankWithPalette(BASE_PALETTE[0]!, 16));
   const [color, setColor] = useState(1);
   const [note, setNote] = useState<string | null>(null);
+  /** **既存の SVG を下敷きに敷く。** ゼロから描くより、今の絵をなぞるほうが早い。 */
+  const [trace, setTrace] = useState(true);
   const painting = useRef(false);
 
   const pick = useCallback((t: string) => {
     setTerrain(t);
     const existing = tileArtFor(t);
-    const next = existing ?? seedFromColor(t, size);
+    const next = existing ?? blankWithPalette(t, size);
     setArt(next);
     setColor(1);
   }, [size]);
@@ -93,7 +98,7 @@ export function TileArtEditor() {
     void file.text().then((txt) => {
       try {
         loadTileArts(JSON.parse(txt));
-        setArt(tileArtFor(terrain) ?? seedFromColor(terrain, size));
+        setArt(tileArtFor(terrain) ?? blankWithPalette(terrain, size));
         setNote('読み込んだ');
       } catch (e) {
         setNote(`読み込めなかった: ${String(e)}`);
@@ -136,7 +141,7 @@ export function TileArtEditor() {
             onChange={(e) => {
               const n = Number(e.target.value);
               setSize(n);
-              setArt(tileArtFor(terrain) ?? seedFromColor(terrain, n));
+              setArt(tileArtFor(terrain) ?? blankWithPalette(terrain, n));
             }}
           >
             {TILE_ART_SIZES.map((n) => <option key={n} value={n}>{n}×{n}</option>)}
@@ -144,31 +149,48 @@ export function TileArtEditor() {
         </label>
       </div>
 
-      {/* パレット (タイル内の色)。索引 0 は透明で固定。 */}
-      <div style={{ display: 'flex', gap: '0.3em', flexWrap: 'wrap', alignItems: 'center', marginBottom: '0.5em' }}>
+      {/* パレット (タイル内の色)。索引 0 は透明で固定。
+          **色見本と色の変更を分ける。** 見本の下に 24×16px の色ピッカーを並べていたが、
+          実機では小さすぎて押せず「色が選べない」状態だった。見本は選ぶだけにして、
+          変更は選択中の色ひとつに対して大きく出す。 */}
+      <div style={{ display: 'flex', gap: '0.3em', flexWrap: 'wrap', alignItems: 'center', marginBottom: '0.4em' }}>
         <span style={{ fontSize: '0.75em', color: 'var(--color-muted)' }}>いろ</span>
         {Array.from({ length: TILE_ART_MAX_COLORS }, (_, i) => i).map((i) => (
-          <span key={i} style={{ display: 'inline-flex', flexDirection: 'column', alignItems: 'center' }}>
-            <button
-              type="button"
-              onClick={() => setColor(i)}
-              title={i === 0 ? '透明' : art.palette[i] || '未設定'}
-              style={{
-                width: 24, height: 24, padding: 0,
-                background: i === 0 ? 'repeating-conic-gradient(#666 0% 25%, #333 0% 50%) 50% / 8px 8px' : (art.palette[i] || '#000'),
-                border: color === i ? '3px solid var(--color-accent)' : '1px solid var(--color-border)',
-              }}
-            />
-            {i > 0 && (
-              <input
-                type="color"
-                value={art.palette[i] || '#000000'}
-                onChange={(e) => setPaletteColor(i, e.target.value)}
-                style={{ width: 24, height: 16, padding: 0, border: 'none', background: 'none' }}
-              />
-            )}
-          </span>
+          <button
+            key={i}
+            type="button"
+            onClick={() => setColor(i)}
+            title={i === 0 ? '透明 (消しゴム)' : art.palette[i] || '未設定'}
+            style={{
+              width: 32, height: 32, padding: 0,
+              background: i === 0
+                ? 'repeating-conic-gradient(#666 0% 25%, #333 0% 50%) 50% / 10px 10px'
+                : (art.palette[i] || 'repeating-conic-gradient(#444 0% 25%, #222 0% 50%) 50% / 10px 10px'),
+              border: color === i ? '3px solid var(--color-accent)' : '1px solid var(--color-border)',
+            }}
+          />
         ))}
+      </div>
+
+      {/* 選択中の色を大きく変える */}
+      <div style={{ display: 'flex', gap: '0.5em', alignItems: 'center', marginBottom: '0.5em', fontSize: '0.8em' }}>
+        {color === 0 ? (
+          <span style={{ color: 'var(--color-muted)' }}>透明 (消しゴム) を選択中</span>
+        ) : (
+          <>
+            <span>いろ {color} を変える</span>
+            <input
+              type="color"
+              value={art.palette[color] || '#000000'}
+              onChange={(e) => setPaletteColor(color, e.target.value)}
+              style={{ width: 56, height: 34, padding: 0, border: '1px solid var(--color-border)', background: 'none' }}
+            />
+            <code style={{ color: 'var(--color-muted)' }}>{art.palette[color] || '未設定'}</code>
+          </>
+        )}
+        <label style={{ marginLeft: 'auto' }}>
+          <input type="checkbox" checked={trace} onChange={(e) => setTrace(e.target.checked)} /> 下敷き
+        </label>
       </div>
 
       {/* 画素グリッド */}
@@ -176,13 +198,27 @@ export function TileArtEditor() {
         onMouseLeave={() => { painting.current = false; }}
         onMouseUp={() => { painting.current = false; }}
         style={{
+          position: 'relative',
           display: 'grid',
           gridTemplateColumns: `repeat(${art.size}, ${CELL}px)`,
           width: art.size * CELL,
           border: '2px solid var(--color-border)',
           background: 'repeating-conic-gradient(#3a3a3a 0% 25%, #2a2a2a 0% 50%) 50% / 12px 12px',
+          touchAction: 'none',
         }}
       >
+        {/* **既存の SVG を下敷きに敷く。** 上からドットでなぞれば、ゼロから描くより早い。
+            透明の画素からは下敷きが透けて見える (置いた画素で隠れる)。 */}
+        {trace && (
+          <svg
+            viewBox="0 0 32 32"
+            width={art.size * CELL}
+            height={art.size * CELL}
+            style={{ position: 'absolute', inset: 0, pointerEvents: 'none', opacity: 0.85 }}
+          >
+            {TERRAIN_TILES[terrain as keyof typeof TERRAIN_TILES] ?? null}
+          </svg>
+        )}
         {Array.from({ length: art.size * art.size }, (_, i) => {
           const x = i % art.size;
           const y = Math.floor(i / art.size);
@@ -190,9 +226,17 @@ export function TileArtEditor() {
           return (
             <div
               key={i}
-              onMouseDown={() => { painting.current = true; paint(x, y); }}
-              onMouseEnter={() => { if (painting.current) paint(x, y); }}
-              style={{ width: CELL, height: CELL, background: c || 'transparent', cursor: 'crosshair' }}
+              onPointerDown={(e) => {
+                painting.current = true;
+                (e.currentTarget as HTMLElement).releasePointerCapture?.(e.pointerId);
+                paint(x, y);
+              }}
+              onPointerEnter={() => { if (painting.current) paint(x, y); }}
+              onPointerUp={() => { painting.current = false; }}
+              style={{
+                width: CELL, height: CELL, background: c || 'transparent',
+                cursor: 'crosshair', position: 'relative', touchAction: 'none',
+              }}
             />
           );
         })}
@@ -222,11 +266,14 @@ export function TileArtEditor() {
   );
 }
 
-/** 新規作成の下敷き: その地形の代表色でべた塗りしておく (真っ白から描き始めない)。 */
-function seedFromColor(terrain: string, size: number): TileArt {
+/**
+ * 新規作成: **画素は透明のまま**、パレットにだけその地形の代表色を入れておく。
+ * 下敷き (既存 SVG) をなぞる前提なので、べた塗りすると下敷きが見えなくなる。
+ * 色が 1 つも無いと「色が選べない」ので、代表色は最初から入れる。
+ */
+function blankWithPalette(terrain: string, size: number): TileArt {
   const base = (TERRAIN_COLORS as Record<string, string>)[terrain] ?? UNKNOWN_TERRAIN_COLOR;
   const art = emptyTileArt(size);
-  art.palette = ['', base];
-  art.pixels.fill(1);
+  art.palette = ['', base, '#ffffff', '#000000'];
   return art;
 }

--- a/apps/web/src/routes/admin-map.tsx
+++ b/apps/web/src/routes/admin-map.tsx
@@ -8,7 +8,6 @@ import {
   encodeWorldMap,
   setTownOverrides,
   worldTownOverrides,
-  loadStaticWorldMap,
   setWorldMap,
   worldMapTiles,
   worldOverlay,
@@ -17,7 +16,7 @@ import {
 } from '@aozoraquest/core';
 import { useSession } from '@/lib/session';
 import { isAdminDid } from '@/lib/runtime-config';
-import { saveWorldMap } from '@/lib/world-authoring';
+import { loadAuthoredWorld, saveWorldMap } from '@/lib/world-authoring';
 import { TERRAIN_TILES, fallbackTile, pixelTile } from '@/components/world-tiles';
 import { TileArtEditor } from '@/components/admin/tile-art-editor';
 
@@ -64,9 +63,13 @@ export function AdminMap() {
   const [townMode, setTownMode] = useState(false);
   const [townTick, setTownTick] = useState(0);
   const painting = useRef(false);
+  const svgRef = useRef<SVGSVGElement>(null);
 
   useEffect(() => {
-    void loadStaticWorldMap()
+    // **保存済みの地図を読む。** 同梱の地図を読んでいたため、編集して保存したあと
+    // この画面を開き直すと**編集が消えて見え、そのまま保存すると上書きされていた**。
+    // 地図の出所は保存経路と必ず同じにする。
+    void loadAuthoredWorld(session.agent ?? null)
       .then(() => {
         const src = worldMapTiles();
         if (!src) throw new Error('地図が読み込めていない');
@@ -79,7 +82,8 @@ export function AdminMap() {
         setReady(true);
       })
       .catch((e) => setNote(`地図を読めなかった: ${String(e)}`));
-  }, []);
+    // agent が入るのは復元後なので、それを待って読む (未ログインだと保存済みを読めない)。
+  }, [session.agent]);
 
   const place = useCallback((cx: number, cy: number) => {
     const tiles = draftRef.current;
@@ -134,6 +138,23 @@ export function AdminMap() {
    * 読み込み済みの地図と差し替わり、**このタブでワールドを歩いて確かめられる**。
    * 他の人には見えないし、リロードすると元に戻る (保存していないため)。
    */
+  /**
+   * **画面座標からマスを引いて置く。**
+   *
+   * `onMouseEnter` に頼ると**タッチでは連続配置できない** — 指を滑らせても
+   * enter/leave が飛ばないため、1 マスずつタップするしかなくなる (実機で発生)。
+   * ポインタ座標を SVG の座標系に落として自分で解決する。
+   */
+  const paintAtPointer = useCallback((clientX: number, clientY: number) => {
+    const svg = svgRef.current;
+    if (!svg) return;
+    const r = svg.getBoundingClientRect();
+    const cx = Math.floor(((clientX - r.left) / r.width) * COLS);
+    const cy = Math.floor(((clientY - r.top) / r.height) * ROWS);
+    if (cx < 0 || cy < 0 || cx >= COLS || cy >= ROWS) return;
+    place(cx, cy);
+  }, [place]);
+
   const preview = useCallback(() => {
     const tiles = draftRef.current;
     if (!tiles) return;
@@ -281,11 +302,22 @@ export function AdminMap() {
           {/* 地図本体 */}
           <div style={{ overflow: 'auto', maxWidth: '100%', border: '2px solid var(--color-border)', width: 'fit-content' }}>
             <svg
+              ref={svgRef}
               width={W}
               height={H}
               viewBox={`0 0 ${COLS * 32} ${ROWS * 32}`}
-              onMouseLeave={() => { painting.current = false; }}
-              onMouseUp={() => { painting.current = false; }}
+              onPointerDown={(e) => {
+                if (townMode) return; // 街は 1 マスずつ (名前を聞くので連続配置しない)
+                painting.current = true;
+                (e.currentTarget as SVGSVGElement).setPointerCapture(e.pointerId);
+                paintAtPointer(e.clientX, e.clientY);
+              }}
+              onPointerMove={(e) => { if (painting.current) paintAtPointer(e.clientX, e.clientY); }}
+              onPointerUp={(e) => {
+                painting.current = false;
+                try { (e.currentTarget as SVGSVGElement).releasePointerCapture(e.pointerId); } catch { /* 既に外れている */ }
+              }}
+              onPointerCancel={() => { painting.current = false; }}
               style={{ display: 'block', cursor: 'crosshair', touchAction: 'none' }}
             >
               {cells.map(({ cx, cy, t }) => (
@@ -323,21 +355,27 @@ export function AdminMap() {
                   key={`h-${cx}-${cy}`}
                   x={cx * 32} y={cy * 32} width={32} height={32}
                   fill="transparent"
-                  onMouseDown={() => {
-                    if (townMode) { editTown(cx, cy); return; }
-                    painting.current = true;
-                    place(cx, cy);
-                  }}
-                  onMouseEnter={() => { if (painting.current && !townMode) place(cx, cy); }}
+                  onClick={() => { if (townMode) editTown(cx, cy); }}
                 />
               ))}
             </svg>
           </div>
 
+          {/* **全体マップ。** 1024 タイルを 1 画素ずつ縮めて出し、押した場所へ飛ぶ。
+              ボタン移動だけだと世界の端から端まで数十回押すことになる。 */}
+          <WorldMinimap
+            tiles={draftRef.current}
+            origin={origin}
+            onJump={(x, y) => setOrigin({ x: wrap(x - Math.floor(COLS / 2)), y: wrap(y - Math.floor(ROWS / 2)) })}
+          />
+
           {/* 移動 */}
           <div style={{ display: 'flex', gap: '0.3em', flexWrap: 'wrap', marginTop: '0.5em', fontSize: '0.85em' }}>
+            {/* **半画面ずつ動かす。** 1 画面まるごと切り替えると接合部が一度も見えず、
+                端をまたぐ地形をつなげられない。 */}
             {([
-              ['←', -COLS, 0], ['→', COLS, 0], ['↑', 0, -ROWS], ['↓', 0, ROWS],
+              ['←', -Math.floor(COLS / 2), 0], ['→', Math.floor(COLS / 2), 0],
+              ['↑', 0, -Math.floor(ROWS / 2)], ['↓', 0, Math.floor(ROWS / 2)],
               ['←1', -1, 0], ['→1', 1, 0], ['↑1', 0, -1], ['↓1', 0, 1],
             ] as const).map(([label, dx, dy]) => (
               <button key={label} type="button" onClick={() => pan(dx, dy)} style={{ padding: '0.2em 0.6em' }}>
@@ -368,6 +406,70 @@ export function AdminMap() {
           </div>
         </>
       )}
+    </div>
+  );
+}
+
+/** 全体マップ (1024×1024 を縮小)。押した場所へビューを飛ばす。 */
+function WorldMinimap({
+  tiles,
+  origin,
+  onJump,
+}: {
+  tiles: Uint8Array | null;
+  origin: { x: number; y: number };
+  onJump: (x: number, y: number) => void;
+}) {
+  const ref = useRef<HTMLCanvasElement>(null);
+  /** 表示サイズ (px)。1024 を SAMPLE 間隔で間引いて描く。 */
+  const PX = 256;
+  const SAMPLE = WORLD_SIZE / PX; // 4
+
+  useEffect(() => {
+    const cv = ref.current;
+    if (!cv || !tiles) return;
+    const ctx = cv.getContext('2d');
+    if (!ctx) return;
+    const img = ctx.createImageData(PX, PX);
+    const buf = new Uint32Array(img.data.buffer);
+    for (let y = 0; y < PX; y++) {
+      const row = y * SAMPLE * WORLD_SIZE;
+      for (let x = 0; x < PX; x++) {
+        const hex = editorColorAt(tiles[row + x * SAMPLE]!);
+        const r = parseInt(hex.slice(1, 3), 16);
+        const g = parseInt(hex.slice(3, 5), 16);
+        const b = parseInt(hex.slice(5, 7), 16);
+        buf[y * PX + x] = (255 << 24) | (b << 16) | (g << 8) | r;
+      }
+    }
+    ctx.putImageData(img, 0, 0);
+    // 今どこを見ているか
+    ctx.strokeStyle = '#fff';
+    ctx.lineWidth = 1;
+    ctx.strokeRect(origin.x / SAMPLE, origin.y / SAMPLE, COLS / SAMPLE, ROWS / SAMPLE);
+  }, [tiles, origin, SAMPLE]);
+
+  return (
+    <div style={{ marginTop: '0.6em' }}>
+      <div style={{ fontSize: '0.75em', color: 'var(--color-muted)', marginBottom: '0.2em' }}>
+        全体マップ (押すとその場所へ飛ぶ)
+      </div>
+      <canvas
+        ref={ref}
+        width={PX}
+        height={PX}
+        onPointerDown={(e) => {
+          const r = e.currentTarget.getBoundingClientRect();
+          onJump(
+            Math.round(((e.clientX - r.left) / r.width) * WORLD_SIZE),
+            Math.round(((e.clientY - r.top) / r.height) * WORLD_SIZE),
+          );
+        }}
+        style={{
+          width: PX, height: PX, imageRendering: 'pixelated',
+          border: '2px solid var(--color-border)', cursor: 'crosshair', touchAction: 'none',
+        }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
Refs #421

## ★ 保存した地図が消えていた (データ消失)

> さっき編集して保存した地図が消えてしまった

**エディタが同梱の地図を読んでいて、保存済みの地図を読んでいなかった。**

```
admin-map.tsx: loadStaticWorldMap()   ← 同梱 (生成そのまま)
world.tsx    : loadAuthoredWorld()    ← 保存済み
```

編集 → 保存 → 画面を開き直す、で**編集が消えて見え、そのまま保存すると同梱の地図で
上書きされる**。地図の出所を保存経路と同じ `loadAuthoredWorld` に揃えた。
`agent` の復元を待ってから読む (未ログインだと保存済みを読めないため)。

## ドラッグで置けなかった (タッチ)

`onMouseEnter` に頼っていたため、**指を滑らせても連続配置できず 1 マスずつタップする
しかなかった**。ポインタ座標から自分でマスを引く方式に変え、`setPointerCapture` で
指が SVG の外に出ても追従するようにした。

## 移動が大変だった

- **全体マップを追加**。1024×1024 を 256px に縮めて出し、**押した場所へ飛ぶ**。
  今どこを見ているかを白枠で重ねる
- スクロールを 1 画面ぶん → **半画面ぶん**に。丸ごと切り替わると**接合部が一度も見えず**、
  端をまたぐ地形をつなげられない

## ドット絵エディタ

> パーツの絵は SVG を読み込んで表示して欲しい。上からドット絵でなぞれるようにしてほしい
> 色選択できないのでできるようにして

- **既存の SVG を下敷きに敷く**。透明の画素から透けて見え、置いた画素で隠れる。オン/オフ可
- 下敷き前提なので新規作成は**画素を透明のまま**に (代表色でべた塗りすると下敷きが見えない)
- **色が選べなかった**のを直す。色見本の下に 24×16px の色ピッカーを並べていたが、
  実機では小さすぎて押せなかった。見本は選ぶだけにして、**変更は選択中の色ひとつに対して
  大きく**出す (56×34px)。新規作成時点でパレットに代表色・白・黒を入れておく

## 検証

web 360 tests + e2e 10 件 green、typecheck・build green。