### PR TITLE
モンスターエディタの使い勝手 4 件

### DIFF
--- a/apps/web/src/routes/admin-monsters.tsx
+++ b/apps/web/src/routes/admin-monsters.tsx
@@ -10,6 +10,8 @@ import {
   setMonsterOverrides,
   MonsterDataError,
   JOBS,
+  ITEMS,
+  type Element,
   type MonsterDef,
   type Tier,
 } from '@aozoraquest/core';
@@ -218,14 +220,19 @@ export function AdminMonsters() {
                 style={{ width: '5em' }}
               />
             )))}
-            {field('XP 上書き', (
-              <input
-                type="number"
-                value={current.xp ?? ''}
-                placeholder={`式: ${baselineXp(current)}`}
-                onChange={(e) => update(current.id, { xp: e.target.value === '' ? undefined : Number(e.target.value) })}
-                style={{ width: '6em' }}
-              />
+            {field('たおした XP', (
+              <span style={{ display: 'flex', gap: '0.4em', alignItems: 'center' }}>
+                <input
+                  type="number"
+                  value={current.xp ?? ''}
+                  placeholder={String(baselineXp(current))}
+                  onChange={(e) => update(current.id, { xp: e.target.value === '' ? undefined : Number(e.target.value) })}
+                  style={{ width: '6em' }}
+                />
+                <span style={{ fontSize: '0.85em', color: 'var(--color-muted)' }}>
+                  空欄 = 強さから自動 ({baselineXp(current)})。特別に多く/少なくしたいときだけ入れる
+                </span>
+              </span>
             ))}
             {field('出現の重み', <input type="number" step="0.01" value={current.spawnWeight ?? 1} onChange={(e) => update(current.id, { spawnWeight: Number(e.target.value) })} style={{ width: '5em' }} />)}
             {field('能力', (
@@ -237,30 +244,92 @@ export function AdminMonsters() {
               </select>
             ))}
             {current.ability === 'charger' && field('技名', <input value={current.skillName ?? ''} onChange={(e) => update(current.id, { skillName: e.target.value || undefined })} />)}
-            {current.ability === 'healer' && field('回復技名', <input value={current.healName ?? ''} onChange={(e) => update(current.id, { healName: e.target.value || undefined })} />)}
-            {current.ability === 'caster' && field('spell (JSON)', (
-              <input
-                value={JSON.stringify(current.spell ?? null)}
-                onChange={(e) => {
-                  try { update(current.id, { spell: JSON.parse(e.target.value) || undefined }); } catch { /* 入力途中 */ }
-                }}
-                style={{ width: '100%', fontFamily: 'ui-monospace, monospace', fontSize: '0.9em' }}
-              />
-            ))}
+            {current.ability === 'healer' && (
+              <>
+                {field('回復技名', <input value={current.healName ?? ''} onChange={(e) => update(current.id, { healName: e.target.value || undefined })} />)}
+                {field('回復幅', (
+                  <span style={{ display: 'flex', gap: '0.4em', alignItems: 'center' }}>
+                    <input
+                      type="number" step="0.05" min="0.05" max="1"
+                      value={current.healRatio ?? ''}
+                      placeholder="0.3"
+                      onChange={(e) => update(current.id, { healRatio: e.target.value === '' ? undefined : Number(e.target.value) })}
+                      style={{ width: '5em' }}
+                    />
+                    <span style={{ fontSize: '0.85em', color: 'var(--color-muted)' }}>最大 HP に対する割合 (空欄 = 0.3)</span>
+                  </span>
+                ))}
+              </>
+            )}
+            {current.ability === 'caster' && (
+              <>
+                {field('魔法の名前', (
+                  <input
+                    value={current.spell?.name ?? ''}
+                    onChange={(e) => update(current.id, { spell: { min: 3, max: 6, ...current.spell, name: e.target.value } })}
+                  />
+                ))}
+                {field('属性', (
+                  <select
+                    value={current.spell?.element ?? ''}
+                    onChange={(e) => {
+                      const next = { name: '', min: 3, max: 6, ...current.spell } as NonNullable<MonsterDef['spell']> & { element?: Element };
+                      if (e.target.value === '') delete next.element;
+                      else next.element = e.target.value as Element;
+                      update(current.id, { spell: next });
+                    }}
+                  >
+                    <option value="">なし (無属性)</option>
+                    {(['fire', 'water', 'wind', 'earth', 'void'] as const).map((el) => (
+                      <option key={el} value={el}>{el}</option>
+                    ))}
+                  </select>
+                ))}
+                {field('ダメージ', (
+                  <span style={{ display: 'flex', gap: '0.3em', alignItems: 'center' }}>
+                    <input
+                      type="number"
+                      value={current.spell?.min ?? 3}
+                      onChange={(e) => update(current.id, { spell: { name: '', max: 6, ...current.spell, min: Number(e.target.value) } })}
+                      style={{ width: '4.5em' }}
+                    />
+                    〜
+                    <input
+                      type="number"
+                      value={current.spell?.max ?? 6}
+                      onChange={(e) => update(current.id, { spell: { name: '', min: 3, ...current.spell, max: Number(e.target.value) } })}
+                      style={{ width: '4.5em' }}
+                    />
+                    <span style={{ fontSize: '0.85em', color: 'var(--color-muted)' }}>+ かしこさ ×</span>
+                    <input
+                      type="number" step="0.05"
+                      value={current.spell?.intScale ?? 0}
+                      onChange={(e) => update(current.id, { spell: { name: '', min: 3, max: 6, ...current.spell, intScale: Number(e.target.value) } })}
+                      style={{ width: '4.5em' }}
+                    />
+                  </span>
+                ))}
+              </>
+            )}
             {field('ひとこと', <input value={current.intro} onChange={(e) => update(current.id, { intro: e.target.value })} style={{ width: '100%' }} />)}
             {/* ドロップ */}
             <div style={{ fontSize: '0.8em' }}>
               <span style={{ color: 'var(--color-muted)' }}>ドロップ</span>
               {current.drops.map((d, i) => (
                 <div key={i} style={{ display: 'flex', gap: '0.3em', alignItems: 'center', margin: '0.15em 0' }}>
-                  <input
+                  {/* **ゲーム内の名前で選ぶ。** 内部 id の自由入力は typo で「落ちない
+                      ドロップ」を静かに作る (エラーにもならない)。 */}
+                  <select
                     value={d.item}
                     onChange={(e) => {
                       const drops = current.drops.map((x, j) => (j === i ? { ...x, item: e.target.value } : x));
                       update(current.id, { drops });
                     }}
-                    style={{ width: '10em' }}
-                  />
+                  >
+                    {Object.entries(ITEMS).map(([id, it]) => (
+                      <option key={id} value={id}>{it.name}</option>
+                    ))}
+                  </select>
                   <input
                     type="number" step="0.05" min="0" max="1"
                     value={d.chance}

--- a/packages/core/src/__tests__/monster-data.test.ts
+++ b/packages/core/src/__tests__/monster-data.test.ts
@@ -117,3 +117,25 @@ describe('空プールで移動を殺さない (#419)', () => {
     expect(r.def.tier).toBe(1); // tier2 が空 → tier1 に繰り下げ
   });
 });
+
+describe('healer の回復幅とspell の検証 (#419)', () => {
+  afterEach(() => setMonsterOverrides(null));
+
+  it('healRatio が敵ごとに効く', () => {
+    setMonsterOverrides([
+      ...trio(1, 'a'),
+      base({ id: 'tough', name: 'しぶとい', hp: 40, mp: 30, ability: 'healer', healRatio: 0.5, stats: [1, 5, 1, 20, 4] }),
+    ]);
+    // 直接 heal 行動を検証するのは resolveTurn 経由になるので、値の伝播だけ固定する
+    expect(MONSTERS_BY_ID['tough']?.healRatio).toBe(0.5);
+  });
+
+  it('壊れた healRatio / spell は保存できない', () => {
+    expect(() => setMonsterOverrides([...trio(1, 'a'), base({ id: 'x', ability: 'healer', healRatio: 1.5 })]))
+      .toThrow(MonsterDataError);
+    expect(() => setMonsterOverrides([...trio(1, 'a'), base({ id: 'x', ability: 'caster', spell: { name: 'x', min: 9, max: 3 } })]))
+      .toThrow(MonsterDataError); // min > max
+    expect(() => setMonsterOverrides([...trio(1, 'a'), base({ id: 'x', ability: 'caster', spell: { name: '', min: 'a' } as never })]))
+      .toThrow(MonsterDataError);
+  });
+});

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -991,6 +991,9 @@ export interface MonsterDef {
   ability?: 'charger' | 'healer' | 'fleer' | 'caster';
   /** healer の回復技名 (省略時デフォルト)。 */
   healName?: string;
+  /** healer の回復幅 (maxHp に対する割合 0〜1)。省略時は BATTLE_TUNING.healerHealRatio。
+   *  敵ごとに「しぶとさ」を変えられる (エディタから編集可能。#419)。 */
+  healRatio?: number;
   /** caster の魔法 (#456)。def 無視・属性つきの int スケール魔撃。ダメージ = min〜max + int*intScale。
    *  魔法致死は onLethal を通らない (物理耐性の覇王/不動 も魔法では死ぬ = 設計どおりの弱点)。
    *  データ規約: min <= max (span 負を避ける)。caster の攻撃ラベルは skillName でなくこの name を使う。 */
@@ -1895,7 +1898,8 @@ export function resolveTurn(prev: BattleState, command: Command, turnSeed?: numb
       } else if (mCommand === 'heal') {
         // healer の自己回復 (MP 消費)。MP が尽きるまでの読み合いを作る
         state.monster.mp = Math.max(0, state.monster.mp - BATTLE_TUNING.monsterHealMpCost);
-        const healed = Math.round(state.monster.maxHp * BATTLE_TUNING.healerHealRatio);
+        const ratio = MONSTERS_BY_ID[state.monsterId]?.healRatio ?? BATTLE_TUNING.healerHealRatio;
+        const healed = Math.round(state.monster.maxHp * ratio);
         const before = state.monster.hp;
         state.monster.hp = Math.min(state.monster.maxHp, state.monster.hp + healed);
         const name = MONSTERS_BY_ID[state.monsterId]?.healName ?? 'きずをいやす';

--- a/packages/core/src/monster-data.ts
+++ b/packages/core/src/monster-data.ts
@@ -86,6 +86,15 @@ function validate(defs: readonly MonsterDef[]): readonly MonsterDef[] {
       throw new MonsterDataError(`${where}: ability が不正 (${m.ability})`);
     }
     if (m.ability === 'caster' && !m.spell) throw new MonsterDataError(`${where}: caster には spell が要る`);
+    if (m.healRatio !== undefined && !(m.healRatio > 0 && m.healRatio <= 1)) {
+      throw new MonsterDataError(`${where}: healRatio は 0〜1 (${m.healRatio})`);
+    }
+    if (m.spell) {
+      const sp = m.spell as { name?: unknown; min?: unknown; max?: unknown };
+      if (typeof sp.name !== 'string' || typeof sp.min !== 'number' || typeof sp.max !== 'number' || (sp.min as number) > (sp.max as number)) {
+        throw new MonsterDataError(`${where}: spell が不正 (name/min/max)`);
+      }
+    }
   }
   // **tier1 は 3 体を下回れない。** spawn 近辺のプールが痩せると summonMonster が
   // 選べる敵を失い、move が 500 になってその街から出られなくなる (既知の事故経路)。


### PR DESCRIPTION
Refs #419

指摘 7 件のうち、この PR で 4 件 + 検証強化。残り 3 件は設計が要るので issue 化した。

## この PR

| 指摘 | 対応 |
|---|---|
| ドロップが内部 id の自由入力で事故る | **ゲーム内の名前のドロップダウン**に。typo は「落ちないドロップ」を静かに作るのでエラーにすらならなかった |
| XP 上書きとは？ | **「たおした XP」**に改名。空欄 = 強さから自動 (式の値を placeholder + 説明で表示) |
| spell の JSON 直編集がキツい | **フォーム化**: 名前 / 属性 (select) / ダメージ min〜max / かしこさ係数 |
| 回復幅が入れられない | **healRatio を追加** (敵ごとの「しぶとさ」。今まで全敵共通の tuning 値しかなかった)。0〜1 で検証 |

spell も保存時に検証 (name/min/max、min > max は拒否)。

## issue 化 (設計が要る)

- **#591 絵の差し替え** — タイルのドット絵エディタを流用 (`monster:<id>` キー、
  既存 SVG を下敷きになぞる)。SVG サニタイズ問題 (#537) を回避
- **#592 能力の複数化 + パラメータのデータ化** — 段階 1: 発動確率・閾値を敵ごとに
  上書き可能に / 段階 2: `abilities[]` (優先順 = 配列順) / 段階 3: 簡易スクリプト DSL は
  1〜2 で表現できないパターンが実際に出てから

## 検証

core 587 / web 360 / edge 216 tests green、typecheck・build green。