### PR TITLE
モンスターの絵をドット絵で描き替え + 回復は固定値を既定に

### DIFF
--- a/apps/web/src/components/admin/tile-art-editor.tsx
+++ b/apps/web/src/components/admin/tile-art-editor.tsx
@@ -35,36 +35,64 @@ import { saveTileArts } from '@/lib/world-authoring';
 /** 編集中の拡大率 (1 画素を何 px で見せるか)。 */
 const CELL = 22;
 
-export function TileArtEditor({ parts: partsIn }: { parts?: readonly { terrain: string; name: string }[] } = {}) {
+/** 描く対象 1 件。地形パーツにもモンスターにも使う (#591)。 */
+export interface ArtSubject {
+  /** 登録簿のキー (`part:3` / `monster:sky-slime`)。 */
+  key: string;
+  /** 一覧での表示名。 */
+  name: string;
+  /** 新規作成時にパレットへ入れる代表色。 */
+  seedColor: string;
+  /** 古い保存のキー (地形名時代の互換)。無ければ key だけ探す。 */
+  legacyKey?: string;
+  /** 下敷き (既存の SVG)。ゼロから描くよりなぞるほうが早い。 */
+  underlay?: React.ReactNode;
+}
+
+export function TileArtEditor({ parts: partsIn, subjects: subjectsIn }: { parts?: readonly { terrain: string; name: string }[]; subjects?: ArtSubject[] } = {}) {
   const session = useSession();
-  // **パーツ index ごとに絵を持つ。** 「縦の橋」のように通行判定は同じで絵だけ違う
-  // パーツを足せるようにするため、地形 id ではなく index をキーにする。
-  // 呼び出し元 (マップ編集画面) が持つ一覧を優先する。別々に読むと、増やした直後に
-  // 片方だけ古い一覧を見て「足したパーツが絵タブに出てこない」になる。
+  // 対象一覧。呼び出し元 (マップ/モンスター編集画面) が持つ一覧を優先する。
+  // 別々に読むと、増やした直後に片方だけ古い一覧を見て「一覧に出てこない」になる。
   const parts = partsIn ?? worldParts();
+  const subjects: ArtSubject[] = subjectsIn ?? parts.map((pt, i) => ({
+    key: partKey(i),
+    name: pt.name,
+    seedColor: (TERRAIN_COLORS as Record<string, string>)[pt.terrain] ?? UNKNOWN_TERRAIN_COLOR,
+    legacyKey: pt.terrain,
+    underlay: <svg viewBox="0 0 32 32" width="100%" height="100%">{TERRAIN_TILES[pt.terrain as keyof typeof TERRAIN_TILES] ?? null}</svg>,
+  }));
   const [partIndex, setPartIndex] = useState(0);
-  const terrain = partKey(partIndex);
+  const subject = subjects[partIndex] ?? subjects[0]!;
+  const terrain = subject.key;
   const [size, setSize] = useState<number>(16);
   // **初期表示も代表色の下敷きから始める。** emptyTileArt だと全画素が透明で、
   // 開いた瞬間は市松模様しか出ず「壊れている」ように見える (実機で確認)。
   // 描いた絵があればそれ、無ければ**透明から**。下敷き (既存 SVG) をなぞる前提なので、
   // 代表色で塗りつぶすと下敷きが見えなくなる。パレットには代表色を入れておく。
-  const [art, setArt] = useState<TileArt>(() => partArtFor(0, BASE_PALETTE[0]!) ?? blankWithPalette(BASE_PALETTE[0]!, 16));
+  const [art, setArt] = useState<TileArt>(() => {
+    const sub = (subjectsIn ?? [])[0];
+    if (sub) return (tileArtFor(sub.key) ?? (sub.legacyKey ? tileArtFor(sub.legacyKey) : undefined)) ?? blankWithSeed(sub.seedColor, 16);
+    return partArtFor(0, BASE_PALETTE[0]!) ?? blankWithSeed((TERRAIN_COLORS as Record<string, string>)[BASE_PALETTE[0]!] ?? UNKNOWN_TERRAIN_COLOR, 16);
+  });
   const [color, setColor] = useState(1);
   const [note, setNote] = useState<string | null>(null);
   /** **既存の SVG を下敷きに敷く。** ゼロから描くより、今の絵をなぞるほうが早い。 */
   const [trace, setTrace] = useState(true);
   const painting = useRef(false);
 
+  const lookup = useCallback((sub: ArtSubject): TileArt | undefined => {
+    // **古い保存 (地形名キー) にも当たる**。描画側と同じ探し方にしないと、
+    // 「地図には出るのに編集画面では SVG に戻る」になる。
+    return tileArtFor(sub.key) ?? (sub.legacyKey ? tileArtFor(sub.legacyKey) : undefined);
+  }, []);
+
   const pick = useCallback((i: number) => {
     setPartIndex(i);
-    const key = partKey(i);
-    const base = worldParts()[i]?.terrain ?? BASE_PALETTE[0]!;
-    // **古い保存 (地形名キー) にも当たる**。地図側と同じ探し方にしないと、
-    // 「地図には出るのに編集画面では SVG に戻る」になる。
-    setArt(partArtFor(i, base) ?? blankWithPalette(base, size));
+    const sub = subjects[i];
+    if (!sub) return;
+    setArt(lookup(sub) ?? blankWithSeed(sub.seedColor, size));
     setColor(1);
-  }, [size]);
+  }, [size, subjects, lookup]);
 
   const paint = useCallback((x: number, y: number) => {
     setArt((a) => {
@@ -109,7 +137,7 @@ export function TileArtEditor({ parts: partsIn }: { parts?: readonly { terrain: 
     void file.text().then((txt) => {
       try {
         loadTileArts(JSON.parse(txt));
-        setArt(partArtFor(partIndex, parts[partIndex]?.terrain ?? 'plains') ?? blankWithPalette(parts[partIndex]?.terrain ?? 'plains', size));
+        setArt(lookup(subject) ?? blankWithSeed(subject.seedColor, size));
         setNote('読み込んだ');
       } catch (e) {
         setNote(`読み込めなかった: ${String(e)}`);
@@ -135,8 +163,8 @@ export function TileArtEditor({ parts: partsIn }: { parts?: readonly { terrain: 
         <label style={{ fontSize: '0.8em' }}>
           地形{' '}
           <select value={partIndex} onChange={(e) => pick(Number(e.target.value))}>
-            {parts.map((pt, i) => (
-              <option key={i} value={i}>{pt.name}{partArtFor(i, pt.terrain) ? ' ●' : ''}</option>
+            {subjects.map((sub, i) => (
+              <option key={sub.key} value={i}>{sub.name}{lookup(sub) ? ' ●' : ''}</option>
             ))}
           </select>
         </label>
@@ -147,7 +175,7 @@ export function TileArtEditor({ parts: partsIn }: { parts?: readonly { terrain: 
             onChange={(e) => {
               const n = Number(e.target.value);
               setSize(n);
-              setArt(partArtFor(partIndex, parts[partIndex]?.terrain ?? 'plains') ?? blankWithPalette(parts[partIndex]?.terrain ?? 'plains', n));
+              setArt(lookup(subject) ?? blankWithSeed(subject.seedColor, n));
             }}
           >
             {TILE_ART_SIZES.map((n) => <option key={n} value={n}>{n}×{n}</option>)}
@@ -215,15 +243,10 @@ export function TileArtEditor({ parts: partsIn }: { parts?: readonly { terrain: 
       >
         {/* **既存の SVG を下敷きに敷く。** 上からドットでなぞれば、ゼロから描くより早い。
             透明の画素からは下敷きが透けて見える (置いた画素で隠れる)。 */}
-        {trace && (
-          <svg
-            viewBox="0 0 32 32"
-            width={art.size * CELL}
-            height={art.size * CELL}
-            style={{ position: 'absolute', inset: 0, pointerEvents: 'none', opacity: 0.85 }}
-          >
-            {TERRAIN_TILES[(parts[partIndex]?.terrain ?? 'plains') as keyof typeof TERRAIN_TILES] ?? null}
-          </svg>
+        {trace && subject.underlay && (
+          <div style={{ position: 'absolute', inset: 0, pointerEvents: 'none', opacity: 0.85 }}>
+            {subject.underlay}
+          </div>
         )}
         {Array.from({ length: art.size * art.size }, (_, i) => {
           const x = i % art.size;
@@ -268,13 +291,12 @@ export function TileArtEditor({ parts: partsIn }: { parts?: readonly { terrain: 
 }
 
 /**
- * 新規作成: **画素は透明のまま**、パレットにだけその地形の代表色を入れておく。
+ * 新規作成: **画素は透明のまま**、パレットにだけ代表色を入れておく。
  * 下敷き (既存 SVG) をなぞる前提なので、べた塗りすると下敷きが見えなくなる。
  * 色が 1 つも無いと「色が選べない」ので、代表色は最初から入れる。
  */
-function blankWithPalette(terrain: string, size: number): TileArt {
-  const base = (TERRAIN_COLORS as Record<string, string>)[terrain] ?? UNKNOWN_TERRAIN_COLOR;
+function blankWithSeed(seedColor: string, size: number): TileArt {
   const art = emptyTileArt(size);
-  art.palette = ['', base, '#ffffff', '#000000'];
+  art.palette = ['', seedColor, '#ffffff', '#000000'];
   return art;
 }

--- a/apps/web/src/components/monster-svg.tsx
+++ b/apps/web/src/components/monster-svg.tsx
@@ -1,12 +1,44 @@
 import type { ReactElement } from 'react';
-import type { MonsterSpecies, TintableSpecies } from '@aozoraquest/core';
+import { monsterArtFor, tileArtColorAt, type MonsterSpecies, type TintableSpecies } from '@aozoraquest/core';
 
 /**
  * モンスターの SVG (あおぞらワールドの野外遭遇で使う)。
  * 画像アセットなしのインライン SVG = 軽量・省メモリ (モバイル方針)。
  * species ごとに 1 枚、viewBox 100x100。ドット RPG 風の太い輪郭とシンプルな形。
  */
-export function MonsterSvg({ species, size = 160, tint }: { species: MonsterSpecies; size?: number; tint?: string | undefined }) {
+/**
+ * モンスターの絵。**ドット絵 (エディタで描いたもの) → 従来の SVG** の順に倒す (#591)。
+ * ドット絵は `monster:<id>` キーで、タイルと同じ登録簿から引く。
+ */
+export function MonsterSvg({ species, size = 160, tint, monsterId }: { species: MonsterSpecies; size?: number; tint?: string | undefined; monsterId?: string }) {
+  const art = monsterId ? monsterArtFor(monsterId) : undefined;
+  if (art) {
+    // ドット絵はアンチエイリアスを切って画素のまま出す (タイルと同じ作法)
+    const px = 100 / art.size;
+    const rects: React.ReactElement[] = [];
+    for (let y = 0; y < art.size; y++) {
+      let runStart = 0;
+      let runColor = tileArtColorAt(art, 0, y);
+      for (let x = 1; x <= art.size; x++) {
+        const c = x < art.size ? tileArtColorAt(art, x, y) : '\u0000';
+        if (c === runColor) continue;
+        if (runColor !== '') {
+          rects.push(<rect key={`${runStart}-${y}`} x={runStart * px} y={y * px} width={(x - runStart) * px} height={px} fill={runColor} />);
+        }
+        runStart = x;
+        runColor = c;
+      }
+    }
+    return (
+      <svg width={size} height={size} viewBox="0 0 100 100" aria-hidden style={{ display: 'block', filter: 'drop-shadow(0 4px 6px rgba(0,0,0,0.35))' }}>
+        <g shapeRendering="crispEdges">{rects}</g>
+      </svg>
+    );
+  }
+  return legacySvg(species, size, tint);
+}
+
+function legacySvg(species: MonsterSpecies, size: number, tint?: string | undefined) {
   return (
     <svg
       width={size}
@@ -24,7 +56,7 @@ const OUT = '#1b2530'; // 輪郭色
 
 // 色違い変種は tint (明示色) で主要な塗りを差し替える。CSS hue-rotate は輝度保存で
 // 「紅のつもりが青緑」になる等の事故があるため、狙った色を直接指定する (レビュー ★)。
-function bodyFor(species: MonsterSpecies, tint?: string): ReactElement {
+export function bodyFor(species: MonsterSpecies, tint?: string): ReactElement {
   switch (species) {
     case 'slime':
       return slimeBody(tint);

--- a/apps/web/src/components/world-battle-controls.tsx
+++ b/apps/web/src/components/world-battle-controls.tsx
@@ -135,7 +135,7 @@ function BattleFieldEnemy({ state, showEnemyVitals, defeated }: { state: BattleS
         style={{ display: 'inline-block', opacity: defeated ? 0.35 : 1, transform: defeated ? 'rotate(180deg)' : 'none', transition: 'opacity 300ms ease' }}
         className={!defeated && state.lastEvents.some((e) => e.actor === 'player' && e.damage) ? 'trial-hit' : ''}
       >
-        <MonsterSvg species={monsterDef?.species ?? 'slime'} tint={monsterDef?.tint} size={84} />
+        <MonsterSvg species={monsterDef?.species ?? 'slime'} tint={monsterDef?.tint} size={84} monsterId={state.monsterId} />
       </div>
       {/* **名前はどの職でも出す。** 以前は右ペインに出していたが、そこをとくぎ一覧にしたので
           消えてしまい、体力を見抜ける 5 職 (sage/seer/miko/mage/ninja) 以外の 11 職では

--- a/apps/web/src/routes/admin-monsters.tsx
+++ b/apps/web/src/routes/admin-monsters.tsx
@@ -18,7 +18,9 @@ import {
 import { useSession } from '@/lib/session';
 import { isAdminDid } from '@/lib/runtime-config';
 import { saveMonsters } from '@/lib/world-authoring';
-import { MonsterSvg } from '@/components/monster-svg';
+import { MonsterSvg, bodyFor } from '@/components/monster-svg';
+import { TileArtEditor, type ArtSubject } from '@/components/admin/tile-art-editor';
+import { monsterArtKey } from '@aozoraquest/core';
 
 /**
  * **モンスターエディタ** (#419)。一覧・編集・複製・削除と、保存前の検証・模擬戦。
@@ -45,6 +47,8 @@ export function AdminMonsters() {
   const [sel, setSel] = useState<string | null>(null);
   const [note, setNote] = useState<string | null>(null);
   const [dirty, setDirty] = useState(false);
+  // 絵を描くモード (ドット絵エディタを開く)。下敷きは従来の SVG。
+  const [drawing, setDrawing] = useState(false);
 
   const current = useMemo(() => list.find((m) => m.id === sel) ?? null, [list, sel]);
   const counts = monsterCountByTier(list);
@@ -176,7 +180,7 @@ export function AdminMonsters() {
                       background: 'transparent',
                     }}
                   >
-                    <MonsterSvg species={m.species} tint={m.tint} size={22} />
+                    <MonsterSvg species={m.species} tint={m.tint} size={22} monsterId={m.id} />
                     <span style={{ flex: 1 }}>{m.name}</span>
                     <span style={{ fontSize: '0.8em', color: 'var(--color-muted)' }}>xp{battleXpFor(m.id) || baselineXp(m)}</span>
                   </button>
@@ -190,10 +194,13 @@ export function AdminMonsters() {
         {current ? (
           <div style={{ display: 'flex', flexDirection: 'column', gap: '0.35em' }}>
             <div style={{ display: 'flex', gap: '0.4em', alignItems: 'center' }}>
-              <MonsterSvg species={current.species} tint={current.tint} size={48} />
+              <MonsterSvg species={current.species} tint={current.tint} size={48} monsterId={current.id} />
               <strong>{current.name}</strong>
               <code style={{ fontSize: '0.75em', color: 'var(--color-muted)' }}>{current.id}</code>
               <span style={{ marginLeft: 'auto', display: 'flex', gap: '0.3em' }}>
+                <button type="button" onClick={() => setDrawing((v) => !v)} style={{ fontSize: '0.8em' }}>
+                  {drawing ? '絵を閉じる' : '絵をかく'}
+                </button>
                 <button type="button" onClick={() => duplicate(current)} style={{ fontSize: '0.8em' }}>複製</button>
                 <button type="button" onClick={() => simulate(current)} style={{ fontSize: '0.8em' }}>模擬戦</button>
                 <button type="button" className="secondary" onClick={() => remove(current.id)} style={{ fontSize: '0.8em' }}>削除</button>
@@ -220,7 +227,7 @@ export function AdminMonsters() {
                 style={{ width: '5em' }}
               />
             )))}
-            {field('たおした XP', (
+            {field('XP', (
               <span style={{ display: 'flex', gap: '0.4em', alignItems: 'center' }}>
                 <input
                   type="number"
@@ -247,16 +254,18 @@ export function AdminMonsters() {
             {current.ability === 'healer' && (
               <>
                 {field('回復技名', <input value={current.healName ?? ''} onChange={(e) => update(current.id, { healName: e.target.value || undefined })} />)}
-                {field('回復幅', (
+                {field('回復量', (
                   <span style={{ display: 'flex', gap: '0.4em', alignItems: 'center' }}>
                     <input
-                      type="number" step="0.05" min="0.05" max="1"
-                      value={current.healRatio ?? ''}
-                      placeholder="0.3"
-                      onChange={(e) => update(current.id, { healRatio: e.target.value === '' ? undefined : Number(e.target.value) })}
+                      type="number" min="1"
+                      value={current.healAmount ?? ''}
+                      placeholder={String(Math.round((current.hp ?? 10) * (current.healRatio ?? 0.3)))}
+                      onChange={(e) => update(current.id, { healAmount: e.target.value === '' ? undefined : Number(e.target.value) })}
                       style={{ width: '5em' }}
                     />
-                    <span style={{ fontSize: '0.85em', color: 'var(--color-muted)' }}>最大 HP に対する割合 (空欄 = 0.3)</span>
+                    <span style={{ fontSize: '0.85em', color: 'var(--color-muted)' }}>
+                      固定値 (空欄 = 最大 HP の割合で自動。割合回復は HP の大きい敵ほど強くなるので固定値を推奨)
+                    </span>
                   </span>
                 ))}
               </>
@@ -312,6 +321,21 @@ export function AdminMonsters() {
               </>
             )}
             {field('ひとこと', <input value={current.intro} onChange={(e) => update(current.id, { intro: e.target.value })} style={{ width: '100%' }} />)}
+            {drawing && (
+              <TileArtEditor
+                subjects={[{
+                  key: monsterArtKey(current.id),
+                  name: current.name,
+                  seedColor: current.tint ?? '#8fd0ff',
+                  // 下敷きは従来の SVG (なぞって描く)。ドット絵を保存すると戦闘画面も差し替わる
+                  underlay: (
+                    <svg viewBox="0 0 100 100" width="100%" height="100%" aria-hidden>
+                      {bodyFor(current.species, current.tint)}
+                    </svg>
+                  ),
+                } satisfies ArtSubject]}
+              />
+            )}
             {/* ドロップ */}
             <div style={{ fontSize: '0.8em' }}>
               <span style={{ color: 'var(--color-muted)' }}>ドロップ</span>

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -992,8 +992,11 @@ export interface MonsterDef {
   /** healer の回復技名 (省略時デフォルト)。 */
   healName?: string;
   /** healer の回復幅 (maxHp に対する割合 0〜1)。省略時は BATTLE_TUNING.healerHealRatio。
-   *  敵ごとに「しぶとさ」を変えられる (エディタから編集可能。#419)。 */
+   *  **healAmount があればそちらが勝つ。** 割合は HP の大きい敵ほど強くなる
+   *  (HP100 の敵が毎回 30 戻る) ので、原則は固定値を使う。 */
   healRatio?: number;
+  /** healer の回復量 (固定値)。**エディタの既定はこちら** — 割合回復は強すぎる (#419)。 */
+  healAmount?: number;
   /** caster の魔法 (#456)。def 無視・属性つきの int スケール魔撃。ダメージ = min〜max + int*intScale。
    *  魔法致死は onLethal を通らない (物理耐性の覇王/不動 も魔法では死ぬ = 設計どおりの弱点)。
    *  データ規約: min <= max (span 負を避ける)。caster の攻撃ラベルは skillName でなくこの name を使う。 */
@@ -1898,8 +1901,10 @@ export function resolveTurn(prev: BattleState, command: Command, turnSeed?: numb
       } else if (mCommand === 'heal') {
         // healer の自己回復 (MP 消費)。MP が尽きるまでの読み合いを作る
         state.monster.mp = Math.max(0, state.monster.mp - BATTLE_TUNING.monsterHealMpCost);
-        const ratio = MONSTERS_BY_ID[state.monsterId]?.healRatio ?? BATTLE_TUNING.healerHealRatio;
-        const healed = Math.round(state.monster.maxHp * ratio);
+        // 固定値 (healAmount) が最優先。割合は HP の大きい敵ほど強くなるので原則使わない。
+        const mdef = MONSTERS_BY_ID[state.monsterId];
+        const healed = mdef?.healAmount
+          ?? Math.round(state.monster.maxHp * (mdef?.healRatio ?? BATTLE_TUNING.healerHealRatio));
         const before = state.monster.hp;
         state.monster.hp = Math.min(state.monster.maxHp, state.monster.hp + healed);
         const name = MONSTERS_BY_ID[state.monsterId]?.healName ?? 'きずをいやす';

--- a/packages/core/src/monster-data.ts
+++ b/packages/core/src/monster-data.ts
@@ -89,6 +89,9 @@ function validate(defs: readonly MonsterDef[]): readonly MonsterDef[] {
     if (m.healRatio !== undefined && !(m.healRatio > 0 && m.healRatio <= 1)) {
       throw new MonsterDataError(`${where}: healRatio は 0〜1 (${m.healRatio})`);
     }
+    if (m.healAmount !== undefined && !(Number.isInteger(m.healAmount) && m.healAmount > 0)) {
+      throw new MonsterDataError(`${where}: healAmount は正の整数 (${m.healAmount})`);
+    }
     if (m.spell) {
       const sp = m.spell as { name?: unknown; min?: unknown; max?: unknown };
       if (typeof sp.name !== 'string' || typeof sp.min !== 'number' || typeof sp.max !== 'number' || (sp.min as number) > (sp.max as number)) {

--- a/packages/core/src/tile-art.ts
+++ b/packages/core/src/tile-art.ts
@@ -145,6 +145,16 @@ export function partKey(index: number): string {
   return `part:${index}`;
 }
 
+/** モンスターの絵のキー (#591)。地形と同じ登録簿に相乗りする (キー空間が別なので衝突しない)。 */
+export function monsterArtKey(id: string): string {
+  return `monster:${id}`;
+}
+
+/** モンスターの絵 (無ければ undefined = 従来の SVG に倒す)。 */
+export function monsterArtFor(id: string): TileArt | undefined {
+  return registry.get(monsterArtKey(id));
+}
+
 /** 登録済みの地形 id 一覧 (エディタが「描いた地形」を並べるため)。 */
 export function tileArtTerrains(): string[] {
   return [...registry.keys()];


### PR DESCRIPTION
Closes #591

> モンスターの画像が変えられない。
> 0〜1って割合ってこと？固定数値はないの？割合回復は強すぎる
> 「たおした XP」じゃなくて単に「XP」でいいとおもうが

## 絵の差し替え

モンスター編集画面に**「絵をかく」**を追加。タイルのドット絵エディタを対象一般化して流用し、
`monster:<id>` キーで保存する (地形と同じレコードに相乗り)。

- **下敷きは従来の SVG** — なぞって描ける (タイルと同じ)
- 描画は **ドット絵 → 従来の SVG** の順。戦闘画面・エディタ一覧の両方に効く
- アンチエイリアスは切ってある (拡大縮小でスジ・潰れが出ない)
- SVG サニタイズ問題 (#537 論点 2) はドット絵なので発生しない

## 回復は固定値を既定に

割合回復は **HP の大きい敵ほど強くなる** (HP100 の敵が毎回 30 戻る)。
`healAmount` (固定値) を追加し、優先順を **固定値 > 割合 > 全体既定** にした。
エディタの欄も「回復量 (固定値)」が主で、空欄のときだけ割合で自動。壊れた値は保存できない。

「たおした XP」→「XP」に改名。

## 検証

core 587 / web 360 tests green、typecheck・build green。