### PR TITLE
feat: ゲーム内クエスト (NPC 発注・サーバー権威報酬) + /admin/quests エディタ

### DIFF
--- a/apps/edge/src/battle-reward.ts
+++ b/apps/edge/src/battle-reward.ts
@@ -13,7 +13,7 @@
  * **seed 秘匿 (#348)**: ドロップ/敗北ロスの seed は**サーバーが独立に引いた rewardSeed/lossSeed** を使う
  * (戦闘 seed は client に返さない・再利用しない)。呼び出し側が entropyU32 で引いて渡す。
  */
-import { battleXpFor, rollDrops, rollDefeatLoss, jobLevelFromXp, levelUpGains, skillsForJob, BATTLE_TUNING, type Archetype, type StatArray } from '@aozoraquest/core';
+import { battleXpFor, rollDrops, rollDefeatLoss, jobLevelFromXp, levelUpGains, skillsForJob, BATTLE_TUNING, type Archetype, type StatArray , gameQuestById } from '@aozoraquest/core';
 import type { GameState } from './game-state';
 
 /** BattleOutcome から 'ongoing' を除いた決着。'monster-fled' = 敵が逃げた (無報酬・無消費)。 */
@@ -132,6 +132,14 @@ export function applyBattleOutcome(state: GameState, o: BattleOutcomeInput): { n
       const seed = i === 0 ? o.rewardSeed : (o.rewardSeed ^ (0x9e3779b1 * (i + 1))) >>> 0;
       drops.push(...rollDrops(id, o.luk, seed, o.dropBonus ?? 0));
     });
+    // ゲーム内クエスト (#423) の討伐カウント。**討伐数はここ (勝利の権威経路) だけが増やす** —
+    // client の自己申告を数えると「戦わずに達成」できてしまう。パワー無し戦闘は上の
+    // unrewarded で早期 return しているので、練習戦では進まない (報酬系と同じ線引き)。
+    const questDef = state.quest ? gameQuestById(state.quest.id) : undefined;
+    const questKills =
+      questDef?.objective.kind === 'defeat'
+        ? ids.filter((id) => id === (questDef.objective as { monsterId: string }).monsterId).length
+        : 0;
     const next: GameState = {
       ...state,
       // #507/#508: プレイヤー XP は**加算しない**。プレイヤーレベルは戦闘力に一切影響しない
@@ -140,6 +148,9 @@ export function applyBattleOutcome(state: GameState, o: BattleOutcomeInput): { n
       jobXp: { ...state.jobXp, [o.archetype]: (state.jobXp[o.archetype] ?? 0) + xp },
       materials: addItems(state.materials, drops, 1),
       power: Math.max(0, state.power - POWER_COST),
+      ...(questKills > 0 && state.quest
+        ? { quest: { id: state.quest.id, progress: state.quest.progress + questKills } }
+        : {}),
     };
     const lv = levelUpOf(state, next, o.archetype, o.baseStats);
     return { next, awarded: { xp, drops, powerSpent: POWER_COST, ...(lv ? { leveledUp: lv } : {}) } };

--- a/apps/edge/src/game-quest.ts
+++ b/apps/edge/src/game-quest.ts
@@ -1,0 +1,113 @@
+/**
+ * **ゲーム内クエストの受注・達成** (#423)。進行と報酬はここ (edge) が権威。
+ *
+ * - 受注: 進行中が無ければ `GameState.quest` に積む。達成済みは再受注できない
+ * - 達成: 条件を**権威データで検証**してから報酬を付与する
+ *   - defeat: 勝利時に数えた討伐数 (battle-reward が増やす)
+ *   - collect: 権威在庫の所持数。達成時に**引き取る** (渡すのが DQ の作法で、
+ *     引かないと同じ素材で何度も達成できてしまう)
+ * - 報酬のパワーは定義の値だけ。client は金額を送らない (サーバー権威)
+ */
+import { gameQuestById, MAX_QUEST_REWARD_POWER } from '@aozoraquest/core';
+import { readModifyWrite, type GameState, type GameStateEnv } from './game-state';
+
+export class GameQuestError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly code?: string,
+  ) {
+    super(message);
+  }
+}
+
+const MAX_DONE = 200;
+
+export interface QuestStateResult {
+  quest?: { id: string; progress: number };
+  questsDone?: string[];
+  power: number;
+  materials: Record<string, number>;
+  /** 達成時のみ: 付与した報酬。 */
+  rewarded?: { power?: number; itemId?: string; count?: number };
+}
+
+export async function handleQuestAccept(
+  env: GameStateEnv,
+  did: string,
+  questId: string,
+  now: number,
+  init?: (did: string, nowIso: string) => Promise<GameState>,
+): Promise<QuestStateResult> {
+  const def = gameQuestById(questId);
+  if (!def) throw new GameQuestError('そのクエストは無い', 404, 'unknown_quest');
+  const next = await readModifyWrite(
+    env,
+    did,
+    (cur) => {
+      if ((cur.questsDone ?? []).includes(questId)) throw new GameQuestError('もう達成している', 400, 'already_done');
+      if (cur.quest?.id === questId) return cur; // 再受注は no-op (連打・再送で壊れない)
+      // **1 つずつ。** 同時進行を許すと「どの敵を数えるか」が曖昧になる (将来 quests[] 化も可能)。
+      if (cur.quest) throw new GameQuestError('別のたのまれごとを うけている', 400, 'quest_busy');
+      return { ...cur, quest: { id: questId, progress: 0 } };
+    },
+    init ? { now, init } : { now },
+  );
+  return { quest: next.quest, questsDone: next.questsDone, power: next.power, materials: next.materials };
+}
+
+export async function handleQuestComplete(
+  env: GameStateEnv,
+  did: string,
+  questId: string,
+  now: number,
+  init?: (did: string, nowIso: string) => Promise<GameState>,
+): Promise<QuestStateResult> {
+  const def = gameQuestById(questId);
+  if (!def) throw new GameQuestError('そのクエストは無い', 404, 'unknown_quest');
+  // 報酬の再検証 (定義レコードが壊れても暴走しない最後の砦)
+  const rewardPower = Math.min(def.reward?.power ?? 0, MAX_QUEST_REWARD_POWER);
+  let rewarded: QuestStateResult['rewarded'];
+  const next = await readModifyWrite(
+    env,
+    did,
+    (cur) => {
+      if ((cur.questsDone ?? []).includes(questId)) throw new GameQuestError('もう達成している', 400, 'already_done');
+      if (cur.quest?.id !== questId) throw new GameQuestError('うけていない', 400, 'not_accepted');
+
+      let materials = cur.materials;
+      const o = def.objective;
+      if (o.kind === 'defeat') {
+        if ((cur.quest.progress ?? 0) < o.count) {
+          throw new GameQuestError(`まだ ${cur.quest.progress ?? 0}/${o.count} たい`, 400, 'not_ready');
+        }
+      } else {
+        const have = cur.materials[o.itemId] ?? 0;
+        if (have < o.count) throw new GameQuestError(`まだ ${have}/${o.count} こ`, 400, 'not_ready');
+        // **引き取る** — 引かないと同じ素材で何度も達成できる (別クエストや将来の複数進行で)。
+        materials = { ...cur.materials };
+        const left = have - o.count;
+        if (left > 0) materials[o.itemId] = left;
+        else delete materials[o.itemId];
+      }
+
+      if (def.reward?.itemId) {
+        materials = { ...materials };
+        materials[def.reward.itemId] = (materials[def.reward.itemId] ?? 0) + (def.reward.count ?? 0);
+      }
+      rewarded = {
+        ...(rewardPower > 0 ? { power: rewardPower } : {}),
+        ...(def.reward?.itemId ? { itemId: def.reward.itemId, count: def.reward.count ?? 0 } : {}),
+      };
+      return {
+        ...cur,
+        quest: undefined,
+        questsDone: [...(cur.questsDone ?? []), questId].slice(-MAX_DONE),
+        power: cur.power + rewardPower,
+        materials,
+      };
+    },
+    init ? { now, init } : { now },
+  );
+  return { quest: next.quest, questsDone: next.questsDone, power: next.power, materials: next.materials, ...(rewarded ? { rewarded } : {}) };
+}

--- a/apps/edge/src/game-quest.ts
+++ b/apps/edge/src/game-quest.ts
@@ -48,7 +48,9 @@ export async function handleQuestAccept(
       if ((cur.questsDone ?? []).includes(questId)) throw new GameQuestError('もう達成している', 400, 'already_done');
       if (cur.quest?.id === questId) return cur; // 再受注は no-op (連打・再送で壊れない)
       // **1 つずつ。** 同時進行を許すと「どの敵を数えるか」が曖昧になる (将来 quests[] 化も可能)。
-      if (cur.quest) throw new GameQuestError('別のたのまれごとを うけている', 400, 'quest_busy');
+      // ただし定義が消された孤児クエスト (管理者がエディタで削除) は無かったことにする —
+      // 破棄手段が無いので、残すとそのプレイヤーは永久に何も受けられなくなる (UX レビュー ★★★)。
+      if (cur.quest && gameQuestById(cur.quest.id)) throw new GameQuestError('別のたのまれごとを うけている', 400, 'quest_busy');
       return { ...cur, quest: { id: questId, progress: 0 } };
     },
     init ? { now, init } : { now },

--- a/apps/edge/src/game-state.ts
+++ b/apps/edge/src/game-state.ts
@@ -102,6 +102,10 @@ export interface GameState {
    *  client の申告を**所持の検証なしで**保存していたため、`{weapon:{id:'wp-shogun-high',plus:99}}`
    *  を送るだけで戦闘に効いた。ここに無い個体は装備できない。 */
   pieces?: OwnedPiece[];
+  /** 進行中のゲーム内クエスト (#423)。討伐数は勝利時に edge が数える。 */
+  quest?: { id: string; progress: number };
+  /** 達成済みクエスト id (再受注させない)。直近 200 件のリング。 */
+  questsDone?: string[];
   version: number;
   updatedAt: string;
 }

--- a/apps/edge/src/router.ts
+++ b/apps/edge/src/router.ts
@@ -166,6 +166,10 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
           return cors(json({ error: 'bad_request' }, 400), allowedOrigin);
         }
         const skillIndex = typeof body.skillIndex === 'number' ? body.skillIndex : 0; // とくぎ選択 (#436)。既定 0=署名
+        // クエスト定義 (#423) の討伐カウントは勝利決着のこの経路で数える。コールド isolate だと
+        // index.ts の waitUntil ロードが間に合わず「倒したのに数えられない」が無言で起きるので待つ
+        // (ロード済みならキャッシュ即返し。設計レビュー ★★)。
+        await ensureAuthoredWorld(env, nsFromOrigin(req), nowSec());
         return cors(json(await handleTurn(env, did, body.battleId, body.turn, body.command as Command, nowSec(), nsFromOrigin(req), skillIndex)), allowedOrigin);
       }
       if (typeof body.dx !== 'number' || typeof body.dy !== 'number') return cors(json({ error: 'bad_request' }, 400), allowedOrigin);

