### PR TITLE
お店のラインナップを店ごとに編集できるようにする

### DIFF
--- a/apps/edge/src/world-authoring.ts
+++ b/apps/edge/src/world-authoring.ts
@@ -1,4 +1,4 @@
-import { decodeWorldMap, loadStaticWorldMap, loadTileArts, setItemOverrides, setMonsterOverrides, setTownOverrides, setWorldMap, WORLD_SIZE, type EquipmentDef, type ItemDefData, type MonsterDef, type TownOverride, type WorldPart } from '@aozoraquest/core';
+import { decodeWorldMap, loadStaticWorldMap, loadTileArts, setItemOverrides, setMonsterOverrides, setShopOverrides, setTownOverrides, setWorldMap, WORLD_SIZE, type EquipmentDef, type ItemDefData, type MonsterDef, type ShopOverride, type TownOverride, type WorldPart } from '@aozoraquest/core';
 import { getRecord } from './pds';
 import { resolveDidDocument } from './service-auth';
 import { pdsEndpointFromDoc } from './oauth-metadata';
@@ -95,6 +95,9 @@ export function ensureAuthoredWorld(env: WorldAuthoringEnv, nsid: string, now: n
     // なので、web だけが編集後の装備を見ていると「見えるのに買えない」が起きる。
     const items = await getRecord<{ items?: ItemDefData[]; equipment?: EquipmentDef[] }>(pds, did, `${nsid}.world.items`, RKEY);
     if (items?.value?.equipment?.length) setItemOverrides({ items: items.value.items ?? [], equipment: items.value.equipment });
+    // 店のラインナップ (#422)。**アイテムの後に読む** (検証が EQUIPMENT_BY_ID を引くため)。
+    const shops = await getRecord<{ shops?: ShopOverride[] }>(pds, did, `${nsid}.world.shops`, RKEY);
+    if (shops?.value?.shops?.length) setShopOverrides(shops.value.shops);
   })()
     .catch((e) => {
       // **落ちてもゲームは続く** (同梱の地図 or ノイズ生成に倒れる)。次の TTL で再試行。

--- a/apps/web/src/lib/collections.ts
+++ b/apps/web/src/lib/collections.ts
@@ -89,6 +89,8 @@ export const ADMIN_COL = {
   monsters: `${ROOT}.world.monsters`,
   /** どうぐ・素材 + 装備。#420 */
   items: `${ROOT}.world.items`,
+  /** 店ごとのラインナップ上書き。#422 */
+  shops: `${ROOT}.world.shops`,
   /** 依頼クエスト集約 (docs/15-user-quest.md §集約インフラ)。
    *  Worker が主管理者 PDS に書く。env 別に rkey を分ける (dev→'dev', prod→'self')。 */
   questIndex: `${ROOT}.questIndex`,

--- a/apps/web/src/lib/world-authoring.ts
+++ b/apps/web/src/lib/world-authoring.ts
@@ -7,6 +7,7 @@ import {
   loadTileArts,
   setItemOverrides,
   setMonsterOverrides,
+  setShopOverrides,
   setTownOverrides,
   setWorldMap,
   setWorldParts,
@@ -17,6 +18,7 @@ import {
   type EquipmentDef,
   type ItemDefData,
   type MonsterDef,
+  type ShopOverride,
   type TileArtRecord,
   type TownOverride,
   type WorldPart,
@@ -155,6 +157,14 @@ export async function loadAuthoredWorld(agent: Agent | null): Promise<void> {
     } catch (e) {
       console.warn('[world] items load failed', e);
     }
+    try {
+      // **アイテムの後に読む** — 上書きの検証が EQUIPMENT_BY_ID / ITEMS を引くので、
+      // 先に読むと「編集した装備を並べた店」が未知 id 扱いで落ちる。
+      const rec = await getRecord<{ shops?: ShopOverride[] }>(agent, adminDid, ADMIN_COL.shops, RKEY);
+      if (rec?.shops?.length) setShopOverrides(rec.shops);
+    } catch (e) {
+      console.warn('[world] shops load failed', e);
+    }
     return;
   }
   await loadStaticWorldMap().catch((e) => console.warn('[world] static map load failed', e));
@@ -189,4 +199,12 @@ export async function saveItems(agent: Agent, items: ItemDefData[], equipment: E
   setItemOverrides({ items, equipment });
   const rec: ItemsRecordData = { items, equipment, updatedAt: new Date().toISOString() };
   await putRecord(agent, ADMIN_COL.items, RKEY, rec);
+}
+
+// ─── 店のラインナップ (#422) ────────────────────────────────
+
+/** 店ごとの上書きを保存する (core の検証を通る = 未知 id は保存で弾かれる)。 */
+export async function saveShops(agent: Agent, shops: ShopOverride[]): Promise<void> {
+  setShopOverrides(shops);
+  await putRecord(agent, ADMIN_COL.shops, RKEY, { shops, updatedAt: new Date().toISOString() });
 }

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -22,6 +22,7 @@ const AdminDashboard = lazy(() => import('@/routes/admin-dashboard').then(m => (
 const AdminMap = lazy(() => import('@/routes/admin-map').then(m => ({ default: m.AdminMap })));
 const AdminMonsters = lazy(() => import('@/routes/admin-monsters').then(m => ({ default: m.AdminMonsters })));
 const AdminItems = lazy(() => import('@/routes/admin-items').then(m => ({ default: m.AdminItems })));
+const AdminShops = lazy(() => import('@/routes/admin-shops').then(m => ({ default: m.AdminShops })));
 const World = lazy(() => import('@/routes/world').then(m => ({ default: m.World })));
 const Onboarding = lazy(() => import('@/routes/onboarding').then(m => ({ default: m.Onboarding })));
 const OAuthCallback = lazy(() => import('@/routes/oauth-callback').then(m => ({ default: m.OAuthCallback })));
@@ -85,6 +86,7 @@ const router = createBrowserRouter([
       { path: 'admin/map', element: <AdminMap /> },
       { path: 'admin/monsters', element: <AdminMonsters /> },
       { path: 'admin/items', element: <AdminItems /> },
+      { path: 'admin/shops', element: <AdminShops /> },
       { path: 'world', element: <World /> },
       { path: 'onboarding', element: <Onboarding /> },
       { path: 'oauth/callback', element: <OAuthCallback /> },

--- a/apps/web/src/routes/admin-dashboard.tsx
+++ b/apps/web/src/routes/admin-dashboard.tsx
@@ -42,7 +42,7 @@ const CONTENT_SECTIONS: Section[] = [
   { key: 'quests', title: 'クエスト', desc: 'ゲーム内クエストの作成・編集', issue: 423 },
   { key: 'scenario', title: 'シナリオ', desc: '進行の筋書き', issue: 545 },
   { key: 'items', title: 'アイテム', desc: 'そうび・どうぐ・素材の編集', to: '/admin/items', issue: 420 },
-  { key: 'shops', title: 'お店', desc: 'ラインナップ・合成素材・店主セリフ', issue: 422 },
+  { key: 'shops', title: 'お店', desc: '店ごとのラインナップ・値札の素材 (セリフは #422 で続き)', to: '/admin/shops', issue: 422 },
   { key: 'flags', title: 'フラグ', desc: '進行フラグでゲート', issue: 426 },
 ];
 

--- a/apps/web/src/routes/admin-shops.tsx
+++ b/apps/web/src/routes/admin-shops.tsx
@@ -1,0 +1,210 @@
+import { useCallback, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  activeEquipment,
+  activeItems,
+  maxShopGradeForTier,
+  shopOverrides,
+  ShopDataError,
+  tierForRegion,
+  townShopStock,
+  worldOverlay,
+  type ShopOverride,
+  type Town,
+} from '@aozoraquest/core';
+import { useSession } from '@/lib/session';
+import { isAdminDid } from '@/lib/runtime-config';
+import { saveShops } from '@/lib/world-authoring';
+
+/**
+ * **お店のラインナップエディタ** (#422)。
+ *
+ * 品揃えは街の座標から決定的に生成されていて、狙って変えられなかった
+ * (街を動かすと品揃えが全部変わる、という副作用しかなかった)。
+ * **上書きした店だけ**明示のラインナップになり、他の店は従来どおり生成。
+ */
+export function AdminShops() {
+  const session = useSession();
+  const admin = isAdminDid(session.did ?? null);
+  const towns = useMemo(() => worldOverlay().towns, []);
+  const [overrides, setOverrides] = useState<ShopOverride[]>(() => shopOverrides());
+  const [sel, setSel] = useState<Town | null>(null);
+  const [note, setNote] = useState<string | null>(null);
+  const [dirty, setDirty] = useState(false);
+
+  const equipment = activeEquipment();
+  const items = activeItems();
+
+  const overrideOf = useCallback(
+    (t: Town) => overrides.find((o) => o.x === t.x && o.y === t.y),
+    [overrides],
+  );
+
+  /** いまの実効ラインナップ (上書き + 生成の合成)。プレイヤーが見るものと同じ。 */
+  const effective = useCallback((t: Town) => {
+    const i = towns.indexOf(t);
+    return townShopStock(t, i < 0 ? 0 : i);
+  }, [towns]);
+
+  // exactOptionalPropertyTypes のため、undefined は「キーごと消す」に読み替える
+  const setField = useCallback((t: Town, patch: { [K in keyof ShopOverride]?: ShopOverride[K] | undefined }) => {
+    setOverrides((xs) => {
+      const rest = xs.filter((o) => o.x !== t.x || o.y !== t.y);
+      const cur = xs.find((o) => o.x === t.x && o.y === t.y) ?? { x: t.x, y: t.y };
+      const merged = { ...cur } as Record<string, unknown>;
+      for (const [k, v] of Object.entries(patch)) {
+        if (v === undefined) delete merged[k];
+        else merged[k] = v;
+      }
+      const m = merged as unknown as ShopOverride;
+      const empty = !m.equipment && !m.consumables && !m.materialId;
+      return empty ? rest : [...rest, m];
+    });
+    setDirty(true);
+  }, []);
+
+  const save = useCallback(async () => {
+    if (!session.agent) return;
+    try {
+      await saveShops(session.agent, overrides);
+      setDirty(false);
+      setNote(`保存した (${overrides.length} 店を上書き)。サーバーは最大 5 分で拾う`);
+    } catch (e) {
+      setNote(e instanceof ShopDataError ? `保存できない: ${e.message}` : `保存できなかった: ${String(e)}`);
+    }
+  }, [session.agent, overrides]);
+
+  if (!admin) {
+    return (
+      <div style={{ padding: '1em' }}>
+        <p>この画面は管理者だけが使えます。</p>
+        <Link to="/admin">管理ダッシュボードへ</Link>
+      </div>
+    );
+  }
+
+  const cur = sel ? overrideOf(sel) : undefined;
+  const eff = sel ? effective(sel) : null;
+  const tier = sel ? tierForRegion(sel.region) : 1;
+  const maxGrade = maxShopGradeForTier(tier);
+
+  return (
+    <div style={{ padding: '0.8em', maxWidth: 980 }}>
+      <div style={{ display: 'flex', gap: '0.6em', alignItems: 'center', marginBottom: '0.4em' }}>
+        <Link to="/admin" style={{ fontSize: '0.8em' }}>← 管理</Link>
+        <strong>お店のラインナップ</strong>
+        <span style={{ fontSize: '0.75em', color: 'var(--color-muted)' }}>{overrides.length} 店を上書き中</span>
+        <button type="button" onClick={() => void save()} disabled={!session.agent || !dirty} style={{ marginLeft: 'auto', fontSize: '0.85em' }}>
+          保存
+        </button>
+      </div>
+
+      {note && <p style={{ fontSize: '0.8em', color: 'var(--color-accent)', margin: '0 0 0.4em' }}>{note}</p>}
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'minmax(180px, 1fr) 2fr', gap: '0.8em' }}>
+        {/* 街の一覧 (tier ごと) */}
+        <div style={{ maxHeight: '75vh', overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 2 }}>
+          {[1, 2, 3, 4, 5, 6].map((t) => {
+            const inTier = towns.filter((x) => tierForRegion(x.region) === t);
+            if (inTier.length === 0) return null;
+            return (
+              <div key={t}>
+                <div style={{ fontSize: '0.7em', color: 'var(--color-muted)', margin: '0.4em 0 0.2em' }}>tier{t}</div>
+                {inTier.map((town) => (
+                  <button
+                    key={`${town.x},${town.y}`}
+                    type="button"
+                    onClick={() => setSel(town)}
+                    style={{
+                      display: 'flex', gap: '0.4em', width: '100%', padding: '0.2em 0.4em',
+                      fontSize: '0.85em', textAlign: 'left',
+                      border: sel === town ? '2px solid var(--color-accent)' : '1px solid var(--color-border)',
+                      background: 'transparent',
+                    }}
+                  >
+                    <span style={{ flex: 1 }}>{town.name}</span>
+                    {overrideOf(town) && <span style={{ fontSize: '0.75em', color: 'var(--color-accent)' }}>上書き</span>}
+                  </button>
+                ))}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* 編集 */}
+        {sel && eff ? (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5em' }}>
+            <div style={{ display: 'flex', gap: '0.5em', alignItems: 'center' }}>
+              <strong>{sel.name}</strong>
+              <span style={{ fontSize: '0.75em', color: 'var(--color-muted)' }}>tier{tier} ({sel.x}, {sel.y})</span>
+              {cur && (
+                <button
+                  type="button"
+                  className="secondary"
+                  onClick={() => { setOverrides((xs) => xs.filter((o) => o.x !== sel.x || o.y !== sel.y)); setDirty(true); }}
+                  style={{ marginLeft: 'auto', fontSize: '0.8em' }}
+                >
+                  生成に戻す
+                </button>
+              )}
+            </div>
+
+            {/* 装備: チェックで選ぶ。未チェック状態 = 生成のまま */}
+            <div style={{ fontSize: '0.8em' }}>
+              <div style={{ color: 'var(--color-muted)', marginBottom: '0.2em' }}>
+                そうび {cur?.equipment ? '(この店だけの品揃え)' : '(生成のまま — 変えると上書きになる)'}
+              </div>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))', gap: '0.1em', maxHeight: '38vh', overflowY: 'auto', border: '1px solid var(--color-border)', padding: '0.3em' }}>
+                {equipment.map((e) => {
+                  const listed = (cur?.equipment ?? eff.equipment).includes(e.id);
+                  const overGrade = e.grade > maxGrade;
+                  return (
+                    <label key={e.id} style={{ display: 'flex', gap: '0.3em', alignItems: 'center' }}>
+                      <input
+                        type="checkbox"
+                        checked={listed}
+                        onChange={(ev) => {
+                          const base = cur?.equipment ?? [...eff.equipment];
+                          const next = ev.target.checked ? [...base, e.id] : base.filter((id) => id !== e.id);
+                          setField(sel, { equipment: next });
+                        }}
+                      />
+                      <span style={{ opacity: overGrade ? 0.75 : 1 }}>
+                        {e.name}
+                        <span style={{ fontSize: '0.85em', color: 'var(--color-muted)' }}> g{e.grade}{e.jobOnly ? ` ${e.jobOnly}` : ''}</span>
+                        {/* **帯より上の品を並べるのは意図的な例外としてはできる**が、#565 の
+                            地域段階化を破ることを明示する (静かに破らせない)。 */}
+                        {overGrade && listed && <span style={{ color: 'var(--color-danger)', fontSize: '0.85em' }}> ⚠ tier{tier} の帯超え</span>}
+                      </span>
+                    </label>
+                  );
+                })}
+              </div>
+            </div>
+
+            {/* 値札の素材 */}
+            <label style={{ display: 'flex', gap: '0.4em', alignItems: 'center', fontSize: '0.8em' }}>
+              <span style={{ color: 'var(--color-muted)' }}>値札の素材</span>
+              <select
+                value={cur?.materialId ?? ''}
+                onChange={(e) => setField(sel, { materialId: e.target.value || undefined })}
+              >
+                <option value="">生成のまま ({items.find((i) => i.id === eff.materialId)?.name ?? eff.materialId})</option>
+                {items.map((i) => <option key={i.id} value={i.id}>{i.name}</option>)}
+              </select>
+            </label>
+
+            {/* プレビュー: プレイヤーが見る最終形 */}
+            <div style={{ fontSize: '0.75em', color: 'var(--color-muted)', lineHeight: 1.7 }}>
+              いまの品揃え: {(cur?.equipment ?? eff.equipment).map((id) => equipment.find((e) => e.id === id)?.name ?? `? ${id}`).join(' / ')}
+            </div>
+          </div>
+        ) : (
+          <div style={{ fontSize: '0.85em', color: 'var(--color-muted)' }}>
+            左の一覧から店を選ぶ。上書きした店だけ明示のラインナップになり、他は従来どおり生成される。
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/core/src/__tests__/monster-data.test.ts
+++ b/packages/core/src/__tests__/monster-data.test.ts
@@ -263,3 +263,42 @@ describe('どうぐ・装備のレコード差し替え (#420)', () => {
     expect(() => core.setItemOverrides({ items: [{ id: '', name: 'x' }], equipment: [ok] as never })).toThrow(core.ItemDataError);
   });
 });
+
+describe('店のラインナップ上書き (#422)', () => {
+  afterEach(() => core.setShopOverrides(null));
+
+  it('上書きした店だけ変わり、他は生成のまま。解除で戻る', () => {
+    const towns = core.worldOverlay().towns;
+    const a = towns[0]!;
+    const b = towns[1]!;
+    const beforeA = core.townShopStock(a, 0);
+    const beforeB = core.townShopStock(b, 1);
+
+    core.setShopOverrides([{ x: a.x, y: a.y, equipment: ['wp-knife'], materialId: 'slime-drop' }]);
+    const afterA = core.townShopStock(a, 0);
+    expect(afterA.equipment).toEqual(['wp-knife']);
+    expect(afterA.materialId).toBe('slime-drop');
+    expect(afterA.consumables).toEqual(beforeA.consumables); // 指定しないフィールドは生成のまま
+    expect(core.townShopStock(b, 1)).toEqual(beforeB); // 他の店は不変
+
+    core.setShopOverrides(null);
+    expect(core.townShopStock(a, 0)).toEqual(beforeA);
+  });
+
+  it('**未知の id は保存で弾く** (「並んでいるのに買えない店」を静かに作らない)', () => {
+    const t = core.worldOverlay().towns[0]!;
+    expect(() => core.setShopOverrides([{ x: t.x, y: t.y, equipment: ['zzz-nope'] }])).toThrow(core.ShopDataError);
+    expect(() => core.setShopOverrides([{ x: t.x, y: t.y, materialId: 'zzz' }])).toThrow(core.ShopDataError);
+    expect(() => core.setShopOverrides([{ x: t.x, y: t.y }, { x: t.x, y: t.y }])).toThrow(core.ShopDataError); // 重複
+    // 全体が落ちている (部分適用していない)
+    expect(core.shopOverrides()).toEqual([]);
+  });
+
+  it('サーバー権威と同じ経路で効く (shopCraft が見る stock が変わる)', () => {
+    // shopAt → townShopStock なので、上書きすれば「買える品」自体が変わる。
+    // ここでは core レベルで stock の一致だけ固定する (edge の結合は shop.test が担う)。
+    const t = core.worldOverlay().towns[0]!;
+    core.setShopOverrides([{ x: t.x, y: t.y, equipment: ['ar-cloth'] }]);
+    expect(core.townShopStock(t, 0).equipment).toEqual(['ar-cloth']);
+  });
+});

--- a/packages/core/src/equipment.ts
+++ b/packages/core/src/equipment.ts
@@ -16,6 +16,7 @@
 
 import type { Archetype } from './types.js';
 import { tierForRegion, worldOverlay } from './world.js';
+import { shopOverrideAt } from './shop-data.js';
 import type { Town } from './world.js';
 
 /** mulberry32 (battle.ts の createRng と同型)。battle → equipment の import を
@@ -452,6 +453,23 @@ function rankAmongTier(town: Town, minTier: number): number {
 export const JOB_HIGH_PER_TOWN = 3;
 
 export function townShopStock(town: Town, townIndex: number): ShopStock {
+  // **店ごとの上書きが最優先** (#422)。指定されたフィールドだけ置き換え、残りは生成。
+  // 上書きが無い店は従来どおり = 全 53 店を手で埋めさせない。
+  const over = shopOverrideAt(town.x, town.y);
+  const generated = over && over.equipment && over.consumables && over.materialId
+    ? null // 全フィールド上書きなら生成をスキップ (無駄な計算をしない)
+    : generatedShopStock(town, townIndex);
+  if (over) {
+    return {
+      consumables: over.consumables ?? generated!.consumables,
+      equipment: over.equipment ?? generated!.equipment,
+      materialId: over.materialId ?? generated!.materialId,
+    };
+  }
+  return generated!;
+}
+
+function generatedShopStock(town: Town, townIndex: number): ShopStock {
   const tier = tierForRegion(town.region);
   const rng = shopRng(((town.x * 73856093) ^ (town.y * 19349663)) >>> 0);
   const consumables = ['herb', 'sky-dew', 'sky-feather'];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,4 +22,5 @@ export * from './world-map.js';
 export * from './tile-art.js';
 export * from './monster-data.js';
 export * from './item-data.js';
+export * from './shop-data.js';
 export * from './equipment.js';

--- a/packages/core/src/shop-data.ts
+++ b/packages/core/src/shop-data.ts
@@ -1,0 +1,76 @@
+/**
+ * **店ごとのラインナップの上書き** (#422)。
+ *
+ * 品揃えは `townShopStock` が街の座標から**決定的に生成**していて、狙って変えられない
+ * (街を 1 タイル動かすと品揃えが全部変わる、という副作用しかなかった)。
+ * 店ごとに明示のラインナップを持てるようにする。
+ *
+ * - **上書きが無い店は従来どおり生成** — 全 53 店を手で埋めさせない。
+ *   「この店だけ品揃えを決めたい」を差分で足す
+ * - 保存先は管理者 PDS の `world.shops` (モンスター #419 / アイテム #420 と同じ流儀)。
+ *   **edge も読む** — 品揃えと値段は edge が権威 (`shopCraft` が `not_in_stock` を弾く) なので、
+ *   web だけが上書きを見ていると「見えるのに買えない」が起きる
+ * - **壊れた 1 件で全体を落とす** (部分適用しない)
+ */
+import { EQUIPMENT_BY_ID } from './equipment.js';
+import { ITEMS } from './battle.js';
+
+export class ShopDataError extends Error {}
+
+/** 店 1 軒の上書き。指定したフィールドだけ生成を置き換える。 */
+export interface ShopOverride {
+  /** 街の座標 (townShopStock と同じキー)。 */
+  x: number;
+  y: number;
+  /** 装備のラインナップ (EQUIPMENT の id)。 */
+  equipment?: string[];
+  /** 消耗品 (ITEMS の id)。 */
+  consumables?: string[];
+  /** 値札の素材 (ITEMS の id)。 */
+  materialId?: string;
+}
+
+export interface ShopsRecord {
+  shops: ShopOverride[];
+  updatedAt: string;
+}
+
+let overrides = new Map<string, ShopOverride>();
+
+const key = (x: number, y: number) => `${x},${y}`;
+
+/**
+ * 上書きを差し替える。`null` で全解除 (生成へ戻す)。
+ *
+ * **未知の id は保存で弾く。** 品揃えに存在しない装備 id が入っても買えないだけで
+ * エラーにならず、「並んでいるのに買えない店」を静かに作る。
+ */
+export function setShopOverrides(list: readonly ShopOverride[] | null): void {
+  const next = new Map<string, ShopOverride>();
+  for (const s of list ?? []) {
+    const where = `(${s?.x}, ${s?.y})`;
+    if (!s || !Number.isInteger(s.x) || !Number.isInteger(s.y)) throw new ShopDataError(`座標が不正 ${where}`);
+    if (next.has(key(s.x, s.y))) throw new ShopDataError(`同じ街の上書きが重複 ${where}`);
+    for (const id of s.equipment ?? []) {
+      if (!EQUIPMENT_BY_ID[id]) throw new ShopDataError(`${where}: 装備 id が存在しない (${id})`);
+    }
+    for (const id of s.consumables ?? []) {
+      if (!ITEMS[id]) throw new ShopDataError(`${where}: どうぐ id が存在しない (${id})`);
+    }
+    if (s.materialId !== undefined && !ITEMS[s.materialId]) {
+      throw new ShopDataError(`${where}: 素材 id が存在しない (${s.materialId})`);
+    }
+    next.set(key(s.x, s.y), { ...s, equipment: s.equipment ? [...s.equipment] : undefined, consumables: s.consumables ? [...s.consumables] : undefined } as ShopOverride);
+  }
+  overrides = next;
+}
+
+/** その店の上書き (無ければ undefined = 生成のまま)。townShopStock が参照する。 */
+export function shopOverrideAt(x: number, y: number): ShopOverride | undefined {
+  return overrides.get(key(x, y));
+}
+
+/** エディタ用: 現在の上書き一覧。 */
+export function shopOverrides(): ShopOverride[] {
+  return [...overrides.values()].map((s) => ({ ...s }));
+}


### PR DESCRIPTION
Refs #422

## なぜ

品揃えは街の座標から**決定的に生成**されていて、狙って変えられなかった
(街を 1 タイル動かすと品揃えが全部変わる、という副作用しかなかった)。

## 変更

- **core**: `townShopStock` に店ごとの上書き層。**上書きした店だけ**明示のラインナップになり、
  指定しないフィールドは生成のまま。他の店は従来どおり = 全 53 店を手で埋めさせない
- **edge も読む** — 品揃えと値段は edge が権威。読み込み順は**アイテムレコードの後**
  (上書きの検証が `EQUIPMENT_BY_ID` を引くため、先に読むと編集した装備が未知 id 扱いで落ちる)
- **エディタ** (`/admin/shops`): 街の一覧 → 装備をチェックで選ぶ。最初の操作で
  「生成 → 上書き」に変わる (現在の生成内容から始まるので微調整がすぐできる)。
  「生成に戻す」で解除

## 安全網

- **未知の id は保存で弾く** — 存在しない装備 id は買えないだけでエラーにならず、
  「並んでいるのに買えない店」を静かに作る
- **帯超え (tier1 の店に grade2) は ⚠ 警告つきで許可** — 意図的な例外 (名物店) の余地は
  残しつつ、#565 の地域段階化を静かに破らせない

店主の名前・セリフは #422 の続き (別 PR)。

## 検証

- core 597 / web 360 / edge 216 tests green、typecheck・build green
- テスト: 上書きした店だけ変わる / 他は不変 / 解除で戻る / 未知 id・重複は保存不可
- **変異テスト 2 件検知**: 未知 id を許す / 上書きを見ない