### PR TITLE
アイテムエディタ (/admin/items) — そうび・どうぐ・素材の編集

### DIFF
--- a/apps/edge/src/world-authoring.ts
+++ b/apps/edge/src/world-authoring.ts
@@ -1,4 +1,4 @@
-import { decodeWorldMap, loadStaticWorldMap, loadTileArts, setMonsterOverrides, setTownOverrides, setWorldMap, WORLD_SIZE, type MonsterDef, type TownOverride, type WorldPart } from '@aozoraquest/core';
+import { decodeWorldMap, loadStaticWorldMap, loadTileArts, setItemOverrides, setMonsterOverrides, setTownOverrides, setWorldMap, WORLD_SIZE, type EquipmentDef, type ItemDefData, type MonsterDef, type TownOverride, type WorldPart } from '@aozoraquest/core';
 import { getRecord } from './pds';
 import { resolveDidDocument } from './service-auth';
 import { pdsEndpointFromDoc } from './oauth-metadata';
@@ -91,6 +91,10 @@ export function ensureAuthoredWorld(env: WorldAuthoringEnv, nsid: string, now: n
     // 編集後の敵を見ていると強さも XP も食い違う。読めなければコード直書きのまま。
     const mon = await getRecord<{ monsters?: MonsterDef[] }>(pds, did, `${nsid}.world.monsters`, RKEY);
     if (mon?.value?.monsters?.length) setMonsterOverrides(mon.value.monsters);
+    // どうぐ・装備 (#420)。**店の品揃えと値段は edge が権威** (shopCraft が not_in_stock を弾く)
+    // なので、web だけが編集後の装備を見ていると「見えるのに買えない」が起きる。
+    const items = await getRecord<{ items?: ItemDefData[]; equipment?: EquipmentDef[] }>(pds, did, `${nsid}.world.items`, RKEY);
+    if (items?.value?.equipment?.length) setItemOverrides({ items: items.value.items ?? [], equipment: items.value.equipment });
   })()
     .catch((e) => {
       // **落ちてもゲームは続く** (同梱の地図 or ノイズ生成に倒れる)。次の TTL で再試行。

--- a/apps/web/src/lib/collections.ts
+++ b/apps/web/src/lib/collections.ts
@@ -87,6 +87,8 @@ export const ADMIN_COL = {
   tileArt: `${ROOT}.world.tileArt`,
   /** モンスター (パラメータ・ドロップ・能力 id)。#419 */
   monsters: `${ROOT}.world.monsters`,
+  /** どうぐ・素材 + 装備。#420 */
+  items: `${ROOT}.world.items`,
   /** 依頼クエスト集約 (docs/15-user-quest.md §集約インフラ)。
    *  Worker が主管理者 PDS に書く。env 別に rkey を分ける (dev→'dev', prod→'self')。 */
   questIndex: `${ROOT}.questIndex`,

--- a/apps/web/src/lib/world-authoring.ts
+++ b/apps/web/src/lib/world-authoring.ts
@@ -5,6 +5,7 @@ import {
   encodeWorldMap,
   loadStaticWorldMap,
   loadTileArts,
+  setItemOverrides,
   setMonsterOverrides,
   setTownOverrides,
   setWorldMap,
@@ -13,6 +14,8 @@ import {
   worldMapTiles,
   worldTownOverrides,
   WORLD_SIZE,
+  type EquipmentDef,
+  type ItemDefData,
   type MonsterDef,
   type TileArtRecord,
   type TownOverride,
@@ -146,6 +149,12 @@ export async function loadAuthoredWorld(agent: Agent | null): Promise<void> {
     } catch (e) {
       console.warn('[world] monsters load failed', e);
     }
+    try {
+      const rec = await getRecord<ItemsRecordData>(agent, adminDid, ADMIN_COL.items, RKEY);
+      if (rec?.equipment?.length) setItemOverrides({ items: rec.items ?? [], equipment: rec.equipment });
+    } catch (e) {
+      console.warn('[world] items load failed', e);
+    }
     return;
   }
   await loadStaticWorldMap().catch((e) => console.warn('[world] static map load failed', e));
@@ -165,4 +174,19 @@ export async function saveMonsters(agent: Agent, monsters: MonsterDef[]): Promis
   const rec: MonstersRecord = { monsters, updatedAt: new Date().toISOString() };
   await putRecord(agent, ADMIN_COL.monsters, RKEY, rec);
   return monsters.length;
+}
+
+// ─── どうぐ・装備 (#420) ────────────────────────────────────
+
+export interface ItemsRecordData {
+  items: ItemDefData[];
+  equipment: EquipmentDef[];
+  updatedAt: string;
+}
+
+/** 編集したどうぐ・装備を保存する (core の検証を通る = 壊れた 1 件で全体を落とす)。 */
+export async function saveItems(agent: Agent, items: ItemDefData[], equipment: EquipmentDef[]): Promise<void> {
+  setItemOverrides({ items, equipment });
+  const rec: ItemsRecordData = { items, equipment, updatedAt: new Date().toISOString() };
+  await putRecord(agent, ADMIN_COL.items, RKEY, rec);
 }

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -21,6 +21,7 @@ const Spirit = lazy(() => import('@/routes/spirit').then(m => ({ default: m.Spir
 const AdminDashboard = lazy(() => import('@/routes/admin-dashboard').then(m => ({ default: m.AdminDashboard })));
 const AdminMap = lazy(() => import('@/routes/admin-map').then(m => ({ default: m.AdminMap })));
 const AdminMonsters = lazy(() => import('@/routes/admin-monsters').then(m => ({ default: m.AdminMonsters })));
+const AdminItems = lazy(() => import('@/routes/admin-items').then(m => ({ default: m.AdminItems })));
 const World = lazy(() => import('@/routes/world').then(m => ({ default: m.World })));
 const Onboarding = lazy(() => import('@/routes/onboarding').then(m => ({ default: m.Onboarding })));
 const OAuthCallback = lazy(() => import('@/routes/oauth-callback').then(m => ({ default: m.OAuthCallback })));
@@ -83,6 +84,7 @@ const router = createBrowserRouter([
       // マップエディタは別画面 (地図が広く、他の管理ツールと同居すると双方が使いにくい)
       { path: 'admin/map', element: <AdminMap /> },
       { path: 'admin/monsters', element: <AdminMonsters /> },
+      { path: 'admin/items', element: <AdminItems /> },
       { path: 'world', element: <World /> },
       { path: 'onboarding', element: <Onboarding /> },
       { path: 'oauth/callback', element: <OAuthCallback /> },

--- a/apps/web/src/routes/admin-dashboard.tsx
+++ b/apps/web/src/routes/admin-dashboard.tsx
@@ -41,7 +41,7 @@ const CONTENT_SECTIONS: Section[] = [
   { key: 'places', title: '街 / ダンジョン / 城', desc: '内部マップの編集', issue: 424 },
   { key: 'quests', title: 'クエスト', desc: 'ゲーム内クエストの作成・編集', issue: 423 },
   { key: 'scenario', title: 'シナリオ', desc: '進行の筋書き', issue: 545 },
-  { key: 'items', title: 'アイテム', desc: '装備 / 消費 / 素材を CRUD', issue: 420 },
+  { key: 'items', title: 'アイテム', desc: 'そうび・どうぐ・素材の編集', to: '/admin/items', issue: 420 },
   { key: 'shops', title: 'お店', desc: 'ラインナップ・合成素材・店主セリフ', issue: 422 },
   { key: 'flags', title: 'フラグ', desc: '進行フラグでゲート', issue: 426 },
 ];

--- a/apps/web/src/routes/admin-items.tsx
+++ b/apps/web/src/routes/admin-items.tsx
@@ -1,0 +1,279 @@
+import { useCallback, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  activeEquipment,
+  activeItems,
+  canEquip,
+  ItemDataError,
+  JOBS,
+  JOB_EQUIP_KINDS,
+  type EquipmentDef,
+  type ItemDefData,
+} from '@aozoraquest/core';
+import { useSession } from '@/lib/session';
+import { isAdminDid } from '@/lib/runtime-config';
+import { saveItems } from '@/lib/world-authoring';
+
+/**
+ * **アイテムエディタ** (#420)。そうび / どうぐ・素材 の 2 タブ。
+ *
+ * モンスターエディタ (#419) と同じ流儀: 保存先は管理者 PDS の `world.items`、
+ * 保存前に core の検証 (壊れた 1 件で全体を落とす)、複製して増やす。
+ */
+
+const SLOT_LABELS: Record<string, string> = { weapon: 'ぶき', armor: 'よろい', charm: 'おまもり' };
+const BONUS_LABELS: Array<[keyof EquipmentDef['bonus'], string]> = [
+  ['atk', 'こうげき'], ['def', 'まもり'], ['agi', 'すばやさ'], ['int', 'かしこさ'], ['luk', 'うん'], ['maxHp', 'さいだいHP'],
+];
+const ALL_KINDS = ['common', 'cloth', 'charm', 'exclusive', ...new Set(Object.values(JOB_EQUIP_KINDS).flat())];
+
+export function AdminItems() {
+  const session = useSession();
+  const admin = isAdminDid(session.did ?? null);
+  const [tab, setTab] = useState<'equipment' | 'items'>('equipment');
+  const [equipment, setEquipment] = useState<EquipmentDef[]>(() => activeEquipment().map((e) => ({ ...e, bonus: { ...e.bonus }, price: { ...e.price } })));
+  const [items, setItems] = useState<ItemDefData[]>(() => activeItems());
+  const [sel, setSel] = useState<string | null>(null);
+  const [note, setNote] = useState<string | null>(null);
+  const [dirty, setDirty] = useState(false);
+
+  const current = useMemo(() => equipment.find((e) => e.id === sel) ?? null, [equipment, sel]);
+
+  const update = useCallback((id: string, patch: { [K in keyof EquipmentDef]?: EquipmentDef[K] | undefined }) => {
+    setEquipment((xs) => xs.map((e) => {
+      if (e.id !== id) return e;
+      const next = { ...e } as Record<string, unknown>;
+      for (const [k, v] of Object.entries(patch)) {
+        if (v === undefined) delete next[k];
+        else next[k] = v;
+      }
+      return next as unknown as EquipmentDef;
+    }));
+    setDirty(true);
+  }, []);
+
+  const duplicate = useCallback((src: EquipmentDef) => {
+    let n = 2;
+    while (equipment.some((e) => e.id === `${src.id}-${n}`)) n++;
+    const copy: EquipmentDef = { ...src, id: `${src.id}-${n}`, name: `${src.name} (コピー)`, bonus: { ...src.bonus }, price: { ...src.price } };
+    setEquipment((xs) => [...xs, copy]);
+    setSel(copy.id);
+    setDirty(true);
+  }, [equipment]);
+
+  const removeEquip = useCallback((id: string) => {
+    const target = equipment.find((e) => e.id === id);
+    if (!target) return;
+    // **持っている人がいるかは分からない** (pieces は各ユーザーの権威レコード)。
+    // 消しても壊れない (未知 id の装備は無視される設計) が、その品は永久に使えなくなる。
+    if (!window.confirm(`「${target.name}」を消す？\n既に持っている人の個体は「効果のない置き物」になる`)) return;
+    setEquipment((xs) => xs.filter((e) => e.id !== id));
+    setSel(null);
+    setDirty(true);
+  }, [equipment]);
+
+  const save = useCallback(async () => {
+    if (!session.agent) return;
+    try {
+      await saveItems(session.agent, items, equipment);
+      setDirty(false);
+      setNote('保存した。サーバーは最大 5 分で拾う');
+    } catch (e) {
+      setNote(e instanceof ItemDataError ? `保存できない: ${e.message}` : `保存できなかった: ${String(e)}`);
+    }
+  }, [session.agent, items, equipment]);
+
+  /** その品を装備できる職 (kind × jobOnly の帰結を可視化する)。 */
+  const wearers = useCallback((def: EquipmentDef): string =>
+    JOBS.filter((j) => canEquip(j.id, def)).map((j) => j.id).join(' ') || 'だれも装備できない！',
+  []);
+
+  if (!admin) {
+    return (
+      <div style={{ padding: '1em' }}>
+        <p>この画面は管理者だけが使えます。</p>
+        <Link to="/admin">管理ダッシュボードへ</Link>
+      </div>
+    );
+  }
+
+  const field = (label: string, input: React.ReactNode) => (
+    <label style={{ display: 'flex', alignItems: 'center', gap: '0.4em', fontSize: '0.8em' }}>
+      <span style={{ width: '7em', color: 'var(--color-muted)' }}>{label}</span>
+      {input}
+    </label>
+  );
+
+  return (
+    <div style={{ padding: '0.8em', maxWidth: 900 }}>
+      <div style={{ display: 'flex', gap: '0.5em', alignItems: 'center', marginBottom: '0.4em' }}>
+        <Link to="/admin" style={{ fontSize: '0.8em' }}>← 管理</Link>
+        {([['equipment', 'そうび'], ['items', 'どうぐ・素材']] as const).map(([k, label]) => (
+          <button
+            key={k}
+            type="button"
+            onClick={() => setTab(k)}
+            style={{ fontSize: '0.85em', padding: '0.25em 0.7em', border: tab === k ? '3px solid var(--color-accent)' : '1px solid var(--color-border)' }}
+          >
+            {label}
+          </button>
+        ))}
+        <button type="button" onClick={() => void save()} disabled={!session.agent || !dirty} style={{ marginLeft: 'auto', fontSize: '0.85em' }}>
+          保存
+        </button>
+      </div>
+
+      {note && <p style={{ fontSize: '0.8em', color: 'var(--color-accent)', margin: '0 0 0.4em' }}>{note}</p>}
+
+      {tab === 'items' ? (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.2em', maxWidth: 460 }}>
+          {items.map((it, i) => (
+            <div key={i} style={{ display: 'flex', gap: '0.3em', alignItems: 'center' }}>
+              <input
+                value={it.id}
+                onChange={(e) => { setItems((xs) => xs.map((x, j) => (j === i ? { ...x, id: e.target.value } : x))); setDirty(true); }}
+                style={{ width: '11em', fontFamily: 'ui-monospace, monospace', fontSize: '0.85em' }}
+              />
+              <input
+                value={it.name}
+                onChange={(e) => { setItems((xs) => xs.map((x, j) => (j === i ? { ...x, name: e.target.value } : x))); setDirty(true); }}
+                style={{ flex: 1 }}
+              />
+              <button
+                type="button"
+                onClick={() => {
+                  if (!window.confirm(`「${it.name}」を消す？\nドロップや在庫でこの id を参照している箇所は名前が出なくなる`)) return;
+                  setItems((xs) => xs.filter((_, j) => j !== i));
+                  setDirty(true);
+                }}
+                style={{ fontSize: '0.8em' }}
+              >
+                ×
+              </button>
+            </div>
+          ))}
+          <button
+            type="button"
+            onClick={() => { setItems((xs) => [...xs, { id: `item-${xs.length + 1}`, name: 'あたらしいどうぐ' }]); setDirty(true); }}
+            style={{ fontSize: '0.85em', alignSelf: 'flex-start', marginTop: '0.3em' }}
+          >
+            ＋どうぐ
+          </button>
+        </div>
+      ) : (
+        <div style={{ display: 'grid', gridTemplateColumns: 'minmax(180px, 1fr) 2fr', gap: '0.8em' }}>
+          {/* 一覧 (slot → grade) */}
+          <div style={{ maxHeight: '70vh', overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 2 }}>
+            {(['weapon', 'armor', 'charm'] as const).map((slot) => {
+              const inSlot = equipment.filter((e) => e.slot === slot).sort((a, b) => a.grade - b.grade);
+              if (inSlot.length === 0) return null;
+              return (
+                <div key={slot}>
+                  <div style={{ fontSize: '0.7em', color: 'var(--color-muted)', margin: '0.4em 0 0.2em' }}>{SLOT_LABELS[slot]}</div>
+                  {inSlot.map((e) => (
+                    <button
+                      key={e.id}
+                      type="button"
+                      onClick={() => setSel(e.id)}
+                      style={{
+                        display: 'flex', alignItems: 'center', gap: '0.4em', width: '100%',
+                        padding: '0.2em 0.4em', fontSize: '0.85em', textAlign: 'left',
+                        border: sel === e.id ? '2px solid var(--color-accent)' : '1px solid var(--color-border)',
+                        background: 'transparent',
+                      }}
+                    >
+                      <span style={{ flex: 1 }}>{e.name}</span>
+                      <span style={{ fontSize: '0.75em', color: 'var(--color-muted)' }}>g{e.grade}{e.jobOnly ? ` ${e.jobOnly}` : ''}</span>
+                    </button>
+                  ))}
+                </div>
+              );
+            })}
+          </div>
+
+          {/* 編集フォーム */}
+          {current ? (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.35em' }}>
+              <div style={{ display: 'flex', gap: '0.4em', alignItems: 'center' }}>
+                <strong>{current.name}</strong>
+                <code style={{ fontSize: '0.75em', color: 'var(--color-muted)' }}>{current.id}</code>
+                <span style={{ marginLeft: 'auto', display: 'flex', gap: '0.3em' }}>
+                  <button type="button" onClick={() => duplicate(current)} style={{ fontSize: '0.8em' }}>複製</button>
+                  <button type="button" className="secondary" onClick={() => removeEquip(current.id)} style={{ fontSize: '0.8em' }}>削除</button>
+                </span>
+              </div>
+              {field('なまえ', <input value={current.name} onChange={(e) => update(current.id, { name: e.target.value })} />)}
+              {field('部位', (
+                <select value={current.slot} onChange={(e) => update(current.id, { slot: e.target.value as EquipmentDef['slot'] })}>
+                  {(['weapon', 'armor', 'charm'] as const).map((s0) => <option key={s0} value={s0}>{SLOT_LABELS[s0]}</option>)}
+                </select>
+              ))}
+              {field('系統', (
+                <select value={current.kind} onChange={(e) => update(current.id, { kind: e.target.value as EquipmentDef['kind'] })}>
+                  {ALL_KINDS.map((k) => <option key={k} value={k}>{k}</option>)}
+                </select>
+              ))}
+              {field('grade', (
+                <span style={{ display: 'flex', gap: '0.4em', alignItems: 'center' }}>
+                  <select value={current.grade} onChange={(e) => update(current.id, { grade: Number(e.target.value) as EquipmentDef['grade'] })}>
+                    {[1, 2, 3].map((g) => <option key={g} value={g}>{g}</option>)}
+                  </select>
+                  <span style={{ fontSize: '0.85em', color: 'var(--color-muted)' }}>売られる街の帯 (1=tier1〜 2=tier2〜 3=tier3〜)</span>
+                </span>
+              ))}
+              {field('専用ジョブ', (
+                <select
+                  value={current.jobOnly ?? ''}
+                  onChange={(e) => update(current.id, { jobOnly: (e.target.value || undefined) as EquipmentDef['jobOnly'] })}
+                >
+                  <option value="">なし (系統で判定)</option>
+                  {JOBS.map((j) => <option key={j.id} value={j.id}>{j.id}</option>)}
+                </select>
+              ))}
+              {BONUS_LABELS.map(([key, label]) => field(label, (
+                <input
+                  type="number"
+                  value={current.bonus[key] ?? ''}
+                  placeholder="0"
+                  onChange={(e) => {
+                    const bonus = { ...current.bonus };
+                    if (e.target.value === '') delete bonus[key];
+                    else bonus[key] = Number(e.target.value);
+                    update(current.id, { bonus });
+                  }}
+                  style={{ width: '5em' }}
+                />
+              )))}
+              {field('値段', (
+                <span style={{ display: 'flex', gap: '0.3em', alignItems: 'center' }}>
+                  パワー
+                  <input
+                    type="number" min="0"
+                    value={current.price.power}
+                    onChange={(e) => update(current.id, { price: { ...current.price, power: Number(e.target.value) } })}
+                    style={{ width: '5em' }}
+                  />
+                  + 素材
+                  <input
+                    type="number" min="0"
+                    value={current.price.materials}
+                    onChange={(e) => update(current.id, { price: { ...current.price, materials: Number(e.target.value) } })}
+                    style={{ width: '4em' }}
+                  />
+                  こ
+                </span>
+              ))}
+              {/* **誰が装備できるかを常に見せる。** kind と jobOnly の組み合わせは間違えやすく、
+                  「exclusive なのに jobOnly なし = 誰も装備できない」を静かに作らないため。 */}
+              <div style={{ fontSize: '0.75em', color: 'var(--color-muted)', lineHeight: 1.6 }}>
+                装備できる職: {wearers(current)}
+              </div>
+            </div>
+          ) : (
+            <div style={{ fontSize: '0.85em', color: 'var(--color-muted)' }}>左の一覧から選ぶ。増やすときは近い品を選んで「複製」。</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/core/src/__tests__/monster-data.test.ts
+++ b/packages/core/src/__tests__/monster-data.test.ts
@@ -228,3 +228,38 @@ describe('複数の能力 (#592 段階 2)', () => {
     expect(() => setMonsterOverrides([...trio(1, 'a'), base({ id: 'x', abilities: ['caster'] })])).toThrow(MonsterDataError);
   });
 });
+
+describe('どうぐ・装備のレコード差し替え (#420)', () => {
+  afterEach(() => core.setItemOverrides(null));
+
+  it('差し替えると ITEMS / EQUIPMENT / 店の品揃え / 装備可否に効き、解除で戻る', () => {
+    const eqCount = core.EQUIPMENT.length;
+    const items = [{ id: 'herb', name: 'すごいやくそう' }];
+    const equipment = [
+      { id: 'wp-test', name: 'てすとの剣', slot: 'weapon', kind: 'common', bonus: { atk: 3 }, grade: 1, price: { power: 4, materials: 1 } },
+      { id: 'ar-test', name: 'てすとの服', slot: 'armor', kind: 'cloth', bonus: { def: 2 }, grade: 1, price: { power: 4, materials: 1 } },
+    ] as const;
+    core.setItemOverrides({ items, equipment: equipment as never });
+    expect(core.ITEMS['herb']?.name).toBe('すごいやくそう');
+    expect(core.EQUIPMENT).toHaveLength(2);
+    expect(core.EQUIPMENT_BY_ID['wp-test']?.name).toBe('てすとの剣');
+    // 装備可否・ボーナスにも効く (canEquip / gearBonus は EQUIPMENT_BY_ID を引く)
+    expect(core.canEquip('warrior', core.EQUIPMENT_BY_ID['wp-test']!)).toBe(true);
+    expect(core.gearBonus('warrior', ['wp-test']).atk).toBe(3);
+
+    core.setItemOverrides(null);
+    expect(core.EQUIPMENT).toHaveLength(eqCount);
+    expect(core.ITEMS['herb']?.name).toBe('やくそう');
+  });
+
+  it('壊れた 1 件で全体を落とす', () => {
+    const ok = { id: 'wp-a', name: 'a', slot: 'weapon', kind: 'common', bonus: {}, grade: 1, price: { power: 1, materials: 0 } } as const;
+    expect(() => core.setItemOverrides({ items: [], equipment: [] })).toThrow(core.ItemDataError); // 0 品
+    expect(() => core.setItemOverrides({ items: [], equipment: [ok, { ...ok }] as never })).toThrow(core.ItemDataError); // id 重複
+    expect(() => core.setItemOverrides({ items: [], equipment: [{ ...ok, grade: 5 }] as never })).toThrow(core.ItemDataError);
+    expect(() => core.setItemOverrides({ items: [], equipment: [{ ...ok, bonus: { zzz: 1 } }] as never })).toThrow(core.ItemDataError);
+    // **exclusive なのに jobOnly なし = 誰も装備できない品** は保存で弾く
+    expect(() => core.setItemOverrides({ items: [], equipment: [{ ...ok, kind: 'exclusive' }] as never })).toThrow(core.ItemDataError);
+    expect(() => core.setItemOverrides({ items: [{ id: '', name: 'x' }], equipment: [ok] as never })).toThrow(core.ItemDataError);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,4 +21,5 @@ export * from './world.js';
 export * from './world-map.js';
 export * from './tile-art.js';
 export * from './monster-data.js';
+export * from './item-data.js';
 export * from './equipment.js';

--- a/packages/core/src/item-data.ts
+++ b/packages/core/src/item-data.ts
@@ -1,0 +1,112 @@
+/**
+ * **アイテムと装備を管理者 PDS のレコードで差し替える** (#420)。
+ *
+ * モンスター (#419 / monster-data.ts) と同じ流儀:
+ * - `ITEMS` / `EQUIPMENT` / `EQUIPMENT_BY_ID` は多数の箇所から import されているので、
+ *   **参照を保ったまま中身を差し替える**。呼び出し側は無変更
+ * - フォールバックは `レコード ?? コード直書き`。読めなくてもゲームは止まらない
+ * - **壊れた 1 件で全体を落とす** (部分適用しない)
+ */
+import { ITEMS } from './battle.js';
+import { EQUIPMENT, EQUIPMENT_BY_ID, JOB_EQUIP_KINDS, type EquipmentDef } from './equipment.js';
+import { JOBS_BY_ID } from './jobs.js';
+
+export class ItemDataError extends Error {}
+
+/** どうぐ・素材 1 件 (ITEMS の 1 エントリ)。 */
+export interface ItemDefData {
+  id: string;
+  name: string;
+}
+
+/** 保存レコードの形。 */
+export interface ItemsRecord {
+  items: ItemDefData[];
+  equipment: EquipmentDef[];
+  updatedAt: string;
+}
+
+const baselineItems: ReadonlyArray<ItemDefData> = Object.entries(ITEMS).map(([id, v]) => ({ id, name: v.name }));
+const baselineEquipment: readonly EquipmentDef[] = EQUIPMENT.map((e) => ({ ...e }));
+
+let overridden = false;
+
+export function hasItemOverrides(): boolean {
+  return overridden;
+}
+
+const SLOTS = ['weapon', 'armor', 'charm'] as const;
+const KINDS = new Set<string>([
+  'common', 'cloth', 'charm', 'exclusive',
+  ...new Set(Object.values(JOB_EQUIP_KINDS).flat()),
+]);
+const BONUS_KEYS = new Set(['atk', 'def', 'agi', 'int', 'luk', 'maxHp']);
+
+/**
+ * 検証して差し替える。`null` でコード直書きへ戻す。
+ * どうぐと装備は**同じレコードで一緒に**差し替える (別々だと片方だけ古い、が起きる)。
+ */
+export function setItemOverrides(rec: { items: readonly ItemDefData[]; equipment: readonly EquipmentDef[] } | null): void {
+  const items = rec === null ? baselineItems : validateItems(rec.items);
+  const equipment = rec === null ? baselineEquipment : validateEquipment(rec.equipment);
+
+  for (const k of Object.keys(ITEMS)) delete ITEMS[k];
+  for (const it of items) ITEMS[it.id] = { name: it.name };
+
+  (EQUIPMENT as EquipmentDef[]).splice(0, EQUIPMENT.length, ...equipment.map((e) => ({ ...e })));
+  for (const k of Object.keys(EQUIPMENT_BY_ID)) delete EQUIPMENT_BY_ID[k];
+  for (const e of EQUIPMENT) EQUIPMENT_BY_ID[e.id] = e;
+
+  overridden = rec !== null;
+}
+
+function validateItems(items: readonly ItemDefData[]): readonly ItemDefData[] {
+  const ids = new Set<string>();
+  for (const it of items) {
+    if (!it || typeof it.id !== 'string' || it.id.trim() === '') throw new ItemDataError('どうぐの id が空');
+    if (ids.has(it.id)) throw new ItemDataError(`どうぐの id が重複 (${it.id})`);
+    ids.add(it.id);
+    if (typeof it.name !== 'string' || it.name.trim() === '') throw new ItemDataError(`${it.id}: 名前が空`);
+  }
+  return items;
+}
+
+function validateEquipment(defs: readonly EquipmentDef[]): readonly EquipmentDef[] {
+  if (defs.length === 0) throw new ItemDataError('装備が 0 品');
+  const ids = new Set<string>();
+  for (const e of defs) {
+    const where = e?.id ?? '(id なし)';
+    if (!e || typeof e.id !== 'string' || e.id.trim() === '') throw new ItemDataError('装備の id が空');
+    if (ids.has(e.id)) throw new ItemDataError(`装備の id が重複 (${e.id})`);
+    ids.add(e.id);
+    if (typeof e.name !== 'string' || e.name.trim() === '') throw new ItemDataError(`${where}: 名前が空`);
+    if (!(SLOTS as readonly string[]).includes(e.slot)) throw new ItemDataError(`${where}: slot が不正 (${e.slot})`);
+    if (!KINDS.has(e.kind)) throw new ItemDataError(`${where}: kind が不正 (${e.kind})`);
+    if (![1, 2, 3].includes(e.grade)) throw new ItemDataError(`${where}: grade は 1〜3 (${e.grade})`);
+    if (!e.price || !(e.price.power >= 0) || !(e.price.materials >= 0)) {
+      throw new ItemDataError(`${where}: price が不正`);
+    }
+    if (!e.bonus || typeof e.bonus !== 'object') throw new ItemDataError(`${where}: bonus が不正`);
+    for (const [k, v] of Object.entries(e.bonus)) {
+      if (!BONUS_KEYS.has(k)) throw new ItemDataError(`${where}: bonus に不正なキー (${k})`);
+      if (typeof v !== 'number' || !Number.isFinite(v)) throw new ItemDataError(`${where}: bonus.${k} が数値でない`);
+    }
+    if (e.jobOnly !== undefined && !(e.jobOnly in JOBS_BY_ID)) {
+      throw new ItemDataError(`${where}: jobOnly が不正 (${e.jobOnly})`);
+    }
+    // **exclusive なのに jobOnly が無い品は誰も装備できない** (canEquip が安全側に倒す)。
+    // 静かに死に筋を作らないよう保存で弾く。
+    if (e.kind === 'exclusive' && !e.jobOnly) throw new ItemDataError(`${where}: exclusive には jobOnly が要る`);
+  }
+  return defs;
+}
+
+/** エディタ用: 現在有効などうぐ一覧 (差し替え前ならコード直書き)。 */
+export function activeItems(): ItemDefData[] {
+  return Object.entries(ITEMS).map(([id, v]) => ({ id, name: v.name }));
+}
+
+/** エディタ用: 現在有効な装備一覧。 */
+export function activeEquipment(): readonly EquipmentDef[] {
+  return EQUIPMENT;
+}


### PR DESCRIPTION
Refs #420

モンスターエディタ (#419) と同じ流儀。

## 変更

- **core**: どうぐ (`ITEMS`) と装備 (`EQUIPMENT`) を `world.items` レコードで差し替え。
  参照を保ったまま中身を入れ替えるので、**店の品揃え・装備可否・ボーナスに自動で効く**
- **edge も読む** — 店の品揃えと値段は edge が権威 (`shopCraft` が `not_in_stock` を弾く) なので、
  web だけが編集後の装備を見ていると「見えるのに買えない」が起きる
- **エディタ** (`/admin/items`): そうび / どうぐ・素材 の 2 タブ。複製して増やす。
  フォームは 部位 / 系統 / grade (売られる街の帯) / 専用ジョブ / 6 ボーナス / 値段

## 安全網

- 壊れた 1 件で全体を落とす (id 重複・不正な grade・不正な bonus キー等)
- **「exclusive なのに jobOnly なし」= 誰も装備できない品は保存で弾く**
  (`canEquip` が安全側に倒すため、エラーにならない静かな死に筋になる)
- **「装備できる職」を常に表示** — kind × jobOnly の帰結を目で確認できる
- 装備の削除は「既に持っている人の個体は効果のない置き物になる」と明示
  (未知 id の装備は無視される既存設計なので壊れはしない)

## 検証

- core 594 / web 360 / edge 216 tests green、typecheck・build green
- テスト: 差し替えが ITEMS / EQUIPMENT / canEquip / gearBonus に効く・解除で完全に戻る・
  壊れた 1 件で全体を落とす
- **変異テスト 3 件検知**: exclusive の jobOnly 必須を外す / id 重複を許す / 解除で戻さない