### PR TITLE
モンスターに複数の能力を持たせられるようにする

### DIFF
--- a/apps/web/src/routes/admin-monsters.tsx
+++ b/apps/web/src/routes/admin-monsters.tsx
@@ -31,7 +31,6 @@ import { monsterArtKey } from '@aozoraquest/core';
  */
 
 const ABILITY_LABELS: Record<string, string> = {
-  '': 'plain (通常攻撃)',
   charger: 'charger (ため→強攻撃)',
   healer: 'healer (自己回復)',
   fleer: 'fleer (逃走)',
@@ -51,6 +50,11 @@ export function AdminMonsters() {
   const [drawing, setDrawing] = useState(false);
 
   const current = useMemo(() => list.find((m) => m.id === sel) ?? null, [list, sel]);
+  /** 単数 (旧) と複数 (新) を吸収した現在の能力列。 */
+  const currentAbilities = useMemo(
+    () => current?.abilities ?? (current?.ability ? [current.ability] : []),
+    [current],
+  );
   const counts = monsterCountByTier(list);
 
   // exactOptionalPropertyTypes のため、undefined を「キーごと消す」に読み替える
@@ -265,22 +269,48 @@ export function AdminMonsters() {
               </span>
             ))}
             {field('出現の重み', <input type="number" step="0.01" value={current.spawnWeight ?? 1} onChange={(e) => update(current.id, { spawnWeight: Number(e.target.value) })} style={{ width: '5em' }} />)}
-            {current.ability === 'fleer' && paramField('逃走の基礎確率', 'fleeBase', 0.35)}
+            {currentAbilities.includes('fleer') && paramField('逃走の基礎確率', 'fleeBase', 0.35)}
             {field('能力', (
-              <select
-                value={current.ability ?? ''}
-                onChange={(e) => update(current.id, { ability: (e.target.value || undefined) as MonsterDef['ability'] })}
-              >
-                {Object.entries(ABILITY_LABELS).map(([v, label]) => <option key={v} value={v}>{label}</option>)}
-              </select>
+              <span style={{ display: 'flex', flexDirection: 'column', gap: '0.15em' }}>
+                {/* **複数選べる。優先順は上から** (毎ターン上から聞き、最初に動いた能力を採る)。
+                    選択順を保持するので、後から選んだものが末尾に付く。 */}
+                {(['charger', 'healer', 'fleer', 'caster'] as const).map((id) => {
+                  const selected = currentAbilities.includes(id);
+                  const order = currentAbilities.indexOf(id);
+                  return (
+                    <label key={id} style={{ display: 'flex', gap: '0.4em', alignItems: 'center' }}>
+                      <input
+                        type="checkbox"
+                        checked={selected}
+                        onChange={(e) => {
+                          const next = e.target.checked
+                            ? [...currentAbilities, id]
+                            : currentAbilities.filter((a) => a !== id);
+                          update(current.id, {
+                            abilities: next.length ? next : undefined,
+                            ability: undefined, // 単数フィールドは複数側へ寄せる
+                          });
+                        }}
+                      />
+                      {selected && <span style={{ fontSize: '0.75em', color: 'var(--color-accent)' }}>{order + 1}.</span>}
+                      <span>{ABILITY_LABELS[id]}</span>
+                    </label>
+                  );
+                })}
+                {currentAbilities.length > 1 && (
+                  <span style={{ fontSize: '0.75em', color: 'var(--color-muted)' }}>
+                    番号の順に判定する (1 が動かなかったら 2 …)。選び直すと順番が変わる
+                  </span>
+                )}
+              </span>
             ))}
