### PR TITLE
店主に名前とセリフを持たせる

### DIFF
--- a/apps/web/src/components/shop-modal.tsx
+++ b/apps/web/src/components/shop-modal.tsx
@@ -16,6 +16,7 @@ import {
   type Archetype,
   type EquipmentDef,
   type Town,
+  shopKeeperFor,
 } from '@aozoraquest/core';
 import type { CraftedPiece } from '@/lib/crafting';
 
@@ -107,6 +108,8 @@ export function ShopModal({
   onClose: () => void;
 }) {
   const stock = useMemo(() => townShopStock(town, townIndex), [town, townIndex]);
+  // 店主 (#385)。既定は街ごとに決定的な口調で、エディタ (#422) から上書きできる。
+  const keeper = useMemo(() => shopKeeperFor(town.x, town.y), [town]);
   const materialName = ITEMS[stock.materialId]?.name ?? stock.materialId;
   // 値札素材を落とすモンスター (店プールは全て単一モンスターの固有ドロップ)
   const dropperName = MONSTERS.find((m) => m.drops.some((d) => d.item === stock.materialId))?.name;
@@ -167,6 +170,9 @@ export function ShopModal({
             とじる
           </button>
         </div>
+        <p style={{ margin: '0 0 0.3em', fontSize: '0.85em' }}>
+          {keeper.name ? `${keeper.name}「` : '「'}{keeper.greeting}」
+        </p>
         <p style={{ margin: '0 0 0.5em', fontSize: '0.75em', color: 'var(--color-muted)' }}>
           パワーと素材をわたすと作ってもらえる (できばえは −1〜+5、うんが高いと良い品に)。
           同じ品を 2 つわたすと 1 つ上にきたえてもらえる (+6 から上はきたえるだけ)。
@@ -195,6 +201,9 @@ export function ShopModal({
               {isMasterwork(lastAction.piece.level) ? '✨ ' : ''}
               {leveledName(lastDef, lastAction.piece.level)}
               {lastAction.kind === 'forge' ? ' に きたえあげた!' : ' ができた!'}
+              <span style={{ fontWeight: 400, marginLeft: '0.4em' }}>
+                「{lastAction.kind === 'forge' ? keeper.forge : keeper.craft}」
+              </span>
             </>
           )}
         </p>

--- a/apps/web/src/routes/admin-shops.tsx
+++ b/apps/web/src/routes/admin-shops.tsx
@@ -4,7 +4,9 @@ import {
   activeEquipment,
   activeItems,
   maxShopGradeForTier,
+  shopKeeperFor,
   shopOverrides,
+  MAX_KEEPER_LINE,
   ShopDataError,
   tierForRegion,
   townShopStock,
@@ -193,6 +195,37 @@ export function AdminShops() {
                 {items.map((i) => <option key={i.id} value={i.id}>{i.name}</option>)}
               </select>
             </label>
+
+            {/* 店主 (#385)。空欄 = 街ごとの既定 (placeholder に表示)。 */}
+            <div style={{ fontSize: '0.8em', display: 'flex', flexDirection: 'column', gap: '0.25em' }}>
+              <div style={{ color: 'var(--color-muted)' }}>店主</div>
+              {([
+                ['name', '名前 (空欄 = 出さない)'],
+                ['greeting', '入店のあいさつ'],
+                ['craft', '作ったとき'],
+                ['sell', 'ひきとったとき'],
+                ['forge', 'きたえたとき'],
+              ] as const).map(([k, label]) => {
+                const defaults = shopKeeperFor(sel.x, sel.y);
+                return (
+                  <label key={k} style={{ display: 'flex', gap: '0.4em', alignItems: 'center' }}>
+                    <span style={{ width: '10em', color: 'var(--color-muted)' }}>{label}</span>
+                    <input
+                      maxLength={MAX_KEEPER_LINE}
+                      value={cur?.keeper?.[k] ?? ''}
+                      placeholder={k === 'name' ? '' : defaults[k]}
+                      onChange={(e) => {
+                        const keeper = { ...cur?.keeper };
+                        if (e.target.value === '') delete keeper[k];
+                        else keeper[k] = e.target.value;
+                        setField(sel, { keeper: Object.keys(keeper).length ? keeper : undefined });
+                      }}
+                      style={{ flex: 1 }}
+                    />
+                  </label>
+                );
+              })}
+            </div>
 
             {/* プレビュー: プレイヤーが見る最終形 */}
             <div style={{ fontSize: '0.75em', color: 'var(--color-muted)', lineHeight: 1.7 }}>

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -52,6 +52,7 @@ function shopErrorText(e: unknown, fallback: string): string {
 }
 import { WORLD_PREVIEW_ENABLED } from '@/lib/world-preview';
 import { loadAuthoredWorld } from '@/lib/world-authoring';
+import { shopKeeperFor } from '@aozoraquest/core';
 import { mappedPartAt } from '@aozoraquest/core';
 import { Avatar } from '@/components/avatar';
 import { WorldBattleControls, type BattlePhase } from '@/components/world-battle-controls';
@@ -1029,7 +1030,12 @@ export function World() {
         // 記帳 (履歴)。数量とパワーはサーバーが確定した値で書く。
         await sellMaterials(agent, { materialId, materialCount: count }, srkey).catch((e) => console.warn('[world] sale log failed', e));
         setLastShopAction(null);
-        setNotice(`${ITEMS[materialId]?.name ?? materialId} ×${count} をひきとってもらい、パワーが ${res.powerGained ?? 0} ふえた!`);
+        {
+          // 店主のひとことを添える (#385)。街ごとに口調が違う。
+          const t = townAt(wsRef.current?.x ?? -1, wsRef.current?.y ?? -1);
+          const keeperSell = t ? shopKeeperFor(t.x, t.y).sell : 'まいど！';
+          setNotice(`${ITEMS[materialId]?.name ?? materialId} ×${count} をひきとってもらい、パワーが ${res.powerGained ?? 0} ふえた!「${keeperSell}」`);
+        }
       } catch (e) {
         console.warn('[world] sell failed', e);
         setShopError(shopErrorText(e, 'ひきとってもらえなかった'));

--- a/packages/core/src/__tests__/monster-data.test.ts
+++ b/packages/core/src/__tests__/monster-data.test.ts
@@ -302,3 +302,29 @@ describe('店のラインナップ上書き (#422)', () => {
     expect(core.townShopStock(t, 0).equipment).toEqual(['ar-cloth']);
   });
 });
+
+describe('店主のセリフ (#385 / #422)', () => {
+  afterEach(() => core.setShopOverrides(null));
+
+  it('既定は街ごとに決定的 (いつ来ても同じ人がいる)', () => {
+    const a = core.shopKeeperFor(64, 64);
+    expect(a.greeting).toBeTruthy();
+    expect(core.shopKeeperFor(64, 64)).toEqual(a); // 決定的
+    // 別の街とは (概ね) 口調が違いうる — 少なくとも API として独立している
+    expect(core.shopKeeperFor(192, 64).greeting).toBeTruthy();
+  });
+
+  it('上書きが部分的に効く (指定したセリフだけ変わる)', () => {
+    const before = core.shopKeeperFor(64, 64);
+    core.setShopOverrides([{ x: 64, y: 64, keeper: { greeting: 'ようこそ、そらみの街へ！', name: 'ドグ' } }]);
+    const after = core.shopKeeperFor(64, 64);
+    expect(after.greeting).toBe('ようこそ、そらみの街へ！');
+    expect(after.name).toBe('ドグ');
+    expect(after.craft).toBe(before.craft); // 指定しないものは既定のまま
+  });
+
+  it('長すぎるセリフは保存で弾く (DQ の窓に収まらない)', () => {
+    expect(() => core.setShopOverrides([{ x: 1, y: 1, keeper: { greeting: 'あ'.repeat(61) } }]))
+      .toThrow(core.ShopDataError);
+  });
+});

--- a/packages/core/src/shop-data.ts
+++ b/packages/core/src/shop-data.ts
@@ -17,6 +17,20 @@ import { ITEMS } from './battle.js';
 
 export class ShopDataError extends Error {}
 
+/** 店主のセリフ (#385)。DQ 風に短く。過剰にしない (DESIGN.md の情報量の美意識)。 */
+export interface ShopKeeper {
+  /** 店主の名前。省略時は出さない (名前より口上が主役)。 */
+  name?: string;
+  /** 入店時のひとこと。 */
+  greeting?: string;
+  /** 作ってもらったとき。 */
+  craft?: string;
+  /** ひきとってもらったとき。 */
+  sell?: string;
+  /** きたえてもらったとき。 */
+  forge?: string;
+}
+
 /** 店 1 軒の上書き。指定したフィールドだけ生成を置き換える。 */
 export interface ShopOverride {
   /** 街の座標 (townShopStock と同じキー)。 */
@@ -28,6 +42,40 @@ export interface ShopOverride {
   consumables?: string[];
   /** 値札の素材 (ITEMS の id)。 */
   materialId?: string;
+  /** 店主 (#385)。 */
+  keeper?: ShopKeeper;
+}
+
+/** セリフの最大長。長文は DQ の窓に収まらず、情報量の美意識にも反する。 */
+export const MAX_KEEPER_LINE = 60;
+
+/** 既定のセリフ (街のハッシュで決定的に選ぶ = 店ごとに口調が違う)。 */
+const GREETINGS = ['いらっしゃい！', 'よく来たね。ゆっくりしていきな。', 'おや、旅の人かい。', 'いらっしゃい。掘り出しものがあるよ。'] as const;
+const CRAFTS = ['ほらよ、できたてだ！', 'いい仕上がりだよ。', 'だいじに使いなよ。'] as const;
+const SELLS = ['まいど！', 'たしかに受け取ったよ。', 'いいものを持ってるね。'] as const;
+const FORGES = ['うんと硬くなったよ！', 'これぞ職人技さ。', 'なかなかの一品になったね。'] as const;
+
+/**
+ * その店の店主 (上書き + 既定の合成)。既定は街の座標から決定的に選ぶので、
+ * 店ごとに口調が違い、いつ来ても同じ人がいる。
+ */
+export function shopKeeperFor(x: number, y: number): Required<Omit<ShopKeeper, 'name'>> & { name?: string } {
+  const h = ((x * 92821) ^ (y * 68917)) >>> 0;
+  const over = overrides.get(key(x, y))?.keeper;
+  const base = {
+    greeting: GREETINGS[h % GREETINGS.length]!,
+    craft: CRAFTS[(h >> 3) % CRAFTS.length]!,
+    sell: SELLS[(h >> 6) % SELLS.length]!,
+    forge: FORGES[(h >> 9) % FORGES.length]!,
+  };
+  return {
+    ...base,
+    ...(over?.greeting ? { greeting: over.greeting } : {}),
+    ...(over?.craft ? { craft: over.craft } : {}),
+    ...(over?.sell ? { sell: over.sell } : {}),
+    ...(over?.forge ? { forge: over.forge } : {}),
+    ...(over?.name ? { name: over.name } : {}),
+  };
 }
 
 export interface ShopsRecord {
@@ -59,6 +107,13 @@ export function setShopOverrides(list: readonly ShopOverride[] | null): void {
     }
     if (s.materialId !== undefined && !ITEMS[s.materialId]) {
       throw new ShopDataError(`${where}: 素材 id が存在しない (${s.materialId})`);
+    }
+    if (s.keeper) {
+      for (const [k, v] of Object.entries(s.keeper)) {
+        if (v !== undefined && (typeof v !== 'string' || v.length > MAX_KEEPER_LINE)) {
+          throw new ShopDataError(`${where}: 店主の ${k} が不正 (${MAX_KEEPER_LINE} 文字まで)`);
+        }
+      }
     }
     next.set(key(s.x, s.y), { ...s, equipment: s.equipment ? [...s.equipment] : undefined, consumables: s.consumables ? [...s.consumables] : undefined } as ShopOverride);
   }


### PR DESCRIPTION
Closes #385
Refs #422 (これで #422 のスコープが完結)

なんでも屋の店主が無言だった。DQ 風に短いセリフを持たせる。

## 設計

- **既定は街の座標から決定的に選ぶ** — 店ごとに口調が違い、いつ来ても同じ人がいる。
  **全 53 店を手で書かなくても最初から喋る**
- 場面は 4 つだけ: 入店 / 作った / ひきとった / きたえた。情報量の美意識 (DESIGN.md) に
  沿って過剰にしない。名前は省略時は出さない (口上が主役)
- **エディタの店ごと上書きに「店主」欄を追加** (#598 の画面)。placeholder に既定のセリフが
  見えるので、どこを変えると何が変わるか分かる
- 60 文字上限 — DQ の窓に収まらない長文は保存で弾く

## 表示

| 場面 | 出る場所 |
|---|---|
| 入店 | ヘッダ直下「いらっしゃい！」 |
| 作った / きたえた | 結果行に添える (「ほらよ、できたてだ！」) |
| ひきとった | notice に添える (「まいど！」) |

## 検証

core 600 / web 360 / edge 216 tests green。
テスト: 既定が決定的 / 上書きが部分的に効く / 長文は保存で弾く。