### PR TITLE
能力の発動パラメータを敵ごとに上書きできるようにする

### DIFF
--- a/apps/web/src/routes/admin-monsters.tsx
+++ b/apps/web/src/routes/admin-monsters.tsx
@@ -137,6 +137,29 @@ export function AdminMonsters() {
     );
   }
 
+  /** 能力パラメータ (0〜1) の 1 欄。空欄 = 全体既定。 */
+  const paramField = (label: string, key: keyof NonNullable<MonsterDef['abilityParams']>, fallback: number) => {
+    if (!current) return null;
+    const val = current.abilityParams?.[key];
+    return field(label, (
+      <span style={{ display: 'flex', gap: '0.4em', alignItems: 'center' }}>
+        <input
+          type="number" step="0.05" min="0" max="1"
+          value={val ?? ''}
+          placeholder={String(fallback)}
+          onChange={(e) => {
+            const params = { ...current.abilityParams };
+            if (e.target.value === '') delete params[key];
+            else params[key] = Number(e.target.value);
+            update(current.id, { abilityParams: Object.keys(params).length ? params : undefined });
+          }}
+          style={{ width: '5em' }}
+        />
+        <span style={{ fontSize: '0.85em', color: 'var(--color-muted)' }}>0〜1 (空欄 = {fallback})</span>
+      </span>
+    ));
+  };
+
   const field = (label: string, input: React.ReactNode) => (
     <label style={{ display: 'flex', alignItems: 'center', gap: '0.4em', fontSize: '0.8em' }}>
       <span style={{ width: '7em', color: 'var(--color-muted)' }}>{label}</span>
@@ -242,6 +265,7 @@ export function AdminMonsters() {
               </span>
             ))}
             {field('出現の重み', <input type="number" step="0.01" value={current.spawnWeight ?? 1} onChange={(e) => update(current.id, { spawnWeight: Number(e.target.value) })} style={{ width: '5em' }} />)}