-            {current.ability === 'charger' && (
+            {currentAbilities.includes('charger') && (
               <>
                 {field('技名', <input value={current.skillName ?? ''} onChange={(e) => update(current.id, { skillName: e.target.value || undefined })} />)}
                 {paramField('ため確率', 'chargeChance', 0.4)}
               </>
             )}
-            {current.ability === 'healer' && (
+            {currentAbilities.includes('healer') && (
               <>
                 {field('回復技名', <input value={current.healName ?? ''} onChange={(e) => update(current.id, { healName: e.target.value || undefined })} />)}
                 {paramField('回復確率', 'healChance', 0.5)}
@@ -301,7 +331,7 @@ export function AdminMonsters() {
                 ))}
               </>
             )}
-            {current.ability === 'caster' && (
+            {currentAbilities.includes('caster') && (
               <>
                 {field('魔法の名前', (
                   <input

--- a/packages/core/src/__tests__/monster-data.test.ts
+++ b/packages/core/src/__tests__/monster-data.test.ts
@@ -172,3 +172,59 @@ describe('能力パラメータの上書き (#592 段階 1)', () => {
       .toThrow(MonsterDataError);
   });
 });
+
+describe('複数の能力 (#592 段階 2)', () => {
+  afterEach(() => setMonsterOverrides(null));
+
+  it('優先順は配列の順 (healer が動かないときだけ charger が動く)', () => {
+    // HP 満タン (healer の閾値に届かない) → charger のため が出る。
+    // HP を削る → healer の回復が優先される。
+    setMonsterOverrides([
+      ...trio(1, 'a'),
+      base({
+        id: 'combo', name: 'こんぼ', hp: 60, mp: 60, stats: [10, 5, 1, 20, 4],
+        abilities: ['healer', 'charger'], skillName: 'ためどん',
+        abilityParams: { healChance: 1, lowHpRatio: 0.6, chargeChance: 1 },
+      }),
+    ]);
+    // HP 満タンから: healer は発動条件 (低 HP) を満たさず attack を返し、charger に回る。
+    // **攻め手は弱い職の低レベル** — 強い職だと healer の閾値に届く前に敵が死ぬ
+    // (guardian Lv20 で実測 2 ターン即死し、回復が一度も観測できなかった)。
+    let charged = 0, healed = 0;
+    for (let seed = 0; seed < 15; seed++) {
+      let s = core.startBattle('warrior', 1, 1, 'x', 1, seed, 0, undefined, { monsterId: 'combo' });
+      for (let i = 0; i < 10 && s.outcome === 'ongoing'; i++) {
+        s = core.resolveTurn(s, 'attack', seed * 131 + i);
+        if (s.lastEvents.some((e) => e.text.includes('ためている'))) charged++;
+        if (s.lastEvents.some((e) => e.text.includes('回復'))) healed++;
+      }
+    }
+    expect(charged, '満タン時に charger が動いていない').toBeGreaterThan(0);
+    expect(healed, '削られたら healer が優先されるはず').toBeGreaterThan(0);
+  });
+
+  it('単数 ability は後方互換で動く', () => {
+    setMonsterOverrides([
+      ...trio(1, 'a'),
+      base({ id: 'old', name: 'ふるい', hp: 40, mp: 40, ability: 'charger', skillName: 'x',
+             stats: [10, 5, 1, 20, 4], abilityParams: { chargeChance: 1 } }),
+    ]);
+    let charged = 0;
+    for (let seed = 0; seed < 10; seed++) {
+      let s = core.startBattle('guardian', 20, 1, 'x', 1, seed, 0, undefined, { monsterId: 'old' });
+      for (let i = 0; i < 4 && s.outcome === 'ongoing'; i++) {
+        s = core.resolveTurn(s, 'guard', seed * 131 + i);
+        if (s.lastEvents.some((e) => e.text.includes('ためている'))) charged++;
+      }
+    }
+    expect(charged).toBeGreaterThan(0);
+  });
+
+  it('壊れた abilities は保存できない', () => {
+    expect(() => setMonsterOverrides([...trio(1, 'a'), base({ id: 'x', abilities: [] })])).toThrow(MonsterDataError);
+    expect(() => setMonsterOverrides([...trio(1, 'a'), base({ id: 'x', abilities: ['charger', 'charger'] })])).toThrow(MonsterDataError);
+    expect(() => setMonsterOverrides([...trio(1, 'a'), base({ id: 'x', abilities: ['zzz' as never] })])).toThrow(MonsterDataError);
+    // abilities 側に caster があるのに spell が無い
+    expect(() => setMonsterOverrides([...trio(1, 'a'), base({ id: 'x', abilities: ['caster'] })])).toThrow(MonsterDataError);
+  });
+});

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -989,6 +989,13 @@ export interface MonsterDef {
    *  'caster' = たまに魔法を撃つ (def 無視の属性魔撃。#456: 対物理型の看板 覇王/不動 の弱点=魔法を
    *    成立させ、後続 (#483) の清き心 (魔法反射) の前提にもなる。要 spell 定義)。 */
   ability?: 'charger' | 'healer' | 'fleer' | 'caster';
+  /**
+   * 複数の能力 (#592 段階 2)。**優先順は配列の順** — 毎ターン先頭から聞き、最初に
+   * 特別な行動 (attack 以外) を返した能力を採る。全員 attack なら通常攻撃。
+   * 「HP が減ったら回復、それ以外はためる」= ['healer', 'charger']。
+   * 指定があれば `ability` (単数) より優先。単数は後方互換で残す。
+   */
+  abilities?: readonly ('charger' | 'healer' | 'fleer' | 'caster')[];
   /** healer の回復技名 (省略時デフォルト)。 */
   healName?: string;
   /** healer の回復幅 (maxHp に対する割合 0〜1)。省略時は BATTLE_TUNING.healerHealRatio。
@@ -1734,11 +1741,17 @@ function monsterCommand(monster: Combatant, state: BattleState, rng: () => numbe
   // 低 HP でたまに身を固める (charger のため中は別処理なのでここでは除外)
   const canGuard = (def?.tier ?? 1) >= 2 && hpRatio < 0.35 && !monster.charging;
 
-  const ability = def?.ability ? MONSTER_ABILITIES[def.ability] : undefined;
-  const action = ability?.decideAction({ state, monster, r, t, hpRatio, canGuard, monsterDef: def });
-  if (action) return action;
+  // 複数対応 (#592 段階 2): 配列の先頭から聞き、**最初に特別な行動を返した能力を採る**。
+  // 'attack' は「この能力は今回何もしない」の意味なので、次の能力に回す
+  // (先頭が attack を返した瞬間に確定すると、2 番目以降が永久に発動しない)。
+  const ids = def?.abilities ?? (def?.ability ? [def.ability] : []);
+  for (const id of ids) {
+    const action = MONSTER_ABILITIES[id]?.decideAction({ state, monster, r, t, hpRatio, canGuard, monsterDef: def });
+    if (action && action !== 'attack') return action;
+  }
+  if (ids.length > 0) return 'attack';
 
-  // plain (ability 無し / null): 通常攻撃 + 低 HP でたまに防御
+  // plain (ability 無し): 通常攻撃 + 低 HP でたまに防御
   if (canGuard && r < 0.25) return 'guard';
   return 'attack';
 }

--- a/packages/core/src/monster-data.ts
+++ b/packages/core/src/monster-data.ts
@@ -85,7 +85,19 @@ function validate(defs: readonly MonsterDef[]): readonly MonsterDef[] {
     if (m.ability !== undefined && !(ABILITIES as readonly string[]).includes(m.ability)) {
       throw new MonsterDataError(`${where}: ability が不正 (${m.ability})`);
     }
-    if (m.ability === 'caster' && !m.spell) throw new MonsterDataError(`${where}: caster には spell が要る`);
+    if (m.abilities !== undefined) {
+      if (!Array.isArray(m.abilities) || m.abilities.length === 0) {
+        throw new MonsterDataError(`${where}: abilities が不正 (空にするなら省略する)`);
+      }
+      for (const a of m.abilities) {
+        if (!(ABILITIES as readonly string[]).includes(a)) throw new MonsterDataError(`${where}: abilities に不正な id (${a})`);
+      }
+      if (new Set(m.abilities).size !== m.abilities.length) {
+        throw new MonsterDataError(`${where}: abilities が重複している`);
+      }
+    }
+    const hasCaster = m.ability === 'caster' || (m.abilities ?? []).includes('caster');
+    if (hasCaster && !m.spell) throw new MonsterDataError(`${where}: caster には spell が要る`);
     if (m.healRatio !== undefined && !(m.healRatio > 0 && m.healRatio <= 1)) {
       throw new MonsterDataError(`${where}: healRatio は 0〜1 (${m.healRatio})`);
     }


### PR DESCRIPTION
Refs #592 (段階 2)

> 能力が一つしか付けられない

## 変更

`MonsterDef.abilities` (配列) を追加。**優先順は配列の順** — 毎ターン先頭から聞き、
最初に特別な行動を返した能力を採る。

```
['healer', 'charger'] = HP が減ったら回復、それ以外はためる
```

**設計上の要点**: `'attack'` は「この能力は今回何もしない」の意味なので**次の能力に回す**。
先頭が attack を返した瞬間に確定すると、2 番目以降が永久に発動しない
(この退行は変異テストで固定した)。

- 単数の `ability` は後方互換で残す (`abilities` があればそちらが勝つ)
- エディタはチェックボックスで複数選択。**選択順を保持し、判定順の番号を表示**
- 検証: 空配列・重複・未知 id は保存不可。caster を含むなら spell 必須

## 検証

- core 592 / web 360 / edge 216 tests green
- **実測テスト**: HP 満タン時は charger のためが出て、削られたら healer が優先される
- **変異テスト 2 件検知**: 先頭の attack で確定してしまう / abilities を見ない