--- a/apps/edge/src/router.ts
+++ b/apps/edge/src/router.ts
@@ -17,6 +17,8 @@ import { claimXp, adminSetJobXp, adminGrantPower, spendPower, XpClaimError } fro
 import { shopCraft, shopSell, shopForge, shopDiscard, ShopError } from './shop';
 import { handleMove, handleTurn, handleTeleport, handleItem, handleGear, handleSearch, handleReset, migrateInitState, playerLuk, ResolverError } from './battle-resolver';
 import { signPosition, verifyPosition } from './world-token';
+import { handleQuestAccept, handleQuestComplete, GameQuestError } from './game-quest';
+import { ensureAuthoredWorld } from './world-authoring';
 import { ServerWriteError } from './server-pds';
 import { isEdgeAdmin } from './oauth-config';
 import { readPdsUsage, opsRemaining, PUT_RECORD_POINTS } from './pds-usage';
@@ -62,6 +64,8 @@ const LXM_SHOP_FORGE = 'app.aozoraquest.shop.forge';
 const LXM_SHOP_DISCARD = 'app.aozoraquest.shop.discard';
 const LXM_POWER_SPEND = 'app.aozoraquest.power.spend';
 const LXM_ADMIN_PDS_USAGE = 'app.aozoraquest.admin.pdsUsage';
+const LXM_QUEST_ACCEPT = 'app.aozoraquest.quest.accept';
+const LXM_QUEST_COMPLETE = 'app.aozoraquest.quest.complete';
 
 const AOZORA_ORIGINS = new Set([
   'https://aozoraquest.app',
@@ -450,6 +454,34 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
       return cors(json(await shopDiscard(env, did, { rkeys, rkey: body.rkey }, nowSec(), (d, iso) => migrateInitState(d, iso, ns))), allowedOrigin);
     } catch (e) {
       if (e instanceof ShopError) return cors(json({ error: e.code ?? 'shop_error', message: e.message }, e.status), allowedOrigin);
+      return cors(battleError(e), allowedOrigin);
+    }
+  }
+
+  // ゲーム内クエスト (#423): 受注 / 達成。**条件検証も報酬付与も権威側** — 討伐数は勝利時に
+  // battle-reward が数え、素材は権威在庫を見て引き取り、パワーは定義の値だけ足す。
+  if (req.method === 'POST' && (url.pathname === '/api/quest/accept' || url.pathname === '/api/quest/complete')) {
+    const accept = url.pathname === '/api/quest/accept';
+    const token = bearer(req);
+    if (!token) return cors(json({ error: 'missing_token' }, 401), allowedOrigin);
+    const audience = env.WORKER_DID ?? 'did:web:edge.aozoraquest.app';
+    let did: string;
+    try {
+      ({ iss: did } = await verifyServiceAuth(token, { audience, lxm: accept ? LXM_QUEST_ACCEPT : LXM_QUEST_COMPLETE }));
+    } catch (e) {
+      return cors(json({ error: 'unauthorized', reason: e instanceof ServiceAuthError ? e.message : 'verify_failed' }, 401), allowedOrigin);
+    }
+    const body = (await req.json().catch(() => ({}))) as { questId?: unknown };
+    if (typeof body.questId !== 'string') return cors(json({ error: 'bad_request' }, 400), allowedOrigin);
+    try {
+      const ns = nsFromOrigin(req);
+      // コールドスタート直後だと定義が未ロードで「そのクエストは無い」に落ちるので、ここは待つ
+      // (TTL 内はキャッシュ即返しでコスト無し)。
+      await ensureAuthoredWorld(env, ns, nowSec());
+      const handler = accept ? handleQuestAccept : handleQuestComplete;
+      return cors(json(await handler(env, did, body.questId, nowSec(), (d, iso) => migrateInitState(d, iso, ns))), allowedOrigin);
+    } catch (e) {
+      if (e instanceof GameQuestError) return cors(json({ error: e.code ?? 'quest_error', message: e.message }, e.status), allowedOrigin);
       return cors(battleError(e), allowedOrigin);
     }
   }

