### PR TITLE
feat: 装備スロット 6 分割 (武器/盾/頭/胴/足/おまもり) + 片手/両手

### DIFF
--- a/apps/edge/src/game-state.ts
+++ b/apps/edge/src/game-state.ts
@@ -9,7 +9,7 @@
  * 読み取りは public getRecord (SERVER_PDS_URL/SERVER_DID、認証不要)。**書き込みは M2.5 の OAuth
  * (DPoP) トークン経由** (server-pds)。ユーザー由来のリクエストは書き込みトークンを持てない。
  */
-import { worldOverlay, type GearSelection } from '@aozoraquest/core';
+import { dropShieldIfHandsExceeded, EQUIPMENT_BY_ID, GEAR_SLOTS, worldOverlay, type GearSelection } from '@aozoraquest/core';
 import { sha256 } from '@noble/hashes/sha256';
 import { bytesToHex } from '@noble/hashes/utils';
 import { getRecord, PdsError } from './pds';
@@ -225,7 +225,7 @@ export async function readModifyWrite(
  */
 export function sanitizeGear(gear: GearSelection, owned: readonly OwnedPiece[]): GearSelection {
   const out: GearSelection = {};
-  for (const slot of ['weapon', 'armor', 'charm'] as const) {
+  for (const slot of GEAR_SLOTS) {
     const sel = gear?.[slot];
     if (!sel) continue;
     // 文字列指定 (旧形式) は個体を特定できない。その品を持っていれば**最低の強化値**で通す。
@@ -240,5 +240,7 @@ export function sanitizeGear(gear: GearSelection, owned: readonly OwnedPiece[]):
     if (!hit) continue;
     out[slot] = { id: hit.itemId, level: hit.level };
   }
-  return out;
+  // 手数の権威検証 (#609): 両手武器 + 盾 (または両手盾 + 武器) は直 POST でも通さない。
+  // 武器を残して盾を落とす (core と同じ判断 — 表示と権威がずれない)。
+  return dropShieldIfHandsExceeded(out, (v) => EQUIPMENT_BY_ID[typeof v === 'string' ? v : v.id]);
 }

--- a/apps/edge/src/shop.ts
+++ b/apps/edge/src/shop.ts
@@ -14,7 +14,7 @@
  * `craft` レコード) はまだユーザー PDS にあり、それを権威化するのは #551 段階 2。
  * ただし**強化値の抽選はサーバーが行い**、client はその結果を記帳するだけにしてある。
  */
-import {
+import { GEAR_SLOTS,
   CRAFT_TUNING,
   EQUIPMENT_BY_ID,
   SALE_TUNING,
@@ -42,7 +42,7 @@ export const MAX_SHOP_OPS = 100;
  * `xpClaims` (200) や `shopOps` (100) と違って**リングにはできない** — 古いものを黙って
  * 消したら装備が消えるため。上限に達したら断り、`shopDiscard` で自分で減らしてもらう。
  *
- * 100 の根拠: 装備スロットは 3 (weapon/armor/charm)。16 職ぶん持ち替えても 48 で、
+ * 100 の根拠: 装備スロットは 6 (weapon/armor/charm)。16 職ぶん持ち替えても 48 で、
  * 合成用の予備を足しても 100 で窮屈にならない。1 個体 ~60 バイトなので 100 個で ~6 KB。
  */
 export const MAX_OWNED_PIECES = 100;
@@ -297,7 +297,9 @@ export async function shopDiscard(
       // 「はずしてから捨てて」と言うほうが、黙って外すより何が起きたか分かる。
       const stillEquipped = sanitizeGear(cur.gearSel ?? {}, owned);
       const afterEquipped = sanitizeGear(cur.gearSel ?? {}, rest);
-      for (const slot of ['weapon', 'armor', 'charm'] as const) {
+      // 全スロットを見る (#609)。3 スロット直書きのままだと盾/頭/足だけ
+      // 「そうび中でも捨てられる」という非対称ができる (レビュー ★★)。
+      for (const slot of GEAR_SLOTS) {
         if (stillEquipped[slot] && !afterEquipped[slot]) {
           throw new ShopError('そうび中の品は すてられない。さきに はずしてほしい', 400, 'equipped');
         }

--- a/apps/edge/test/game-state.test.ts
+++ b/apps/edge/test/game-state.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { p256 } from '@noble/curves/p256';
 import { base64urlnopad } from '@scure/base';
-import { rkeyForDid, readModifyWrite, type GameState, type GameStateEnv } from '../src/game-state';
+import { rkeyForDid, readModifyWrite, type GameState, type GameStateEnv, sanitizeGear, type OwnedPiece } from '../src/game-state';
 import { writeServerTokens } from '../src/oauth-store';
 
 const DID = 'did:plc:alice'; // 対象ユーザー
@@ -167,5 +167,45 @@ describe('game-state (OAuth 権威書き込み)', () => {
     (env as { OAUTH_TOKENS?: KVNamespace }).OAUTH_TOKENS = mockKv(); // 空 = 未 bootstrap
     globalThis.fetch = (async (url: string) => jsonRes(url.includes('getRecord') ? 400 : 200, url.includes('getRecord') ? { error: 'RecordNotFound' } : {})) as unknown as typeof fetch;
     await expect(readModifyWrite(env, DID, (c) => c, { now: NOW })).rejects.toMatchObject({ reason: 'not-bootstrapped' });
+  });
+});
+
+describe('sanitizeGear の手数検証 (#609)', () => {
+  const own = (itemId: string, rkey: string): OwnedPiece => ({ rkey, itemId, level: 0, at: '' });
+
+  it('片手武器 + 盾は両方通る', () => {
+    const out = sanitizeGear(
+      { weapon: { id: 'wp-knife', level: 0 }, shield: { id: 'sh-wood', level: 0 } },
+      [own('wp-knife', 'a'), own('sh-wood', 'b')],
+    );
+    expect(out.weapon).toEqual({ id: 'wp-knife', level: 0 });
+    expect(out.shield).toEqual({ id: 'sh-wood', level: 0 });
+  });
+
+  it('両手武器 + 盾は直 POST でも盾が落ちる (サーバー権威)', () => {
+    const out = sanitizeGear(
+      { weapon: { id: 'wp-great-sword', level: 0 }, shield: { id: 'sh-wood', level: 0 } },
+      [own('wp-great-sword', 'a'), own('sh-wood', 'b')],
+    );
+    expect(out.weapon).toEqual({ id: 'wp-great-sword', level: 0 });
+    expect(out.shield).toBeUndefined();
+  });
+
+  it('両手盾 + 武器も盾が落ちる', () => {
+    const out = sanitizeGear(
+      { weapon: { id: 'wp-knife', level: 0 }, shield: { id: 'sh-tower', level: 0 } },
+      [own('wp-knife', 'a'), own('sh-tower', 'b')],
+    );
+    expect(out.shield).toBeUndefined();
+  });
+
+  it('頭・足スロットも所持検証つきで通る', () => {
+    const out = sanitizeGear(
+      { head: { id: 'hd-leather-hat', level: 1 }, feet: { id: 'ft-cloth-shoes', level: 0 } },
+      [own('hd-leather-hat', 'a'), own('ft-cloth-shoes', 'b')],
+    );
+    // 持っていない強化値 (+1) の頭は落ち、足は通る
+    expect(out.head).toBeUndefined();
+    expect(out.feet).toEqual({ id: 'ft-cloth-shoes', level: 0 });
   });
 });

--- a/apps/edge/test/game-state.test.ts
+++ b/apps/edge/test/game-state.test.ts
@@ -171,7 +171,7 @@ describe('game-state (OAuth 権威書き込み)', () => {
 });
 
 describe('sanitizeGear の手数検証 (#609)', () => {
-  const own = (itemId: string, rkey: string): OwnedPiece => ({ rkey, itemId, level: 0, at: '' });
+  const own = (itemId: string, rkey: string): OwnedPiece => ({ rkey, itemId, level: 0 });
 
   it('片手武器 + 盾は両方通る', () => {
     const out = sanitizeGear(

--- a/apps/web/src/components/gear-modal.tsx
+++ b/apps/web/src/components/gear-modal.tsx
@@ -2,6 +2,9 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   EQUIPMENT_BY_ID,
   canEquip,
+  GEAR_SLOTS,
+  GEAR_SLOT_LABELS,
+  equipHands,
   gearBonusFromGear,
   jobDisplayName,
   leveledName,
@@ -17,11 +20,7 @@ import { resolveGear, type GearRefs } from '@/lib/gear';
  * 装備は craft/forge 個体の rkey 参照で保存する (強化値は直書きしない)。
  */
 
-const SLOT_LABELS: Record<EquipSlot, string> = {
-  weapon: 'ぶき',
-  armor: 'よろい',
-  charm: 'おまもり',
-};
+const SLOT_LABELS = GEAR_SLOT_LABELS;
 
 const STAT_LABELS: Record<string, string> = {
   atk: 'こうげき',
@@ -121,13 +120,19 @@ export function GearModal({
           </p>
         )}
         <div style={{ overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 8 }}>
-          {(['weapon', 'armor', 'charm'] as const).map((slot) => {
+          {GEAR_SLOTS.map((slot) => {
             const equippedRkey = refs[slot];
             const equipped = equippedRkey ? byRkey.get(equippedRkey) : undefined;
             const equippedDef = equipped ? EQUIPMENT_BY_ID[equipped.itemId] : undefined;
             const candidates = pieces
               .filter((p) => EQUIPMENT_BY_ID[p.itemId]?.slot === slot)
               .sort((a, b) => b.level - a.level);
+            // 手数 (#609): 両手武器を構えている間は盾を持てない (逆も同じ)。
+            const weaponDef = refs.weapon ? EQUIPMENT_BY_ID[byRkey.get(refs.weapon)?.itemId ?? ''] : undefined;
+            const shieldDef = refs.shield ? EQUIPMENT_BY_ID[byRkey.get(refs.shield)?.itemId ?? ''] : undefined;
+            const handsBlocked =
+              (slot === 'shield' && weaponDef && equipHands(weaponDef) >= 2) ||
+              (slot === 'weapon' && shieldDef && equipHands(shieldDef) >= 2);
             return (
               <div key={slot} style={{ border: '2px solid var(--color-border)', borderRadius: 4, padding: '0.4em 0.6em', fontSize: '0.85em' }}>
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
@@ -148,6 +153,11 @@ export function GearModal({
                     </button>
                   )}
                 </div>
+                {handsBlocked && (
+                  <div style={{ color: 'var(--color-danger)', fontSize: '0.85em', marginBottom: 4 }}>
+                    りょうてが ふさがっている ({slot === 'shield' ? 'ぶき' : 'たて'}を はずすと もてる)
+                  </div>
+                )}
                 {candidates.length === 0 ? (
                   <div style={{ color: 'var(--color-muted)', fontSize: '0.85em' }}>もっていない</div>
                 ) : (

--- a/apps/web/src/components/gear-modal.tsx
+++ b/apps/web/src/components/gear-modal.tsx
@@ -127,12 +127,10 @@ export function GearModal({
             const candidates = pieces
               .filter((p) => EQUIPMENT_BY_ID[p.itemId]?.slot === slot)
               .sort((a, b) => b.level - a.level);
-            // 手数 (#609): 両手武器を構えている間は盾を持てない (逆も同じ)。
+            // 手数 (#609): core は超過時**必ず盾を落とす**ので、案内も盾側にだけ出す
+            // (武器側に出すと「効いているのに塞がっている」の誤情報になる — レビュー ★★★)。
             const weaponDef = refs.weapon ? EQUIPMENT_BY_ID[byRkey.get(refs.weapon)?.itemId ?? ''] : undefined;
-            const shieldDef = refs.shield ? EQUIPMENT_BY_ID[byRkey.get(refs.shield)?.itemId ?? ''] : undefined;
-            const handsBlocked =
-              (slot === 'shield' && weaponDef && equipHands(weaponDef) >= 2) ||
-              (slot === 'weapon' && shieldDef && equipHands(shieldDef) >= 2);
+            const handsBlocked = slot === 'shield' && weaponDef && equipHands(weaponDef) >= 2;
             return (
               <div key={slot} style={{ border: '2px solid var(--color-border)', borderRadius: 4, padding: '0.4em 0.6em', fontSize: '0.85em' }}>
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
@@ -143,7 +141,9 @@ export function GearModal({
                         「そうび中なのに効果なし」の矛盾を可視化 (レビュー指摘) */}
                     {equipped && !resolved.pieces[slot] && (
                       <span style={{ marginLeft: '0.4em', fontSize: '0.85em', color: 'var(--color-danger)' }}>
-                        (いまのジョブでは効果なし)
+                        {/* 失効理由を正しく言う — 手数で外れた盾に「ジョブでは効果なし」と
+                            出すとジョブが原因だと誤診させる (レビュー ★★★) */}
+                        {handsBlocked ? '(りょうてが ふさがっていて 効果なし)' : '(いまのジョブでは効果なし)'}
                       </span>
                     )}
                   </span>
@@ -153,9 +153,9 @@ export function GearModal({
                     </button>
                   )}
                 </div>
-                {handsBlocked && (
-                  <div style={{ color: 'var(--color-danger)', fontSize: '0.85em', marginBottom: 4 }}>
-                    りょうてが ふさがっている ({slot === 'shield' ? 'ぶき' : 'たて'}を はずすと もてる)
+                {handsBlocked && !equipped && (
+                  <div style={{ color: 'var(--color-muted)', fontSize: '0.85em', marginBottom: 4 }}>
+                    りょうてが ふさがっている (たてを そうびすると ぶきが はずれる)
                   </div>
                 )}
                 {candidates.length === 0 ? (
@@ -170,6 +170,7 @@ export function GearModal({
                         <div key={p.rkey} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '0.5em' }}>
                           <span style={{ opacity: equipable ? 1 : 0.6 }}>
                             {leveledName(def, p.level)}
+                            {equipHands(def) === 2 && <span style={{ marginLeft: '0.3em', fontSize: '0.85em', color: 'var(--color-muted)' }}>(両手)</span>}
                             {def.jobOnly && !equipable && (
                               <span style={{ marginLeft: '0.4em', fontSize: '0.85em', color: 'var(--color-danger)' }}>
                                 (要: {jobDisplayName(def.jobOnly, 'default')})

--- a/apps/web/src/components/shop-modal.tsx
+++ b/apps/web/src/components/shop-modal.tsx
@@ -5,6 +5,7 @@ import {
   ITEMS,
   SALE_TUNING,
   canEquip,
+  equipHands,
   forgedLevel,
   isMasterwork,
   isSellableMaterial,
@@ -275,6 +276,7 @@ export function ShopModal({
                 <div style={{ minWidth: 0 }}>
                   <div>
                     <strong>{def.name}</strong>
+                    {equipHands(def) === 2 && <span style={{ marginLeft: '0.3em', fontSize: '0.8em', color: 'var(--color-muted)' }}>(両手)</span>}
                     {owned.length > 0 && (
                       <span style={{ marginLeft: '0.4em', color: 'var(--color-muted)' }}>
                         所持 {owned.length}{bestOwned !== null && bestOwned !== 0 ? ` (最高${bestOwned > 0 ? `+${bestOwned}` : bestOwned})` : ''}

--- a/apps/web/src/components/status-modal.tsx
+++ b/apps/web/src/components/status-modal.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useRef } from 'react';
 import {
+  GEAR_SLOTS,
+  GEAR_SLOT_LABELS,
   EQUIPMENT_BY_ID,
   skillKindLabel,
   skillsForJob,
@@ -23,11 +25,7 @@ import type { CraftedPiece } from '@/lib/crafting';
  * そのまま表示する — 「つよさ画面の数字 = 戦闘の数字」を崩さない。
  */
 
-const SLOT_LABELS: Record<EquipSlot, string> = {
-  weapon: 'ぶき',
-  armor: 'よろい',
-  charm: 'おまもり',
-};
+const SLOT_LABELS = GEAR_SLOT_LABELS;
 
 const STAT_ROWS: readonly { key: 'atk' | 'def' | 'agi' | 'int' | 'luk'; label: string }[] = [
   { key: 'atk', label: 'こうげき' },
@@ -183,7 +181,7 @@ export function StatusModal({
           {/* そうび */}
           <Section title="そうび">
             <div style={{ lineHeight: 1.8 }}>
-              {(['weapon', 'armor', 'charm'] as const).map((slot) => {
+              {GEAR_SLOTS.map((slot) => {
                 const piece = gearPieces[slot];
                 const def = piece ? EQUIPMENT_BY_ID[piece.itemId] : undefined;
                 return (

--- a/apps/web/src/lib/gear.ts
+++ b/apps/web/src/lib/gear.ts
@@ -9,19 +9,15 @@
  */
 
 import type { Agent } from '@atproto/api';
-import { EQUIPMENT_BY_ID, canEquip, type Archetype, type EquipSlot, type GearSelection } from '@aozoraquest/core';
+import { EQUIPMENT_BY_ID, GEAR_SLOTS, canEquip, dropShieldIfHandsExceeded, type Archetype, type EquipSlot, type GearSelection } from '@aozoraquest/core';
 import { getRecord, putRecord } from './atproto';
 import { COL } from './collections';
 import type { CraftedPiece } from './crafting';
 
-/** gear/self のレコード形 (rkey 参照)。 */
-export interface GearRefs {
-  weapon?: string;
-  armor?: string;
-  charm?: string;
-}
+/** gear/self のレコード形 (rkey 参照)。スロットは core の GEAR_SLOTS が単一の出所 (#609)。 */
+export type GearRefs = Partial<Record<EquipSlot, string>>;
 
-const SLOTS: readonly EquipSlot[] = ['weapon', 'armor', 'charm'];
+const SLOTS: readonly EquipSlot[] = GEAR_SLOTS;
 
 export async function loadGearRefs(agent: Agent, did: string): Promise<GearRefs> {
   const rec = await getRecord<Record<string, unknown>>(agent, did, COL.gear, 'self').catch(() => null);
@@ -36,9 +32,7 @@ export async function loadGearRefs(agent: Agent, did: string): Promise<GearRefs>
 
 export async function saveGearRefs(agent: Agent, refs: GearRefs): Promise<void> {
   await putRecord(agent, COL.gear, 'self', {
-    ...(refs.weapon ? { weapon: refs.weapon } : {}),
-    ...(refs.armor ? { armor: refs.armor } : {}),
-    ...(refs.charm ? { charm: refs.charm } : {}),
+    ...Object.fromEntries(SLOTS.filter((sl) => refs[sl]).map((sl) => [sl, refs[sl]])),
     updatedAt: new Date().toISOString(),
   });
 }
@@ -69,7 +63,11 @@ export function resolveGear(refs: GearRefs, pieces: readonly CraftedPiece[], arc
     selection[slot] = { id: piece.itemId, level: piece.level };
     resolved[slot] = piece;
   }
-  return { selection, pieces: resolved };
+  // 手数ルール (#609): 両手武器 + 盾は盾側を外す。権威 (sanitizeGear) と同じ判断を
+  // 表示にも適用する — ここで外さないと「画面では盾を構えているのに効いていない」になる。
+  const capped = dropShieldIfHandsExceeded(selection, (v) => EQUIPMENT_BY_ID[typeof v === 'string' ? v : v.id]);
+  if (!capped.shield) delete resolved.shield;
+  return { selection: capped, pieces: resolved };
 }
 
 /** gear の読取 + 個体解決を一括で (me.tsx / trial 用の便宜関数)。 */

--- a/apps/web/src/routes/admin-items.tsx
+++ b/apps/web/src/routes/admin-items.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import {
+  GEAR_SLOTS,
+  GEAR_SLOT_LABELS,
   activeEquipment,
   activeItems,
   canEquip,
@@ -21,7 +23,7 @@ import { saveItems } from '@/lib/world-authoring';
  * 保存前に core の検証 (壊れた 1 件で全体を落とす)、複製して増やす。
  */
 
-const SLOT_LABELS: Record<string, string> = { weapon: 'ぶき', armor: 'よろい', charm: 'おまもり' };
+const SLOT_LABELS: Record<string, string> = GEAR_SLOT_LABELS;
 const BONUS_LABELS: Array<[keyof EquipmentDef['bonus'], string]> = [
   ['atk', 'こうげき'], ['def', 'まもり'], ['agi', 'すばやさ'], ['int', 'かしこさ'], ['luk', 'うん'], ['maxHp', 'さいだいHP'],
 ];
@@ -164,7 +166,7 @@ export function AdminItems() {
         <div style={{ display: 'grid', gridTemplateColumns: 'minmax(180px, 1fr) 2fr', gap: '0.8em' }}>
           {/* 一覧 (slot → grade) */}
           <div style={{ maxHeight: '70vh', overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 2 }}>
-            {(['weapon', 'armor', 'charm'] as const).map((slot) => {
+            {GEAR_SLOTS.map((slot) => {
               const inSlot = equipment.filter((e) => e.slot === slot).sort((a, b) => a.grade - b.grade);
               if (inSlot.length === 0) return null;
               return (
@@ -205,7 +207,20 @@ export function AdminItems() {
               {field('なまえ', <input value={current.name} onChange={(e) => update(current.id, { name: e.target.value })} />)}
               {field('部位', (
                 <select value={current.slot} onChange={(e) => update(current.id, { slot: e.target.value as EquipmentDef['slot'] })}>
-                  {(['weapon', 'armor', 'charm'] as const).map((s0) => <option key={s0} value={s0}>{SLOT_LABELS[s0]}</option>)}
+                  {GEAR_SLOTS.map((s0) => <option key={s0} value={s0}>{SLOT_LABELS[s0]}</option>)}
+                </select>
+              ))}
+              {(current.slot === 'weapon' || current.slot === 'shield') && field('手数', (
+                <select
+                  value={current.hands ?? 1}
+                  onChange={(e) => {
+                    const hands = Number(e.target.value) as 1 | 2;
+                    // 片手 (既定) はキーごと消す (update は undefined で delete する契約)
+                    update(current.id, { hands: hands === 1 ? undefined : hands });
+                  }}
+                >
+                  <option value={1}>片手</option>
+                  <option value={2}>両手 (盾と併用できない)</option>
                 </select>
               ))}
               {field('系統', (

--- a/apps/web/src/routes/admin-items.tsx
+++ b/apps/web/src/routes/admin-items.tsx
@@ -206,7 +206,16 @@ export function AdminItems() {
               </div>
               {field('なまえ', <input value={current.name} onChange={(e) => update(current.id, { name: e.target.value })} />)}
               {field('部位', (
-                <select value={current.slot} onChange={(e) => update(current.id, { slot: e.target.value as EquipmentDef['slot'] })}>
+                <select
+                  value={current.slot}
+                  onChange={(e) => {
+                    const slot = e.target.value as EquipmentDef['slot'];
+                    // 武器/盾以外へ変えるとき hands を残すと検証で保存が全体ブロックされ、
+                    // 手数セレクトも非表示で復旧手段が無くなる (レビュー ★★)。同時に消す。
+                    const clearHands = slot !== 'weapon' && slot !== 'shield';
+                    update(current.id, { slot, ...(clearHands ? { hands: undefined } : {}) });
+                  }}
+                >
                   {GEAR_SLOTS.map((s0) => <option key={s0} value={s0}>{SLOT_LABELS[s0]}</option>)}
                 </select>
               ))}

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -54,7 +54,7 @@ function shopErrorText(e: unknown, fallback: string): string {
 }
 import { WORLD_PREVIEW_ENABLED } from '@/lib/world-preview';
 import { loadAuthoredWorld } from '@/lib/world-authoring';
-import { allNpcs, gameQuestById, gameQuestByNpc, npcArtKey, npcAt, type NpcDef } from '@aozoraquest/core';
+import { allNpcs, EQUIPMENT_BY_ID, equipHands, gameQuestById, gameQuestByNpc, npcArtKey, npcAt, type NpcDef } from '@aozoraquest/core';
 import { mappedPartAt } from '@aozoraquest/core';
 import { Avatar } from '@/components/avatar';
 import { WorldBattleControls, type BattlePhase } from '@/components/world-battle-controls';
@@ -1579,7 +1579,19 @@ export function World() {
               }
             })();
           }}
-          onEquip={(slot, rkey) => void onEquipChange({ ...gearRefs, [slot]: rkey })}
+          onEquip={(slot, rkey) => {
+            const next = { ...gearRefs, [slot]: rkey };
+            // 手数の競合 (#609) は**装備した側を通し、逆側を外す** (DQ 流の入れ替え)。
+            // 外さず保存すると core が盾を落とすので「そうび中なのに効果なし」の矛盾表示になる。
+            if (slot === 'weapon' || slot === 'shield') {
+              const other = slot === 'weapon' ? 'shield' : 'weapon';
+              const defOfRkey = (rk?: string) => (rk ? EQUIPMENT_BY_ID[craftedPieces.find((p) => p.rkey === rk)?.itemId ?? ''] : undefined);
+              const mine = defOfRkey(rkey);
+              const theirs = defOfRkey(next[other]);
+              if (mine && theirs && equipHands(mine) + equipHands(theirs) > 2) delete next[other];
+            }
+            void onEquipChange(next);
+          }}
           onUnequip={(slot) => {
             const next = { ...gearRefs };
             delete next[slot];
@@ -1596,7 +1608,9 @@ export function World() {
           balance={serverPower ?? 0} // 残高は権威側が正 (#551)
           materials={materialsView}
           pieces={craftedPieces}
-          equippedRkeys={Object.values(resolvedGear?.pieces ?? {}).map((p) => p.rkey)}
+          // **参照している rkey 全部を保護する** (#609 レビュー)。resolved (実効) だけだと、
+          // 手数で無効化中の盾が「そうび中」表示のまま きたえる で黙って燃える。
+          equippedRkeys={Object.values(gearRefs ?? {}).filter((v): v is string => typeof v === 'string')}
           busy={craftBusy}
           lastAction={lastShopAction}
           errorText={shopError}

--- a/packages/core/src/__tests__/gear-slots.test.ts
+++ b/packages/core/src/__tests__/gear-slots.test.ts
@@ -1,0 +1,107 @@
+/**
+ * 装備スロット拡張 (#609)。守るべき不変条件:
+ * - 6 スロット (武器/盾/頭/胴/足/おまもり) 全部がボーナスに効く
+ * - **両手の合計 ≤ 2**。両手武器 + 盾、両手盾 + 武器は盾側が落ちる (武器優先)
+ * - 手数の検証は戦闘値の入口 (gearBonusFromGear) でも効く = レコード偽造でも超過は効かない
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  EQUIPMENT,
+  EQUIPMENT_BY_ID,
+  GEAR_SLOTS,
+  dropShieldIfHandsExceeded,
+  equipHands,
+  gearBonusFromGear,
+  type GearSelection,
+} from '../equipment.js';
+
+const defOf = (v: { id: string } | string) => EQUIPMENT_BY_ID[typeof v === 'string' ? v : v.id];
+
+describe('ロスターの健全性', () => {
+  it('盾・頭・足のスロットに品がある', () => {
+    for (const slot of ['shield', 'head', 'feet'] as const) {
+      expect(EQUIPMENT.some((e) => e.slot === slot), slot).toBe(true);
+    }
+  });
+
+  it('hands は武器と盾にしか付いていない', () => {
+    for (const e of EQUIPMENT) {
+      if (e.hands !== undefined) expect(['weapon', 'shield']).toContain(e.slot);
+    }
+  });
+
+  it('両手武器と両手盾が存在する (ルールが機能する前提)', () => {
+    expect(EQUIPMENT.some((e) => e.slot === 'weapon' && e.hands === 2)).toBe(true);
+    expect(EQUIPMENT.some((e) => e.slot === 'shield' && e.hands === 2)).toBe(true);
+  });
+
+  it('鉄の盾は盾スロットに移っている', () => {
+    expect(EQUIPMENT_BY_ID['wp-iron-shield']!.slot).toBe('shield');
+  });
+});
+
+describe('equipHands', () => {
+  it('武器・盾は既定 1、両手品は 2、他スロットは 0', () => {
+    expect(equipHands(EQUIPMENT_BY_ID['wp-knife']!)).toBe(1);
+    expect(equipHands(EQUIPMENT_BY_ID['wp-great-sword']!)).toBe(2);
+    expect(equipHands(EQUIPMENT_BY_ID['sh-tower']!)).toBe(2);
+    expect(equipHands(EQUIPMENT_BY_ID['ar-cloth']!)).toBe(0);
+    expect(equipHands(EQUIPMENT_BY_ID['ch-traveler']!)).toBe(0);
+  });
+});
+
+describe('dropShieldIfHandsExceeded', () => {
+  it('片手武器 + 盾は両立する', () => {
+    const sel = { weapon: 'wp-knife', shield: 'sh-wood' };
+    expect(dropShieldIfHandsExceeded(sel, defOf)).toEqual(sel);
+  });
+
+  it('両手武器 + 盾は盾が落ちる (武器優先)', () => {
+    const out = dropShieldIfHandsExceeded({ weapon: 'wp-great-sword', shield: 'sh-wood' }, defOf);
+    expect(out.weapon).toBe('wp-great-sword');
+    expect(out.shield).toBeUndefined();
+  });
+
+  it('両手盾 + 武器も盾が落ちる (片手が空いていないと盾は持てない)', () => {
+    const out = dropShieldIfHandsExceeded({ weapon: 'wp-knife', shield: 'sh-tower' }, defOf);
+    expect(out.weapon).toBe('wp-knife');
+    expect(out.shield).toBeUndefined();
+  });
+
+  it('両手盾だけなら持てる', () => {
+    const sel = { shield: 'sh-tower' };
+    expect(dropShieldIfHandsExceeded(sel, defOf)).toEqual(sel);
+  });
+});
+
+describe('gearBonusFromGear (#609)', () => {
+  it('6 スロット全部が合算される', () => {
+    const gear: GearSelection = {
+      weapon: 'wp-knife', // atk 2
+      shield: 'sh-wood', // def 3
+      head: 'hd-leather-hat', // def 2
+      armor: 'ar-cloth', // def 5
+      feet: 'ft-cloth-shoes', // def 1 agi 1
+      charm: 'ch-traveler', // def 2
+    };
+    const b = gearBonusFromGear('warrior', gear);
+    expect(b.atk).toBe(2);
+    expect(b.def).toBe(3 + 2 + 5 + 1 + 2);
+    expect(b.agi).toBe(1);
+  });
+
+  it('両手武器 + 盾は盾のぶんが 1 ポイントも効かない (レコード偽造対策)', () => {
+    const withShield = gearBonusFromGear('warrior', { weapon: 'wp-great-sword', shield: 'wp-iron-shield' });
+    const without = gearBonusFromGear('warrior', { weapon: 'wp-great-sword' });
+    expect(withShield).toEqual(without);
+  });
+
+  it('スロット違いの品はどのスロットにも入らない (盾を武器枠に書けない)', () => {
+    const b = gearBonusFromGear('warrior', { weapon: 'sh-wood' });
+    expect(b.def).toBe(0);
+  });
+
+  it('GEAR_SLOTS は 6 スロット', () => {
+    expect(GEAR_SLOTS).toEqual(['weapon', 'shield', 'head', 'armor', 'feet', 'charm']);
+  });
+});

--- a/packages/core/src/equipment.ts
+++ b/packages/core/src/equipment.ts
@@ -32,7 +32,21 @@ function shopRng(seed: number): () => number {
   };
 }
 
-export type EquipSlot = 'weapon' | 'armor' | 'charm';
+/** 装備スロット (#609)。armor は歴史的経緯で「胴」を指す (既存データ無移行のため名を変えない)。 */
+export type EquipSlot = 'weapon' | 'shield' | 'head' | 'armor' | 'feet' | 'charm';
+
+/** 全スロットの列挙 (UI とサーバー検証が同じ並びを共有する)。 */
+export const GEAR_SLOTS: readonly EquipSlot[] = ['weapon', 'shield', 'head', 'armor', 'feet', 'charm'];
+
+/** スロットの表示名 (単一の出所 — 画面ごとに別表記が生えるのを防ぐ)。 */
+export const GEAR_SLOT_LABELS: Record<EquipSlot, string> = {
+  weapon: 'ぶき',
+  shield: 'たて',
+  head: 'あたま',
+  armor: 'どう',
+  feet: 'あし',
+  charm: 'おまもり',
+};
 
 /** 装備カテゴリ。common/cloth/charm は全ジョブ暗黙 ○。 */
 export type EquipKind =
@@ -57,6 +71,9 @@ export interface EquipmentDef {
   kind: EquipKind;
   /** ステータス加算 (ブレンド・レベル補正の後に平坦加算)。 */
   bonus: Partial<Record<'atk' | 'def' | 'agi' | 'int' | 'luk' | 'maxHp', number>>;
+  /** 使う手の数 (#609)。武器・盾のみ意味を持つ。省略 = 1 (片手)。
+   *  武器 + 盾の合計が 2 を超える組合せは装備できない (両手武器 + 盾、両手盾 + 武器)。 */
+  hands?: 1 | 2;
   /** 1 職専用 (指定があればカテゴリ不問でそのジョブのみ装備可)。 */
   jobOnly?: Archetype;
   /** 品揃え生成の階級。1=初級 2=中位 3=上位 (特色枠)。 */
@@ -128,9 +145,11 @@ export const EQUIPMENT: EquipmentDef[] = [
   { id: 'wp-knife', name: 'ナイフ', slot: 'weapon', kind: 'common', bonus: { atk: 2 }, grade: 1, price: { power: 4, materials: 1 } },
   { id: 'wp-club', name: 'こんぼう', slot: 'weapon', kind: 'common', bonus: { atk: 4 }, grade: 1, price: { power: 8, materials: 2 } },
   { id: 'wp-travel-sword', name: 'たびのつるぎ', slot: 'weapon', kind: 'common', bonus: { atk: 7 }, grade: 2, price: { power: 14, materials: 3 } },
+  // 両手武器 (#609): 盾を捨てるぶん同 grade の片手より atk 高め (数値は暫定)
+  { id: 'wp-great-club', name: 'おおきづち', slot: 'weapon', kind: 'common', hands: 2, bonus: { atk: 7 }, grade: 1, price: { power: 12, materials: 2 } },
+  { id: 'wp-great-sword', name: 'グレートソード', slot: 'weapon', kind: 'sword', hands: 2, bonus: { atk: 13 }, grade: 2, price: { power: 24, materials: 4 } },
   // ─── 系統カテゴリ武器 (初級 +4、意匠なしの汎用) ───
   { id: 'wp-axe', name: '戦斧', slot: 'weapon', kind: 'axe', bonus: { atk: 4 }, grade: 1, price: { power: 10, materials: 2 } },
-  { id: 'wp-iron-shield', name: '鉄の盾', slot: 'weapon', kind: 'shield', bonus: { def: 4 }, grade: 1, price: { power: 10, materials: 2 } },
   { id: 'wp-swift-dagger', name: '疾風の短刀', slot: 'weapon', kind: 'dagger', bonus: { agi: 4 }, grade: 1, price: { power: 10, materials: 2 } },
   { id: 'wp-novice-staff', name: '見習いの杖', slot: 'weapon', kind: 'staff', bonus: { int: 4 }, grade: 1, price: { power: 10, materials: 2 } },
   { id: 'wp-lucky-dice', name: '幸運のダイス', slot: 'weapon', kind: 'lucky', bonus: { luk: 4 }, grade: 1, price: { power: 10, materials: 2 } },
@@ -157,6 +176,18 @@ export const EQUIPMENT: EquipmentDef[] = [
       price: { power: 40, materials: 6 },
     },
   ]),
+  // ─── 盾 (#609)。片手が空いているときだけ持てる。両手盾は武器と併用不可 ───
+  { id: 'sh-wood', name: '木の盾', slot: 'shield', kind: 'shield', bonus: { def: 3 }, grade: 1, price: { power: 6, materials: 1 } },
+  { id: 'wp-iron-shield', name: '鉄の盾', slot: 'shield', kind: 'shield', bonus: { def: 4 }, grade: 1, price: { power: 10, materials: 2 } },
+  { id: 'sh-tower', name: '騎士の大盾', slot: 'shield', kind: 'shield', hands: 2, bonus: { def: 12 }, grade: 2, price: { power: 22, materials: 4 } },
+  // ─── 頭 (#609) ───
+  { id: 'hd-leather-hat', name: 'かわのぼうし', slot: 'head', kind: 'cloth', bonus: { def: 2 }, grade: 1, price: { power: 5, materials: 1 } },
+  { id: 'hd-iron-helm', name: '鉄かぶと', slot: 'head', kind: 'heavy', bonus: { def: 7 }, grade: 2, price: { power: 16, materials: 3 } },
+  { id: 'hd-sage-hood', name: 'かしこさのずきん', slot: 'head', kind: 'robe', bonus: { def: 4, int: 2 }, grade: 2, price: { power: 16, materials: 3 } },
+  // ─── 足 (#609) ───
+  { id: 'ft-cloth-shoes', name: 'ぬののくつ', slot: 'feet', kind: 'cloth', bonus: { def: 1, agi: 1 }, grade: 1, price: { power: 4, materials: 1 } },
+  { id: 'ft-leather-boots', name: 'かわのブーツ', slot: 'feet', kind: 'light', bonus: { def: 3, agi: 2 }, grade: 2, price: { power: 14, materials: 3 } },
+  { id: 'ft-iron-greaves', name: '鉄のすねあて', slot: 'feet', kind: 'heavy', bonus: { def: 6 }, grade: 2, price: { power: 16, materials: 3 } },
   // ─── 防具 ───
   { id: 'ar-cloth', name: 'ぬののふく', slot: 'armor', kind: 'cloth', bonus: { def: 5 }, grade: 1, price: { power: 4, materials: 1 } },
   { id: 'ar-leather', name: 'かわのよろい', slot: 'armor', kind: 'cloth', bonus: { def: 5 }, grade: 1, price: { power: 8, materials: 2 } },
@@ -339,8 +370,34 @@ export interface GearPiece {
 
 export interface GearSelection {
   weapon?: GearPiece | string;
+  shield?: GearPiece | string;
+  head?: GearPiece | string;
   armor?: GearPiece | string;
+  feet?: GearPiece | string;
   charm?: GearPiece | string;
+}
+
+/** その装備が使う手の数。武器・盾以外は 0。 */
+export function equipHands(def: EquipmentDef): number {
+  return def.slot === 'weapon' || def.slot === 'shield' ? (def.hands ?? 1) : 0;
+}
+
+/**
+ * 手数超過なら**盾を落とした** selection を返す (#609)。武器を優先するのは
+ * 「片手が空いていれば盾が装備可能」の裏返し — 両手武器を構えた時点で盾は持てない。
+ * 表示 (resolveGear) と権威 (sanitizeGear / gearBonusFromGear) が同じ判断を共有する。
+ */
+export function dropShieldIfHandsExceeded<T extends { weapon?: unknown; shield?: unknown }>(
+  sel: T,
+  defOf: (v: NonNullable<T['weapon']> | NonNullable<T['shield']>) => EquipmentDef | undefined,
+): T {
+  if (!sel.weapon || !sel.shield) return sel;
+  const w = defOf(sel.weapon as NonNullable<T['weapon']>);
+  const sh = defOf(sel.shield as NonNullable<T['shield']>);
+  if (!w || !sh) return sel;
+  if (equipHands(w) + equipHands(sh) <= 2) return sel;
+  const { shield: _drop, ...rest } = sel;
+  return rest as T;
 }
 
 /**
@@ -350,7 +407,10 @@ export interface GearSelection {
  */
 export function gearBonusFromGear(archetype: Archetype, gear: GearSelection): GearBonus {
   const total: GearBonus = { atk: 0, def: 0, agi: 0, int: 0, luk: 0, maxHp: 0 };
-  for (const slot of ['weapon', 'armor', 'charm'] as const) {
+  // 手数超過 (両手武器 + 盾) はここでも落とす — 戦闘値の入口なので、レコードを
+  // 直接偽造されても超過分は 1 ポイントも効かない (#609)。
+  gear = dropShieldIfHandsExceeded(gear, (v) => EQUIPMENT_BY_ID[typeof v === 'string' ? v : (v as GearPiece).id]);
+  for (const slot of GEAR_SLOTS) {
     const piece = gear[slot];
     if (!piece) continue;
     const id = typeof piece === 'string' ? piece : piece.id;

--- a/packages/core/src/item-data.ts
+++ b/packages/core/src/item-data.ts
@@ -35,7 +35,7 @@ export function hasItemOverrides(): boolean {
   return overridden;
 }
 
-const SLOTS = ['weapon', 'armor', 'charm'] as const;
+const SLOTS = ['weapon', 'shield', 'head', 'armor', 'feet', 'charm'] as const;
 const KINDS = new Set<string>([
   'common', 'cloth', 'charm', 'exclusive',
   ...new Set(Object.values(JOB_EQUIP_KINDS).flat()),
@@ -81,6 +81,10 @@ function validateEquipment(defs: readonly EquipmentDef[]): readonly EquipmentDef
     ids.add(e.id);
     if (typeof e.name !== 'string' || e.name.trim() === '') throw new ItemDataError(`${where}: 名前が空`);
     if (!(SLOTS as readonly string[]).includes(e.slot)) throw new ItemDataError(`${where}: slot が不正 (${e.slot})`);
+    if (e.hands !== undefined) {
+      if (e.hands !== 1 && e.hands !== 2) throw new ItemDataError(`${where}: hands は 1 か 2`);
+      if (e.slot !== 'weapon' && e.slot !== 'shield') throw new ItemDataError(`${where}: hands は武器と盾だけ`);
+    }
     if (!KINDS.has(e.kind)) throw new ItemDataError(`${where}: kind が不正 (${e.kind})`);
     if (![1, 2, 3].includes(e.grade)) throw new ItemDataError(`${where}: grade は 1〜3 (${e.grade})`);
     if (!e.price || !(e.price.power >= 0) || !(e.price.materials >= 0)) {


### PR DESCRIPTION
Closes #609

## 概要

オーナー要望: 武器・盾に片手/両手の種別、防具を頭・胴・足に分割。

- スロット: `weapon / shield / head / armor(胴) / feet / charm` の 6 つ。armor は「胴」として名を変えず**既存データ無移行**
- `hands: 1|2` (武器・盾のみ)。**武器 + 盾の合計 ≤ 2** — 超過時は武器を優先して盾側が外れる
- 手数の判断は `dropShieldIfHandsExceeded` に一本化し、表示 (resolveGear)・戦闘値 (gearBonusFromGear)・**サーバー権威 (edge sanitizeGear)** の 3 か所が共有。gearSel を直 POST で偽造しても超過分は 1 ポイントも効かない (設計レビューが実測確認)
- そうび画面は **DQ 流の入れ替え**: 両手武器を装備すると盾が自動で外れる (逆も同じ)
- 鉄の盾は武器スロット → 盾スロットへ (id 据え置き)
- 新装備: 盾 2 + 両手盾 1、頭 3、足 3、両手武器 2 (数値は暫定)。品名に (両手) を表示
- アイテムエディタ: 部位 6 種 + 手数の編集

## テスト

- core: gear-slots 12 件 / edge: sanitizeGear 手数検証 4 件
- core 640 / edge 237 / web 360 全緑、typecheck / build 緑

## Review

3 観点 (設計/実装/UX — GameState スキーマ変更のため)。★★★ 1 + ★★ 計 8 (観点間重複あり) を 30f15a5 / 6326c2f で対応:

- **★★★ 手数の案内が武器側に出て、実際に無効な盾側には「ジョブでは効果なし」の誤情報** (UX) → 案内は盾側に固定し、失効理由を手数/ジョブで分岐
- **★★ 装備ボタンで矛盾状態を作れる** (UX/実装/設計) → 装備時に競合側を自動で外す入れ替え方式へ
- **★★ 片手/両手がどこにも表示されない** (UX) → そうび画面・店の品名に (両手)
- **★★ 手数で無効化中の盾が きたえる で燃える** (UX/設計) → 保護対象を resolved から**参照 rkey 全部**へ
- **★★ 捨てるガードが旧 3 スロットのまま** (実装/設計) → GEAR_SLOTS 化 (装備中の盾/頭/足も直 POST で捨てられない)
- **★★ エディタで部位変更時に hands が残留し保存が全体ブロック** (実装) → 部位変更と同時に hands を掃除
- **★★ 旧データ (武器枠の鉄の盾) は def+4 が外れる** (設計) → **無移行と判断**: あおぞらワールドは dev 限定でプレイヤー 0 人 (オーナー確認済みの前提)。次回のそうび操作で自然に整合する

設計レビューの実測: 戦闘値の全権威経路 (sealEncounter/handleItem/playerLuk/handleSearch) が手数検証込みの gearBonusFromGear を通ること、店の grade ゲート (#565) が新スロット品にも効くことを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SpSiVHa5hXp7sEUAXAfWEE