+            {current.ability === 'fleer' && paramField('逃走の基礎確率', 'fleeBase', 0.35)}
             {field('能力', (
               <select
                 value={current.ability ?? ''}
@@ -250,10 +274,17 @@ export function AdminMonsters() {
                 {Object.entries(ABILITY_LABELS).map(([v, label]) => <option key={v} value={v}>{label}</option>)}
               </select>
             ))}
-            {current.ability === 'charger' && field('技名', <input value={current.skillName ?? ''} onChange={(e) => update(current.id, { skillName: e.target.value || undefined })} />)}
+            {current.ability === 'charger' && (
+              <>
+                {field('技名', <input value={current.skillName ?? ''} onChange={(e) => update(current.id, { skillName: e.target.value || undefined })} />)}
+                {paramField('ため確率', 'chargeChance', 0.4)}
+              </>
+            )}
             {current.ability === 'healer' && (
               <>
                 {field('回復技名', <input value={current.healName ?? ''} onChange={(e) => update(current.id, { healName: e.target.value || undefined })} />)}
+                {paramField('回復確率', 'healChance', 0.5)}
+                {paramField('発動する HP', 'lowHpRatio', 0.55)}
                 {field('回復量', (
                   <span style={{ display: 'flex', gap: '0.4em', alignItems: 'center' }}>
                     <input
@@ -294,6 +325,7 @@ export function AdminMonsters() {
                     ))}
                   </select>
                 ))}
+                {paramField('詠唱確率', 'castChance', 0.3)}
                 {field('ダメージ', (
                   <span style={{ display: 'flex', gap: '0.3em', alignItems: 'center' }}>
                     <input

--- a/packages/core/src/__tests__/monster-data.test.ts
+++ b/packages/core/src/__tests__/monster-data.test.ts
@@ -139,3 +139,36 @@ describe('healer の回復幅とspell の検証 (#419)', () => {
       .toThrow(MonsterDataError);
   });
 });
+
+describe('能力パラメータの上書き (#592 段階 1)', () => {
+  afterEach(() => setMonsterOverrides(null));
+
+  it('ため確率が敵ごとに効く (実測: 0 なら一度もためない / 1 なら MP がある限りためる)', () => {
+    const mk = (chargeChance: number) => [
+      ...trio(1, 'a'),
+      base({ id: 'ch', name: 'ためんぼ', hp: 60, mp: 50, ability: 'charger', skillName: 'ためどん',
+             stats: [10, 5, 1, 20, 4], abilityParams: { chargeChance } }),
+    ];
+    const chargeCount = (chance: number) => {
+      setMonsterOverrides(mk(chance));
+      let n = 0;
+      for (let seed = 0; seed < 20; seed++) {
+        let s = core.startBattle('guardian', 20, 1, 'x', 1, seed, 0, undefined, { monsterId: 'ch' });
+        for (let i = 0; i < 8 && s.outcome === 'ongoing'; i++) {
+          s = core.resolveTurn(s, 'guard', seed * 131 + i);
+          if (s.lastEvents.some((e) => e.text.includes('ためている'))) n++;
+        }
+      }
+      return n;
+    };
+    expect(chargeCount(0), 'ため確率 0 なのにためた').toBe(0);
+    expect(chargeCount(1), 'ため確率 1 なのにためない').toBeGreaterThan(20);
+  });
+
+  it('壊れたパラメータは保存できない (0〜1 の範囲外)', () => {
+    expect(() => setMonsterOverrides([...trio(1, 'a'), base({ id: 'x', abilityParams: { chargeChance: 1.5 } })]))
+      .toThrow(MonsterDataError);
+    expect(() => setMonsterOverrides([...trio(1, 'a'), base({ id: 'x', abilityParams: { fleeBase: -0.1 } })]))
+      .toThrow(MonsterDataError);
+  });
+});

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -997,6 +997,22 @@ export interface MonsterDef {
   healRatio?: number;
   /** healer の回復量 (固定値)。**エディタの既定はこちら** — 割合回復は強すぎる (#419)。 */
   healAmount?: number;
+  /**
+   * 能力の発動パラメータの上書き (#592 段階 1)。省略時は BATTLE_TUNING の全体既定。
+   * 「よくためる敵」「なかなか逃げない敵」を、コードを触らずデータで作れる。
+   */
+  abilityParams?: {
+    /** charger: ため確率 (0〜1)。 */
+    chargeChance?: number;
+    /** healer: 回復確率 (0〜1)。 */
+    healChance?: number;
+    /** healer: 発動する HP 閾値 (0〜1。これを下回ったら回復を考える)。 */
+    lowHpRatio?: number;
+    /** caster: 詠唱確率 (0〜1)。 */
+    castChance?: number;
+    /** fleer: 逃走の基礎確率 (0〜1。agi 補正の前)。 */
+    fleeBase?: number;
+  };
   /** caster の魔法 (#456)。def 無視・属性つきの int スケール魔撃。ダメージ = min〜max + int*intScale。
    *  魔法致死は onLethal を通らない (物理耐性の覇王/不動 も魔法では死ぬ = 設計どおりの弱点)。
    *  データ規約: min <= max (span 負を避ける)。caster の攻撃ラベルは skillName でなくこの name を使う。 */
@@ -1660,18 +1676,21 @@ const MONSTER_ABILITIES: Record<string, AbilityDef> = {
   // charger: 1 ターン ため → 強攻撃 (予告を防御する読み合い。全体の ~20%)
   charger: {
     id: 'charger',
-    decideAction: ({ monster, r, t, canGuard }) => {
-      if (monster.mp >= t.monsterChargeMpCost && r < t.chargerChargeChance) return 'charge';
-      if (canGuard && r < t.chargerChargeChance + 0.15) return 'guard';
+    decideAction: ({ monster, r, t, canGuard, monsterDef }) => {
+      const chance = monsterDef?.abilityParams?.chargeChance ?? t.chargerChargeChance;
+      if (monster.mp >= t.monsterChargeMpCost && r < chance) return 'charge';
+      if (canGuard && r < chance + 0.15) return 'guard';
       return 'attack';
     },
   },
   // healer: 低 HP でたまに自己回復 (削り切る前に倒す読み合い)
   healer: {
     id: 'healer',
-    decideAction: ({ monster, r, t, hpRatio, canGuard }) => {
-      if (monster.mp >= t.monsterHealMpCost && hpRatio < t.healerLowHpRatio && r < t.healerHealChance) return 'heal';
-      if (canGuard && r < t.healerHealChance + 0.15) return 'guard';
+    decideAction: ({ monster, r, t, hpRatio, canGuard, monsterDef }) => {
+      const low = monsterDef?.abilityParams?.lowHpRatio ?? t.healerLowHpRatio;
+      const chance = monsterDef?.abilityParams?.healChance ?? t.healerHealChance;
+      if (monster.mp >= t.monsterHealMpCost && hpRatio < low && r < chance) return 'heal';
+      if (canGuard && r < chance + 0.15) return 'guard';
       return 'attack';
     },
   },
@@ -1680,10 +1699,11 @@ const MONSTER_ABILITIES: Record<string, AbilityDef> = {
   caster: {
     id: 'caster',
     decideAction: ({ monster, r, t, canGuard, monsterDef }) => {
-      if (monsterDef?.spell && monster.mp >= t.monsterCastMpCost && r < t.casterCastChance) return 'cast';
+      const castChance = monsterDef?.abilityParams?.castChance ?? t.casterCastChance;
+      if (monsterDef?.spell && monster.mp >= t.monsterCastMpCost && r < castChance) return 'cast';
       // guard バンドは charger/healer (+0.15) よりやや狭い +0.1 — caster は攻撃寄りに保ち、魔法を撃てない
       // (MP 枯渇) ターンも殴りに来る威圧感を残すため (守りに籠らせない)。
-      if (canGuard && r < t.casterCastChance + 0.1) return 'guard';
+      if (canGuard && r < castChance + 0.1) return 'guard';
       return 'attack';
     },
   },
@@ -1694,7 +1714,8 @@ const MONSTER_ABILITIES: Record<string, AbilityDef> = {
     id: 'fleer',
     decideAction: ({ r, t, monsterDef }) => {
       const baseAgi = monsterDef?.stats[2] ?? 0;
-      const fleeChance = Math.min(t.monsterFleeMax, Math.max(0, t.monsterFleeBase + baseAgi * t.monsterFleeAgiScale));
+      const fleeBase = monsterDef?.abilityParams?.fleeBase ?? t.monsterFleeBase;
+      const fleeChance = Math.min(t.monsterFleeMax, Math.max(0, fleeBase + baseAgi * t.monsterFleeAgiScale));
       if (r < fleeChance) return 'flee';
       return 'attack';
     },

--- a/packages/core/src/monster-data.ts
+++ b/packages/core/src/monster-data.ts
@@ -92,6 +92,13 @@ function validate(defs: readonly MonsterDef[]): readonly MonsterDef[] {
     if (m.healAmount !== undefined && !(Number.isInteger(m.healAmount) && m.healAmount > 0)) {
       throw new MonsterDataError(`${where}: healAmount は正の整数 (${m.healAmount})`);
     }
+    if (m.abilityParams) {
+      for (const [k, v] of Object.entries(m.abilityParams)) {
+        if (v !== undefined && !(typeof v === 'number' && v >= 0 && v <= 1)) {
+          throw new MonsterDataError(`${where}: abilityParams.${k} は 0〜1 (${v})`);
+        }
+      }
+    }
     if (m.spell) {
       const sp = m.spell as { name?: unknown; min?: unknown; max?: unknown };
       if (typeof sp.name !== 'string' || typeof sp.min !== 'number' || typeof sp.max !== 'number' || (sp.min as number) > (sp.max as number)) {


### PR DESCRIPTION
Refs #592 (段階 1)

> 能力がリスト選択だが、能力を編集する方法がない

発動確率・閾値は全体共通の調整値しかなく、「よくためる敵」「なかなか逃げない敵」を
作るにはコードを触るしかなかった。

## 変更

`MonsterDef.abilityParams` を追加:

| 能力 | パラメータ |
|---|---|
| charger | ため確率 |
| healer | 回復確率 / 発動する HP 閾値 |
| caster | 詠唱確率 |
| fleer | 逃走の基礎確率 |

- **省略時は従来どおり全体既定** — 既存の敵の挙動は 1 つも変わらない
- エディタは能力を選んだときだけ該当欄を出す (空欄 = 既定値を placeholder 表示)
- 0〜1 で検証。壊れた値は保存できない

## 検証

- core 589 / web 360 / edge 216 tests green
- **実測テスト**: ため確率 0 なら 20 戦 × 8 ターンで一度もためず、1 なら MP がある限りためる
- **変異テスト**: パラメータを見ない実装に戻すと落ちる

段階 2 (複数の能力 `abilities[]`) は次の PR。