--- a/apps/edge/src/world-authoring.ts
+++ b/apps/edge/src/world-authoring.ts
@@ -104,7 +104,9 @@ export function ensureAuthoredWorld(env: WorldAuthoringEnv, nsid: string, now: n
     // ゲーム内クエスト (#423)。**報酬付与は edge が権威**なので必須。検証が NPC・モンスター・
     // アイテムの実在を引くため、**この 3 つより後に読む** (店 ← アイテムと同じ順序依存)。
     const quests = await getRecord<{ quests?: GameQuestDef[] }>(pds, did, `${nsid}.world.quests`, RKEY);
-    if (quests?.value?.quests?.length) setGameQuests(quests.value.quests);
+    // **空配列も適用する** (length で弾かない) — 全クエスト削除の保存が {quests: []} になるので、
+    // スキップすると warm isolate に削除済みクエストが残り続け、受注も報酬も通ってしまう。
+    if (quests?.value?.quests) setGameQuests(quests.value.quests);
   })()
     .catch((e) => {
       // **落ちてもゲームは続く** (同梱の地図 or ノイズ生成に倒れる)。次の TTL で再試行。

--- a/apps/edge/src/world-authoring.ts
+++ b/apps/edge/src/world-authoring.ts
@@ -1,4 +1,4 @@
-import { decodeWorldMap, loadStaticWorldMap, loadTileArts, setItemOverrides, setMonsterOverrides, setNpcs, setShopOverrides, setTownOverrides, setWorldMap, WORLD_SIZE, type EquipmentDef, type ItemDefData, type MonsterDef, type NpcDef, type ShopOverride, type TownOverride, type WorldPart } from '@aozoraquest/core';
+import { decodeWorldMap, loadStaticWorldMap, loadTileArts, setGameQuests, setItemOverrides, setMonsterOverrides, setNpcs, setShopOverrides, setTownOverrides, setWorldMap, WORLD_SIZE, type EquipmentDef, type GameQuestDef, type ItemDefData, type MonsterDef, type NpcDef, type ShopOverride, type TownOverride, type WorldPart } from '@aozoraquest/core';
 import { getRecord } from './pds';
 import { resolveDidDocument } from './service-auth';
 import { pdsEndpointFromDoc } from './oauth-metadata';
@@ -101,6 +101,10 @@ export function ensureAuthoredWorld(env: WorldAuthoringEnv, nsid: string, now: n
     // NPC (#425)。**移動判定に効く** (立っているマスは塞ぐ) ので edge も必須。
     const npcs = await getRecord<{ npcs?: NpcDef[] }>(pds, did, `${nsid}.world.npcs`, RKEY);
     if (npcs?.value?.npcs?.length) setNpcs(npcs.value.npcs);
+    // ゲーム内クエスト (#423)。**報酬付与は edge が権威**なので必須。検証が NPC・モンスター・
+    // アイテムの実在を引くため、**この 3 つより後に読む** (店 ← アイテムと同じ順序依存)。
+    const quests = await getRecord<{ quests?: GameQuestDef[] }>(pds, did, `${nsid}.world.quests`, RKEY);
+    if (quests?.value?.quests?.length) setGameQuests(quests.value.quests);
   })()
     .catch((e) => {
       // **落ちてもゲームは続く** (同梱の地図 or ノイズ生成に倒れる)。次の TTL で再試行。

--- a/apps/edge/test/game-quest.test.ts
+++ b/apps/edge/test/game-quest.test.ts
@@ -1,0 +1,220 @@
+/**
+ * ゲーム内クエスト (#423) の受注・達成 (edge 権威)。
+ *
+ * 守るべき不変条件:
+ *   - 討伐数は勝利の権威経路 (applyBattleOutcome) だけが増やす
+ *   - collect は権威在庫を検証し、達成時に**引き取る** (引かないと同素材で何度も達成できる)
+ *   - 達成済みは再受注・再達成できない (二重報酬防止)
+ *   - 報酬パワーは定義の値だけ。上限 MAX_QUEST_REWARD_POWER で clamp
+ */
+import { describe, it, expect, afterEach, beforeAll } from 'vitest';
+import { p256 } from '@noble/curves/p256';
+import { base64urlnopad } from '@scure/base';
+import { MONSTERS, setGameQuests, setNpcs, type GameQuestDef } from '@aozoraquest/core';
+import { handleQuestAccept, handleQuestComplete, GameQuestError } from '../src/game-quest';
+import { applyBattleOutcome } from '../src/battle-reward';
+import { rkeyForDid, XP_EPOCH, type GameState, type GameStateEnv } from '../src/game-state';
+import { writeServerTokens } from '../src/oauth-store';
+
+const DID = 'did:plc:alice';
+const SERVER_DID = 'did:plc:testserver';
+const NOW = 1_700_000_000;
+
+function jwkJson(fill: number): string {
+  const d = new Uint8Array(32).fill(fill);
+  const pub = p256.getPublicKey(d, false);
+  return JSON.stringify({ kty: 'EC', crv: 'P-256', x: base64urlnopad.encode(pub.slice(1, 33)), y: base64urlnopad.encode(pub.slice(33, 65)), d: base64urlnopad.encode(d), kid: `k${fill}` });
+}
+function mockKv() {
+  const m = new Map<string, string>();
+  return { get: async (k: string) => m.get(k) ?? null, put: async (k: string, v: string) => { m.set(k, v); }, delete: async (k: string) => { m.delete(k); } } as unknown as KVNamespace;
+}
+async function makeEnv(): Promise<GameStateEnv> {
+  const kv = mockKv();
+  await writeServerTokens(kv, { did: SERVER_DID, accessToken: 'AT', refreshToken: 'RT', tokenType: 'DPoP', expiresAt: NOW + 3600, pdsUrl: 'https://pds.example', authServer: 'https://bsky.social', updatedAt: NOW });
+  return { SERVER_DID, OAUTH_CLIENT_PRIVATE_JWK: jwkJson(3), OAUTH_DPOP_PRIVATE_JWK: jwkJson(5), WORKER_DID: 'did:web:edge.aozoraquest.app', OAUTH_TOKENS: kv };
+}
+function statefulPds(seed?: GameState) {
+  const store = new Map<string, { value: unknown; cid: string }>();
+  if (seed) store.set(rkeyForDid(DID), { value: seed, cid: 'c0' });
+  let counter = 0;
+  const json = (status: number, body: unknown) => new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+  const fn = (async (url: string, init: RequestInit = {}) => {
+    if (url.includes('com.atproto.repo.getRecord')) {
+      const rkey = new URL(url).searchParams.get('rkey')!;
+      const rec = store.get(rkey);
+      return rec ? json(200, { uri: `at://${rkey}`, cid: rec.cid, value: rec.value }) : json(400, { error: 'RecordNotFound' });
+    }
+    if (url.includes('com.atproto.repo.putRecord')) {
+      const b = JSON.parse(init.body as string) as { rkey: string; record: unknown; swapRecord?: string | null };
+      const cur = store.get(b.rkey);
+      if (b.swapRecord === null && cur) return json(400, { error: 'InvalidSwap' });
+      if (typeof b.swapRecord === 'string' && (!cur || cur.cid !== b.swapRecord)) return json(400, { error: 'InvalidSwap' });
+      store.set(b.rkey, { value: b.record, cid: `cid${++counter}` });
+      return json(200, { uri: `at://${b.rkey}`, cid: `cid${counter}` });
+    }
+    return json(404, { error: 'not_found' });
+  }) as unknown as typeof fetch;
+  return { fn, store };
+}
+const stored = (store: Map<string, { value: unknown; cid: string }>) => store.get(rkeyForDid(DID))!.value as GameState;
+
+const MON = MONSTERS.find((m) => m.tier === 1)!;
+
+const stateAt = (over: Partial<GameState> = {}): GameState => ({
+  did: DID, power: 10, playerXp: 0, jobXp: {},
+  materials: { herb: 5 },
+  gear: [], x: 0, y: 0, xpEpoch: XP_EPOCH, version: 1, updatedAt: '', ...over,
+});
+
+const DEFEAT_Q: GameQuestDef = {
+  id: 'q-defeat', title: 'スライム たいじ', npcId: 'npc-t1',
+  intro: ['たのむ!'], done: ['ありがとう!'],
+  objective: { kind: 'defeat', monsterId: MON.id, count: 2 },
+  reward: { power: 7 },
+};
+const COLLECT_Q: GameQuestDef = {
+  id: 'q-collect', title: 'やくそう あつめ', npcId: 'npc-t2',
+  intro: ['やくそうを 3つ たのむ'], done: ['たすかった!'],
+  objective: { kind: 'collect', itemId: 'herb', count: 3 },
+  reward: { power: 5, itemId: 'sky-feather', count: 1 },
+};
+
+beforeAll(() => {
+  setNpcs([
+    { id: 'npc-t1', name: 'そんちょう', x: 5, y: 5, lines: ['こんにちは'] },
+    { id: 'npc-t2', name: 'くすしや', x: 6, y: 5, lines: ['こんにちは'] },
+  ]);
+  setGameQuests([DEFEAT_Q, COLLECT_Q]);
+});
+
+describe('handleQuestAccept', () => {
+  const orig = globalThis.fetch;
+  afterEach(() => { globalThis.fetch = orig; });
+
+  it('受注で quest が積まれる (progress 0)', async () => {
+    const m = statefulPds(stateAt());
+    globalThis.fetch = m.fn;
+    const res = await handleQuestAccept(await makeEnv(), DID, 'q-defeat', NOW);
+    expect(res.quest).toEqual({ id: 'q-defeat', progress: 0 });
+    expect(stored(m.store).quest).toEqual({ id: 'q-defeat', progress: 0 });
+  });
+
+  it('未知のクエストは 404', async () => {
+    globalThis.fetch = statefulPds(stateAt()).fn;
+    await expect(handleQuestAccept(await makeEnv(), DID, 'nope', NOW)).rejects.toThrow(GameQuestError);
+  });
+
+  it('別クエスト進行中は受けられない (1 つずつ)', async () => {
+    globalThis.fetch = statefulPds(stateAt({ quest: { id: 'q-collect', progress: 0 } })).fn;
+    await expect(handleQuestAccept(await makeEnv(), DID, 'q-defeat', NOW)).rejects.toMatchObject({ code: 'quest_busy' });
+  });
+
+  it('同じクエストの再受注は no-op (連打・再送で壊れない)', async () => {
+    const m = statefulPds(stateAt({ quest: { id: 'q-defeat', progress: 1 } }));
+    globalThis.fetch = m.fn;
+    const res = await handleQuestAccept(await makeEnv(), DID, 'q-defeat', NOW);
+    expect(res.quest).toEqual({ id: 'q-defeat', progress: 1 }); // progress を巻き戻さない
+  });
+
+  it('達成済みは再受注できない', async () => {
+    globalThis.fetch = statefulPds(stateAt({ questsDone: ['q-defeat'] })).fn;
+    await expect(handleQuestAccept(await makeEnv(), DID, 'q-defeat', NOW)).rejects.toMatchObject({ code: 'already_done' });
+  });
+});
+
+describe('handleQuestComplete (defeat)', () => {
+  const orig = globalThis.fetch;
+  afterEach(() => { globalThis.fetch = orig; });
+
+  it('討伐数が足りないと not_ready (サーバーが進行を検証)', async () => {
+    globalThis.fetch = statefulPds(stateAt({ quest: { id: 'q-defeat', progress: 1 } })).fn;
+    await expect(handleQuestComplete(await makeEnv(), DID, 'q-defeat', NOW)).rejects.toMatchObject({ code: 'not_ready' });
+  });
+
+  it('足りたら報酬パワーが入り、done に積まれ、quest が消える', async () => {
+    const m = statefulPds(stateAt({ quest: { id: 'q-defeat', progress: 2 } }));
+    globalThis.fetch = m.fn;
+    const res = await handleQuestComplete(await makeEnv(), DID, 'q-defeat', NOW);
+    expect(res.power).toBe(17); // 10 + 7
+    expect(res.rewarded).toEqual({ power: 7 });
+    const s = stored(m.store);
+    expect(s.quest).toBeUndefined();
+    expect(s.questsDone).toEqual(['q-defeat']);
+  });
+
+  it('受けていないクエストは達成できない', async () => {
+    globalThis.fetch = statefulPds(stateAt()).fn;
+    await expect(handleQuestComplete(await makeEnv(), DID, 'q-defeat', NOW)).rejects.toMatchObject({ code: 'not_accepted' });
+  });
+
+  it('達成済みは二重達成できない (二重報酬防止)', async () => {
+    // quest が残ったまま done にもある壊れ state でも、done が勝つ
+    globalThis.fetch = statefulPds(stateAt({ quest: { id: 'q-defeat', progress: 9 }, questsDone: ['q-defeat'] })).fn;
+    await expect(handleQuestComplete(await makeEnv(), DID, 'q-defeat', NOW)).rejects.toMatchObject({ code: 'already_done' });
+  });
+});
+
+describe('handleQuestComplete (collect)', () => {
+  const orig = globalThis.fetch;
+  afterEach(() => { globalThis.fetch = orig; });
+
+  it('素材が足りないと not_ready (権威在庫で検証)', async () => {
+    globalThis.fetch = statefulPds(stateAt({ materials: { herb: 2 }, quest: { id: 'q-collect', progress: 0 } })).fn;
+    await expect(handleQuestComplete(await makeEnv(), DID, 'q-collect', NOW)).rejects.toMatchObject({ code: 'not_ready' });
+  });
+
+  it('達成で素材を引き取り、報酬 (パワー + アイテム) を付与する', async () => {
+    const m = statefulPds(stateAt({ materials: { herb: 5 }, quest: { id: 'q-collect', progress: 0 } }));
+    globalThis.fetch = m.fn;
+    const res = await handleQuestComplete(await makeEnv(), DID, 'q-collect', NOW);
+    const s = stored(m.store);
+    expect(s.materials['herb']).toBe(2); // 5 - 3 引き取られた
+    expect(s.materials['sky-feather']).toBe(1); // 報酬アイテム
+    expect(s.power).toBe(15); // 10 + 5
+    expect(res.rewarded).toEqual({ power: 5, itemId: 'sky-feather', count: 1 });
+  });
+
+  it('ちょうど使い切ると素材キーが消える (0 を残さない)', async () => {
+    const m = statefulPds(stateAt({ materials: { herb: 3 }, quest: { id: 'q-collect', progress: 0 } }));
+    globalThis.fetch = m.fn;
+    await handleQuestComplete(await makeEnv(), DID, 'q-collect', NOW);
+    expect(stored(m.store).materials['herb']).toBeUndefined();
+  });
+});
+
+describe('applyBattleOutcome の討伐カウント', () => {
+  const win = (state: GameState, ids: string[]) =>
+    applyBattleOutcome(state, {
+      outcome: 'win', monsterId: ids[0]!, archetype: 'guardian', luk: 0,
+      enemyIds: ids, rewardSeed: 1, lossSeed: 2, rewarded: true,
+    });
+
+  it('対象モンスターを倒すと進行が増える (群れは頭数分)', async () => {
+    const s = stateAt({ quest: { id: 'q-defeat', progress: 0 } });
+    const { next } = win(s, [MON.id, MON.id]);
+    expect(next.quest).toEqual({ id: 'q-defeat', progress: 2 });
+  });
+
+  it('対象外のモンスターでは進まない', async () => {
+    const other = MONSTERS.find((m) => m.id !== MON.id)!;
+    const s = stateAt({ quest: { id: 'q-defeat', progress: 1 } });
+    const { next } = win(s, [other.id]);
+    expect(next.quest).toEqual({ id: 'q-defeat', progress: 1 });
+  });
+
+  it('パワー無し (unrewarded) の練習戦では進まない', async () => {
+    const s = stateAt({ quest: { id: 'q-defeat', progress: 0 } });
+    const { next } = applyBattleOutcome(s, {
+      outcome: 'win', monsterId: MON.id, archetype: 'guardian', luk: 0,
+      rewardSeed: 1, lossSeed: 2, rewarded: false,
+    });
+    expect(next.quest).toEqual({ id: 'q-defeat', progress: 0 });
+  });
+
+  it('collect クエスト中の討伐では進まない', async () => {
+    const s = stateAt({ quest: { id: 'q-collect', progress: 0 } });
+    const { next } = win(s, [MON.id]);
+    expect(next.quest).toEqual({ id: 'q-collect', progress: 0 });
+  });
+});

--- a/apps/edge/test/game-quest.test.ts
+++ b/apps/edge/test/game-quest.test.ts
@@ -117,6 +117,16 @@ describe('handleQuestAccept', () => {
     expect(res.quest).toEqual({ id: 'q-defeat', progress: 1 }); // progress を巻き戻さない
   });
 
+  it('定義が消された孤児クエストを抱えていても、新しいクエストを受けられる', async () => {
+    // 管理者がエディタで削除した後もプレイヤーの GameState には残る。破棄手段が無いので、
+    // 受注時に孤児を落とさないと永久に何も受けられない。
+    const m = statefulPds(stateAt({ quest: { id: 'q-deleted', progress: 3 } }));
+    globalThis.fetch = m.fn;
+    const res = await handleQuestAccept(await makeEnv(), DID, 'q-defeat', NOW);
+    expect(res.quest).toEqual({ id: 'q-defeat', progress: 0 });
+    expect(stored(m.store).quest).toEqual({ id: 'q-defeat', progress: 0 });
+  });
+
   it('達成済みは再受注できない', async () => {
     globalThis.fetch = statefulPds(stateAt({ questsDone: ['q-defeat'] })).fn;
     await expect(handleQuestAccept(await makeEnv(), DID, 'q-defeat', NOW)).rejects.toMatchObject({ code: 'already_done' });

--- a/apps/web/src/lib/collections.ts
+++ b/apps/web/src/lib/collections.ts
@@ -93,6 +93,8 @@ export const ADMIN_COL = {
   shops: `${ROOT}.world.shops`,
   /** NPC (位置・名前・セリフ)。#425 */
   npcs: `${ROOT}.world.npcs`,
+  /** ゲーム内クエスト (NPC 発注・達成条件・報酬)。#423 */
+  quests: `${ROOT}.world.quests`,
   /** 依頼クエスト集約 (docs/15-user-quest.md §集約インフラ)。
    *  Worker が主管理者 PDS に書く。env 別に rkey を分ける (dev→'dev', prod→'self')。 */
   questIndex: `${ROOT}.questIndex`,

--- a/apps/web/src/lib/world-authoring.ts
+++ b/apps/web/src/lib/world-authoring.ts
@@ -178,7 +178,8 @@ export async function loadAuthoredWorld(agent: Agent | null): Promise<void> {
     try {
       // 検証が NPC・モンスター・アイテムの実在を引くため、**この 3 つより後に読む** (#423)。
       const rec = await getRecord<{ quests?: GameQuestDef[] }>(agent, adminDid, ADMIN_COL.quests, RKEY);
-      if (rec?.quests?.length) setGameQuests(rec.quests);
+      // 空配列も適用する (全削除の反映。edge 側と同じ理由)。
+      if (rec?.quests) setGameQuests(rec.quests);
     } catch (e) {
       console.warn('[world] quests load failed', e);
     }

--- a/apps/web/src/lib/world-authoring.ts
+++ b/apps/web/src/lib/world-authoring.ts
@@ -5,6 +5,7 @@ import {
   encodeWorldMap,
   loadStaticWorldMap,
   loadTileArts,
+  setGameQuests,
   setItemOverrides,
   setMonsterOverrides,
   setNpcs,
@@ -17,6 +18,7 @@ import {
   worldTownOverrides,
   WORLD_SIZE,
   type EquipmentDef,
+  type GameQuestDef,
   type ItemDefData,
   type MonsterDef,
   type NpcDef,
@@ -173,6 +175,13 @@ export async function loadAuthoredWorld(agent: Agent | null): Promise<void> {
     } catch (e) {
       console.warn('[world] npcs load failed', e);
     }
+    try {
+      // 検証が NPC・モンスター・アイテムの実在を引くため、**この 3 つより後に読む** (#423)。
+      const rec = await getRecord<{ quests?: GameQuestDef[] }>(agent, adminDid, ADMIN_COL.quests, RKEY);
+      if (rec?.quests?.length) setGameQuests(rec.quests);
+    } catch (e) {
+      console.warn('[world] quests load failed', e);
+    }
     return;
   }
   await loadStaticWorldMap().catch((e) => console.warn('[world] static map load failed', e));
@@ -223,4 +232,10 @@ export async function saveShops(agent: Agent, shops: ShopOverride[]): Promise<vo
 export async function saveNpcs(agent: Agent, npcs: NpcDef[]): Promise<void> {
   setNpcs(npcs);
   await putRecord(agent, ADMIN_COL.npcs, RKEY, { npcs, updatedAt: new Date().toISOString() });
+}
+
+/** ゲーム内クエスト (#423)。setGameQuests が先に検証で落とす (壊れた定義を保存させない)。 */
+export async function saveGameQuests(agent: Agent, quests: GameQuestDef[]): Promise<void> {
+  setGameQuests(quests);
+  await putRecord(agent, ADMIN_COL.quests, RKEY, { quests, updatedAt: new Date().toISOString() });
 }

--- a/apps/web/src/lib/world-server.ts
+++ b/apps/web/src/lib/world-server.ts
@@ -26,6 +26,8 @@ const LXM_SHOP_CRAFT = 'app.aozoraquest.shop.craft';
 const LXM_SHOP_SELL = 'app.aozoraquest.shop.sell';
 const LXM_SHOP_FORGE = 'app.aozoraquest.shop.forge';
 const LXM_SHOP_DISCARD = 'app.aozoraquest.shop.discard';
+const LXM_QUEST_ACCEPT = 'app.aozoraquest.quest.accept';
+const LXM_QUEST_COMPLETE = 'app.aozoraquest.quest.complete';
 const LXM_POWER_SPEND = 'app.aozoraquest.power.spend';
 const LXM_ADMIN_PDS_USAGE = 'app.aozoraquest.admin.pdsUsage';
 
@@ -91,7 +93,7 @@ export interface ServerMoveResult { x: number; y: number; terrain: string; heale
 /** 権威 GameState (パワー/XP/素材/位置/carry HP-MP 等)。表示はこれを正とする。 */
 /** 所持装備の 1 個体 (#551 段階 2)。**権威側が唯一の正**で、ここに無い個体は装備できない。 */
 export interface ServerOwnedPiece { rkey: string; itemId: string; level: number }
-export interface ServerGameState { did: string; power: number; playerXp: number; jobXp: Record<string, number>; materials: Record<string, number>; gear: string[]; pieces?: ServerOwnedPiece[]; x: number; y: number; carryHp?: number; carryMp?: number; herbs?: number; tonics?: number; version: number; updatedAt: string }
+export interface ServerGameState { did: string; power: number; playerXp: number; jobXp: Record<string, number>; materials: Record<string, number>; gear: string[]; pieces?: ServerOwnedPiece[]; x: number; y: number; carryHp?: number; carryMp?: number; herbs?: number; tonics?: number; quest?: { id: string; progress: number }; questsDone?: string[]; version: number; updatedAt: string }
 export interface ServerStateResult { state: ServerGameState; initialized: boolean; token?: string }
 export interface ServerAward {
   /** パワー不足で報酬対象外だった (勝っても逃げても XP・素材が入らない)。 */
@@ -207,6 +209,25 @@ export function serverShopForge(agent: Agent, rkeys: [string, string], rkey: str
  */
 export function serverShopDiscard(agent: Agent, rkeys: string[], rkey: string): Promise<ServerShopResult> {
   return callEdge<ServerShopResult>(agent, LXM_SHOP_DISCARD, '/api/shop/discard', { rkeys, rkey });
+}
+
+export interface ServerQuestResult {
+  quest?: { id: string; progress: number };
+  questsDone?: string[];
+  power: number;
+  materials: Record<string, number>;
+  /** 達成時のみ: 付与された報酬。 */
+  rewarded?: { power?: number; itemId?: string; count?: number };
+}
+
+/** ゲーム内クエスト (#423): 受注。進行は GameState に積まれ、討伐は勝利時にサーバーが数える。 */
+export function serverQuestAccept(agent: Agent, questId: string): Promise<ServerQuestResult> {
+  return callEdge<ServerQuestResult>(agent, LXM_QUEST_ACCEPT, '/api/quest/accept', { questId });
+}
+
+/** ゲーム内クエスト (#423): 達成。**条件も報酬もサーバーが検証・付与する** (collect は素材を引き取られる)。 */
+export function serverQuestComplete(agent: Agent, questId: string): Promise<ServerQuestResult> {
+  return callEdge<ServerQuestResult>(agent, LXM_QUEST_COMPLETE, '/api/quest/complete', { questId });
 }
 
 /** なんでも屋: 素材のひきとり (#551)。権威側の在庫と残高を動かす。 */

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -24,6 +24,7 @@ const AdminMonsters = lazy(() => import('@/routes/admin-monsters').then(m => ({ 
 const AdminItems = lazy(() => import('@/routes/admin-items').then(m => ({ default: m.AdminItems })));
 const AdminShops = lazy(() => import('@/routes/admin-shops').then(m => ({ default: m.AdminShops })));
 const AdminNpcs = lazy(() => import('@/routes/admin-npcs').then(m => ({ default: m.AdminNpcs })));
+const AdminQuests = lazy(() => import('@/routes/admin-quests').then(m => ({ default: m.AdminQuests })));
 const World = lazy(() => import('@/routes/world').then(m => ({ default: m.World })));
 const Onboarding = lazy(() => import('@/routes/onboarding').then(m => ({ default: m.Onboarding })));
 const OAuthCallback = lazy(() => import('@/routes/oauth-callback').then(m => ({ default: m.OAuthCallback })));
@@ -89,6 +90,7 @@ const router = createBrowserRouter([
       { path: 'admin/items', element: <AdminItems /> },
       { path: 'admin/shops', element: <AdminShops /> },
       { path: 'admin/npcs', element: <AdminNpcs /> },
+      { path: 'admin/quests', element: <AdminQuests /> },
       { path: 'world', element: <World /> },
       { path: 'onboarding', element: <Onboarding /> },
       { path: 'oauth/callback', element: <OAuthCallback /> },

--- a/apps/web/src/routes/admin-dashboard.tsx
+++ b/apps/web/src/routes/admin-dashboard.tsx
@@ -38,6 +38,7 @@ const CONTENT_SECTIONS: Section[] = [
   { key: 'map', title: 'マップ', desc: '地形をパーツで編集 (エリア・出現配置は #421 で続き)', to: '/admin/map', issue: 421 },
   { key: 'jobs', title: 'ジョブ', desc: '各種パラメータ設定 + 模擬戦', issue: 544 },
   { key: 'npc', title: 'NPC', desc: '位置・名前・セリフ・絵 (フラグ制御は #425 で続き)', to: '/admin/npcs', issue: 425 },
+  { key: 'quest', title: 'クエスト', desc: 'NPC 発注・達成条件 (討伐/収集)・報酬', to: '/admin/quests', issue: 423 },
   { key: 'places', title: '街 / ダンジョン / 城', desc: '内部マップの編集', issue: 424 },
   { key: 'quests', title: 'クエスト', desc: 'ゲーム内クエストの作成・編集', issue: 423 },
   { key: 'scenario', title: 'シナリオ', desc: '進行の筋書き', issue: 545 },

--- a/apps/web/src/routes/admin-dashboard.tsx
+++ b/apps/web/src/routes/admin-dashboard.tsx
@@ -40,7 +40,6 @@ const CONTENT_SECTIONS: Section[] = [
   { key: 'npc', title: 'NPC', desc: '位置・名前・セリフ・絵 (フラグ制御は #425 で続き)', to: '/admin/npcs', issue: 425 },
   { key: 'quest', title: 'クエスト', desc: 'NPC 発注・達成条件 (討伐/収集)・報酬', to: '/admin/quests', issue: 423 },
   { key: 'places', title: '街 / ダンジョン / 城', desc: '内部マップの編集', issue: 424 },
-  { key: 'quests', title: 'クエスト', desc: 'ゲーム内クエストの作成・編集', issue: 423 },
   { key: 'scenario', title: 'シナリオ', desc: '進行の筋書き', issue: 545 },
   { key: 'items', title: 'アイテム', desc: 'そうび・どうぐ・素材の編集', to: '/admin/items', issue: 420 },
   { key: 'shops', title: 'お店', desc: '店ごとのラインナップ・値札の素材 (セリフは #422 で続き)', to: '/admin/shops', issue: 422 },

--- a/apps/web/src/routes/admin-npcs.tsx
+++ b/apps/web/src/routes/admin-npcs.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import {
   allNpcs,
+  gameQuests,
   isWalkableAt,
   npcArtKey,
   NpcDataError,
@@ -53,6 +54,14 @@ export function AdminNpcs() {
 
   const save = useCallback(async () => {
     if (!session.agent) return;
+    // クエストが発注させている NPC を消させない (#423。実装レビュー ★★) —
+    // 参照切れの NPC が 1 人でもいると setGameQuests が全体を落とす設計なので、
+    // 消した NPC と無関係な全クエストまで web/edge から消えてしまう。
+    const orphan = gameQuests().find((q) => !list.some((n) => n.id === q.npcId));
+    if (orphan) {
+      setNote(`保存できない: クエスト「${orphan.title}」が NPC (${orphan.npcId}) に発注させている。先にクエストを消すか発注者を変える`);
+      return;
+    }
     try {
       await saveNpcs(session.agent, list);
       setDirty(false);

--- a/apps/web/src/routes/admin-quests.tsx
+++ b/apps/web/src/routes/admin-quests.tsx
@@ -1,0 +1,301 @@
+import { useCallback, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  allNpcs,
+  gameQuests,
+  ITEMS,
+  MONSTERS,
+  QuestDataError,
+  setGameQuests,
+  type GameQuestDef,
+  type QuestObjective,
+} from '@aozoraquest/core';
+import { useSession } from '@/lib/session';
+import { isAdminDid } from '@/lib/runtime-config';
+import { saveGameQuests } from '@/lib/world-authoring';
+
+/**
+ * **ゲーム内クエスト エディタ** (#423)。NPC 発注・達成条件・報酬。
+ *
+ * 達成条件は**サーバーが検証できるもの**だけ (討伐数 / 素材の所持)。進行と報酬は
+ * edge が権威なので、ここで作った定義は保存 → サーバーが最大 5 分で拾ってから効く。
+ */
+export function AdminQuests() {
+  const session = useSession();
+  const admin = isAdminDid(session.did ?? null);
+  const [list, setList] = useState<GameQuestDef[]>(() =>
+    gameQuests().map((q) => ({ ...q, intro: [...q.intro], done: [...q.done], ...(q.progress ? { progress: [...q.progress] } : {}) })),
+  );
+  const [sel, setSel] = useState<string | null>(null);
+  const [note, setNote] = useState<string | null>(null);
+  const [dirty, setDirty] = useState(false);
+
+  const npcs = useMemo(() => allNpcs(), []);
+  const monsters = useMemo(() => [...MONSTERS].sort((a, b) => a.tier - b.tier), []);
+  const items = useMemo(() => Object.entries(ITEMS).map(([id, v]) => ({ id, name: v.name })), []);
+  const current = useMemo(() => list.find((q) => q.id === sel) ?? null, [list, sel]);
+
+  const update = useCallback((id: string, patch: Partial<GameQuestDef>) => {
+    setList((xs) => xs.map((q) => (q.id === id ? { ...q, ...patch } : q)));
+    setDirty(true);
+  }, []);
+
+  const add = useCallback(() => {
+    let i = list.length + 1;
+    while (list.some((q) => q.id === `quest-${i}`)) i++;
+    const q: GameQuestDef = {
+      id: `quest-${i}`,
+      title: 'あたらしい たのまれごと',
+      npcId: npcs[0]?.id ?? '',
+      intro: ['たのみが あるんだ。'],
+      done: ['ありがとう!'],
+      objective: { kind: 'defeat', monsterId: monsters[0]?.id ?? '', count: 3 },
+      reward: { power: 5 },
+    };
+    setList((xs) => [...xs, q]);
+    setSel(q.id);
+    setDirty(true);
+  }, [list, npcs, monsters]);
+
+  const save = useCallback(async () => {
+    if (!session.agent) return;
+    try {
+      await saveGameQuests(session.agent, list);
+      setDirty(false);
+      setNote(`${list.length} 件を保存した。サーバーは最大 5 分で拾う`);
+    } catch (e) {
+      // 検証で落ちたら現在のメモリ状態が壊れている可能性があるので元に戻す
+      try { setGameQuests(null); } catch { /* noop */ }
+      setNote(e instanceof QuestDataError ? `保存できない: ${e.message}` : `保存できなかった: ${String(e)}`);
+    }
+  }, [session.agent, list]);
+
+  if (!admin) {
+    return (
+      <div style={{ padding: '1em' }}>
+        <p>この画面は管理者だけが使えます。</p>
+        <Link to="/admin">管理ダッシュボードへ</Link>
+      </div>
+    );
+  }
+
+  const field = (label: string, input: React.ReactNode) => (
+    <label style={{ display: 'flex', alignItems: 'center', gap: '0.4em', fontSize: '0.8em' }}>
+      <span style={{ width: '6em', color: 'var(--color-muted)' }}>{label}</span>
+      {input}
+    </label>
+  );
+
+  const lineEditor = (q: GameQuestDef, key: 'intro' | 'done' | 'progress', label: string, hint: string) => {
+    const lines = q[key] ?? [];
+    const set = (next: string[]) => {
+      if (key === 'progress' && next.length === 0) {
+        // exactOptionalPropertyTypes: 空にしたら省略 (既定セリフに戻す)
+        setList((xs) => xs.map((x) => {
+          if (x.id !== q.id) return x;
+          const { progress: _p, ...rest } = x;
+          return rest as GameQuestDef;
+        }));
+        setDirty(true);
+      } else {
+        update(q.id, { [key]: next } as Partial<GameQuestDef>);
+      }
+    };
+    return (
+      <div style={{ fontSize: '0.8em' }}>
+        <span style={{ color: 'var(--color-muted)' }}>{label} ({hint})</span>
+        {lines.map((l, i) => (
+          <div key={i} style={{ display: 'flex', gap: '0.3em', margin: '0.15em 0' }}>
+            <input value={l} onChange={(e) => set(lines.map((x, j) => (j === i ? e.target.value : x)))} style={{ flex: 1 }} />
+            <button
+              type="button"
+              disabled={key !== 'progress' && lines.length <= 1}
+              onClick={() => set(lines.filter((_, j) => j !== i))}
+              style={{ fontSize: '0.8em' }}
+            >
+              ×
+            </button>
+          </div>
+        ))}
+        <button type="button" onClick={() => set([...lines, ''])} style={{ fontSize: '0.8em', marginTop: '0.2em' }}>
+          ＋セリフ
+        </button>
+      </div>
+    );
+  };
+
+  const npcNameOf = (id: string) => npcs.find((n) => n.id === id)?.name ?? id;
+
+  return (
+    <div style={{ padding: '0.8em', maxWidth: 900 }}>
+      <div style={{ display: 'flex', gap: '0.6em', alignItems: 'center', marginBottom: '0.4em' }}>
+        <Link to="/admin" style={{ fontSize: '0.8em' }}>← 管理</Link>
+        <strong>クエスト</strong>
+        <span style={{ fontSize: '0.75em', color: 'var(--color-muted)' }}>{list.length} 件</span>
+        <button type="button" onClick={add} disabled={npcs.length === 0} style={{ fontSize: '0.85em' }}>＋クエスト</button>
+        <button type="button" onClick={() => void save()} disabled={!session.agent || !dirty} style={{ marginLeft: 'auto', fontSize: '0.85em' }}>
+          保存
+        </button>
+      </div>
+
+      {note && <p style={{ fontSize: '0.8em', color: 'var(--color-accent)', margin: '0 0 0.4em' }}>{note}</p>}
+      {npcs.length === 0 && (
+        <p style={{ fontSize: '0.8em', color: 'var(--color-danger)' }}>
+          発注する NPC がまだ居ない。先に <Link to="/admin/npcs">NPC</Link> を置く
+        </p>
+      )}
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'minmax(160px, 1fr) 2fr', gap: '0.8em' }}>
+        <div style={{ maxHeight: '70vh', overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 2 }}>
+          {list.map((q) => (
+            <button
+              key={q.id}
+              type="button"
+              onClick={() => setSel(q.id)}
+              style={{
+                display: 'flex', gap: '0.4em', width: '100%', padding: '0.2em 0.4em',
+                fontSize: '0.85em', textAlign: 'left',
+                border: sel === q.id ? '2px solid var(--color-accent)' : '1px solid var(--color-border)',
+                background: 'transparent',
+              }}
+            >
+              <span style={{ flex: 1 }}>{q.title}</span>
+              <span style={{ fontSize: '0.75em', color: 'var(--color-muted)' }}>{npcNameOf(q.npcId)}</span>
+            </button>
+          ))}
+          {list.length === 0 && (
+            <span style={{ fontSize: '0.8em', color: 'var(--color-muted)' }}>まだ無い。「＋クエスト」で作る</span>
+          )}
+        </div>
+
+        {current ? (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.35em' }}>
+            <div style={{ display: 'flex', gap: '0.4em', alignItems: 'center' }}>
+              <strong>{current.title}</strong>
+              <code style={{ fontSize: '0.75em', color: 'var(--color-muted)' }}>{current.id}</code>
+              <button
+                type="button"
+                className="secondary"
+                onClick={() => {
+                  if (!window.confirm(`「${current.title}」を消す？`)) return;
+                  setList((xs) => xs.filter((q) => q.id !== current.id));
+                  setSel(null);
+                  setDirty(true);
+                }}
+                style={{ marginLeft: 'auto', fontSize: '0.8em' }}
+              >
+                削除
+              </button>
+            </div>
+            {field('タイトル', <input value={current.title} onChange={(e) => update(current.id, { title: e.target.value })} style={{ flex: 1 }} />)}
+            {field('発注 NPC', (
+              <select value={current.npcId} onChange={(e) => update(current.id, { npcId: e.target.value })}>
+                {npcs.map((n) => (
+                  <option key={n.id} value={n.id}>{n.name} ({n.x},{n.y})</option>
+                ))}
+              </select>
+            ))}
+            {field('条件', (
+              <span style={{ display: 'flex', gap: '0.3em', alignItems: 'center', flexWrap: 'wrap' }}>
+                <select
+                  value={current.objective.kind}
+                  onChange={(e) => {
+                    const kind = e.target.value as QuestObjective['kind'];
+                    const count = current.objective.count;
+                    update(current.id, {
+                      objective: kind === 'defeat'
+                        ? { kind, monsterId: monsters[0]?.id ?? '', count }
+                        : { kind, itemId: items[0]?.id ?? '', count },
+                    });
+                  }}
+                >
+                  <option value="defeat">たおす</option>
+                  <option value="collect">あつめる (素材を渡す)</option>
+                </select>
+                {current.objective.kind === 'defeat' ? (
+                  <select
+                    value={current.objective.monsterId}
+                    onChange={(e) => update(current.id, { objective: { ...current.objective, monsterId: e.target.value } as QuestObjective })}
+                  >
+                    {monsters.map((m) => (
+                      <option key={m.id} value={m.id}>T{m.tier} {m.name}</option>
+                    ))}
+                  </select>
+                ) : (
+                  <select
+                    value={current.objective.itemId}
+                    onChange={(e) => update(current.id, { objective: { ...current.objective, itemId: e.target.value } as QuestObjective })}
+                  >
+                    {items.map((it) => (
+                      <option key={it.id} value={it.id}>{it.name}</option>
+                    ))}
+                  </select>
+                )}
+                ×
+                <input
+                  type="number"
+                  min={1}
+                  max={99}
+                  value={current.objective.count}
+                  onChange={(e) => update(current.id, { objective: { ...current.objective, count: Number(e.target.value) } as QuestObjective })}
+                  style={{ width: '4.5em' }}
+                />
+              </span>
+            ))}
+            {field('報酬', (
+              <span style={{ display: 'flex', gap: '0.3em', alignItems: 'center', flexWrap: 'wrap' }}>
+                パワー
+                <input
+                  type="number"
+                  min={0}
+                  value={current.reward?.power ?? 0}
+                  onChange={(e) => {
+                    const power = Number(e.target.value);
+                    const base = { ...(current.reward ?? {}) };
+                    if (power > 0) base.power = power;
+                    else delete base.power;
+                    update(current.id, Object.keys(base).length ? { reward: base } : ({ reward: undefined } as unknown as Partial<GameQuestDef>));
+                  }}
+                  style={{ width: '5em' }}
+                />
+                アイテム
+                <select
+                  value={current.reward?.itemId ?? ''}
+                  onChange={(e) => {
+                    const itemId = e.target.value;
+                    const base = { ...(current.reward ?? {}) };
+                    if (itemId) { base.itemId = itemId; base.count = base.count && base.count > 0 ? base.count : 1; }
+                    else { delete base.itemId; delete base.count; }
+                    update(current.id, Object.keys(base).length ? { reward: base } : ({ reward: undefined } as unknown as Partial<GameQuestDef>));
+                  }}
+                >
+                  <option value="">なし</option>
+                  {items.map((it) => (
+                    <option key={it.id} value={it.id}>{it.name}</option>
+                  ))}
+                </select>
+                {current.reward?.itemId && (
+                  <>
+                    ×
+                    <input
+                      type="number"
+                      min={1}
+                      value={current.reward?.count ?? 1}
+                      onChange={(e) => update(current.id, { reward: { ...(current.reward ?? {}), count: Number(e.target.value) } })}
+                      style={{ width: '4.5em' }}
+                    />
+                  </>
+                )}
+              </span>
+            ))}
+            {lineEditor(current, 'intro', '依頼のセリフ', '読み終えると受注する')}
+            {lineEditor(current, 'progress', '進行中のセリフ', '空なら既定「たのんだよ。」+ サーバーの「まだ n/m」')}
+            {lineEditor(current, 'done', '達成のセリフ', 'お礼。この後に報酬が出る')}
+          </div>
+        ) : (
+          <div style={{ fontSize: '0.85em', color: 'var(--color-muted)' }}>左の一覧から選ぶか「＋クエスト」。</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/routes/admin-quests.tsx
+++ b/apps/web/src/routes/admin-quests.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import {
   allNpcs,
@@ -12,7 +12,7 @@ import {
 } from '@aozoraquest/core';
 import { useSession } from '@/lib/session';
 import { isAdminDid } from '@/lib/runtime-config';
-import { saveGameQuests } from '@/lib/world-authoring';
+import { loadAuthoredWorld, saveGameQuests } from '@/lib/world-authoring';
 
 /**
  * **ゲーム内クエスト エディタ** (#423)。NPC 発注・達成条件・報酬。
@@ -29,10 +29,24 @@ export function AdminQuests() {
   const [sel, setSel] = useState<string | null>(null);
   const [note, setNote] = useState<string | null>(null);
   const [dirty, setDirty] = useState(false);
+  const [loaded, setLoaded] = useState(false);
 
-  const npcs = useMemo(() => allNpcs(), []);
-  const monsters = useMemo(() => [...MONSTERS].sort((a, b) => a.tier - b.tier), []);
-  const items = useMemo(() => Object.entries(ITEMS).map(([id, v]) => ({ id, name: v.name })), []);
+  // **保存済みレコードを必ず読み込んでから編集させる** (実装レビュー ★★)。
+  // メモリの gameQuests() は /world か /admin/map を先に開いた時しか埋まっておらず、
+  // この画面を直接開いて保存すると空リストで world.quests を上書き = 既存クエスト全損する。
+  useEffect(() => {
+    let cancelled = false;
+    void loadAuthoredWorld(session.agent ?? null).finally(() => {
+      if (cancelled) return;
+      setList(gameQuests().map((q) => ({ ...q, intro: [...q.intro], done: [...q.done], ...(q.progress ? { progress: [...q.progress] } : {}) })));
+      setLoaded(true);
+    });
+    return () => { cancelled = true; };
+  }, [session.agent]);
+
+  const npcs = useMemo(() => allNpcs(), [loaded]);
+  const monsters = useMemo(() => [...MONSTERS].sort((a, b) => a.tier - b.tier), [loaded]);
+  const items = useMemo(() => Object.entries(ITEMS).map(([id, v]) => ({ id, name: v.name })), [loaded]);
   const current = useMemo(() => list.find((q) => q.id === sel) ?? null, [list, sel]);
 
   const update = useCallback((id: string, patch: Partial<GameQuestDef>) => {
@@ -64,8 +78,9 @@ export function AdminQuests() {
       setDirty(false);
       setNote(`${list.length} 件を保存した。サーバーは最大 5 分で拾う`);
     } catch (e) {
-      // 検証で落ちたら現在のメモリ状態が壊れている可能性があるので元に戻す
-      try { setGameQuests(null); } catch { /* noop */ }
+      // setGameQuests は全検証を終えてから差し替えるので、throw してもメモリは前の状態のまま。
+      // ここで setGameQuests(null) してはいけない — 全解除になり、再訪 + 保存で
+      // world.quests レコードごと消える事故につながる (UX レビュー ★★★)。
       setNote(e instanceof QuestDataError ? `保存できない: ${e.message}` : `保存できなかった: ${String(e)}`);
     }
   }, [session.agent, list]);
@@ -133,7 +148,7 @@ export function AdminQuests() {
         <strong>クエスト</strong>
         <span style={{ fontSize: '0.75em', color: 'var(--color-muted)' }}>{list.length} 件</span>
         <button type="button" onClick={add} disabled={npcs.length === 0} style={{ fontSize: '0.85em' }}>＋クエスト</button>
-        <button type="button" onClick={() => void save()} disabled={!session.agent || !dirty} style={{ marginLeft: 'auto', fontSize: '0.85em' }}>
+        <button type="button" onClick={() => void save()} disabled={!session.agent || !dirty || !loaded} style={{ marginLeft: 'auto', fontSize: '0.85em' }}>
           保存
         </button>
       </div>

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -38,6 +38,8 @@ import { serverMove, serverTurn, serverState, serverTeleport, serverItem, server
   serverShopSell,
   serverShopForge,
   serverShopDiscard,
+  serverQuestAccept,
+  serverQuestComplete,
 } from '@/lib/world-server';
 import { craftItem, discardItems, forgeItems, loadCraftInventory, newCraftRkey, newDiscardRkey, newForgeRkey, newSaleRkey, sellMaterials, type CraftedPiece } from '@/lib/crafting';
 import { ShopModal, type LastShopAction } from '@/components/shop-modal';
@@ -52,7 +54,7 @@ function shopErrorText(e: unknown, fallback: string): string {
 }
 import { WORLD_PREVIEW_ENABLED } from '@/lib/world-preview';
 import { loadAuthoredWorld } from '@/lib/world-authoring';
-import { allNpcs, npcArtKey, npcAt, shopKeeperFor, type NpcDef } from '@aozoraquest/core';
+import { allNpcs, gameQuestById, gameQuestByNpc, npcArtKey, npcAt, shopKeeperFor, type NpcDef } from '@aozoraquest/core';
 import { mappedPartAt } from '@aozoraquest/core';
 import { Avatar } from '@/components/avatar';
 import { WorldBattleControls, type BattlePhase } from '@/components/world-battle-controls';
@@ -146,7 +148,11 @@ export function World() {
   const [loadErr, setLoadErr] = useState(false);
   const [retryNonce, setRetryNonce] = useState(0);
   const [notice, setNotice] = useState<string | null>(null); // 進めない/回復などの一行メッセージ
-  const [npcTalk, setNpcTalk] = useState<NpcDef | null>(null);
+  /** NPC 会話 (#425/#423)。lines は通常セリフかクエスト文脈のセリフ。acceptQuestId が
+   *  あるときは**読み終えたら受注する** (DQ の作法: 依頼を聞いた = 引き受けた)。 */
+  const [npcTalk, setNpcTalk] = useState<{ npc: NpcDef; lines: string[]; acceptQuestId?: string } | null>(null);
+  /** ゲーム内クエストの進行 (#423)。**サーバーが正** — 受注/達成の応答と serverState だけが書く。 */
+  const questRef = useRef<{ active?: { id: string; progress: number }; done: string[] }>({ done: [] });
   const [onboarding, setOnboarding] = useState(false);
   const onboardingRef = useRef(false);
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
@@ -357,6 +363,7 @@ export function World() {
           if (!cancelled) {
             serverInv = { materials: ss.state.materials ?? {}, carryHp: ss.state.carryHp, carryMp: ss.state.carryMp };
             setServerPower(ss.state.power ?? 0);
+            questRef.current = { ...(ss.state.quest ? { active: ss.state.quest } : {}), done: ss.state.questsDone ?? [] };
             // **所持個体もサーバーが正** (#551 段階 2)。ユーザー PDS の craft レコードは
             // 記帳 (履歴) であって所持の根拠ではない。
             if (ss.state.pieces) setCraftedPieces(ss.state.pieces.map((p) => ({ rkey: p.rkey, itemId: p.itemId, level: p.level, at: '' })));
@@ -519,9 +526,44 @@ export function World() {
       const nx = wrap(s.x + dx);
       const ny = wrap(s.y + dy);
       // **NPC にぶつかったら会話** (#425)。DQ の作法: 移動はせず、話しかける。
+      // クエスト発注 NPC (#423) は状況で話が変わる: 未受注→依頼 (読了で受注)、
+      // 進行中→達成を試みる (条件検証はサーバー)、達成済み→通常セリフ。
       const npc = npcAt(nx, ny);
       if (npc) {
-        setNpcTalk(npc);
+        const q = gameQuestByNpc(npc.id);
+        const qs = questRef.current;
+        if (!q || qs.done.includes(q.id)) {
+          setNpcTalk({ npc, lines: npc.lines });
+        } else if (qs.active?.id === q.id) {
+          void (async () => {
+            try {
+              const res = await serverQuestComplete(agent, q.id);
+              questRef.current = { ...(res.quest ? { active: res.quest } : {}), done: res.questsDone ?? [] };
+              setServerPower(res.power);
+              applyServerMaterials(res.materials);
+              const r = res.rewarded;
+              const got = [
+                r?.power ? `あおぞらパワー ${r.power}` : null,
+                r?.itemId ? `${ITEMS[r.itemId]?.name ?? r.itemId} ×${r.count}` : null,
+              ].filter(Boolean).join(' と ');
+              setNpcTalk({ npc, lines: [...q.done, ...(got ? [`${got} を もらった!`] : [])] });
+            } catch (e) {
+              // not_ready はサーバーの「まだ n/m」をそのまま出す (進行数はサーバーが正)。
+              const notReady = e instanceof WorldServerError && e.code === 'not_ready';
+              setNpcTalk({
+                npc,
+                lines: notReady
+                  ? [...(q.progress ?? ['たのんだよ。']), (e as WorldServerError).message]
+                  : q.progress ?? ['たのんだよ。'],
+              });
+            }
+          })();
+        } else if (qs.active) {
+          // 別のクエスト進行中: 依頼は聞けるが受けられない (1 つずつ)。
+          setNpcTalk({ npc, lines: [...q.intro, '(いまは べつの たのまれごとを うけている…)'] });
+        } else {
+          setNpcTalk({ npc, lines: q.intro, acceptQuestId: q.id });
+        }
         return;
       }
       if (!isWalkableAt(nx, ny)) {
@@ -1360,8 +1402,20 @@ export function World() {
           {!battle && npcTalk && !onboarding && (
             <DialogueWindow
               anchor="map"
-              lines={npcTalk.lines.map((text) => ({ speaker: npcTalk.name, text }))}
-              onDone={() => setNpcTalk(null)}
+              lines={npcTalk.lines.map((text) => ({ speaker: npcTalk.npc.name, text }))}
+              onDone={() => {
+                const accept = npcTalk.acceptQuestId;
+                setNpcTalk(null);
+                if (!accept || !agent) return;
+                // 依頼を聞き終えた = 引き受けた (#423)。受注もサーバーが正。
+                void serverQuestAccept(agent, accept)
+                  .then((res) => {
+                    questRef.current = { ...(res.quest ? { active: res.quest } : {}), done: res.questsDone ?? [] };
+                    const title = gameQuestById(accept)?.title ?? accept;
+                    setNotice(`「${title}」を うけおった!`);
+                  })
+                  .catch((e) => setNotice(e instanceof WorldServerError ? e.message : 'うけおいに しっぱいした…'));
+              }}
             />
           )}
           {!battle && onboarding && (

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -532,9 +532,17 @@ export function World() {
       if (npc) {
         const q = gameQuestByNpc(npc.id);
         const qs = questRef.current;
+        // 進行中クエストの定義が消されていたら (管理者が削除)、無かったことにする。
+        // 放置すると「べつの たのまれごと」で全クエストが永久に受けられない (UX レビュー ★★★)。
+        // サーバー側 (handleQuestAccept) も同じ判断で孤児クエストを落とす。
+        const active = qs.active && gameQuestById(qs.active.id) ? qs.active : undefined;
         if (!q || qs.done.includes(q.id)) {
           setNpcTalk({ npc, lines: npc.lines });
-        } else if (qs.active?.id === q.id) {
+        } else if (active?.id === q.id) {
+          // 達成試行はサーバー往復。**往復中は移動もバンプも塞ぐ** (moveBusyRef) —
+          // 塞がないとキー押しっぱなしで並行リクエストが飛び、成功の報酬ダイアログを
+          // 後続の already_done が上書きしたり、歩き出した先の戦闘中に会話が湧く (UX レビュー ★★★/★★)。
+          moveBusyRef.current = true;
           void (async () => {
             try {
               const res = await serverQuestComplete(agent, q.id);
@@ -548,17 +556,23 @@ export function World() {
               ].filter(Boolean).join(' と ');
               setNpcTalk({ npc, lines: [...q.done, ...(got ? [`${got} を もらった!`] : [])] });
             } catch (e) {
-              // not_ready はサーバーの「まだ n/m」をそのまま出す (進行数はサーバーが正)。
-              const notReady = e instanceof WorldServerError && e.code === 'not_ready';
-              setNpcTalk({
-                npc,
-                lines: notReady
-                  ? [...(q.progress ?? ['たのんだよ。']), (e as WorldServerError).message]
-                  : q.progress ?? ['たのんだよ。'],
-              });
+              if (e instanceof WorldServerError && e.code === 'not_ready') {
+                // 「まだ n/m」はサーバーの言い分をそのまま出す (進行数はサーバーが正)。
+                setNpcTalk({ npc, lines: [...(q.progress ?? ['たのんだよ。']), e.message] });
+              } else if (e instanceof WorldServerError && e.code === 'already_done') {
+                // 並行達成の敗者 (レース)。done に積んで通常セリフへ。
+                questRef.current = { done: [...qs.done, q.id] };
+                setNpcTalk({ npc, lines: npc.lines });
+              } else {
+                // 通信失敗を進行セリフの顔で出さない — 条件を満たしているのに
+                // 「まだ頼み中」に見えると、達成済みなのに狩り続けてしまう (UX レビュー ★★)。
+                setNotice('つうしんに しっぱいした… もういちど はなしかけてみよう。');
+              }
+            } finally {
+              moveBusyRef.current = false;
             }
           })();
-        } else if (qs.active) {
+        } else if (active) {
           // 別のクエスト進行中: 依頼は聞けるが受けられない (1 つずつ)。
           setNpcTalk({ npc, lines: [...q.intro, '(いまは べつの たのまれごとを うけている…)'] });
         } else {

--- a/packages/core/src/__tests__/quest-data.test.ts
+++ b/packages/core/src/__tests__/quest-data.test.ts
@@ -1,0 +1,96 @@
+/**
+ * ゲーム内クエスト定義 (#423) の検証。**壊れた 1 件で全体を落とす** (他エディタと同じ流儀)。
+ * 参照先 (NPC/モンスター/アイテム) の実在検証が要 — 未知 id を通すと
+ * 「受けられるのに絶対に達成できないクエスト」が静かに生まれる。
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { setGameQuests, gameQuests, gameQuestById, gameQuestByNpc, QuestDataError, MAX_QUEST_REWARD_POWER, type GameQuestDef } from '../quest-data.js';
+import { setNpcs } from '../npc-data.js';
+import { MONSTERS, ITEMS } from '../battle.js';
+
+const MON = MONSTERS[0]!.id;
+const ITEM = Object.keys(ITEMS)[0]!;
+
+const base = (over: Partial<GameQuestDef> = {}): GameQuestDef => ({
+  id: 'q1', title: 'たいじ', npcId: 'n1',
+  intro: ['たのむ'], done: ['ありがとう'],
+  objective: { kind: 'defeat', monsterId: MON, count: 3 },
+  ...over,
+});
+
+beforeEach(() => {
+  setNpcs([
+    { id: 'n1', name: 'そんちょう', x: 1, y: 1, lines: ['やあ'] },
+    { id: 'n2', name: 'むらびと', x: 2, y: 1, lines: ['やあ'] },
+  ]);
+});
+afterEach(() => {
+  setGameQuests(null);
+  setNpcs(null);
+});
+
+describe('setGameQuests の検証', () => {
+  it('正常な定義を受け付け、id / NPC で引ける', () => {
+    setGameQuests([base()]);
+    expect(gameQuests()).toHaveLength(1);
+    expect(gameQuestById('q1')?.title).toBe('たいじ');
+    expect(gameQuestByNpc('n1')?.id).toBe('q1');
+    expect(gameQuestByNpc('n2')).toBeUndefined();
+  });
+
+  it('null で全解除', () => {
+    setGameQuests([base()]);
+    setGameQuests(null);
+    expect(gameQuests()).toHaveLength(0);
+    expect(gameQuestByNpc('n1')).toBeUndefined();
+  });
+
+  it('存在しない NPC を弾く', () => {
+    expect(() => setGameQuests([base({ npcId: 'ghost' })])).toThrow(QuestDataError);
+  });
+
+  it('存在しないモンスターを弾く', () => {
+    expect(() => setGameQuests([base({ objective: { kind: 'defeat', monsterId: 'ghost', count: 1 } })])).toThrow(QuestDataError);
+  });
+
+  it('存在しないアイテム (collect / 報酬とも) を弾く', () => {
+    expect(() => setGameQuests([base({ objective: { kind: 'collect', itemId: 'ghost', count: 1 } })])).toThrow(QuestDataError);
+    expect(() => setGameQuests([base({ reward: { itemId: 'ghost', count: 1 } })])).toThrow(QuestDataError);
+  });
+
+  it('1 NPC 1 クエスト (重複した発注を弾く)', () => {
+    expect(() => setGameQuests([base(), base({ id: 'q2' })])).toThrow(QuestDataError);
+  });
+
+  it('id 重複を弾く', () => {
+    expect(() => setGameQuests([base(), base({ npcId: 'n2' })])).toThrow(QuestDataError);
+  });
+
+  it('個数は 1〜99 の整数', () => {
+    for (const count of [0, -1, 1.5, 100]) {
+      expect(() => setGameQuests([base({ objective: { kind: 'defeat', monsterId: MON, count } })])).toThrow(QuestDataError);
+    }
+  });
+
+  it('報酬パワーの上限を超える定義を弾く (経済の暴走防止)', () => {
+    expect(() => setGameQuests([base({ reward: { power: MAX_QUEST_REWARD_POWER + 1 } })])).toThrow(QuestDataError);
+    setGameQuests([base({ reward: { power: MAX_QUEST_REWARD_POWER } })]); // 上限ちょうどは OK
+  });
+
+  it('報酬アイテムには個数が必須', () => {
+    expect(() => setGameQuests([base({ reward: { itemId: ITEM } })])).toThrow(QuestDataError);
+  });
+
+  it('セリフの空配列・空文字を弾く', () => {
+    expect(() => setGameQuests([base({ intro: [] })])).toThrow(QuestDataError);
+    expect(() => setGameQuests([base({ done: ['  '] })])).toThrow(QuestDataError);
+  });
+
+  it('壊れた 1 件で全体を落とす (部分適用しない)', () => {
+    setGameQuests([base()]);
+    expect(() => setGameQuests([base({ id: 'ok', npcId: 'n2' }), base({ id: 'bad', npcId: 'ghost' })])).toThrow(QuestDataError);
+    // 落ちた後も前の状態のまま (ok だけが入る、はしない)
+    expect(gameQuestById('ok')).toBeUndefined();
+    expect(gameQuestById('q1')).toBeDefined();
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,4 +24,5 @@ export * from './monster-data.js';
 export * from './item-data.js';
 export * from './shop-data.js';
 export * from './npc-data.js';
+export * from './quest-data.js';
 export * from './equipment.js';

--- a/packages/core/src/quest-data.ts
+++ b/packages/core/src/quest-data.ts
@@ -1,0 +1,126 @@
+/**
+ * **ゲーム内クエスト** (#423)。NPC が発注し、達成すると報酬が出る。
+ *
+ * デイリークエスト (投稿系) や依頼クエスト (ユーザー間) とは別物で、
+ * **ワールド内で完結する** DQ 風のおつかい。定義はエディタで作り、管理者 PDS の
+ * `world.quests` に置く (モンスター #419 と同じ流儀)。
+ *
+ * ## 進行と報酬はサーバーが権威
+ *
+ * 進行 (討伐数) は `GameState.quest` に、達成済みは `GameState.questsDone` に持ち、
+ * **報酬 (パワー・アイテム) は edge が検証して付与する**。client の自己申告では
+ * 1 パワーも増えない (docs/21 のサーバー権威)。
+ *
+ * 達成条件は**サーバーが検証できるものだけ**にする:
+ * - defeat: 対象モンスターの討伐数 (勝利時に edge が数える)
+ * - collect: 素材の所持数 (権威在庫を見る。達成時に**引き取る**)
+ * 「場所に行く」「人と話す」は検証手段が固まってから足す。
+ */
+import { MONSTERS_BY_ID, ITEMS } from './battle.js';
+import { allNpcs } from './npc-data.js';
+
+export class QuestDataError extends Error {}
+
+export type QuestObjective =
+  | { kind: 'defeat'; monsterId: string; count: number }
+  | { kind: 'collect'; itemId: string; count: number };
+
+export interface GameQuestDef {
+  id: string;
+  /** 一覧・通知に出す名前。 */
+  title: string;
+  /** 発注する NPC。ぶつかると依頼を話す。 */
+  npcId: string;
+  /** 依頼のセリフ (受ける前)。読み終えると受注する。 */
+  intro: string[];
+  /** 達成時のセリフ (お礼)。 */
+  done: string[];
+  /** 進行中に話しかけたときのセリフ (省略時は「たのんだよ」風の既定)。 */
+  progress?: string[];
+  objective: QuestObjective;
+  /** 報酬。省略可 (お礼のセリフだけのクエストも作れる)。 */
+  reward?: { power?: number; itemId?: string; count?: number };
+}
+
+export interface GameQuestsRecord {
+  quests: GameQuestDef[];
+  updatedAt: string;
+}
+
+export const MAX_GAME_QUESTS = 200;
+export const MAX_QUEST_LINE = 120;
+/** 報酬パワーの上限 (打ち間違いで経済を壊さない)。 */
+export const MAX_QUEST_REWARD_POWER = 500;
+
+let quests: GameQuestDef[] = [];
+let byId = new Map<string, GameQuestDef>();
+let byNpc = new Map<string, GameQuestDef>();
+
+/**
+ * 検証して差し替える。`null` で全解除。**壊れた 1 件で全体を落とす**。
+ *
+ * npcId / monsterId / itemId の実在は**読み込み順に依存する** — NPC・モンスター・
+ * アイテムのレコードを先に適用してから呼ぶこと (world-authoring がその順で読む)。
+ */
+export function setGameQuests(list: readonly GameQuestDef[] | null): void {
+  const next = list ?? [];
+  if (next.length > MAX_GAME_QUESTS) throw new QuestDataError(`クエストが多すぎる (${next.length} > ${MAX_GAME_QUESTS})`);
+  const ids = new Set<string>();
+  const npcIds = new Set(allNpcs().map((n) => n.id));
+  const perNpc = new Map<string, string>();
+  for (const q of next) {
+    const where = q?.id ?? '(id なし)';
+    if (!q || typeof q.id !== 'string' || q.id.trim() === '') throw new QuestDataError('クエストの id が空');
+    if (ids.has(q.id)) throw new QuestDataError(`id が重複 (${q.id})`);
+    ids.add(q.id);
+    if (typeof q.title !== 'string' || q.title.trim() === '') throw new QuestDataError(`${where}: タイトルが空`);
+    if (!npcIds.has(q.npcId)) throw new QuestDataError(`${where}: NPC が存在しない (${q.npcId})`);
+    // **1 NPC 1 クエスト。** 複数あるとぶつかったときどれを話すのか決められない
+    // (連続クエストは「達成で次が解放」の形で将来やる)。
+    if (perNpc.has(q.npcId)) throw new QuestDataError(`${where}: NPC ${q.npcId} には既に「${perNpc.get(q.npcId)}」がある`);
+    perNpc.set(q.npcId, q.title);
+    for (const [name, lines] of [['intro', q.intro], ['done', q.done], ['progress', q.progress ?? ['たのんだよ。']]] as const) {
+      if (!Array.isArray(lines) || lines.length === 0) throw new QuestDataError(`${where}: ${name} が空`);
+      for (const l of lines) {
+        if (typeof l !== 'string' || l.trim() === '' || l.length > MAX_QUEST_LINE) {
+          throw new QuestDataError(`${where}: ${name} のセリフが不正`);
+        }
+      }
+    }
+    const o = q.objective;
+    if (!o) throw new QuestDataError(`${where}: 達成条件が無い`);
+    if (o.kind === 'defeat') {
+      if (!MONSTERS_BY_ID[o.monsterId]) throw new QuestDataError(`${where}: モンスターが存在しない (${o.monsterId})`);
+    } else if (o.kind === 'collect') {
+      if (!ITEMS[o.itemId]) throw new QuestDataError(`${where}: アイテムが存在しない (${o.itemId})`);
+    } else {
+      throw new QuestDataError(`${where}: 達成条件の種類が不正`);
+    }
+    if (!Number.isInteger(o.count) || o.count < 1 || o.count > 99) throw new QuestDataError(`${where}: 個数は 1〜99`);
+    if (q.reward) {
+      if (q.reward.power !== undefined && !(Number.isInteger(q.reward.power) && q.reward.power > 0 && q.reward.power <= MAX_QUEST_REWARD_POWER)) {
+        throw new QuestDataError(`${where}: 報酬パワーは 1〜${MAX_QUEST_REWARD_POWER}`);
+      }
+      if (q.reward.itemId !== undefined) {
+        if (!ITEMS[q.reward.itemId]) throw new QuestDataError(`${where}: 報酬アイテムが存在しない (${q.reward.itemId})`);
+        if (!(Number.isInteger(q.reward.count) && (q.reward.count ?? 0) > 0)) throw new QuestDataError(`${where}: 報酬アイテムの個数が不正`);
+      }
+    }
+  }
+  quests = next.map((q) => ({ ...q, intro: [...q.intro], done: [...q.done], ...(q.progress ? { progress: [...q.progress] } : {}) }));
+  byId = new Map(quests.map((q) => [q.id, q]));
+  byNpc = new Map(quests.map((q) => [q.npcId, q]));
+}
+
+export function gameQuests(): readonly GameQuestDef[] {
+  return quests;
+}
+
+export function gameQuestById(id: string): GameQuestDef | undefined {
+  return byId.get(id);
+}
+
+/** その NPC が発注しているクエスト (無ければ undefined = ただの会話)。 */
+export function gameQuestByNpc(npcId: string): GameQuestDef | undefined {
+  return byNpc.get(npcId);
+}


### PR DESCRIPTION
Closes #423

## 概要

NPC が発注する DQ 風のゲーム内クエストと、管理エディタ `/admin/quests` を追加。

- **定義**: 管理者 PDS `world.quests` (rkey self)。web / edge 両方が読む (NPC・モンスター・アイテムの後 = 実在検証の順序依存)
- **達成条件**: 討伐 (対象モンスターを n 体) / 収集 (素材 n 個を渡す) の 2 種。**サーバーが検証できる条件のみ**
- **進行・報酬はサーバー権威**:
  - 討伐数は勝利の権威経路 (`applyBattleOutcome`) だけが増やす。パワー無し練習戦は数えない
  - 収集は権威在庫で検証し、達成時に**引き取る**
  - 報酬パワーは定義値のみ + `MAX_QUEST_REWARD_POWER` (500) で clamp
  - 達成済みリング (`questsDone` 直近 200) で再受注・二重達成を拒否
- **プレイ側**: NPC にぶつかると 未受注→依頼 (読了で受注) / 進行中→達成試行 (足りなければサーバーの「まだ n/m」) / 達成→お礼 + 報酬 / 達成済み→通常セリフ
- **エディタ**: NPC/モンスター/アイテムは全部ドロップダウン。1 NPC 1 クエスト・同時進行 1 件 (どの依頼・どの敵か曖昧にならない)

## 設計判断

- 「場所に行く」「人と話す」条件は見送り (自己申告になり権威検証できない)
- 受注は「依頼を聞き終えた = 引き受けた」の一本 (受ける/断るの分岐は要望が出たら)

## テスト

- core: 定義検証 12 件 (実在検証・部分適用しない・報酬 clamp)
- edge: 受注/達成/討伐カウント 16 件 (二重達成・no-op 再受注・孤児破棄・引き取り・練習戦は数えない)
- typecheck / build / core 615 + edge 233 + web 360 全緑

## Review

パワー付与経路 + GameState スキーマ変更のため 3 観点 (設計/実装/UX) で実施。7baf53e で対応:

**★★★ (3 件、全て PR 内で修正)**
- 孤児クエスト詰み (設計/実装/UX 共通指摘): 定義が消された進行中クエストを受注時にサーバーが自動破棄 + web も定義消失を進行なし扱い。テスト追加
- 達成試行の並行リクエストで報酬ダイアログが上書き (UX): 往復中は moveBusyRef で移動・バンプを塞ぎ直列化
- エディタ保存失敗の setGameQuests(null) で全クエスト消滅 → 再保存でレコード全損 (UX): 削除 (検証は原子的でメモリは無傷)

**★★ (PR 内で修正)**
- コールド isolate で討伐が数えられない (設計): battle/turn で定義ロードを await
- 全削除が warm isolate に残り報酬を配り続ける (設計/実装): 空配列も setGameQuests に渡す
- already_done を web が処理せず無限「たのんだよ」(設計): done 扱いで自己修復
- 通信失敗が進行セリフの顔で出る (UX): notice で明示
- エディタが保存済みレコード読み込み前に保存できる (実装): マウント時 loadAuthoredWorld + 完了まで保存禁止
- NPC 削除で参照切れ → 全クエスト消滅 (実装): NPC エディタに逆参照ガード
- 管理ダッシュボードにクエストカードが 2 枚 (実装): 旧プレースホルダ削除

**★★ (issue 化)**
- questsDone リング溢れで再報酬 → #602
- エディタ横断の参照整合・読み込み前上書き (モンスター/アイテム側) → #603

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SpSiVHa5hXp7sEUAXAfWEE