### PR TITLE
feat: ジョブエディタ (パラメータ編集 + 連戦シミュレーション) (#544)

### DIFF
--- a/apps/edge/src/world-authoring.ts
+++ b/apps/edge/src/world-authoring.ts
@@ -1,4 +1,4 @@
-import { decodeWorldMap, loadStaticWorldMap, loadTileArts, setGameQuests, setItemOverrides, setMonsterOverrides, setNpcs, setShopOverrides, setTownOverrides, setWorldMap, WORLD_SIZE, type EquipmentDef, type GameQuestDef, type ItemDefData, type MonsterDef, type NpcDef, type ShopOverride, type TownOverride, type WorldPart } from '@aozoraquest/core';
+import { decodeWorldMap, loadStaticWorldMap, loadTileArts, setGameQuests, setItemOverrides, setJobOverrides, setMonsterOverrides, setNpcs, setShopOverrides, setTownOverrides, setWorldMap, WORLD_SIZE, type EquipmentDef, type GameQuestDef, type ItemDefData, type JobOverride, type MonsterDef, type NpcDef, type ShopOverride, type TownOverride, type WorldPart } from '@aozoraquest/core';
 import { getRecord } from './pds';
 import { resolveDidDocument } from './service-auth';
 import { pdsEndpointFromDoc } from './oauth-metadata';
@@ -101,6 +101,10 @@ export function ensureAuthoredWorld(env: WorldAuthoringEnv, nsid: string, now: n
     // NPC (#425)。**移動判定に効く** (立っているマスは塞ぐ) ので edge も必須。
     const npcs = await getRecord<{ npcs?: NpcDef[] }>(pds, did, `${nsid}.world.npcs`, RKEY);
     if (npcs?.value?.npcs?.length) setNpcs(npcs.value.npcs);
+    // ジョブ (#544)。**戦闘計算は edge が権威**なので、web だけが編集後の値を見ていると
+    // 画面の強さとサーバーの強さが食い違う。
+    const jobs = await getRecord<{ jobs?: JobOverride[] }>(pds, did, `${nsid}.world.jobs`, RKEY);
+    if (jobs?.value?.jobs) setJobOverrides(jobs.value.jobs);
     // ゲーム内クエスト (#423)。**報酬付与は edge が権威**なので必須。検証が NPC・モンスター・
     // アイテムの実在を引くため、**この 3 つより後に読む** (店 ← アイテムと同じ順序依存)。
     const quests = await getRecord<{ quests?: GameQuestDef[] }>(pds, did, `${nsid}.world.quests`, RKEY);

--- a/apps/web/src/lib/collections.ts
+++ b/apps/web/src/lib/collections.ts
@@ -95,6 +95,8 @@ export const ADMIN_COL = {
   npcs: `${ROOT}.world.npcs`,
   /** ゲーム内クエスト (NPC 発注・達成条件・報酬)。#423 */
   quests: `${ROOT}.world.quests`,
+  /** ジョブのパラメータ上書き (ステータス比・たいりょく・曲線・装備適性)。#544 */
+  jobs: `${ROOT}.world.jobs`,
   /** 依頼クエスト集約 (docs/15-user-quest.md §集約インフラ)。
    *  Worker が主管理者 PDS に書く。env 別に rkey を分ける (dev→'dev', prod→'self')。 */
   questIndex: `${ROOT}.questIndex`,

--- a/apps/web/src/lib/world-authoring.ts
+++ b/apps/web/src/lib/world-authoring.ts
@@ -6,6 +6,7 @@ import {
   loadStaticWorldMap,
   loadTileArts,
   setGameQuests,
+  setJobOverrides,
   setItemOverrides,
   setMonsterOverrides,
   setNpcs,
@@ -19,6 +20,7 @@ import {
   WORLD_SIZE,
   type EquipmentDef,
   type GameQuestDef,
+  type JobOverride,
   type ItemDefData,
   type MonsterDef,
   type NpcDef,
@@ -176,6 +178,13 @@ export async function loadAuthoredWorld(agent: Agent | null): Promise<void> {
       console.warn('[world] npcs load failed', e);
     }
     try {
+      // ジョブ (#544)。装備カテゴリを検証するのでアイテムより後だが、他への依存はない。
+      const rec = await getRecord<{ jobs?: JobOverride[] }>(agent, adminDid, ADMIN_COL.jobs, RKEY);
+      if (rec?.jobs) setJobOverrides(rec.jobs);
+    } catch (e) {
+      console.warn('[world] jobs load failed', e);
+    }
+    try {
       // 検証が NPC・モンスター・アイテムの実在を引くため、**この 3 つより後に読む** (#423)。
       const rec = await getRecord<{ quests?: GameQuestDef[] }>(agent, adminDid, ADMIN_COL.quests, RKEY);
       // 空配列も適用する (全削除の反映。edge 側と同じ理由)。
@@ -233,6 +242,12 @@ export async function saveShops(agent: Agent, shops: ShopOverride[]): Promise<vo
 export async function saveNpcs(agent: Agent, npcs: NpcDef[]): Promise<void> {
   setNpcs(npcs);
   await putRecord(agent, ADMIN_COL.npcs, RKEY, { npcs, updatedAt: new Date().toISOString() });
+}
+
+/** ジョブのパラメータ (#544)。setJobOverrides が先に検証で落とす。 */
+export async function saveJobs(agent: Agent, jobs: JobOverride[]): Promise<void> {
+  setJobOverrides(jobs);
+  await putRecord(agent, ADMIN_COL.jobs, RKEY, { jobs, updatedAt: new Date().toISOString() });
 }
 
 /** ゲーム内クエスト (#423)。setGameQuests が先に検証で落とす (壊れた定義を保存させない)。 */

--- a/apps/web/src/lib/world-authoring.ts
+++ b/apps/web/src/lib/world-authoring.ts
@@ -244,6 +244,19 @@ export async function saveNpcs(agent: Agent, npcs: NpcDef[]): Promise<void> {
   await putRecord(agent, ADMIN_COL.npcs, RKEY, { npcs, updatedAt: new Date().toISOString() });
 }
 
+/**
+ * ジョブのレコードだけを読む (#544)。**読めたかどうかを返す**のが要点 —
+ * loadAuthoredWorld は失敗を握り潰すので、エディタがそれを使うと
+ * 「読み込み失敗 → コード値が並ぶ → 保存 → 保存済みの調整が全職ぶん消える」が起きる。
+ * `null` = レコードが無い (初回)。throw = 読めなかった (保存させてはいけない)。
+ */
+export async function loadJobsRecord(agent: Agent, adminDid: string): Promise<JobOverride[] | null> {
+  const rec = await getRecord<{ jobs?: JobOverride[] }>(agent, adminDid, ADMIN_COL.jobs, RKEY);
+  if (!rec?.jobs) return null;
+  setJobOverrides(rec.jobs);
+  return rec.jobs;
+}
+
 /** ジョブのパラメータ (#544)。setJobOverrides が先に検証で落とす。 */
 export async function saveJobs(agent: Agent, jobs: JobOverride[]): Promise<void> {
   setJobOverrides(jobs);

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -25,6 +25,7 @@ const AdminItems = lazy(() => import('@/routes/admin-items').then(m => ({ defaul
 const AdminShops = lazy(() => import('@/routes/admin-shops').then(m => ({ default: m.AdminShops })));
 const AdminNpcs = lazy(() => import('@/routes/admin-npcs').then(m => ({ default: m.AdminNpcs })));
 const AdminQuests = lazy(() => import('@/routes/admin-quests').then(m => ({ default: m.AdminQuests })));
+const AdminJobs = lazy(() => import('@/routes/admin-jobs').then(m => ({ default: m.AdminJobs })));
 const World = lazy(() => import('@/routes/world').then(m => ({ default: m.World })));
 const Onboarding = lazy(() => import('@/routes/onboarding').then(m => ({ default: m.Onboarding })));
 const OAuthCallback = lazy(() => import('@/routes/oauth-callback').then(m => ({ default: m.OAuthCallback })));
@@ -91,6 +92,7 @@ const router = createBrowserRouter([
       { path: 'admin/shops', element: <AdminShops /> },
       { path: 'admin/npcs', element: <AdminNpcs /> },
       { path: 'admin/quests', element: <AdminQuests /> },
+      { path: 'admin/jobs', element: <AdminJobs /> },
       { path: 'world', element: <World /> },
       { path: 'onboarding', element: <Onboarding /> },
       { path: 'oauth/callback', element: <OAuthCallback /> },

--- a/apps/web/src/routes/admin-dashboard.tsx
+++ b/apps/web/src/routes/admin-dashboard.tsx
@@ -36,7 +36,7 @@ const CONTENT_SECTIONS: Section[] = [
   // 並びは着手の優先順。#418 (データ化) が全部の前提。
   { key: 'monsters', title: 'モンスター', desc: 'パラメータ・能力・ドロップ・模擬戦', to: '/admin/monsters', issue: 419 },
   { key: 'map', title: 'マップ', desc: '地形をパーツで編集 (エリア・出現配置は #421 で続き)', to: '/admin/map', issue: 421 },
-  { key: 'jobs', title: 'ジョブ', desc: '各種パラメータ設定 + 模擬戦', issue: 544 },
+  { key: 'jobs', title: 'ジョブ', desc: 'ステータス比・たいりょく・曲線・装備適性 + 連戦シミュ', to: '/admin/jobs', issue: 544 },
   { key: 'npc', title: 'NPC', desc: '位置・名前・セリフ・絵 (フラグ制御は #425 で続き)', to: '/admin/npcs', issue: 425 },
   { key: 'quest', title: 'クエスト', desc: 'NPC 発注・達成条件 (討伐/収集)・報酬', to: '/admin/quests', issue: 423 },
   { key: 'places', title: '街 / ダンジョン / 城', desc: '内部マップの編集', issue: 424 },

--- a/apps/web/src/routes/admin-jobs.tsx
+++ b/apps/web/src/routes/admin-jobs.tsx
@@ -1,0 +1,280 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  JOBS,
+  JOB_EQUIP_KINDS,
+  JOB_STATS_SUM,
+  JobDataError,
+  MAX_PACE,
+  MAX_VIT,
+  MIN_PACE,
+  MIN_VIT,
+  currentJobParams,
+  jobDisplayName,
+  runAutoBattle,
+  setJobOverrides,
+  startBattle,
+  type Archetype,
+  type EquipKind,
+  type JobOverride,
+  type StatArray,
+} from '@aozoraquest/core';
+import { useSession } from '@/lib/session';
+import { isAdminDid } from '@/lib/runtime-config';
+import { loadAuthoredWorld, saveJobs } from '@/lib/world-authoring';
+
+/**
+ * **ジョブエディタ** (#544)。ステータス比・たいりょく・レベル曲線・装備適性 +
+ * **編集値のまま回せる連戦シミュレーション**。
+ *
+ * バランス調整は「値を変えて試す」を何十回も回す作業なので、保存しなくても
+ * 試せることを最優先にしている (試す → 良ければ保存)。
+ *
+ * とくぎ・パッシブの**効果**はここでは編集できない (関数なので DSL が要る)。
+ */
+
+/** 持ち込みやくそうの上限 (連戦の持久力に効く。scripts/sim-endurance と同じ値)。 */
+const WORLD_HERB_MAX = 3;
+
+const STAT_LABELS = ['こうげき', 'まもり', 'すばやさ', 'かしこさ', 'うん'] as const;
+const ALL_KINDS: readonly EquipKind[] = ['common', 'sword', 'axe', 'shield', 'dagger', 'staff', 'lucky', 'heavy', 'light', 'robe', 'cloth', 'charm'];
+
+/** 連戦シミュレーション: 街に戻らず何戦もつか (#535 の指標。勝率より職差が見える)。 */
+function simulateEndurance(job: Archetype, tier: number, lv: number, trials: number): number {
+  const CAP = 40;
+  let total = 0;
+  for (let t = 0; t < trials; t++) {
+    let hp: number | undefined;
+    let mp: number | undefined;
+    let herbs = WORLD_HERB_MAX;
+    let battles = 0;
+    for (let b = 0; b < CAP; b++) {
+      const s = startBattle(
+        job, lv, 1, 'sim',
+        tier as never,
+        t * 977 + b,
+        herbs,
+        hp !== undefined ? { hp, mp: mp! } : undefined,
+      );
+      const r = runAutoBattle(s);
+      if (r.outcome !== 'win') break;
+      battles++;
+      hp = r.player.hp;
+      mp = r.player.mp;
+      herbs = Math.min(WORLD_HERB_MAX, r.herbs ?? 0);
+    }
+    total += battles;
+  }
+  return total / trials;
+}
+
+export function AdminJobs() {
+  const session = useSession();
+  const admin = isAdminDid(session.did ?? null);
+  const [list, setList] = useState<JobOverride[]>(() => currentJobParams());
+  const [sel, setSel] = useState<Archetype>(JOBS[0]!.id);
+  const [note, setNote] = useState<string | null>(null);
+  const [dirty, setDirty] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [tier, setTier] = useState(1);
+  const [lv, setLv] = useState(5);
+  const [trials, setTrials] = useState(30);
+  const [simRows, setSimRows] = useState<Array<[Archetype, number]> | null>(null);
+  const [simBusy, setSimBusy] = useState(false);
+
+  // 保存済みを読み込んでから編集させる (メモリ初期値のまま保存すると上書きで消える)。
+  useEffect(() => {
+    let cancelled = false;
+    void loadAuthoredWorld(session.agent ?? null).finally(() => {
+      if (cancelled) return;
+      setList(currentJobParams());
+      setLoaded(true);
+    });
+    return () => { cancelled = true; };
+  }, [session.agent]);
+
+  const current = useMemo(() => list.find((j) => j.id === sel) ?? null, [list, sel]);
+  const update = useCallback((id: Archetype, patch: Partial<JobOverride>) => {
+    setList((xs) => xs.map((j) => (j.id === id ? { ...j, ...patch } : j)));
+    setDirty(true);
+  }, []);
+
+  /** 編集値を**保存せずに**適用して試す。終わったら保存済みの状態へ戻す。 */
+  const runSim = useCallback(() => {
+    setSimBusy(true);
+    setNote(null);
+    // 同期で回すと画面が固まって見えるので、描画を挟んでから走らせる。
+    setTimeout(() => {
+      const saved = currentJobParams();
+      try {
+        setJobOverrides(list);
+        const rows = JOBS.map((j) => [j.id, simulateEndurance(j.id, tier, lv, trials)] as [Archetype, number]);
+        rows.sort((a, b) => a[1] - b[1]);
+        setSimRows(rows);
+      } catch (e) {
+        setNote(e instanceof JobDataError ? `試せない: ${e.message}` : String(e));
+      } finally {
+        // **必ず戻す** — 試した値がこの端末に残ると、以後の表示も戦闘も編集中の値で動く。
+        setJobOverrides(saved);
+        setSimBusy(false);
+      }
+    }, 0);
+  }, [list, tier, lv, trials]);
+
+  const save = useCallback(async () => {
+    if (!session.agent) return;
+    try {
+      await saveJobs(session.agent, list);
+      setDirty(false);
+      setNote('保存した。サーバーは最大 5 分で拾う');
+    } catch (e) {
+      setNote(e instanceof JobDataError ? `保存できない: ${e.message}` : `保存できなかった: ${String(e)}`);
+    }
+  }, [session.agent, list]);
+
+  if (!admin) {
+    return (
+      <div style={{ padding: '1em' }}>
+        <p>この画面は管理者だけが使えます。</p>
+        <Link to="/admin">管理ダッシュボードへ</Link>
+      </div>
+    );
+  }
+
+  const statSum = current ? (current.stats ?? [0, 0, 0, 0, 0]).reduce((a, b) => a + b, 0) : 0;
+  const field = (label: string, input: React.ReactNode) => (
+    <label style={{ display: 'flex', alignItems: 'center', gap: '0.4em', fontSize: '0.8em' }}>
+      <span style={{ width: '7em', color: 'var(--color-muted)' }}>{label}</span>
+      {input}
+    </label>
+  );
+
+  return (
+    <div style={{ padding: '0.8em', maxWidth: 960 }}>
+      <div style={{ display: 'flex', gap: '0.6em', alignItems: 'center', marginBottom: '0.4em' }}>
+        <Link to="/admin" style={{ fontSize: '0.8em' }}>← 管理</Link>
+        <strong>ジョブ</strong>
+        <button type="button" onClick={() => void save()} disabled={!session.agent || !dirty || !loaded} style={{ marginLeft: 'auto', fontSize: '0.85em' }}>
+          保存
+        </button>
+      </div>
+
+      {note && <p style={{ fontSize: '0.8em', color: 'var(--color-accent)', margin: '0 0 0.4em' }}>{note}</p>}
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'minmax(150px, 1fr) 2fr', gap: '0.8em' }}>
+        <div style={{ maxHeight: '70vh', overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 2 }}>
+          {list.map((j) => (
+            <button
+              key={j.id}
+              type="button"
+              onClick={() => setSel(j.id)}
+              style={{
+                display: 'flex', gap: '0.4em', width: '100%', padding: '0.2em 0.4em',
+                fontSize: '0.85em', textAlign: 'left',
+                border: sel === j.id ? '2px solid var(--color-accent)' : '1px solid var(--color-border)',
+                background: 'transparent',
+              }}
+            >
+              <span style={{ flex: 1 }}>{jobDisplayName(j.id, 'default')}</span>
+              <span style={{ fontSize: '0.75em', color: 'var(--color-muted)' }}>体{j.vit} 曲{j.pace?.toFixed(2)}</span>
+            </button>
+          ))}
+        </div>
+
+        {current && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.35em' }}>
+            <strong>{jobDisplayName(current.id, 'default')}</strong>
+            <div style={{ fontSize: '0.8em' }}>
+              <span style={{ color: 'var(--color-muted)' }}>ステータス比 (合計 {JOB_STATS_SUM})</span>
+              {STAT_LABELS.map((label, i) => (
+                <div key={label} style={{ display: 'flex', gap: '0.4em', alignItems: 'center', margin: '0.1em 0' }}>
+                  <span style={{ width: '5em' }}>{label}</span>
+                  <input
+                    type="number"
+                    value={current.stats?.[i] ?? 0}
+                    onChange={(e) => {
+                      const cur = current.stats ?? [0, 0, 0, 0, 0];
+                      const next = cur.map((v, j) => (j === i ? Number(e.target.value) : v)) as unknown as StatArray;
+                      update(current.id, { stats: next });
+                    }}
+                    style={{ width: '5em' }}
+                  />
+                </div>
+              ))}
+              <div style={{ color: statSum === JOB_STATS_SUM ? 'var(--color-muted)' : 'var(--color-danger)' }}>
+                合計 {statSum}{statSum !== JOB_STATS_SUM && ` (${JOB_STATS_SUM} にしないと保存できない)`}
+              </div>
+            </div>
+            {field('たいりょく', (
+              <input
+                type="number" min={MIN_VIT} max={MAX_VIT}
+                value={current.vit ?? 0}
+                onChange={(e) => update(current.id, { vit: Number(e.target.value) })}
+                style={{ width: '6em' }}
+              />
+            ))}
+            {field('レベル曲線', (
+              <span style={{ display: 'flex', gap: '0.4em', alignItems: 'center' }}>
+                <input
+                  type="number" step={0.01} min={MIN_PACE} max={MAX_PACE}
+                  value={current.pace ?? 1}
+                  onChange={(e) => update(current.id, { pace: Number(e.target.value) })}
+                  style={{ width: '6em' }}
+                />
+                <span style={{ fontSize: '0.85em', color: 'var(--color-muted)' }}>小さいほど早く上がる</span>
+              </span>
+            ))}
+            <div style={{ fontSize: '0.8em' }}>
+              <span style={{ color: 'var(--color-muted)' }}>装備できるカテゴリ</span>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.4em', marginTop: '0.2em' }}>
+                {ALL_KINDS.map((k) => {
+                  const on = (current.equipKinds ?? JOB_EQUIP_KINDS[current.id]).includes(k);
+                  return (
+                    <label key={k} style={{ display: 'flex', gap: '0.2em', alignItems: 'center' }}>
+                      <input
+                        type="checkbox"
+                        checked={on}
+                        onChange={(e) => {
+                          const base = current.equipKinds ?? [...JOB_EQUIP_KINDS[current.id]];
+                          update(current.id, { equipKinds: e.target.checked ? [...base, k] : base.filter((x) => x !== k) });
+                        }}
+                      />
+                      {k}
+                    </label>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div style={{ marginTop: '0.8em', borderTop: '1px solid var(--color-border)', paddingTop: '0.5em' }}>
+        <div style={{ display: 'flex', gap: '0.5em', alignItems: 'center', flexWrap: 'wrap', fontSize: '0.8em' }}>
+          <strong style={{ fontSize: '0.95em' }}>連戦シミュレーション</strong>
+          <label>tier <input type="number" min={1} max={8} value={tier} onChange={(e) => setTier(Number(e.target.value))} style={{ width: '4em' }} /></label>
+          <label>Lv <input type="number" min={1} max={50} value={lv} onChange={(e) => setLv(Number(e.target.value))} style={{ width: '4em' }} /></label>
+          <label>試行 <input type="number" min={1} max={200} value={trials} onChange={(e) => setTrials(Number(e.target.value))} style={{ width: '5em' }} /></label>
+          <button type="button" onClick={runSim} disabled={simBusy}>
+            {simBusy ? '計算中…' : '編集値で試す'}
+          </button>
+          <span style={{ color: 'var(--color-muted)' }}>保存せずに試せる (端末にも残らない)</span>
+        </div>
+        {simRows && (
+          <div style={{ marginTop: '0.4em', fontSize: '0.8em' }}>
+            <div style={{ color: 'var(--color-muted)' }}>
+              街に戻らず何戦もつか (平均 {(simRows.reduce((s, r) => s + r[1], 0) / simRows.length).toFixed(1)} 戦)
+            </div>
+            {simRows.map(([id, v]) => (
+              <div key={id} style={{ display: 'flex', gap: '0.4em', alignItems: 'center' }}>
+                <span style={{ width: '6em' }}>{jobDisplayName(id, 'default')}</span>
+                <span style={{ width: '3.5em', textAlign: 'right' }}>{v.toFixed(1)}</span>
+                <span style={{ background: 'var(--color-accent)', height: 8, width: `${Math.min(100, v * 6)}%` }} />
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/routes/admin-jobs.tsx
+++ b/apps/web/src/routes/admin-jobs.tsx
@@ -10,6 +10,7 @@ import {
   MIN_PACE,
   MIN_VIT,
   currentJobParams,
+  jobOverridesDiff,
   jobDisplayName,
   runAutoBattle,
   setJobOverrides,
@@ -20,8 +21,8 @@ import {
   type StatArray,
 } from '@aozoraquest/core';
 import { useSession } from '@/lib/session';
-import { isAdminDid } from '@/lib/runtime-config';
-import { loadAuthoredWorld, saveJobs } from '@/lib/world-authoring';
+import { getPrimaryAdminDid, isAdminDid } from '@/lib/runtime-config';
+import { loadJobsRecord, saveJobs } from '@/lib/world-authoring';
 
 /**
  * **ジョブエディタ** (#544)。ステータス比・たいりょく・レベル曲線・装備適性 +
@@ -37,12 +38,15 @@ import { loadAuthoredWorld, saveJobs } from '@/lib/world-authoring';
 const WORLD_HERB_MAX = 3;
 
 const STAT_LABELS = ['こうげき', 'まもり', 'すばやさ', 'かしこさ', 'うん'] as const;
-const ALL_KINDS: readonly EquipKind[] = ['common', 'sword', 'axe', 'shield', 'dagger', 'staff', 'lucky', 'heavy', 'light', 'robe', 'cloth', 'charm'];
+/** チェックで意味があるカテゴリだけ。**common / cloth / charm は canEquip が
+ *  JOB_EQUIP_KINDS を見る前に true を返す**ので、並べても「表示も操作も嘘」になる。 */
+const ALL_KINDS: readonly EquipKind[] = ['sword', 'axe', 'shield', 'dagger', 'staff', 'lucky', 'heavy', 'light', 'robe'];
 
 /** 連戦シミュレーション: 街に戻らず何戦もつか (#535 の指標。勝率より職差が見える)。 */
-function simulateEndurance(job: Archetype, tier: number, lv: number, trials: number): number {
-  const CAP = 40;
+function simulateEndurance(job: Archetype, tier: number, lv: number, trials: number): { avg: number; capped: number } {
+  const CAP = 200; // 上限で頭打ちになると強化の効果が読めなくなる (16職×30試行で 0.2 秒程度)
   let total = 0;
+  let capped = 0; // 上限で打ち切った試行 (平均が過小評価になっていることの印)
   for (let t = 0; t < trials; t++) {
     let hp: number | undefined;
     let mp: number | undefined;
@@ -64,8 +68,9 @@ function simulateEndurance(job: Archetype, tier: number, lv: number, trials: num
       herbs = Math.min(WORLD_HERB_MAX, r.herbs ?? 0);
     }
     total += battles;
+    if (battles >= CAP) capped++;
   }
-  return total / trials;
+  return { avg: total / trials, capped };
 }
 
 export function AdminJobs() {
@@ -75,21 +80,34 @@ export function AdminJobs() {
   const [sel, setSel] = useState<Archetype>(JOBS[0]!.id);
   const [note, setNote] = useState<string | null>(null);
   const [dirty, setDirty] = useState(false);
-  const [loaded, setLoaded] = useState(false);
+  /** 保存済みレコードを読めたか。**読めていないと保存させない** — コード値のまま
+   *  保存すると全職ぶんの調整が消える (レビュー ★★★)。 */
+  const [loadState, setLoadState] = useState<'loading' | 'ok' | 'failed'>('loading');
   const [tier, setTier] = useState(1);
   const [lv, setLv] = useState(5);
   const [trials, setTrials] = useState(30);
-  const [simRows, setSimRows] = useState<Array<[Archetype, number]> | null>(null);
+  const [simRows, setSimRows] = useState<Array<{ id: Archetype; avg: number; capped: number }> | null>(null);
   const [simBusy, setSimBusy] = useState(false);
 
-  // 保存済みを読み込んでから編集させる (メモリ初期値のまま保存すると上書きで消える)。
+  // 保存済みを読み込んでから編集させる。**読めなければ保存を塞ぐ** (握り潰して
+  // コード値を出すと、1 職直して保存した瞬間に他 15 職の調整が消える)。
   useEffect(() => {
     let cancelled = false;
-    void loadAuthoredWorld(session.agent ?? null).finally(() => {
-      if (cancelled) return;
-      setList(currentJobParams());
-      setLoaded(true);
-    });
+    const agent = session.agent;
+    const adminDid = getPrimaryAdminDid();
+    if (!agent || !adminDid) { setLoadState('failed'); return; }
+    void loadJobsRecord(agent, adminDid)
+      .then(() => {
+        if (cancelled) return;
+        setList(currentJobParams());
+        setLoadState('ok');
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        console.warn('[admin] jobs load failed', e);
+        setLoadState('failed');
+        setNote('保存済みのジョブ設定を読み込めなかった。上書きで消える恐れがあるので保存できない (再読み込みしてほしい)');
+      });
     return () => { cancelled = true; };
   }, [session.agent]);
 
@@ -108,8 +126,8 @@ export function AdminJobs() {
       const saved = currentJobParams();
       try {
         setJobOverrides(list);
-        const rows = JOBS.map((j) => [j.id, simulateEndurance(j.id, tier, lv, trials)] as [Archetype, number]);
-        rows.sort((a, b) => a[1] - b[1]);
+        const rows = JOBS.map((j) => ({ id: j.id, ...simulateEndurance(j.id, tier, lv, trials) }));
+        rows.sort((a, b) => a.avg - b.avg);
         setSimRows(rows);
       } catch (e) {
         setNote(e instanceof JobDataError ? `試せない: ${e.message}` : String(e));
@@ -124,7 +142,7 @@ export function AdminJobs() {
   const save = useCallback(async () => {
     if (!session.agent) return;
     try {
-      await saveJobs(session.agent, list);
+      await saveJobs(session.agent, jobOverridesDiff(list));
       setDirty(false);
       setNote('保存した。サーバーは最大 5 分で拾う');
     } catch (e) {
@@ -154,7 +172,7 @@ export function AdminJobs() {
       <div style={{ display: 'flex', gap: '0.6em', alignItems: 'center', marginBottom: '0.4em' }}>
         <Link to="/admin" style={{ fontSize: '0.8em' }}>← 管理</Link>
         <strong>ジョブ</strong>
-        <button type="button" onClick={() => void save()} disabled={!session.agent || !dirty || !loaded} style={{ marginLeft: 'auto', fontSize: '0.85em' }}>
+        <button type="button" onClick={() => void save()} disabled={!session.agent || !dirty || loadState !== 'ok'} style={{ marginLeft: 'auto', fontSize: '0.85em' }}>
           保存
         </button>
       </div>
@@ -225,7 +243,7 @@ export function AdminJobs() {
               </span>
             ))}
             <div style={{ fontSize: '0.8em' }}>
-              <span style={{ color: 'var(--color-muted)' }}>装備できるカテゴリ</span>
+              <span style={{ color: 'var(--color-muted)' }}>装備できるカテゴリ (common / cloth / charm は全職共通)</span>
               <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.4em', marginTop: '0.2em' }}>
                 {ALL_KINDS.map((k) => {
                   const on = (current.equipKinds ?? JOB_EQUIP_KINDS[current.id]).includes(k);
@@ -263,15 +281,23 @@ export function AdminJobs() {
         {simRows && (
           <div style={{ marginTop: '0.4em', fontSize: '0.8em' }}>
             <div style={{ color: 'var(--color-muted)' }}>
-              街に戻らず何戦もつか (平均 {(simRows.reduce((s, r) => s + r[1], 0) / simRows.length).toFixed(1)} 戦)
+              街に戻らず何戦もつか (平均 {(simRows.reduce((s, r) => s + r.avg, 0) / simRows.length).toFixed(1)} 戦)
             </div>
-            {simRows.map(([id, v]) => (
-              <div key={id} style={{ display: 'flex', gap: '0.4em', alignItems: 'center' }}>
-                <span style={{ width: '6em' }}>{jobDisplayName(id, 'default')}</span>
-                <span style={{ width: '3.5em', textAlign: 'right' }}>{v.toFixed(1)}</span>
-                <span style={{ background: 'var(--color-accent)', height: 8, width: `${Math.min(100, v * 6)}%` }} />
-              </div>
-            ))}
+            {(() => {
+              // 棒の目盛りは**その回の最大値**に合わせる (固定係数だと強い職が振り切れて差が見えない)。
+              const max = Math.max(1, ...simRows.map((r) => r.avg));
+              return simRows.map((r) => (
+                <div key={r.id} style={{ display: 'flex', gap: '0.4em', alignItems: 'center' }}>
+                  <span style={{ width: '6em' }}>{jobDisplayName(r.id, 'default')}</span>
+                  <span style={{ width: '3.5em', textAlign: 'right' }}>{r.avg.toFixed(1)}</span>
+                  <span style={{ background: 'var(--color-accent)', height: 8, width: `${(r.avg / max) * 70}%` }} />
+                  {/* 上限で打ち切った試行があると平均は過小評価。黙って頭打ちにしない */}
+                  {r.capped > 0 && (
+                    <span style={{ color: 'var(--color-danger)' }}>打ち切り {r.capped}/{trials}</span>
+                  )}
+                </div>
+              ));
+            })()}
           </div>
         )}
       </div>

--- a/packages/core/src/__tests__/gear-slots.test.ts
+++ b/packages/core/src/__tests__/gear-slots.test.ts
@@ -15,7 +15,7 @@ import {
   type GearSelection,
 } from '../equipment.js';
 
-const defOf = (v: { id: string } | string) => EQUIPMENT_BY_ID[typeof v === 'string' ? v : v.id];
+const defOf = (v: unknown) => EQUIPMENT_BY_ID[typeof v === 'string' ? v : (v as { id: string }).id];
 
 describe('ロスターの健全性', () => {
   it('盾・頭・足のスロットに品がある', () => {

--- a/packages/core/src/__tests__/job-data.test.ts
+++ b/packages/core/src/__tests__/job-data.test.ts
@@ -1,0 +1,111 @@
+/**
+ * ジョブのパラメータ上書き (#544)。守るべき不変条件:
+ * - 上書きは **JOBS / JOBS_BY_ID / JOB_LEVEL_PACE / JOB_EQUIP_KINDS の参照を保ったまま**効く
+ *   (各所が import 時に掴んでいるので、再代入すると片方だけ古い値のままになる)
+ * - stats の合計 100 を崩す編集は通さない (職間の強さの物差しが消える)
+ * - 壊れた 1 件で全体を落とす。null で完全にコード値へ戻る
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { JOBS, JOBS_BY_ID } from '../jobs.js';
+import { JOB_LEVEL_PACE } from '../tuning.js';
+import { JOB_EQUIP_KINDS, canEquip, EQUIPMENT_BY_ID } from '../equipment.js';
+import { currentJobParams, setJobOverrides, JobDataError, JOB_STATS_SUM } from '../job-data.js';
+import { jobLevelFromXp } from '../quest.js';
+
+afterEach(() => setJobOverrides(null));
+
+describe('setJobOverrides', () => {
+  it('stats と vit が JOBS / JOBS_BY_ID の両方に効く (参照が保たれる)', () => {
+    setJobOverrides([{ id: 'warrior', stats: [50, 20, 10, 10, 10], vit: 60 }]);
+    const fromList = JOBS.find((j) => j.id === 'warrior')!;
+    expect(fromList.stats).toEqual([50, 20, 10, 10, 10]);
+    expect(fromList.vit).toBe(60);
+    // JOBS_BY_ID は JOBS と同じオブジェクトを指しているはず
+    expect(JOBS_BY_ID.warrior).toBe(fromList);
+    expect(JOBS_BY_ID.warrior.stats).toEqual([50, 20, 10, 10, 10]);
+  });
+
+  it('pace が XP 曲線に効く (レベルが実際に動く)', () => {
+    const xp = 500;
+    const before = jobLevelFromXp(xp, 'warrior');
+    setJobOverrides([{ id: 'warrior', pace: 0.2 }]); // うんと早く上がる
+    expect(JOB_LEVEL_PACE.warrior).toBe(0.2);
+    expect(jobLevelFromXp(xp, 'warrior')).toBeGreaterThan(before);
+  });
+
+  it('equipKinds が canEquip に効く', () => {
+    const staff = EQUIPMENT_BY_ID['wp-novice-staff']!;
+    expect(canEquip('warrior', staff)).toBe(false);
+    setJobOverrides([{ id: 'warrior', equipKinds: ['staff'] }]);
+    expect(canEquip('warrior', staff)).toBe(true);
+  });
+
+  it('未指定のフィールドはコード値のまま (部分上書き)', () => {
+    const baseVit = JOBS_BY_ID.mage.vit;
+    setJobOverrides([{ id: 'mage', pace: 0.9 }]);
+    expect(JOBS_BY_ID.mage.vit).toBe(baseVit);
+  });
+
+  it('null で全部コード値に戻る', () => {
+    const base = currentJobParams().find((j) => j.id === 'warrior')!;
+    setJobOverrides([{ id: 'warrior', stats: [50, 20, 10, 10, 10], vit: 60, pace: 0.3, equipKinds: ['staff'] }]);
+    setJobOverrides(null);
+    const now = currentJobParams().find((j) => j.id === 'warrior')!;
+    expect(now).toEqual(base);
+  });
+
+  it('一覧から外した職もコード値へ戻る (前回の上書きが残らない)', () => {
+    const base = JOBS_BY_ID.mage.vit;
+    setJobOverrides([{ id: 'mage', vit: 44 }]);
+    setJobOverrides([{ id: 'warrior', vit: 44 }]); // mage は指定なし
+    expect(JOBS_BY_ID.mage.vit).toBe(base);
+  });
+});
+
+describe('検証', () => {
+  it('stats の合計が 100 でないと落ちる', () => {
+    expect(() => setJobOverrides([{ id: 'warrior', stats: [99, 99, 99, 99, 99] }])).toThrow(JobDataError);
+    expect(() => setJobOverrides([{ id: 'warrior', stats: [10, 10, 10, 10, 10] }])).toThrow(JobDataError);
+  });
+
+  it('要素数 5 でない / 負 / 非数の stats を弾く', () => {
+    expect(() => setJobOverrides([{ id: 'warrior', stats: [100, 0, 0, 0] as never }])).toThrow(JobDataError);
+    expect(() => setJobOverrides([{ id: 'warrior', stats: [110, -10, 0, 0, 0] }])).toThrow(JobDataError);
+    expect(() => setJobOverrides([{ id: 'warrior', stats: [NaN, 0, 0, 0, 0] as never }])).toThrow(JobDataError);
+  });
+
+  it('vit と pace の範囲外を弾く', () => {
+    expect(() => setJobOverrides([{ id: 'warrior', vit: 0 }])).toThrow(JobDataError);
+    expect(() => setJobOverrides([{ id: 'warrior', vit: 100 }])).toThrow(JobDataError);
+    expect(() => setJobOverrides([{ id: 'warrior', pace: 0 }])).toThrow(JobDataError);
+    expect(() => setJobOverrides([{ id: 'warrior', pace: 99 }])).toThrow(JobDataError);
+  });
+
+  it('未知のジョブ・重複・未知の装備カテゴリを弾く', () => {
+    expect(() => setJobOverrides([{ id: 'nobody' as never }])).toThrow(JobDataError);
+    expect(() => setJobOverrides([{ id: 'warrior' }, { id: 'warrior' }])).toThrow(JobDataError);
+    expect(() => setJobOverrides([{ id: 'warrior', equipKinds: ['zzz' as never] }])).toThrow(JobDataError);
+  });
+
+  it('壊れた 1 件で全体を落とす (部分適用しない)', () => {
+    const baseVit = JOBS_BY_ID.mage.vit;
+    expect(() => setJobOverrides([
+      { id: 'mage', vit: 44 },
+      { id: 'warrior', stats: [1, 1, 1, 1, 1] }, // 合計 5 で落ちる
+    ])).toThrow(JobDataError);
+    expect(JOBS_BY_ID.mage.vit).toBe(baseVit); // 先頭の 1 件も効いていない
+  });
+
+  it('currentJobParams は今の値をそのまま返す (シミュ後の復元に使える)', () => {
+    const snapshot = currentJobParams();
+    setJobOverrides([{ id: 'warrior', vit: 55 }]);
+    setJobOverrides(snapshot);
+    expect(JOBS_BY_ID.warrior.vit).toBe(snapshot.find((j) => j.id === 'warrior')!.vit);
+    expect(JOB_EQUIP_KINDS.warrior).toEqual(snapshot.find((j) => j.id === 'warrior')!.equipKinds);
+  });
+
+  it('合計 100 ちょうどは通る', () => {
+    setJobOverrides([{ id: 'warrior', stats: [20, 20, 20, 20, 20] }]);
+    expect(JOBS_BY_ID.warrior.stats.reduce((a, b) => a + b, 0)).toBe(JOB_STATS_SUM);
+  });
+});

--- a/packages/core/src/__tests__/job-data.test.ts
+++ b/packages/core/src/__tests__/job-data.test.ts
@@ -9,7 +9,7 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { JOBS, JOBS_BY_ID } from '../jobs.js';
 import { JOB_LEVEL_PACE } from '../tuning.js';
 import { JOB_EQUIP_KINDS, canEquip, EQUIPMENT_BY_ID } from '../equipment.js';
-import { currentJobParams, setJobOverrides, JobDataError, JOB_STATS_SUM } from '../job-data.js';
+import { currentJobParams, jobOverridesDiff, setJobOverrides, JobDataError, JOB_STATS_SUM } from '../job-data.js';
 import { jobLevelFromXp } from '../quest.js';
 
 afterEach(() => setJobOverrides(null));
@@ -107,5 +107,34 @@ describe('検証', () => {
   it('合計 100 ちょうどは通る', () => {
     setJobOverrides([{ id: 'warrior', stats: [20, 20, 20, 20, 20] }]);
     expect(JOBS_BY_ID.warrior.stats.reduce((a, b) => a + b, 0)).toBe(JOB_STATS_SUM);
+  });
+});
+
+describe('jobOverridesDiff (#544 レビュー ★★)', () => {
+  it('コード値と同じ職は保存対象に入らない (コード側の再調整が効き続ける)', () => {
+    expect(jobOverridesDiff(currentJobParams())).toEqual([]);
+  });
+
+  it('触った職の触ったフィールドだけ返す', () => {
+    const params = currentJobParams().map((j) => (j.id === 'mage' ? { ...j, vit: 33 } : j));
+    const diff = jobOverridesDiff(params);
+    expect(diff).toHaveLength(1);
+    expect(diff[0]!.id).toBe('mage');
+    expect(diff[0]!.vit).toBe(33);
+    expect(diff[0]!.pace).toBeUndefined(); // 触っていないフィールドは書かない
+    expect(diff[0]!.stats).toBeUndefined();
+  });
+
+  it('差分を適用しても現在値は同じ (往復で壊れない)', () => {
+    const params = currentJobParams().map((j) => (j.id === 'warrior' ? { ...j, pace: 0.85 } : j));
+    setJobOverrides(jobOverridesDiff(params));
+    expect(JOB_LEVEL_PACE.warrior).toBe(0.85);
+    expect(JOBS_BY_ID.mage.vit).toBe(currentJobParams().find((j) => j.id === 'mage')!.vit);
+  });
+
+  it('上書き適用後に取り直しても差分は増えない (保存済みの値を基準にしない)', () => {
+    setJobOverrides([{ id: 'mage', vit: 33 }]);
+    const diff = jobOverridesDiff(currentJobParams());
+    expect(diff).toEqual([{ id: 'mage', vit: 33 }]);
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,4 +26,5 @@ export * from './shop-data.js';
 export * from './npc-data.js';
 export * from './quest-data.js';
 export * from './part-presets.js';
+export * from './job-data.js';
 export * from './equipment.js';

--- a/packages/core/src/job-data.ts
+++ b/packages/core/src/job-data.ts
@@ -1,0 +1,128 @@
+/**
+ * **ジョブのパラメータ上書き** (#544)。エディタで数値を触れるようにする。
+ *
+ * 数値 (ステータス比・たいりょく・レベル曲線・装備適性) は編集できるが、
+ * **とくぎ・パッシブの効果は編集できない** — 効果は `EFFECT_HANDLERS` の関数で、
+ * データにするには DSL が要る (モンスター能力 #537 と同じ論点。必要になってから)。
+ *
+ * 保存先は管理者 PDS の `world.jobs` (モンスター #419・アイテム #420 と同じ流儀)。
+ * **edge も読む** — 戦闘計算は edge が権威なので、web だけが編集後のジョブを見ていると
+ * 画面の強さとサーバーの強さが食い違う。
+ *
+ * ## 参照を保ったまま差し替える
+ *
+ * `JOBS` / `JOBS_BY_ID` / `JOB_LEVEL_PACE` / `JOB_EQUIP_KINDS` は各所が
+ * import 時に掴んでいるので、**中身を書き換える** (再代入しない)。
+ * 診断 (`archetype-pair`) や表示も同じオブジェクトを見ているため、上書きは全経路に効く。
+ */
+import { JOBS, JOBS_BY_ID } from './jobs.js';
+import { JOB_LEVEL_PACE } from './tuning.js';
+import { JOB_EQUIP_KINDS, type EquipKind } from './equipment.js';
+import type { Archetype, JobDefinition, StatArray } from './types.js';
+
+export class JobDataError extends Error {}
+
+/** 1 職ぶんの上書き。指定したフィールドだけ差し替える (未指定はコード値のまま)。 */
+export interface JobOverride {
+  id: Archetype;
+  /** [atk, def, agi, int, luk]。**合計 100** (診断の比率としての意味を保つ)。 */
+  stats?: StatArray;
+  /** たいりょく (HP の元)。 */
+  vit?: number;
+  /** レベル曲線の係数。小さいほど早く上がる。 */
+  pace?: number;
+  /** 装備できるカテゴリ。 */
+  equipKinds?: EquipKind[];
+}
+
+export interface JobsRecord {
+  jobs: JobOverride[];
+  updatedAt: string;
+}
+
+/** stats 合計の許容 (丸め誤差を吸収。ズレると診断の比率が壊れる)。 */
+export const JOB_STATS_SUM = 100;
+export const MIN_VIT = 1;
+export const MAX_VIT = 99;
+/** pace の範囲。0 以下や極端な値は XP 曲線を壊す (0 で除算・レベルが動かない)。 */
+export const MIN_PACE = 0.1;
+export const MAX_PACE = 5;
+
+const KNOWN_KINDS = new Set<string>(['common', 'exclusive', 'sword', 'axe', 'shield', 'dagger', 'staff', 'lucky', 'heavy', 'light', 'robe', 'cloth', 'charm']);
+
+/** コード直書きの値 (上書きを解除するときに戻す先)。最初の setJobOverrides で撮る。 */
+let baseline: Map<Archetype, { stats: StatArray; vit: number; pace: number; equipKinds: readonly EquipKind[] }> | null = null;
+
+function snapshot(): void {
+  if (baseline) return;
+  baseline = new Map(
+    JOBS.map((j) => [
+      j.id,
+      {
+        stats: [...j.stats] as StatArray,
+        vit: j.vit,
+        pace: JOB_LEVEL_PACE[j.id] ?? 1,
+        equipKinds: [...JOB_EQUIP_KINDS[j.id]],
+      },
+    ]),
+  );
+}
+
+/**
+ * 上書きを適用する。`null` で全解除 (コード値へ戻す)。
+ * **壊れた 1 件で全体を落とす** (部分適用しない。他エディタと同じ流儀)。
+ */
+export function setJobOverrides(list: readonly JobOverride[] | null): void {
+  snapshot();
+  const seen = new Set<string>();
+  for (const o of list ?? []) {
+    const where = o?.id ?? '(id なし)';
+    if (!o || !JOBS_BY_ID[o.id]) throw new JobDataError(`ジョブが存在しない (${where})`);
+    if (seen.has(o.id)) throw new JobDataError(`ジョブの上書きが重複 (${where})`);
+    seen.add(o.id);
+    if (o.stats !== undefined) {
+      if (!Array.isArray(o.stats) || o.stats.length !== 5) throw new JobDataError(`${where}: stats は 5 要素`);
+      for (const v of o.stats) {
+        if (!Number.isFinite(v) || v < 0) throw new JobDataError(`${where}: stats に負や非数がある`);
+      }
+      const sum = o.stats.reduce((a, b) => a + b, 0);
+      // 合計 100 を崩すと**職間の強さの物差しが消える** (全部 999 にすれば最強になる)。
+      if (Math.abs(sum - JOB_STATS_SUM) > 0.01) throw new JobDataError(`${where}: stats の合計は ${JOB_STATS_SUM} (いまは ${sum})`);
+    }
+    if (o.vit !== undefined && (!Number.isFinite(o.vit) || o.vit < MIN_VIT || o.vit > MAX_VIT)) {
+      throw new JobDataError(`${where}: たいりょくは ${MIN_VIT}〜${MAX_VIT}`);
+    }
+    if (o.pace !== undefined && (!Number.isFinite(o.pace) || o.pace < MIN_PACE || o.pace > MAX_PACE)) {
+      throw new JobDataError(`${where}: レベル曲線は ${MIN_PACE}〜${MAX_PACE}`);
+    }
+    if (o.equipKinds !== undefined) {
+      if (!Array.isArray(o.equipKinds)) throw new JobDataError(`${where}: equipKinds が配列でない`);
+      for (const k of o.equipKinds) {
+        if (!KNOWN_KINDS.has(k)) throw new JobDataError(`${where}: 未知の装備カテゴリ (${k})`);
+      }
+    }
+  }
+
+  // 検証を全部通してから適用する (途中で落ちて半分だけ効いた状態を作らない)。
+  const byId = new Map((list ?? []).map((o) => [o.id, o]));
+  for (const job of JOBS) {
+    const base = baseline!.get(job.id)!;
+    const o = byId.get(job.id);
+    const m = job as JobDefinition; // 中身だけ書き換える (配列の参照は保つ)
+    m.stats = [...(o?.stats ?? base.stats)] as StatArray;
+    m.vit = o?.vit ?? base.vit;
+    JOB_LEVEL_PACE[job.id] = o?.pace ?? base.pace;
+    (JOB_EQUIP_KINDS as Record<Archetype, readonly EquipKind[]>)[job.id] = [...(o?.equipKinds ?? base.equipKinds)];
+  }
+}
+
+/** エディタ用: 現在値をそのまま上書き形式で読み出す (コード値 + 適用済みの上書き)。 */
+export function currentJobParams(): JobOverride[] {
+  return JOBS.map((j) => ({
+    id: j.id,
+    stats: [...j.stats] as StatArray,
+    vit: j.vit,
+    pace: JOB_LEVEL_PACE[j.id] ?? 1,
+    equipKinds: [...JOB_EQUIP_KINDS[j.id]],
+  }));
+}

--- a/packages/core/src/job-data.ts
+++ b/packages/core/src/job-data.ts
@@ -116,6 +116,32 @@ export function setJobOverrides(list: readonly JobOverride[] | null): void {
   }
 }
 
+/**
+ * **コード値と違うところだけ**を上書き形式で返す (#544 レビュー ★★)。
+ *
+ * 全職のフル値を保存すると、後日コード側で `JOB_LEVEL_PACE` を引き直しても
+ * レコードが常に勝って**恒久的に無視される** (tuning.ts の pace は計測条件が
+ * 変われば引き直す前提のデータなので、実際に踏む)。差分だけ保存すれば、
+ * 触っていない職はコードの再調整がそのまま効く。
+ */
+export function jobOverridesDiff(params: readonly JobOverride[]): JobOverride[] {
+  snapshot();
+  const out: JobOverride[] = [];
+  for (const p of params) {
+    const base = baseline!.get(p.id);
+    if (!base) continue;
+    const o: JobOverride = { id: p.id };
+    if (p.stats && p.stats.some((v, i) => v !== base.stats[i])) o.stats = [...p.stats] as StatArray;
+    if (p.vit !== undefined && p.vit !== base.vit) o.vit = p.vit;
+    if (p.pace !== undefined && p.pace !== base.pace) o.pace = p.pace;
+    if (p.equipKinds && (p.equipKinds.length !== base.equipKinds.length || p.equipKinds.some((k, i) => k !== base.equipKinds[i]))) {
+      o.equipKinds = [...p.equipKinds];
+    }
+    if (Object.keys(o).length > 1) out.push(o);
+  }
+  return out;
+}
+
 /** エディタ用: 現在値をそのまま上書き形式で読み出す (コード値 + 適用済みの上書き)。 */
 export function currentJobParams(): JobOverride[] {
   return JOBS.map((j) => ({


### PR DESCRIPTION
Closes #544

## 概要

ジョブの数値を管理画面から編集し、**保存せずにその場で連戦シミュレーション**を回せるようにする。

- **編集**: ステータス比 (合計 100)・たいりょく・レベル曲線 (pace)・装備適性カテゴリ
- **対象外**: とくぎ/パッシブの効果 (EFFECT_HANDLERS の関数。DSL が要るので #537 と同じく必要になってから)
- **試す**: 編集値を一時適用して全 16 職の連戦数を計測 → finally で必ず元へ戻す (端末にも残さない)。指標を勝率でなく連戦数にしたのは職差が勝率では見えないため (#535 / docs/19 §6.6)
- **保存**: 管理者 PDS `world.jobs`。web と edge の両方が読む (戦闘は edge が権威)

## 実装メモ

上書きは `JOBS` / `JOBS_BY_ID` / `JOB_LEVEL_PACE` / `JOB_EQUIP_KINDS` の**中身を書き換える** (再代入しない)。各所が import 時に参照を掴んでいるため、再代入だと診断や表示が古い値のままになる。

`stats` の合計 100 を検証するのは、崩すと職間の強さの物差しが消えるため (全部 999 にすれば最強)。

保存は**コード値との差分だけ**。全職フル値を書くと、後日コード側で pace を引き直してもレコードが勝って恒久的に無視される。

## テスト

- core: job-data 17 件 (参照が保たれること・pace が XP 曲線に効く・equipKinds が canEquip に効く・部分上書き・一覧から外した職の復帰・全検証・部分適用しない・差分保存の往復)
- core 657 / edge 237 / web 360 全緑、typecheck / build 緑

## Review

1 観点 (実装/設計) で実施。3c1c318 で全件対応:

- **★★★ 読み込み失敗を握り潰したままコード値を並べ、1 職直して保存すると残り 15 職の調整が消える** → 成否を返す `loadJobsRecord` を足し、読めなければ保存を塞いで理由を表示
- **★★ 全職フル値保存でコード側の再調整が恒久的に無視される** → `jobOverridesDiff` で差分だけ保存
- **★★ common / cloth / charm のチェックは canEquip が先に true を返すため「表示も操作も嘘」** → 一覧から外し全職共通と明記
- **★★ 連戦シミュの上限 40 戦で強い職が頭打ち (実測: 遊び人は既定値で 50% が打ち切り)** → 上限 200、打ち切り試行数の表示、棒の目盛りを実測最大に追随

レビューが実測で確認した健全な点: baseline スナップショットは適用前に撮るので PDS 値で汚染されない / 一時適用は同期完結で復元漏れなし (16 職 30 試行 148ms) / pace 変更はレベルを毎回導出するためデータ破壊なし / 空配列 `{jobs: []}` の全解除も正しく反映。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SpSiVHa5hXp7sEUAXAfWEE