### PR TITLE
feat: 内部マップ (街の中・城・ダンジョン) とゲート (#424)

### DIFF
--- a/apps/edge/src/battle-resolver.ts
+++ b/apps/edge/src/battle-resolver.ts
@@ -15,6 +15,12 @@ import {
   terrainAt,
   isWalkableAt, wrap, townAt, regionOf, tierForRegion, encounterRateFor, worldOverlay, BATTLE_TUNING, type Tier,
   type BattleState, type Command, type Archetype, type StatVector, type StatArray, type GearSelection,
+  WORLD_MAP_ID,
+  gateAt,
+  interiorById,
+  interiorTerrainAt,
+  isInterior,
+  walkableIn,
 } from '@aozoraquest/core';
 import { entropyU32 } from './kuda';
 import { readGuard, createGuard, advanceGuard, deleteGuard, type BattleGuard } from './battle-guard';
@@ -235,6 +241,8 @@ export async function sealEncounter(env: ResolverEnv, userDid: string, state: Ga
 }
 
 export interface MoveResult {
+  /** 移動後のマップ (#424)。省略 = フィールド。ゲートを踏むと切り替わる。 */
+  mapId?: string;
   x: number;
   y: number;
   terrain: string;
@@ -256,31 +264,61 @@ export async function handleMove(env: ResolverEnv, userDid: string, dx: number, 
 
   // 現在位置: 署名トークンが権威。無効/失効なら gameState から再同期 (位置偽造は署名で不可)。
   let cx: number, cy: number, counter = 0;
+  // mapId (#424) はトークン → state の順に引く。**どちらにも無ければフィールド** —
+  // 旧トークン・旧 state をそのまま通すため (移行なし)。
+  let mapId: string = WORLD_MAP_ID;
   try {
     const claim = verifyPosition(env, token ?? '', userDid, now);
-    cx = claim.x; cy = claim.y; counter = claim.counter;
+    cx = claim.x; cy = claim.y; counter = claim.counter; mapId = claim.mapId ?? WORLD_MAP_ID;
   } catch {
     const rec = await readState(env, userDid);
     const s = rec?.state ?? (await migrateInitState(userDid, new Date(now * 1000).toISOString(), ns, fetchImpl));
-    cx = s.x; cy = s.y;
+    cx = s.x; cy = s.y; mapId = s.mapId ?? WORLD_MAP_ID;
+  }
+  // 定義が消えた内部マップに取り残されない (エディタで削除された場合)。フィールドへ戻す。
+  if (mapId !== WORLD_MAP_ID && !isInterior(mapId)) mapId = WORLD_MAP_ID;
+
+  // 内部マップ (#424) は端で折り返さない (外に出るのはゲートからだけ)。
+  const inside = isInterior(mapId) ? interiorById(mapId)! : null;
+  let nx = inside ? cx + dx : wrap(cx + dx);
+  let ny = inside ? cy + dy : wrap(cy + dy);
+  if (!walkableIn(mapId, nx, ny, isWalkableAt)) throw new ResolverError('進めない地形', 400);
+
+  // **ゲートを踏んだら移る** (#424)。通行判定の後に見るのは、壁の中の入口を
+  // 「歩けないが入れる」にしないため (入口タイル自体は歩けるパーツで置く)。
+  const gate = gateAt(mapId, nx, ny);
+  if (gate) {
+    mapId = gate.to.mapId;
+    nx = gate.to.x;
+    ny = gate.to.y;
+    const dest = isInterior(mapId) ? interiorById(mapId)! : null;
+    // 行き先の地形は権威側で確定する。壁の中に出す設定は保存時に弾いているが、
+    // 万一そうなっていても**移動そのものは通す** (出られない状態を作らない)。
+    const destTerrain = dest ? interiorTerrainAt(dest, nx, ny) : terrainAt(nx, ny);
+    // 位置は PDS に確定させる (マップをまたぐのは稀 = 書き込みコストが乗ってよい)。
+    await readModifyWrite(env, userDid, (cur) => ({ ...cur, mapId: mapId === WORLD_MAP_ID ? undefined : mapId, x: nx, y: ny }),
+      { now, init: (d, iso) => migrateInitState(d, iso, ns, fetchImpl) });
+    const gateToken = signPosition(env, { did: userDid, mapId, x: nx, y: ny, counter: counter + 1, iat: now });
+    // フィールドへ戻るときは mapId を載せない (旧 client が知らないキーを解釈しない)。
+    return { ...(mapId !== WORLD_MAP_ID ? { mapId } : {}), x: nx, y: ny, terrain: destTerrain, token: gateToken };
   }
 
-  const nx = wrap(cx + dx), ny = wrap(cy + dy);
-  const terrain = terrainAt(nx, ny);
-  if (!isWalkableAt(nx, ny)) throw new ResolverError('進めない地形', 400);
+  const terrain = inside ? interiorTerrainAt(inside, nx, ny) : terrainAt(nx, ny);
 
   let healed = false;
-  if (terrain === 'town') {
+  // 街の全回復はフィールドの街タイルのみ (内部マップの床を town で塗っても回復しない)。
+  if (!inside && terrain === 'town') {
     // 街: HP/MP 全回復 + 位置 + 最後の街 (敗北帰還先) を gameState に確定 (稀なので PDS 書き OK)。
     await readModifyWrite(env, userDid, (cur) => ({ ...cur, x: nx, y: ny, carryHp: undefined, carryMp: undefined, lastTown: { x: nx, y: ny } }),
       { now, init: (d, iso) => migrateInitState(d, iso, ns, fetchImpl) });
     healed = true;
   }
 
-  const nextToken = signPosition(env, { did: userDid, x: nx, y: ny, counter: counter + 1, iat: now });
+  const nextToken = signPosition(env, { did: userDid, mapId, x: nx, y: ny, counter: counter + 1, iat: now });
 
   // エンカウント: tile+30分枠+秘密から決定的 (見えない・予測不可・30分でリポップ)。街では出さない。
-  if (terrain !== 'town') {
+  // **内部マップは encounterTier を設定したときだけ敵が出る** (街の中・城の広間は無し)。
+  if (terrain !== 'town' && (!inside || inside.encounterTier !== undefined)) {
     const window = enemyWindow(now);
     const { roll, monsterSeed } = tileEncounter(env, nx, ny, window);
     if (roll < encounterRateFor(terrain)) {
@@ -302,7 +340,7 @@ export async function handleMove(env: ResolverEnv, userDid: string, dx: number, 
       }
     }
   }
-  return { x: nx, y: ny, terrain, healed: healed || undefined, token: nextToken };
+  return { ...(mapId !== WORLD_MAP_ID ? { mapId } : {}), x: nx, y: ny, terrain, healed: healed || undefined, token: nextToken };
 }
 
 export interface TeleportResult { x: number; y: number; token: string; materials: Record<string, number> }

--- a/apps/edge/src/battle-resolver.ts
+++ b/apps/edge/src/battle-resolver.ts
@@ -47,11 +47,30 @@ export const VALID_COMMANDS: readonly Command[] = ['attack', 'guard', 'skill', '
 export type ResolverEnv = GameStateEnv;
 
 /** ガードに封印する startBattle 由来のメタ (turn では state を使うが、報酬/撃破記録用に残す)。 */
+/** 遭遇タイルのキー。**mapId を含める** — フィールドと内部の同じ座標を別のマスとして扱う。
+ *  フィールドは従来どおり "x,y" (旧ガード・旧 defeated と互換)。 */
+function tileKey(mapId: string, x: number, y: number): string {
+  return mapId === WORLD_MAP_ID ? `${x},${y}` : `${mapId}:${x},${y}`;
+}
+
+/** tileKey の逆。旧形式 ("x,y") も読める。 */
+function parseTileKey(key: string): { mapId: string; x: number; y: number } | null {
+  const colon = key.lastIndexOf(':');
+  const mapId = colon >= 0 ? key.slice(0, colon) : WORLD_MAP_ID;
+  const [x, y] = key.slice(colon + 1).split(',').map(Number);
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+  return { mapId, x: x!, y: y! };
+}
+
 interface SealedMeta {
   archetype: string;
   tier: Tier;
   /** 遭遇したタイル "x,y" (撃破時に defeated へ入れ、その枠で再エンカウントさせない)。 */
   tile: string;
+  /** 遭遇したマップ (#424)。**決着で位置を書き戻すときに要る** — 内部マップで
+   *  戦って mapId を落とすと、内部ローカル座標のままフィールドに放り出される。
+   *  省略 = フィールド (旧ガードとの互換)。 */
+  mapId?: string;
   /** 遭遇時の素ステ。**決着でレベルアップの内訳を出すために封じておく** —
    *  ここに無いと handleTurn が診断を読み直すことになり、決着のたびに PDS 往復が増える。 */
   baseStats?: number[];
@@ -211,9 +230,12 @@ export interface EncounterInfo {
 
 /** 遭遇を成立させ snapshot を封印してガードを作る。位置は**権威** (move が渡す) = tier を選べない。
  *  `monsterSeed` は tile+30分枠+秘密から決定的 (置かれた敵)。client には返さない。export はテスト用。 */
-export async function sealEncounter(env: ResolverEnv, userDid: string, state: GameState, x: number, y: number, monsterSeed: number, now: number, ns: string = DEFAULT_NS, fetchImpl?: typeof fetch): Promise<EncounterInfo> {
+export async function sealEncounter(env: ResolverEnv, userDid: string, state: GameState, x: number, y: number, monsterSeed: number, now: number, ns: string = DEFAULT_NS, fetchImpl?: typeof fetch, mapId: string = WORLD_MAP_ID): Promise<EncounterInfo> {
   const { archetype, baseStats, handle, playerXp } = await readDiagnosis(userDid, ns, fetchImpl);
-  const tier = tierForRegion(regionOf(x, y));
+  // 内部マップ (#424) は座標が 0〜127 のローカル系で region が常に 0 になるため、
+  // 地域から tier を引くと**どの危険度を選んでも tier1 の敵しか出ない**。設定値を使う。
+  const interior = mapId !== WORLD_MAP_ID ? interiorById(mapId) : undefined;
+  const tier = (interior?.encounterTier ?? tierForRegion(regionOf(x, y))) as ReturnType<typeof tierForRegion>;
   // Lv は権威 state 由来 (#534)。戦闘で使うレベルと、報酬を積む先が同じレコードになる。
   const jobLevel = jobLevelFromXp(jobXpOf(state, archetype), archetype);
   const playerLevel = playerLevelFromXp(playerXp);
@@ -233,7 +255,7 @@ export async function sealEncounter(env: ResolverEnv, userDid: string, state: Ga
   const existing = await readGuard<SealedMeta, BattleState>(env, userDid);
   if (existing) await deleteGuard(env, now, userDid, existing.cid);
   const guard: Guard = {
-    did: userDid, battleId, turn: 0, sealed: { archetype, tier, tile: `${x},${y}`, baseStats: [...baseStats] }, state: battle, pendingTurnSeed, rewarded,
+    did: userDid, battleId, turn: 0, sealed: { archetype, tier, tile: tileKey(mapId, x, y), ...(mapId !== WORLD_MAP_ID ? { mapId } : {}), baseStats: [...baseStats] }, state: battle, pendingTurnSeed, rewarded,
     expiresAt: new Date((now + GUARD_TTL_SEC) * 1000).toISOString(), createdAt: nowIso, updatedAt: nowIso,
   };
   await createGuard(env, now, guard); // 生きたガードがあれば InvalidSwap → 上位で 409
@@ -277,6 +299,13 @@ export async function handleMove(env: ResolverEnv, userDid: string, dx: number, 
   }
   // 定義が消えた内部マップに取り残されない (エディタで削除された場合)。フィールドへ戻す。
   if (mapId !== WORLD_MAP_ID && !isInterior(mapId)) mapId = WORLD_MAP_ID;
+  // **範囲外に立っている state の保険** (#424 レビュー ★★★)。過去のバグや手編集で
+  // 「内部マップ × 範囲外の座標」になると全方向 400 で一歩も動けなくなるので、
+  // フィールド扱いに倒して脱出させる (位置は既に街の座標なので実害なく戻れる)。
+  if (mapId !== WORLD_MAP_ID) {
+    const here = interiorById(mapId)!;
+    if (cx < 0 || cy < 0 || cx >= here.size || cy >= here.size) mapId = WORLD_MAP_ID;
+  }
 
   // 内部マップ (#424) は端で折り返さない (外に出るのはゲートからだけ)。
   const inside = isInterior(mapId) ? interiorById(mapId)! : null;
@@ -309,7 +338,8 @@ export async function handleMove(env: ResolverEnv, userDid: string, dx: number, 
   // 街の全回復はフィールドの街タイルのみ (内部マップの床を town で塗っても回復しない)。
   if (!inside && terrain === 'town') {
     // 街: HP/MP 全回復 + 位置 + 最後の街 (敗北帰還先) を gameState に確定 (稀なので PDS 書き OK)。
-    await readModifyWrite(env, userDid, (cur) => ({ ...cur, x: nx, y: ny, carryHp: undefined, carryMp: undefined, lastTown: { x: nx, y: ny } }),
+    // フィールドの街なので mapId は消す (位置は必ず (mapId,x,y) の 3 つ組で書く)。
+    await readModifyWrite(env, userDid, (cur) => ({ ...cur, mapId: undefined, x: nx, y: ny, carryHp: undefined, carryMp: undefined, lastTown: { x: nx, y: ny } }),
       { now, init: (d, iso) => migrateInitState(d, iso, ns, fetchImpl) });
     healed = true;
   }
@@ -326,14 +356,18 @@ export async function handleMove(env: ResolverEnv, userDid: string, dx: number, 
       const state = rec?.state ?? (await migrateInitState(userDid, new Date(now * 1000).toISOString(), ns, fetchImpl));
       // その 30 分枠で撃破済みのタイルには敵が居ない (同一敵の無限狩り防止)。
       const defeated = state.defeatedWindow === window ? (state.defeated ?? []) : [];
-      if (!defeated.includes(`${nx},${ny}`)) {
+      // **キーに mapId を含める** — 含めないと内部の (4,4) とフィールドの (4,4) が
+      // 同じ 30 分枠の敵・同じ撃破済み枠を共有する (ダンジョンで倒すとフィールドも空く)。
+      if (!defeated.includes(tileKey(mapId, nx, ny))) {
         // **遭遇の失敗で移動そのものを殺さない。** ここが throw すると 500 になり、
         // プレイヤーはその場から一歩も動けなくなる (実際に危うく起きた)。遭遇データが
         // 壊れているなら「敵が出ないまま歩ける」に倒すのが正しい — 探索は続けられ、
         // 原因はログで追える。
         try {
-          const encounter = await sealEncounter(env, userDid, state, nx, ny, monsterSeed, now, ns, fetchImpl);
-          return { x: nx, y: ny, terrain, token: nextToken, encounter };
+          const encounter = await sealEncounter(env, userDid, state, nx, ny, monsterSeed, now, ns, fetchImpl, mapId);
+          // **mapId を落とさない** — ここだけ落ちていると web が「内部マップを抜けた」と
+          // 解釈し、遭遇の裏でフィールドの地形が描かれる (レビュー ★★★)。
+          return { ...(mapId !== WORLD_MAP_ID ? { mapId } : {}), x: nx, y: ny, terrain, token: nextToken, encounter };
         } catch (e) {
           console.error('encounter failed (移動は通す)', e);
         }
@@ -363,7 +397,9 @@ export async function handleTeleport(env: ResolverEnv, userDid: string, x: numbe
     const m: Record<string, number> = { ...cur.materials };
     m['sky-feather'] = have - 1;
     if (m['sky-feather'] <= 0) delete m['sky-feather'];
-    return { ...cur, x: tx, y: ty, carryHp: undefined, carryMp: undefined, lastTown: { x: tx, y: ty }, materials: m };
+    // そらのはねはフィールドの街へ飛ぶ。**mapId を消さないと**「内部マップ × 街の座標」
+    // という壊れた state が残り、次のリロードで動けなくなる (レビュー ★★★)。
+    return { ...cur, mapId: undefined, x: tx, y: ty, carryHp: undefined, carryMp: undefined, lastTown: { x: tx, y: ty }, materials: m };
   }, { now, init: (d, iso) => migrateInitState(d, iso, ns, fetchImpl) });
   materials = written.materials;
   const token = signPosition(env, { did: userDid, x: tx, y: ty, counter: 0, iat: now });
@@ -419,19 +455,23 @@ export interface SearchResult { found: string | null; materials: Record<string, 
  *  **パワーの消費も権威側** (#551) — client の台帳だけで引いていた頃は、いくらでも しらべられた。 */
 export async function handleSearch(env: ResolverEnv, userDid: string, token: string | undefined, now: number, ns: string = DEFAULT_NS, fetchImpl?: typeof fetch, opKey?: string): Promise<SearchResult> {
   let x: number, y: number;
+  let mapId: string = WORLD_MAP_ID;
   try {
     const c = verifyPosition(env, token ?? '', userDid, now);
-    x = c.x; y = c.y;
+    x = c.x; y = c.y; mapId = c.mapId ?? WORLD_MAP_ID;
   } catch {
     const rec = await readState(env, userDid);
     const s = rec?.state ?? (await migrateInitState(userDid, new Date(now * 1000).toISOString(), ns, fetchImpl));
-    x = s.x; y = s.y;
+    x = s.x; y = s.y; mapId = s.mapId ?? WORLD_MAP_ID;
   }
   const rec = await readState(env, userDid);
   const state = rec?.state ?? (await migrateInitState(userDid, new Date(now * 1000).toISOString(), ns, fetchImpl));
   const { archetype, baseStats, handle, playerXp } = await readDiagnosis(userDid, ns, fetchImpl);
   const luk = playerCombatant(archetype, jobLevelFromXp(jobXpOf(state, archetype), archetype), playerLevelFromXp(playerXp), handle, baseStats, undefined, state.gearSel).luk;
-  const tier = tierForRegion(regionOf(x, y));
+  // 内部マップ (#424) の座標はローカル系で region が常に 0 になるため、
+  // 危険度は内部マップの設定を使う (フィールドは従来どおり地域から)。
+  const interiorHere = mapId !== WORLD_MAP_ID ? interiorById(mapId) : undefined;
+  const tier = (interiorHere?.encounterTier ?? tierForRegion(regionOf(x, y))) as ReturnType<typeof tierForRegion>;
   // **パワーは権威側から引く** (#551)。それまで消費は client の台帳だけで、権威 state の
   // power は動いていなかった = いくらでも しらべられた。
   if (state.power < SEARCH_POWER_COST) throw new ResolverError('あおぞらパワーが たりない', 400, 'no_power');
@@ -523,6 +563,7 @@ export async function handleTurn(env: ResolverEnv, userDid: string, battleId: st
     const lossSeed = (await entropyU32({ useKuda: true, apiKey: env.KUDA_API_KEY })).value;
     let awarded: AwardBreakdown = {};
     let finalPos = { x: 0, y: 0 };
+    let finalMapId: string = WORLD_MAP_ID;
     const window = enemyWindow(now);
     const written = await readModifyWrite(env, userDid, (cur: GameState): GameState => {
       // 戦闘中に消費したやくそう/しずくを materials に反映してから報酬 (ドロップ/ロス) を適用。
@@ -546,12 +587,18 @@ export async function handleTurn(env: ResolverEnv, userDid: string, battleId: st
         ? [...prevDefeated.filter((t) => t !== guard.sealed.tile), guard.sealed.tile].slice(-256)
         : prevDefeated;
       // 位置を権威 state に確定。**敗北は最後の街へ帰還** (無ければ spawn)。勝ち/引き分けは戦闘タイルに留まる。
-      const [tx, ty] = guard.sealed.tile.split(',').map(Number);
-      const battleTile = Number.isFinite(tx) && Number.isFinite(ty) ? { x: tx, y: ty } : { x: cur.x, y: cur.y };
+      const parsed = parseTileKey(guard.sealed.tile);
+      const battleTile = parsed ? { x: parsed.x, y: parsed.y } : { x: cur.x, y: cur.y };
       const spawn = worldOverlay().spawn;
       finalPos = decision === 'lose' ? (cur.lastTown ?? { x: spawn.x, y: spawn.y }) : battleTile;
+      // **敗北の帰還先はフィールドの街** なので mapId を落とす。勝ち/引き分けは戦闘した
+      // マップに留まる (封印済みの mapId を使う — state 側は書き換わっている可能性がある)。
+      // ここで mapId を扱わないと、内部マップの座標のままフィールドに放り出される /
+      // 内部の範囲外に立って全方向「進めない」になる (レビュー ★★★)。
+      finalMapId = decision === 'lose' ? WORLD_MAP_ID : (guard.sealed.mapId ?? parsed?.mapId ?? WORLD_MAP_ID);
       return {
         ...r.next,
+        mapId: finalMapId === WORLD_MAP_ID ? undefined : finalMapId,
         x: finalPos.x,
         y: finalPos.y,
         // **レベルアップしたら HP/MP 全回復** (#547)。
@@ -567,7 +614,7 @@ export async function handleTurn(env: ResolverEnv, userDid: string, battleId: st
       };
     }, { now, init: (did, nowIso) => migrateInitState(did, nowIso, ns) });
     // 決着後の位置に対応する新トークンを発行 (敗北帰還で位置が変わるので client はこれで同期)。
-    const token = signPosition(env, { did: userDid, x: finalPos.x, y: finalPos.y, counter: 0, iat: now });
+    const token = signPosition(env, { did: userDid, ...(finalMapId !== WORLD_MAP_ID ? { mapId: finalMapId } : {}), x: finalPos.x, y: finalPos.y, counter: 0, iat: now });
     return { state: stripState(next), events: next.lastEvents, outcome: next.outcome, awarded, position: finalPos, token,
       materials: written.materials, carryHp: written.carryHp, carryMp: written.carryMp };
   }

--- a/apps/edge/src/game-state.ts
+++ b/apps/edge/src/game-state.ts
@@ -102,6 +102,8 @@ export interface GameState {
    *  client の申告を**所持の検証なしで**保存していたため、`{weapon:{id:'wp-shogun-high',plus:99}}`
    *  を送るだけで戦闘に効いた。ここに無い個体は装備できない。 */
   pieces?: OwnedPiece[];
+  /** 今いるマップ (#424)。省略 = フィールド ('world')。内部マップ (街の中・城) に居るとき id が入る。 */
+  mapId?: string;
   /** 進行中のゲーム内クエスト (#423)。討伐数は勝利時に edge が数える。 */
   quest?: { id: string; progress: number };
   /** 達成済みクエスト id (再受注させない)。直近 200 件のリング。 */

--- a/apps/edge/src/router.ts
+++ b/apps/edge/src/router.ts
@@ -140,7 +140,9 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
       const rec = await readState(env, did);
       const state = rec?.state ?? (await migrateInitState(did, new Date().toISOString(), nsFromOrigin(req)));
       // 位置トークンも一緒に返す → client は初回から有効トークンを持て、初手 move の再同期/ワープを防ぐ。
-      const token = signPosition(env, { did, x: state.x, y: state.y, counter: 0, iat: nowSec() });
+      // mapId (#424) も載せる — 内部マップに居るまま再読み込みしたとき、
+      // 初手 move がフィールド判定になって壁にめり込むのを防ぐ。
+      const token = signPosition(env, { did, ...(state.mapId ? { mapId: state.mapId } : {}), x: state.x, y: state.y, counter: 0, iat: nowSec() });
       return cors(json({ state, initialized: rec !== null, token }), allowedOrigin);
     } catch (e) {
       return cors(battleError(e), allowedOrigin);

--- a/apps/edge/src/world-authoring.ts
+++ b/apps/edge/src/world-authoring.ts
@@ -1,4 +1,4 @@
-import { decodeWorldMap, loadStaticWorldMap, loadTileArts, setGameQuests, setItemOverrides, setJobOverrides, setMonsterOverrides, setNpcs, setShopOverrides, setTownOverrides, setWorldMap, WORLD_SIZE, type EquipmentDef, type GameQuestDef, type ItemDefData, type JobOverride, type MonsterDef, type NpcDef, type ShopOverride, type TownOverride, type WorldPart } from '@aozoraquest/core';
+import { decodeWorldMap, loadStaticWorldMap, loadTileArts, setGameQuests, setInteriors, setItemOverrides, setJobOverrides, setMonsterOverrides, setNpcs, setShopOverrides, setTownOverrides, setWorldMap, WORLD_SIZE, type EquipmentDef, type Gate, type GameQuestDef, type InteriorMap, type ItemDefData, type JobOverride, type MonsterDef, type NpcDef, type ShopOverride, type TownOverride, type WorldPart } from '@aozoraquest/core';
 import { getRecord } from './pds';
 import { resolveDidDocument } from './service-auth';
 import { pdsEndpointFromDoc } from './oauth-metadata';
@@ -105,6 +105,17 @@ export function ensureAuthoredWorld(env: WorldAuthoringEnv, nsid: string, now: n
     // 画面の強さとサーバーの強さが食い違う。
     const jobs = await getRecord<{ jobs?: JobOverride[] }>(pds, did, `${nsid}.world.jobs`, RKEY);
     if (jobs?.value?.jobs) setJobOverrides(jobs.value.jobs);
+    // 内部マップとゲート (#424)。**移動判定と遷移は edge が権威**なので必須。
+    // 読めなければフィールドだけの世界として動く (内部に居る人はフィールドへ戻る)。
+    const inter = await getRecord<{ interiors?: Array<Omit<InteriorMap, 'tiles'> & { gz: string }>; gates?: Gate[] }>(pds, did, `${nsid}.world.interiors`, RKEY);
+    if (inter?.value) {
+      const maps: InteriorMap[] = [];
+      for (const m of inter.value.interiors ?? []) {
+        const { gz, ...rest } = m;
+        maps.push({ ...rest, tiles: await decodeWorldMap(fromBase64(gz)) });
+      }
+      setInteriors(maps, inter.value.gates ?? []);
+    }
     // ゲーム内クエスト (#423)。**報酬付与は edge が権威**なので必須。検証が NPC・モンスター・
     // アイテムの実在を引くため、**この 3 つより後に読む** (店 ← アイテムと同じ順序依存)。
     const quests = await getRecord<{ quests?: GameQuestDef[] }>(pds, did, `${nsid}.world.quests`, RKEY);

--- a/apps/edge/src/world-token.ts
+++ b/apps/edge/src/world-token.ts
@@ -33,6 +33,8 @@ export interface WorldTokenEnv {
 export interface PositionClaim {
   /** 本人確認用 (JWT の iss と一致必須)。 */
   did: string;
+  /** 今いるマップ (#424)。**省略 = 'world'** — 旧トークン (mapId 無し) をそのまま通す。 */
+  mapId?: string;
   x: number;
   y: number;
   /** 手数 (監査/デバッグ用。ステートレスなので厳密な単調性は担保しない)。 */

--- a/apps/edge/test/battle-resolver.test.ts
+++ b/apps/edge/test/battle-resolver.test.ts
@@ -3,7 +3,7 @@ import { p256 } from '@noble/curves/p256';
 import { base64urlnopad } from '@scure/base';
 import { sealEncounter, handleMove, handleTurn, handleReset, migrateInitState, ResolverError, GUARD_TTL_SEC, type ResolverEnv } from '../src/battle-resolver';
 import { writeServerTokens } from '../src/oauth-store';
-import { terrainAt, isWalkable, type Command } from '@aozoraquest/core';
+import { BASE_PALETTE, setInteriors, terrainAt, isWalkable, type Command, type InteriorMap } from '@aozoraquest/core';
 import { XP_EPOCH, type GameState } from '../src/game-state';
 
 const USER = 'did:plc:alice';
@@ -238,5 +238,85 @@ describe('battle-resolver (サーバー権威 移動/戦闘)', () => {
     expect(mock.store.has('guard')).toBe(false);
     // 冪等: state/guard 無しでも例外を投げない
     await expect(handleReset(env, USER, NOW)).resolves.toEqual({ ok: true });
+  });
+});
+
+describe('内部マップとゲート (#424)', () => {
+  const orig = globalThis.fetch;
+  afterEach(() => { globalThis.fetch = orig; setInteriors(null, null); });
+
+  const FLOOR = BASE_PALETTE.indexOf('plains');
+  const WALL = BASE_PALETTE.indexOf('mountain');
+  /** 外周が壁・中が床の 8×8。 */
+  const room = (id = 'in-1'): InteriorMap => {
+    const size = 8;
+    const tiles = new Uint8Array(size * size).fill(FLOOR);
+    for (let k = 0; k < size; k++) {
+      tiles[k] = WALL; tiles[(size - 1) * size + k] = WALL; tiles[k * size] = WALL; tiles[k * size + size - 1] = WALL;
+    }
+    return { id, name: 'へや', size, tiles };
+  };
+
+  /** フィールドの (x,y) から歩ける隣接マスを探す。 */
+  const walkableStep = (x: number, y: number) => {
+    for (const [dx, dy] of [[1, 0], [0, 1], [-1, 0], [0, -1]] as const) {
+      if (isWalkable(terrainAt(x + dx, y + dy))) return { dx, dy, nx: x + dx, ny: y + dy };
+    }
+    throw new Error('歩ける隣接マスがない');
+  };
+
+  it('フィールドのゲートを踏むと内部マップへ移り、mapId 付きのトークンが返る', async () => {
+    const env = await makeEnv();
+    globalThis.fetch = resolverMock({ diagnosis: DIAG, gameState: GS({ x: 10, y: 10 }) }).fn;
+    const step = walkableStep(10, 10);
+    setInteriors([room()], [{ from: { mapId: 'world', x: step.nx, y: step.ny }, to: { mapId: 'in-1', x: 4, y: 4 } }]);
+    const r = await handleMove(env, USER, step.dx, step.dy, undefined, NOW);
+    expect(r.mapId).toBe('in-1');
+    expect(r.x).toBe(4);
+    expect(r.y).toBe(4);
+    // 返ったトークンで内部を歩ける (内部の床は通れる)
+    const r2 = await handleMove(env, USER, 1, 0, r.token, NOW);
+    expect(r2.mapId).toBe('in-1');
+    expect(r2.x).toBe(5);
+  });
+
+  it('内部マップの壁には進めない (400)', async () => {
+    const env = await makeEnv();
+    globalThis.fetch = resolverMock({ diagnosis: DIAG, gameState: GS({ x: 10, y: 10 }) }).fn;
+    const step = walkableStep(10, 10);
+    setInteriors([room()], [{ from: { mapId: 'world', x: step.nx, y: step.ny }, to: { mapId: 'in-1', x: 1, y: 1 } }]);
+    const enter = await handleMove(env, USER, step.dx, step.dy, undefined, NOW);
+    // (1,1) の左と上は外周の壁
+    await expect(handleMove(env, USER, -1, 0, enter.token, NOW)).rejects.toMatchObject({ status: 400 });
+    await expect(handleMove(env, USER, 0, -1, enter.token, NOW)).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('内部マップは端で折り返さない (外周の外へは出られない)', async () => {
+    const env = await makeEnv();
+    globalThis.fetch = resolverMock({ diagnosis: DIAG, gameState: GS({ mapId: 'in-1', x: 1, y: 1 }) }).fn;
+    setInteriors([room()], []);
+    // state 由来の mapId で内部に居る。壁の向こう (負の座標) へは進めない。
+    await expect(handleMove(env, USER, -1, 0, undefined, NOW)).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('内部のゲートを踏むとフィールドへ戻る', async () => {
+    const env = await makeEnv();
+    globalThis.fetch = resolverMock({ diagnosis: DIAG, gameState: GS({ mapId: 'in-1', x: 4, y: 4 }) }).fn;
+    const back = walkableStep(20, 20); // 戻り先が歩ける地形になるよう実地形から選ぶ
+    setInteriors([room()], [{ from: { mapId: 'in-1', x: 5, y: 4 }, to: { mapId: 'world', x: back.nx, y: back.ny } }]);
+    const r = await handleMove(env, USER, 1, 0, undefined, NOW);
+    expect(r.mapId).toBeUndefined(); // フィールドは mapId を返さない (旧 client 互換)
+    expect(r.x).toBe(back.nx);
+    expect(r.y).toBe(back.ny);
+  });
+
+  it('定義が消えた内部マップに居てもフィールド扱いで動ける (取り残されない)', async () => {
+    const env = await makeEnv();
+    globalThis.fetch = resolverMock({ diagnosis: DIAG, gameState: GS({ mapId: 'deleted', x: 10, y: 10 }) }).fn;
+    setInteriors([], []); // そのマップはもう無い
+    const step = walkableStep(10, 10);
+    const r = await handleMove(env, USER, step.dx, step.dy, undefined, NOW);
+    expect(r.mapId).toBeUndefined();
+    expect(r.x).toBe(step.nx);
   });
 });

--- a/apps/edge/test/battle-resolver.test.ts
+++ b/apps/edge/test/battle-resolver.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { p256 } from '@noble/curves/p256';
 import { base64urlnopad } from '@scure/base';
-import { sealEncounter, handleMove, handleTurn, handleReset, migrateInitState, ResolverError, GUARD_TTL_SEC, type ResolverEnv } from '../src/battle-resolver';
+import { sealEncounter, handleMove, handleTeleport, handleTurn, handleReset, migrateInitState, ResolverError, GUARD_TTL_SEC, type ResolverEnv } from '../src/battle-resolver';
 import { writeServerTokens } from '../src/oauth-store';
-import { BASE_PALETTE, setInteriors, terrainAt, isWalkable, type Command, type InteriorMap } from '@aozoraquest/core';
+import { BASE_PALETTE, setInteriors, terrainAt, isWalkable, worldOverlay, type Command, type InteriorMap } from '@aozoraquest/core';
 import { XP_EPOCH, type GameState } from '../src/game-state';
 
 const USER = 'did:plc:alice';
@@ -310,6 +310,28 @@ describe('内部マップとゲート (#424)', () => {
     expect(r.y).toBe(back.ny);
   });
 
+  it('内部で遭遇した move の応答も mapId を落とさない', async () => {
+    // 落とすと web が「内部を抜けた」と誤認し、遭遇の裏でフィールドの地形が描かれる。
+    // 遭遇するかは seed 次第なので、応答に mapId が必ず載ることだけを確かめる。
+    const env = await makeEnv();
+    globalThis.fetch = resolverMock({ diagnosis: DIAG, gameState: GS({ mapId: 'in-1', x: 4, y: 4 }) }).fn;
+    setInteriors([{ ...room(), encounterTier: 3 }], []);
+    const r = await handleMove(env, USER, 1, 0, undefined, NOW);
+    expect(r.mapId).toBe('in-1');
+  });
+
+  it('そらのはねで内部から飛ぶと state の mapId が消える (壊れた state を残さない)', async () => {
+    const env = await makeEnv();
+    const m = resolverMock({ diagnosis: DIAG, gameState: GS({ mapId: 'in-1', x: 4, y: 4, materials: { 'sky-feather': 1 } }) });
+    globalThis.fetch = m.fn;
+    setInteriors([room()], []);
+    const town = worldOverlay().towns[0]!;
+    await handleTeleport(env, USER, town.x, town.y, NOW);
+    const stored = m.store.get('gs')!.value as GameState;
+    expect(stored.mapId).toBeUndefined();
+    expect(stored.x).toBe(town.x);
+  });
+
   it('定義が消えた内部マップに居てもフィールド扱いで動ける (取り残されない)', async () => {
     const env = await makeEnv();
     globalThis.fetch = resolverMock({ diagnosis: DIAG, gameState: GS({ mapId: 'deleted', x: 10, y: 10 }) }).fn;
@@ -318,5 +340,38 @@ describe('内部マップとゲート (#424)', () => {
     const r = await handleMove(env, USER, step.dx, step.dy, undefined, NOW);
     expect(r.mapId).toBeUndefined();
     expect(r.x).toBe(step.nx);
+  });
+});
+
+describe('内部マップの詰み対策 (#424 レビュー)', () => {
+  const orig = globalThis.fetch;
+  afterEach(() => { globalThis.fetch = orig; setInteriors(null, null); });
+
+  const FLOOR2 = BASE_PALETTE.indexOf('plains');
+  const WALL2 = BASE_PALETTE.indexOf('mountain');
+  const room2 = (): InteriorMap => {
+    const size = 8;
+    const tiles = new Uint8Array(size * size).fill(FLOOR2);
+    for (let k = 0; k < size; k++) {
+      tiles[k] = WALL2; tiles[(size - 1) * size + k] = WALL2; tiles[k * size] = WALL2; tiles[k * size + size - 1] = WALL2;
+    }
+    return { id: 'in-1', name: 'へや', size, tiles };
+  };
+
+  it('内部マップの範囲外に立っていてもフィールド扱いで脱出できる', async () => {
+    // 「mapId は内部のまま x/y は街の座標」という壊れた state (過去のバグ・手編集) でも
+    // 全方向 400 で固まらない。
+    const env = await makeEnv();
+    globalThis.fetch = resolverMock({ diagnosis: DIAG, gameState: GS({ mapId: 'in-1', x: 300, y: 300 }) }).fn;
+    setInteriors([room2()], []);
+    let moved = false;
+    for (const [dx, dy] of [[1, 0], [0, 1], [-1, 0], [0, -1]] as const) {
+      if (!isWalkable(terrainAt(300 + dx, 300 + dy))) continue;
+      const r = await handleMove(env, USER, dx, dy, undefined, NOW);
+      expect(r.mapId).toBeUndefined(); // フィールドとして動く
+      moved = true;
+      break;
+    }
+    expect(moved).toBe(true);
   });
 });

--- a/apps/web/src/lib/collections.ts
+++ b/apps/web/src/lib/collections.ts
@@ -97,6 +97,8 @@ export const ADMIN_COL = {
   quests: `${ROOT}.world.quests`,
   /** ジョブのパラメータ上書き (ステータス比・たいりょく・曲線・装備適性)。#544 */
   jobs: `${ROOT}.world.jobs`,
+  /** 内部マップ (街の中・城・ダンジョン) とゲート。#424 */
+  interiors: `${ROOT}.world.interiors`,
   /** 依頼クエスト集約 (docs/15-user-quest.md §集約インフラ)。
    *  Worker が主管理者 PDS に書く。env 別に rkey を分ける (dev→'dev', prod→'self')。 */
   questIndex: `${ROOT}.questIndex`,

--- a/apps/web/src/lib/world-authoring.ts
+++ b/apps/web/src/lib/world-authoring.ts
@@ -6,6 +6,7 @@ import {
   loadStaticWorldMap,
   loadTileArts,
   setGameQuests,
+  setInteriors,
   setJobOverrides,
   setItemOverrides,
   setMonsterOverrides,
@@ -19,7 +20,9 @@ import {
   worldTownOverrides,
   WORLD_SIZE,
   type EquipmentDef,
+  type Gate,
   type GameQuestDef,
+  type InteriorMap,
   type JobOverride,
   type ItemDefData,
   type MonsterDef,
@@ -178,6 +181,20 @@ export async function loadAuthoredWorld(agent: Agent | null): Promise<void> {
       console.warn('[world] npcs load failed', e);
     }
     try {
+      // 内部マップとゲート (#424)。移動判定に効くので web も必ず読む。
+      const rec = await getRecord<{ interiors?: Array<Omit<InteriorMap, 'tiles'> & { gz: string }>; gates?: Gate[] }>(agent, adminDid, ADMIN_COL.interiors, RKEY);
+      if (rec) {
+        const maps: InteriorMap[] = [];
+        for (const m of rec.interiors ?? []) {
+          const { gz, ...rest } = m;
+          maps.push({ ...rest, tiles: await decodeWorldMap(fromBase64(gz)) });
+        }
+        setInteriors(maps, rec.gates ?? []);
+      }
+    } catch (e) {
+      console.warn('[world] interiors load failed', e);
+    }
+    try {
       // ジョブ (#544)。装備カテゴリを検証するのでアイテムより後だが、他への依存はない。
       const rec = await getRecord<{ jobs?: JobOverride[] }>(agent, adminDid, ADMIN_COL.jobs, RKEY);
       if (rec?.jobs) setJobOverrides(rec.jobs);
@@ -255,6 +272,33 @@ export async function loadJobsRecord(agent: Agent, adminDid: string): Promise<Jo
   if (!rec?.jobs) return null;
   setJobOverrides(rec.jobs);
   return rec.jobs;
+}
+
+/**
+ * 内部マップとゲート (#424)。タイルは gzip+base64 (フィールドの地図と同じ形式)。
+ * setInteriors が先に検証で落とす (行き先が無いゲートを保存させない)。
+ */
+export async function saveInteriors(agent: Agent, maps: InteriorMap[], gates: Gate[]): Promise<void> {
+  setInteriors(maps, gates);
+  const interiors = [];
+  for (const m of maps) {
+    const { tiles, ...rest } = m;
+    interiors.push({ ...rest, gz: toBase64(await encodeWorldMap(tiles)) });
+  }
+  await putRecord(agent, ADMIN_COL.interiors, RKEY, { interiors, gates, updatedAt: new Date().toISOString() });
+}
+
+/** 内部マップだけを読む (エディタ用。読めたかどうかを返す = 上書き事故を防ぐ)。 */
+export async function loadInteriorsRecord(agent: Agent, adminDid: string): Promise<{ maps: InteriorMap[]; gates: Gate[] }> {
+  const rec = await getRecord<{ interiors?: Array<Omit<InteriorMap, 'tiles'> & { gz: string }>; gates?: Gate[] }>(agent, adminDid, ADMIN_COL.interiors, RKEY);
+  const maps: InteriorMap[] = [];
+  for (const m of rec?.interiors ?? []) {
+    const { gz, ...rest } = m;
+    maps.push({ ...rest, tiles: await decodeWorldMap(fromBase64(gz)) });
+  }
+  const gates = rec?.gates ?? [];
+  setInteriors(maps, gates);
+  return { maps, gates };
 }
 
 /** ジョブのパラメータ (#544)。setJobOverrides が先に検証で落とす。 */

--- a/apps/web/src/lib/world-server.ts
+++ b/apps/web/src/lib/world-server.ts
@@ -89,11 +89,13 @@ async function callEdge<T>(agent: Agent, lxm: string, path: string, body: unknow
 export interface ServerMonster { name: string; maxHp: number; hp: number; maxMp: number; mp: number; [k: string]: unknown }
 export interface ServerBattleState { player: ServerMonster; monster: ServerMonster; monsterId: string; outcome: string; turn: number; lastEvents: { actor: string; text: string }[]; [k: string]: unknown }
 export interface ServerEncounter { battleId: string; monsterId: string; state: ServerBattleState; rewarded: boolean }
-export interface ServerMoveResult { x: number; y: number; terrain: string; healed?: boolean; token: string; encounter?: ServerEncounter }
+export interface ServerMoveResult {
+  /** 移動後のマップ (#424)。省略 = フィールド。 */
+  mapId?: string; x: number; y: number; terrain: string; healed?: boolean; token: string; encounter?: ServerEncounter }
 /** 権威 GameState (パワー/XP/素材/位置/carry HP-MP 等)。表示はこれを正とする。 */
 /** 所持装備の 1 個体 (#551 段階 2)。**権威側が唯一の正**で、ここに無い個体は装備できない。 */
 export interface ServerOwnedPiece { rkey: string; itemId: string; level: number }
-export interface ServerGameState { did: string; power: number; playerXp: number; jobXp: Record<string, number>; materials: Record<string, number>; gear: string[]; pieces?: ServerOwnedPiece[]; x: number; y: number; carryHp?: number; carryMp?: number; herbs?: number; tonics?: number; quest?: { id: string; progress: number }; questsDone?: string[]; version: number; updatedAt: string }
+export interface ServerGameState { did: string; power: number; playerXp: number; jobXp: Record<string, number>; materials: Record<string, number>; gear: string[]; pieces?: ServerOwnedPiece[]; x: number; y: number; carryHp?: number; carryMp?: number; herbs?: number; tonics?: number; mapId?: string; quest?: { id: string; progress: number }; questsDone?: string[]; version: number; updatedAt: string }
 export interface ServerStateResult { state: ServerGameState; initialized: boolean; token?: string }
 export interface ServerAward {
   /** パワー不足で報酬対象外だった (勝っても逃げても XP・素材が入らない)。 */

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -26,6 +26,7 @@ const AdminShops = lazy(() => import('@/routes/admin-shops').then(m => ({ defaul
 const AdminNpcs = lazy(() => import('@/routes/admin-npcs').then(m => ({ default: m.AdminNpcs })));
 const AdminQuests = lazy(() => import('@/routes/admin-quests').then(m => ({ default: m.AdminQuests })));
 const AdminJobs = lazy(() => import('@/routes/admin-jobs').then(m => ({ default: m.AdminJobs })));
+const AdminInteriors = lazy(() => import('@/routes/admin-interiors').then(m => ({ default: m.AdminInteriors })));
 const World = lazy(() => import('@/routes/world').then(m => ({ default: m.World })));
 const Onboarding = lazy(() => import('@/routes/onboarding').then(m => ({ default: m.Onboarding })));
 const OAuthCallback = lazy(() => import('@/routes/oauth-callback').then(m => ({ default: m.OAuthCallback })));
@@ -93,6 +94,7 @@ const router = createBrowserRouter([
       { path: 'admin/npcs', element: <AdminNpcs /> },
       { path: 'admin/quests', element: <AdminQuests /> },
       { path: 'admin/jobs', element: <AdminJobs /> },
+      { path: 'admin/interiors', element: <AdminInteriors /> },
       { path: 'world', element: <World /> },
       { path: 'onboarding', element: <Onboarding /> },
       { path: 'oauth/callback', element: <OAuthCallback /> },

--- a/apps/web/src/routes/admin-dashboard.tsx
+++ b/apps/web/src/routes/admin-dashboard.tsx
@@ -39,7 +39,7 @@ const CONTENT_SECTIONS: Section[] = [
   { key: 'jobs', title: 'ジョブ', desc: 'ステータス比・たいりょく・曲線・装備適性 + 連戦シミュ', to: '/admin/jobs', issue: 544 },
   { key: 'npc', title: 'NPC', desc: '位置・名前・セリフ・絵 (フラグ制御は #425 で続き)', to: '/admin/npcs', issue: 425 },
   { key: 'quest', title: 'クエスト', desc: 'NPC 発注・達成条件 (討伐/収集)・報酬', to: '/admin/quests', issue: 423 },
-  { key: 'places', title: '街 / ダンジョン / 城', desc: '内部マップの編集', issue: 424 },
+  { key: 'places', title: '街 / ダンジョン / 城', desc: '内部マップとゲート (出入口) の編集', to: '/admin/interiors', issue: 424 },
   { key: 'scenario', title: 'シナリオ', desc: '進行の筋書き', issue: 545 },
   { key: 'items', title: 'アイテム', desc: 'そうび・どうぐ・素材の編集', to: '/admin/items', issue: 420 },
   { key: 'shops', title: 'お店', desc: '店ごとのラインナップ・値札の素材 (セリフは #422 で続き)', to: '/admin/shops', issue: 422 },

--- a/apps/web/src/routes/admin-interiors.tsx
+++ b/apps/web/src/routes/admin-interiors.tsx
@@ -6,6 +6,7 @@ import {
   MAX_INTERIOR_SIZE,
   WORLD_MAP_ID,
   interiorPartAt,
+  interiorWalkableAt,
   worldParts,
   type Gate,
   type InteriorMap,
@@ -265,6 +266,7 @@ export function AdminInteriors() {
                 const r = (e.currentTarget as SVGSVGElement).getBoundingClientRect();
                 const cx = Math.floor(((e.clientX - r.left) / r.width) * current.size);
                 const cy = Math.floor(((e.clientY - r.top) / r.height) * current.size);
+                if (linking && !e.shiftKey) { setLinking(null); setNote('ゲートの行き先選びをやめた'); return; }
                 if (e.shiftKey) {
                   // Shift = ゲート。1 回目で入口、2 回目で出口 (一方通行 1 本ぶん)。
                   if (!linking) { setLinking({ mapId: current.id, x: cx, y: cy }); return; }
@@ -325,7 +327,9 @@ export function AdminInteriors() {
             {/* フィールド ⇄ このマップ のゲートは座標入力で張る (フィールドは広すぎて
                 この画面に出せないため。マップエディタ側の座標表示を見て入れる) */}
             <WorldGateForm
+              key={current.id}
               mapId={current.id}
+              map={current}
               size={current.size}
               onAdd={(g) => { setGates((gs) => [...gs.filter((x) => !(x.from.mapId === g.from.mapId && x.from.x === g.from.x && x.from.y === g.from.y)), g]); setDirty(true); }}
             />
@@ -339,11 +343,16 @@ export function AdminInteriors() {
 }
 
 /** フィールド側の入口 (x, y) → この内部マップ の 1 本と、その戻り 1 本を張る。 */
-function WorldGateForm({ mapId, size, onAdd }: { mapId: string; size: number; onAdd: (g: Gate) => void }) {
+function WorldGateForm({ mapId, map, size, onAdd }: { mapId: string; map: InteriorMap; size: number; onAdd: (g: Gate) => void }) {
   const [wx, setWx] = useState(0);
   const [wy, setWy] = useState(0);
   const [ix, setIx] = useState(Math.floor(size / 2));
-  const [iy, setIy] = useState(size - 2);
+  // 出口は下から 3 マス目。**戻りゲートを出口の 1 マス下に張る**ので、既定 size-2 だと
+  // 戻りが外周の壁に乗って踏めなくなる (= 入ったら出られない罠。レビュー ★★★)。
+  const [iy, setIy] = useState(Math.max(1, size - 3));
+  // 戻りゲートが壁の上だと**踏めない = 入ったら出られない**ので、張る前に気づかせる。
+  const backBlocked = !interiorWalkableAt(map, ix, iy + 1);
+  const exitBlocked = !interiorWalkableAt(map, ix, iy);
   return (
     <div style={{ fontSize: '0.8em', borderTop: '1px solid var(--color-border)', paddingTop: '0.4em' }}>
       <span style={{ color: 'var(--color-muted)' }}>フィールドと繋ぐ (マップエディタの座標表示と同じ)</span>
@@ -354,6 +363,7 @@ function WorldGateForm({ mapId, size, onAdd }: { mapId: string; size: number; on
         y<input type="number" value={iy} onChange={(e) => setIy(Number(e.target.value))} style={{ width: '4em' }} />
         <button
           type="button"
+          disabled={backBlocked || exitBlocked}
           onClick={() => {
             // **往復 2 本まとめて張る。** 入る道だけ作ると出られなくなる。
             onAdd({ from: { mapId: WORLD_MAP_ID, x: wx, y: wy }, to: { mapId, x: ix, y: iy } });
@@ -363,8 +373,12 @@ function WorldGateForm({ mapId, size, onAdd }: { mapId: string; size: number; on
           往復を張る
         </button>
       </div>
-      <span style={{ color: 'var(--color-muted)' }}>
-        戻りは出口の 1 マス下 → フィールドの入口の 1 マス下 に張る (入口を踏み直して即戻るのを防ぐ)
+      <span style={{ color: backBlocked || exitBlocked ? 'var(--color-danger)' : 'var(--color-muted)' }}>
+        {exitBlocked
+          ? `出口 (${ix}, ${iy}) が歩けないマス。床の上に置いて`
+          : backBlocked
+            ? `戻り口 (${ix}, ${iy + 1}) が歩けないマス。壁の上のゲートは踏めないので、出口を 1 つ上へ`
+            : '戻りは出口の 1 マス下 → フィールドの入口の 1 マス下 に張る (入口を踏み直して即戻るのを防ぐ)'}
       </span>
     </div>
   );

--- a/apps/web/src/routes/admin-interiors.tsx
+++ b/apps/web/src/routes/admin-interiors.tsx
@@ -1,0 +1,371 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  BASE_PALETTE,
+  InteriorError,
+  MAX_INTERIOR_SIZE,
+  WORLD_MAP_ID,
+  interiorPartAt,
+  worldParts,
+  type Gate,
+  type InteriorMap,
+  type Terrain,
+} from '@aozoraquest/core';
+import { useSession } from '@/lib/session';
+import { getPrimaryAdminDid, isAdminDid } from '@/lib/runtime-config';
+import { loadInteriorsRecord, saveInteriors } from '@/lib/world-authoring';
+import { TERRAIN_TILES, fallbackTile, pixelPart } from '@/components/world-tiles';
+
+/**
+ * **内部マップエディタ** (#424)。街の中・城・ダンジョンを描き、フィールドと繋ぐ。
+ *
+ * フィールドのマップエディタ (#421) と同じ「パーツを置く」方式。違いは:
+ * - **端で折り返さない** (外へ出るのはゲートからだけ) ので、全体が 1 画面に収まる
+ * - **ゲート** (出入口) を張る画面がある。ゲートは一方通行なので、往復は 2 本要る
+ */
+
+/** 新しい内部マップの既定の広さ。 */
+const DEFAULT_SIZE = 16;
+const BOX = 448;
+
+function partOf(index: number, terrain: string) {
+  return pixelPart(index, terrain) ?? TERRAIN_TILES[terrain as Terrain] ?? fallbackTile(terrain);
+}
+
+export function AdminInteriors() {
+  const session = useSession();
+  const admin = isAdminDid(session.did ?? null);
+  const [maps, setMaps] = useState<InteriorMap[]>([]);
+  const [gates, setGates] = useState<Gate[]>([]);
+  const [sel, setSel] = useState<string | null>(null);
+  const [brush, setBrush] = useState(0);
+  const [note, setNote] = useState<string | null>(null);
+  const [dirty, setDirty] = useState(false);
+  const [loadState, setLoadState] = useState<'loading' | 'ok' | 'failed'>('loading');
+  /** ゲートを張る途中 (from を選んだ状態)。 */
+  const [linking, setLinking] = useState<{ mapId: string; x: number; y: number } | null>(null);
+  const painting = useRef(false);
+  const svgRef = useRef<SVGSVGElement>(null);
+  const parts = useMemo(() => [...worldParts()], []);
+
+  // 保存済みを読めなければ保存させない (コード値/空で上書きすると全部消える)。
+  useEffect(() => {
+    let cancelled = false;
+    const agent = session.agent;
+    const adminDid = getPrimaryAdminDid();
+    if (!agent || !adminDid) { setLoadState('failed'); return; }
+    void loadInteriorsRecord(agent, adminDid)
+      .then((r) => {
+        if (cancelled) return;
+        setMaps(r.maps.map((m) => ({ ...m, tiles: new Uint8Array(m.tiles) })));
+        setGates(r.gates.map((g) => ({ from: { ...g.from }, to: { ...g.to } })));
+        setLoadState('ok');
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        console.warn('[admin] interiors load failed', e);
+        setLoadState('failed');
+        setNote('保存済みの内部マップを読み込めなかった。上書きで消える恐れがあるので保存できない');
+      });
+    return () => { cancelled = true; };
+  }, [session.agent]);
+
+  const current = useMemo(() => maps.find((m) => m.id === sel) ?? null, [maps, sel]);
+
+  const addMap = useCallback(() => {
+    let i = maps.length + 1;
+    while (maps.some((m) => m.id === `in-${i}`)) i++;
+    // 既定は「床で埋めて外周を壁」— 白紙 (全部 index 0) だと外に歩いて出られてしまう。
+    const size = DEFAULT_SIZE;
+    const floor = Math.max(0, BASE_PALETTE.indexOf('plains'));
+    const wall = Math.max(0, BASE_PALETTE.indexOf('mountain'));
+    const tiles = new Uint8Array(size * size).fill(floor);
+    for (let k = 0; k < size; k++) {
+      tiles[k] = wall;
+      tiles[(size - 1) * size + k] = wall;
+      tiles[k * size] = wall;
+      tiles[k * size + size - 1] = wall;
+    }
+    const m: InteriorMap = { id: `in-${i}`, name: 'あたらしい内部マップ', size, tiles };
+    setMaps((xs) => [...xs, m]);
+    setSel(m.id);
+    setDirty(true);
+  }, [maps]);
+
+  const paintAt = useCallback((cx: number, cy: number) => {
+    if (!current) return;
+    if (cx < 0 || cy < 0 || cx >= current.size || cy >= current.size) return;
+    setMaps((xs) => xs.map((m) => {
+      if (m.id !== current.id) return m;
+      const tiles = new Uint8Array(m.tiles);
+      tiles[cy * m.size + cx] = brush;
+      return { ...m, tiles };
+    }));
+    setDirty(true);
+  }, [current, brush]);
+
+  const pointerPaint = useCallback((clientX: number, clientY: number) => {
+    const svg = svgRef.current;
+    if (!svg || !current) return;
+    const r = svg.getBoundingClientRect();
+    const cx = Math.floor(((clientX - r.left) / r.width) * current.size);
+    const cy = Math.floor(((clientY - r.top) / r.height) * current.size);
+    if (linking !== null) return; // ゲート張り中は塗らない
+    paintAt(cx, cy);
+  }, [current, paintAt, linking]);
+
+  const save = useCallback(async () => {
+    if (!session.agent) return;
+    try {
+      await saveInteriors(session.agent, maps, gates);
+      setDirty(false);
+      setNote(`${maps.length} マップ / ${gates.length} ゲートを保存した。サーバーは最大 5 分で拾う`);
+    } catch (e) {
+      setNote(e instanceof InteriorError ? `保存できない: ${e.message}` : `保存できなかった: ${String(e)}`);
+    }
+  }, [session.agent, maps, gates]);
+
+  if (!admin) {
+    return (
+      <div style={{ padding: '1em' }}>
+        <p>この画面は管理者だけが使えます。</p>
+        <Link to="/admin">管理ダッシュボードへ</Link>
+      </div>
+    );
+  }
+
+  const tile = current ? BOX / current.size : 0;
+  const gatesHere = current ? gates.filter((g) => g.from.mapId === current.id) : [];
+
+  return (
+    <div style={{ padding: '0.8em', maxWidth: 980 }}>
+      <div style={{ display: 'flex', gap: '0.6em', alignItems: 'center', marginBottom: '0.4em' }}>
+        <Link to="/admin" style={{ fontSize: '0.8em' }}>← 管理</Link>
+        <strong>内部マップ</strong>
+        <span style={{ fontSize: '0.75em', color: 'var(--color-muted)' }}>{maps.length} マップ / {gates.length} ゲート</span>
+        <button type="button" onClick={addMap} style={{ fontSize: '0.85em' }}>＋マップ</button>
+        <button type="button" onClick={() => void save()} disabled={!session.agent || !dirty || loadState !== 'ok'} style={{ marginLeft: 'auto', fontSize: '0.85em' }}>
+          保存
+        </button>
+      </div>
+
+      {note && <p style={{ fontSize: '0.8em', color: 'var(--color-accent)', margin: '0 0 0.4em' }}>{note}</p>}
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'minmax(150px, 1fr) 3fr', gap: '0.8em' }}>
+        <div style={{ maxHeight: '75vh', overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 2 }}>
+          {maps.map((m) => (
+            <button
+              key={m.id}
+              type="button"
+              onClick={() => setSel(m.id)}
+              style={{
+                display: 'flex', gap: '0.3em', width: '100%', padding: '0.2em 0.4em', fontSize: '0.85em', textAlign: 'left',
+                border: sel === m.id ? '2px solid var(--color-accent)' : '1px solid var(--color-border)', background: 'transparent',
+              }}
+            >
+              <span style={{ flex: 1 }}>{m.name}</span>
+              <span style={{ fontSize: '0.75em', color: 'var(--color-muted)' }}>{m.size}²</span>
+            </button>
+          ))}
+          {maps.length === 0 && <span style={{ fontSize: '0.8em', color: 'var(--color-muted)' }}>まだ無い。「＋マップ」で作る</span>}
+        </div>
+
+        {current ? (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.4em' }}>
+            <div style={{ display: 'flex', gap: '0.4em', alignItems: 'center', flexWrap: 'wrap', fontSize: '0.8em' }}>
+              <input
+                value={current.name}
+                onChange={(e) => { setMaps((xs) => xs.map((m) => (m.id === current.id ? { ...m, name: e.target.value } : m))); setDirty(true); }}
+                style={{ width: '12em' }}
+              />
+              <code style={{ fontSize: '0.85em', color: 'var(--color-muted)' }}>{current.id}</code>
+              <label>
+                おおきさ{' '}
+                <input
+                  type="number" min={4} max={MAX_INTERIOR_SIZE} value={current.size}
+                  onChange={(e) => {
+                    const size = Math.max(4, Math.min(MAX_INTERIOR_SIZE, Number(e.target.value) || 4));
+                    setMaps((xs) => xs.map((m) => {
+                      if (m.id !== current.id) return m;
+                      // 広げ縮めても既存の絵を保つ (作り直させない)。増えた分は 0 (床)。
+                      const tiles = new Uint8Array(size * size);
+                      for (let y = 0; y < Math.min(size, m.size); y++) {
+                        for (let x = 0; x < Math.min(size, m.size); x++) tiles[y * size + x] = m.tiles[y * m.size + x]!;
+                      }
+                      return { ...m, size, tiles };
+                    }));
+                    setDirty(true);
+                  }}
+                  style={{ width: '4.5em' }}
+                />
+              </label>
+              <label>
+                危険度{' '}
+                <select
+                  value={current.encounterTier ?? ''}
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    setMaps((xs) => xs.map((m) => {
+                      if (m.id !== current.id) return m;
+                      if (v === '') { const { encounterTier: _t, ...rest } = m; return rest as InteriorMap; }
+                      return { ...m, encounterTier: Number(v) };
+                    }));
+                    setDirty(true);
+                  }}
+                >
+                  <option value="">敵なし</option>
+                  {[1, 2, 3, 4, 5, 6, 7, 8].map((t) => <option key={t} value={t}>tier {t}</option>)}
+                </select>
+              </label>
+              <button
+                type="button"
+                className="secondary"
+                onClick={() => {
+                  if (!window.confirm(`「${current.name}」を消す？\nこのマップへのゲートも一緒に消える`)) return;
+                  setMaps((xs) => xs.filter((m) => m.id !== current.id));
+                  // 参照が残ると保存時に検証で落ちる (行き先の無いゲート) ので一緒に掃除する。
+                  setGates((gs) => gs.filter((g) => g.from.mapId !== current.id && g.to.mapId !== current.id));
+                  setSel(null);
+                  setDirty(true);
+                }}
+                style={{ marginLeft: 'auto', fontSize: '0.8em' }}
+              >
+                削除
+              </button>
+            </div>
+
+            {/* パーツのパレット (フィールドと共用) */}
+            <div style={{ display: 'flex', gap: 3, flexWrap: 'wrap', alignItems: 'center' }}>
+              {parts.map((pt, i) => (
+                <button
+                  key={i}
+                  type="button"
+                  onClick={() => setBrush(i)}
+                  title={pt.name}
+                  style={{ padding: 0, lineHeight: 0, border: brush === i ? '3px solid var(--color-accent)' : '1px solid var(--color-border)' }}
+                >
+                  <svg width={32} height={32} viewBox="0 0 32 32">{partOf(i, pt.terrain)}</svg>
+                </button>
+              ))}
+            </div>
+
+            <div style={{ fontSize: '0.8em', color: linking ? 'var(--color-accent)' : 'var(--color-muted)' }}>
+              {linking
+                ? `ゲートの出口を選ぶ: ${linking.mapId === WORLD_MAP_ID ? 'フィールド' : linking.mapId} (${linking.x}, ${linking.y}) → ここをクリック`
+                : 'クリックで配置 / ドラッグで連続。Shift + クリックでゲートの入口にする'}
+            </div>
+
+            <svg
+              ref={svgRef}
+              width={BOX}
+              height={BOX}
+              viewBox={`0 0 ${current.size * 32} ${current.size * 32}`}
+              onPointerDown={(e) => {
+                e.preventDefault();
+                const r = (e.currentTarget as SVGSVGElement).getBoundingClientRect();
+                const cx = Math.floor(((e.clientX - r.left) / r.width) * current.size);
+                const cy = Math.floor(((e.clientY - r.top) / r.height) * current.size);
+                if (e.shiftKey) {
+                  // Shift = ゲート。1 回目で入口、2 回目で出口 (一方通行 1 本ぶん)。
+                  if (!linking) { setLinking({ mapId: current.id, x: cx, y: cy }); return; }
+                  setGates((gs) => [...gs.filter((g) => !(g.from.mapId === linking.mapId && g.from.x === linking.x && g.from.y === linking.y)),
+                    { from: linking, to: { mapId: current.id, x: cx, y: cy } }]);
+                  setLinking(null);
+                  setDirty(true);
+                  return;
+                }
+                painting.current = true;
+                (e.currentTarget as SVGSVGElement).setPointerCapture(e.pointerId);
+                paintAt(cx, cy);
+              }}
+              onPointerMove={(e) => { if (painting.current) pointerPaint(e.clientX, e.clientY); }}
+              onPointerUp={(e) => {
+                painting.current = false;
+                try { (e.currentTarget as SVGSVGElement).releasePointerCapture(e.pointerId); } catch { /* 既に外れている */ }
+              }}
+              onPointerCancel={() => { painting.current = false; }}
+              style={{ display: 'block', cursor: linking ? 'crosshair' : 'pointer', touchAction: 'none', userSelect: 'none' }}
+            >
+              <defs>
+                {[...new Set(Array.from(current.tiles))].map((idx) => (
+                  <g id={`it-${idx}`} key={idx}>{partOf(idx, parts[idx]?.terrain ?? BASE_PALETTE[idx] ?? 'plains')}</g>
+                ))}
+              </defs>
+              {Array.from({ length: current.size }).map((_, cy) =>
+                Array.from({ length: current.size }).map((_, cx) => (
+                  <use key={`${cx}-${cy}`} href={`#it-${interiorPartAt(current, cx, cy)}`} x={cx * 32} y={cy * 32} />
+                )),
+              )}
+              {/* ゲートの印 (どのマスが出入口か分からないと張り直せない) */}
+              {gatesHere.map((g) => (
+                <g key={`${g.from.x}-${g.from.y}`} transform={`translate(${g.from.x * 32},${g.from.y * 32})`}>
+                  <rect x={2} y={2} width={28} height={28} fill="none" stroke="#f5d442" strokeWidth={3} />
+                  <title>{`→ ${g.to.mapId === WORLD_MAP_ID ? 'フィールド' : g.to.mapId} (${g.to.x}, ${g.to.y})`}</title>
+                </g>
+              ))}
+            </svg>
+
+            <div style={{ fontSize: '0.8em' }}>
+              <span style={{ color: 'var(--color-muted)' }}>このマップのゲート</span>
+              {gatesHere.length === 0 && <div style={{ color: 'var(--color-muted)' }}>まだ無い</div>}
+              {gatesHere.map((g) => (
+                <div key={`${g.from.x},${g.from.y}`} style={{ display: 'flex', gap: '0.4em', alignItems: 'center' }}>
+                  <span>({g.from.x}, {g.from.y}) → {g.to.mapId === WORLD_MAP_ID ? 'フィールド' : maps.find((m) => m.id === g.to.mapId)?.name ?? g.to.mapId} ({g.to.x}, {g.to.y})</span>
+                  <button
+                    type="button"
+                    onClick={() => { setGates((gs) => gs.filter((x) => x !== g)); setDirty(true); }}
+                    style={{ fontSize: '0.8em' }}
+                  >
+                    ×
+                  </button>
+                </div>
+              ))}
+            </div>
+
+            {/* フィールド ⇄ このマップ のゲートは座標入力で張る (フィールドは広すぎて
+                この画面に出せないため。マップエディタ側の座標表示を見て入れる) */}
+            <WorldGateForm
+              mapId={current.id}
+              size={current.size}
+              onAdd={(g) => { setGates((gs) => [...gs.filter((x) => !(x.from.mapId === g.from.mapId && x.from.x === g.from.x && x.from.y === g.from.y)), g]); setDirty(true); }}
+            />
+          </div>
+        ) : (
+          <div style={{ fontSize: '0.85em', color: 'var(--color-muted)' }}>左の一覧から選ぶか「＋マップ」。</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** フィールド側の入口 (x, y) → この内部マップ の 1 本と、その戻り 1 本を張る。 */
+function WorldGateForm({ mapId, size, onAdd }: { mapId: string; size: number; onAdd: (g: Gate) => void }) {
+  const [wx, setWx] = useState(0);
+  const [wy, setWy] = useState(0);
+  const [ix, setIx] = useState(Math.floor(size / 2));
+  const [iy, setIy] = useState(size - 2);
+  return (
+    <div style={{ fontSize: '0.8em', borderTop: '1px solid var(--color-border)', paddingTop: '0.4em' }}>
+      <span style={{ color: 'var(--color-muted)' }}>フィールドと繋ぐ (マップエディタの座標表示と同じ)</span>
+      <div style={{ display: 'flex', gap: '0.3em', alignItems: 'center', flexWrap: 'wrap', marginTop: '0.2em' }}>
+        フィールド x<input type="number" value={wx} onChange={(e) => setWx(Number(e.target.value))} style={{ width: '5.5em' }} />
+        y<input type="number" value={wy} onChange={(e) => setWy(Number(e.target.value))} style={{ width: '5.5em' }} />
+        → 出口 x<input type="number" value={ix} onChange={(e) => setIx(Number(e.target.value))} style={{ width: '4em' }} />
+        y<input type="number" value={iy} onChange={(e) => setIy(Number(e.target.value))} style={{ width: '4em' }} />
+        <button
+          type="button"
+          onClick={() => {
+            // **往復 2 本まとめて張る。** 入る道だけ作ると出られなくなる。
+            onAdd({ from: { mapId: WORLD_MAP_ID, x: wx, y: wy }, to: { mapId, x: ix, y: iy } });
+            onAdd({ from: { mapId, x: ix, y: iy + 1 }, to: { mapId: WORLD_MAP_ID, x: wx, y: wy + 1 } });
+          }}
+        >
+          往復を張る
+        </button>
+      </div>
+      <span style={{ color: 'var(--color-muted)' }}>
+        戻りは出口の 1 マス下 → フィールドの入口の 1 マス下 に張る (入口を踏み直して即戻るのを防ぐ)
+      </span>
+    </div>
+  );
+}

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -359,6 +359,8 @@ export function World() {
         // 使うことで、初回移動でクライアント位置とサーバー位置がズレて「ワープ」するのを防ぐ。
         // 街/地図/HP 等の探索メモは従来どおり client の world-record を使う。取得失敗時は world-record 位置。
         let px = state.x, py = state.y;
+        /** サーバー権威の mapId (#424)。内部マップに居るならその id。 */
+        let serverMapId: string | undefined;
         // サーバー gameState を在庫/HP/位置の**唯一の正**とする (#372)。取得失敗時のみ world-record にフォールバック。
         try {
           const ss = await serverState(agent);
@@ -366,6 +368,7 @@ export function World() {
             serverInv = { materials: ss.state.materials ?? {}, carryHp: ss.state.carryHp, carryMp: ss.state.carryMp };
             setServerPower(ss.state.power ?? 0);
             questRef.current = { ...(ss.state.quest ? { active: ss.state.quest } : {}), done: ss.state.questsDone ?? [] };
+            serverMapId = ss.state.mapId;
             // **所持個体もサーバーが正** (#551 段階 2)。ユーザー PDS の craft レコードは
             // 記帳 (履歴) であって所持の根拠ではない。
             if (ss.state.pieces) setCraftedPieces(ss.state.pieces.map((p) => ({ rkey: p.rkey, itemId: p.itemId, level: p.level, at: '' })));
@@ -385,6 +388,10 @@ export function World() {
           ? [...state.visitedTowns, { x: px, y: py }]
           : state.visitedTowns;
         const initialWs = {
+          // **内部マップ (#424) を維持する。** ここで捨てると、内部でリロードした瞬間
+          // 内部座標をフィールドとして描き、移動判定もフィールドで行って食い違う
+          // (サーバーは mapId 入りのトークンを返している。レビュー ★★)。
+          ...(serverMapId ? { mapId: serverMapId } : {}),
           x: px,
           y: py,
           // HP/MP はサーバー権威 (carryHp/Mp)。undefined=満タンなので null に。取得失敗時のみ world-record。
@@ -531,7 +538,9 @@ export function World() {
       // **NPC にぶつかったら会話** (#425)。DQ の作法: 移動はせず、話しかける。
       // クエスト発注 NPC (#423) は状況で話が変わる: 未受注→依頼 (読了で受注)、
       // 進行中→達成を試みる (条件検証はサーバー)、達成済み→通常セリフ。
-      const npc = npcAt(nx, ny);
+      // NPC はフィールドにしか置けない (#425 の座標に mapId が無い)。内部で引くと
+      // 同じ座標の NPC が「幽霊」として現れ、戻りゲートを塞ぐこともある (レビュー ★★)。
+      const npc = cur ? undefined : npcAt(nx, ny);
       if (npc) {
         const q = gameQuestByNpc(npc.id);
         const qs = questRef.current;
@@ -1196,12 +1205,16 @@ export function World() {
   // シーン (敵+ログ) はマップ上オーバーレイ、コマンド/リザルトはマップ下に出す。
   const inBattle = battle !== null && (wipe === null || wipe === 'reveal');
 
-  const town = townAt(ws.x, ws.y);
   const insideHere = ws.mapId ? interiorById(ws.mapId) ?? null : null;
+  // 内部では**フィールドの街表を引かない** — 内部座標がたまたま街と重なると、
+  // 街の HUD が出て「なんでも屋」が生えるのにサーバーは回復しない、という食い違いになる。
+  const town = insideHere ? null : townAt(ws.x, ws.y);
   const here = insideHere ? interiorTerrainAt(insideHere, ws.x, ws.y) : terrainAt(ws.x, ws.y);
   // 地域相性: この地方で出やすいモンスター名を現地ヒントにする (相性が見えない導線対策)
   // 「このあたり」の見出しと「何が多いか」は同じ tier を見る (ラベルと中身が食い違わないように)。
-  const hereTier = tierForRegion(regionOf(ws.x, ws.y));
+  // 内部マップ (#424) の座標はローカル系なので、地域から引く危険度・敵は意味を持たない
+  // (常に region 0 になる)。内部では自分の危険度設定を使い、未設定なら「敵なし」。
+  const hereTier = insideHere ? ((insideHere.encounterTier ?? 1) as ReturnType<typeof tierForRegion>) : tierForRegion(regionOf(ws.x, ws.y));
   const favoredMonsterName = favoredMonsterFor(hereTier, regionAffinity(regionOf(ws.x, ws.y))).name;
 
   // 自分タップで開く DQ 風コマンド。街にいるときだけ「なんでも屋」を足す。
@@ -1276,7 +1289,8 @@ export function World() {
 
   // ビューポート内の NPC (#425)。ドット絵 (npc:<id>) → 代替の見た目 (人form) に倒す。
   const npcSprites = [];
-  for (const n of allNpcs()) {
+  // NPC はフィールド専用 (#425 の座標に mapId が無い)。内部では描かない。
+  for (const n of insideHere ? [] : allNpcs()) {
     const vx = wrap(n.x - (ws.x - HALF));
     const vy = wrap(n.y - (ws.y - HALF));
     if (vx >= VIEW || vy >= VIEW) continue;
@@ -1356,7 +1370,13 @@ export function World() {
               mp={battle ? battle.state.player.mp : curMp}
               power={serverPower}
               maxMp={battle ? battle.state.player.maxMp : combat.maxMp}
-              locationLabel={town ? `🏘 ${town.name}` : `${dangerLabel(hereTier)}${here === 'forest' ? '・深い森' : ''} / ${favoredMonsterName}`}
+              locationLabel={
+                // 内部では**そのマップの名前**を出す (どこに居るか分かる唯一の手掛かり)。
+                // 敵が出ない内部 (街の中・広間) では危険度も敵名も出さない。
+                insideHere
+                  ? `🚪 ${insideHere.name}${insideHere.encounterTier !== undefined ? ` / ${dangerLabel(hereTier)}` : ''}`
+                  : town ? `🏘 ${town.name}` : `${dangerLabel(hereTier)}${here === 'forest' ? '・深い森' : ''} / ${favoredMonsterName}`
+              }
               // 戦闘/リザルト中は HP/MP を暗転オーバーレイより上に出して上枠で鮮明に
               // 見せる (下段の重複バーは廃止し上枠へ一本化)。
               // 値は phase を問わず battle 優先 (上記)、レイヤー (z) だけ wipe を見る

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -54,7 +54,7 @@ function shopErrorText(e: unknown, fallback: string): string {
 }
 import { WORLD_PREVIEW_ENABLED } from '@/lib/world-preview';
 import { loadAuthoredWorld } from '@/lib/world-authoring';
-import { allNpcs, EQUIPMENT_BY_ID, equipHands, gameQuestById, gameQuestByNpc, npcArtKey, npcAt, type NpcDef } from '@aozoraquest/core';
+import { allNpcs, EQUIPMENT_BY_ID, equipHands, gameQuestById, gameQuestByNpc, interiorById, interiorPartAt, interiorTerrainAt, npcArtKey, npcAt, walkableIn, WORLD_MAP_ID, type NpcDef } from '@aozoraquest/core';
 import { mappedPartAt } from '@aozoraquest/core';
 import { Avatar } from '@/components/avatar';
 import { WorldBattleControls, type BattlePhase } from '@/components/world-battle-controls';
@@ -110,6 +110,8 @@ const dangerLabel = (tier: number) =>
 const asBattleState = (s: ServerBattleState): BattleState => s as unknown as BattleState;
 
 interface Vitals {
+  /** 今いるマップ (#424)。省略 = フィールド。内部マップ (街の中・城) では id が入る。 */
+  mapId?: string;
   x: number;
   y: number;
   /** null = 全快 (最大値はジョブ/レベルから導出) */
@@ -523,8 +525,9 @@ export function World() {
       if (moveBusyRef.current) return; // 直前の移動がサーバー往復中 (トークン連鎖を直列化)
       if (!worldServerEnabled || !agent) { setNotice('サーバーに接続できないため移動できない。'); return; }
       const { dx, dy } = DIRS[dir];
-      const nx = wrap(s.x + dx);
-      const ny = wrap(s.y + dy);
+      const cur = s.mapId ? interiorById(s.mapId) ?? null : null;
+      const nx = cur ? s.x + dx : wrap(s.x + dx);
+      const ny = cur ? s.y + dy : wrap(s.y + dy);
       // **NPC にぶつかったら会話** (#425)。DQ の作法: 移動はせず、話しかける。
       // クエスト発注 NPC (#423) は状況で話が変わる: 未受注→依頼 (読了で受注)、
       // 進行中→達成を試みる (条件検証はサーバー)、達成済み→通常セリフ。
@@ -580,7 +583,7 @@ export function World() {
         }
         return;
       }
-      if (!isWalkableAt(nx, ny)) {
+      if (!walkableIn(s.mapId ?? WORLD_MAP_ID, nx, ny, isWalkableAt)) {
         setNotice('そっちには進めない!');
         return;
       }
@@ -595,10 +598,14 @@ export function World() {
           const res = await serverMove(agent, dx, dy, tokenRef.current);
           tokenRef.current = res.token;
           const cur = wsRef.current ?? optimistic;
-          const t = townAt(res.x, res.y);
-          let next: Vitals = { ...cur, x: res.x, y: res.y };
+          // マップの切り替え (#424)。ゲートを踏むとサーバーが mapId を返す。
+          // **フィールドの街判定は mapId が無いときだけ**通す (内部の床が town でも街にしない)。
+          const onWorld = !res.mapId;
+          const t = onWorld ? townAt(res.x, res.y) : null;
+          let next: Vitals = { ...cur, x: res.x, y: res.y, ...(res.mapId ? { mapId: res.mapId } : {}) };
+          if (!res.mapId) delete next.mapId;
           if (res.healed) { next.hp = null; next.mp = null; }
-          if (res.terrain === 'town') {
+          if (onWorld && res.terrain === 'town') {
             // ちずのかけら: 街に入るとその街の地方一帯 (3×3 リージョン) が地図に加わる。
             // 訪問済みの街 (そらのはねの行き先候補) も積む。どちらも表示用の探索メモ。
             const around = regionsAround(regionOf(res.x, res.y));
@@ -1190,7 +1197,8 @@ export function World() {
   const inBattle = battle !== null && (wipe === null || wipe === 'reveal');
 
   const town = townAt(ws.x, ws.y);
-  const here = terrainAt(ws.x, ws.y);
+  const insideHere = ws.mapId ? interiorById(ws.mapId) ?? null : null;
+  const here = insideHere ? interiorTerrainAt(insideHere, ws.x, ws.y) : terrainAt(ws.x, ws.y);
   // 地域相性: この地方で出やすいモンスター名を現地ヒントにする (相性が見えない導線対策)
   // 「このあたり」の見出しと「何が多いか」は同じ tier を見る (ラベルと中身が食い違わないように)。
   const hereTier = tierForRegion(regionOf(ws.x, ws.y));
@@ -1234,17 +1242,20 @@ export function World() {
   // **同じパーツは <defs> に 1 回だけ定義して <use> で参照する** (#605)。全地形が
   // ドット絵 (タイルあたり最大 ~150 rect) になったので、マスごとにインライン展開すると
   // ビューポートだけで数千〜万 rect の DOM になり、歩くたびの再描画がモバイルで重くなる。
+  // 今いるマップ (#424)。内部なら地形もパーツもそのマップから引く。
+  const inside = ws.mapId ? interiorById(ws.mapId) ?? null : null;
   const tileDefs = new Map<string, React.ReactElement>();
   const tiles = [];
   for (let vy = 0; vy < VIEW; vy++) {
     for (let vx = 0; vx < VIEW; vx++) {
-      const x = wrap(ws.x - HALF + vx);
-      const y = wrap(ws.y - HALF + vy);
-      const t = terrainAt(x, y);
+      // 内部マップ (#424) は端で折り返さない (範囲外は壁として描く)。
+      const x = inside ? ws.x - HALF + vx : wrap(ws.x - HALF + vx);
+      const y = inside ? ws.y - HALF + vy : wrap(ws.y - HALF + vy);
+      const t = inside ? interiorTerrainAt(inside, x, y) : terrainAt(x, y);
       // ドット絵 (エディタ or 同梱 #605) → 従来の SVG → 代表色のべた塗り、の順に倒す。
       // **パーツ (index) ごとの絵を最優先。** 「縦の橋」のように、通行判定は同じで
       // 絵だけ違うパーツを足せるようにするため、地形 id ではなく index で引く。
-      const pi = mappedPartAt(x, y);
+      const pi = inside ? interiorPartAt(inside, x, y) : mappedPartAt(x, y);
       // 平地でドット絵が無いときだけ SVG バリアント (見た目散らし) が効くので、id に含める。
       const detail = t === 'plains' && !pixelPart(pi, t) ? tileDetailAt(x, y) : 0;
       const defId = `wt-${pi ?? 'x'}-${t}-${detail}`;

--- a/packages/core/src/__tests__/interior.test.ts
+++ b/packages/core/src/__tests__/interior.test.ts
@@ -1,0 +1,155 @@
+/**
+ * 内部マップとゲート (#424)。守るべき不変条件:
+ * - **行き先が実在しないゲートを保存させない** (踏むとどこにも居ない状態になる)
+ * - 内部マップは端で折り返さない (範囲外は歩けない = 外に出るのはゲートだけ)
+ * - 同じマスに 2 つのゲートを置かせない (どちらへ行くのか決められない)
+ * - 壊れた 1 件で全体を落とす
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  InteriorError,
+  MAX_INTERIOR_SIZE,
+  WORLD_MAP_ID,
+  allGates,
+  allInteriors,
+  gateAt,
+  interiorById,
+  interiorTerrainAt,
+  interiorWalkableAt,
+  isInterior,
+  setInteriors,
+  walkableIn,
+  type InteriorMap,
+} from '../interior.js';
+import { BASE_PALETTE } from '../world-map.js';
+
+const FLOOR = BASE_PALETTE.indexOf('plains');
+const WALL = BASE_PALETTE.indexOf('mountain');
+
+/** 外周が壁・中が床の 8×8。 */
+function room(id = 'in-1', size = 8): InteriorMap {
+  const tiles = new Uint8Array(size * size).fill(FLOOR);
+  for (let k = 0; k < size; k++) {
+    tiles[k] = WALL;
+    tiles[(size - 1) * size + k] = WALL;
+    tiles[k * size] = WALL;
+    tiles[k * size + size - 1] = WALL;
+  }
+  return { id, name: 'へや', size, tiles };
+}
+
+afterEach(() => setInteriors(null, null));
+
+describe('setInteriors', () => {
+  it('登録した内部マップを id で引ける', () => {
+    setInteriors([room()], []);
+    expect(interiorById('in-1')?.name).toBe('へや');
+    expect(allInteriors()).toHaveLength(1);
+    expect(isInterior('in-1')).toBe(true);
+    expect(isInterior(WORLD_MAP_ID)).toBe(false);
+    expect(isInterior(undefined)).toBe(false);
+  });
+
+  it('null で全解除', () => {
+    setInteriors([room()], [{ from: { mapId: 'in-1', x: 1, y: 1 }, to: { mapId: WORLD_MAP_ID, x: 5, y: 5 } }]);
+    setInteriors(null, null);
+    expect(allInteriors()).toHaveLength(0);
+    expect(allGates()).toHaveLength(0);
+    expect(interiorById('in-1')).toBeUndefined();
+  });
+
+  it("id に 'world' は使えない (フィールドの予約語)", () => {
+    expect(() => setInteriors([{ ...room(), id: WORLD_MAP_ID }], [])).toThrow(InteriorError);
+  });
+
+  it('id 重複・名前空・おおきさ範囲外・タイル数不一致を弾く', () => {
+    expect(() => setInteriors([room('a'), room('a')], [])).toThrow(InteriorError);
+    expect(() => setInteriors([{ ...room(), name: ' ' }], [])).toThrow(InteriorError);
+    expect(() => setInteriors([{ ...room(), size: 3 }], [])).toThrow(InteriorError);
+    expect(() => setInteriors([{ ...room(), size: MAX_INTERIOR_SIZE + 1 }], [])).toThrow(InteriorError);
+    expect(() => setInteriors([{ ...room(), tiles: new Uint8Array(5) }], [])).toThrow(InteriorError);
+  });
+
+  it('危険度は 1〜8 (省略で敵なし)', () => {
+    setInteriors([{ ...room(), encounterTier: 3 }], []);
+    expect(interiorById('in-1')!.encounterTier).toBe(3);
+    expect(() => setInteriors([{ ...room(), encounterTier: 0 }], [])).toThrow(InteriorError);
+    expect(() => setInteriors([{ ...room(), encounterTier: 9 }], [])).toThrow(InteriorError);
+  });
+});
+
+describe('ゲート', () => {
+  it('登録したゲートを座標で引ける', () => {
+    const g = { from: { mapId: WORLD_MAP_ID, x: 10, y: 20 }, to: { mapId: 'in-1', x: 4, y: 6 } };
+    setInteriors([room()], [g]);
+    expect(gateAt(WORLD_MAP_ID, 10, 20)).toEqual(g);
+    expect(gateAt(WORLD_MAP_ID, 10, 21)).toBeUndefined();
+    expect(gateAt('in-1', 10, 20)).toBeUndefined(); // マップが違えば別のマス
+  });
+
+  it('行き先の内部マップが存在しないゲートを弾く (踏むとどこにも居なくなる)', () => {
+    expect(() => setInteriors([room()], [
+      { from: { mapId: WORLD_MAP_ID, x: 1, y: 1 }, to: { mapId: 'ghost', x: 0, y: 0 } },
+    ])).toThrow(InteriorError);
+  });
+
+  it('行き先が内部マップの外を指すゲートを弾く', () => {
+    expect(() => setInteriors([room()], [
+      { from: { mapId: WORLD_MAP_ID, x: 1, y: 1 }, to: { mapId: 'in-1', x: 99, y: 0 } },
+    ])).toThrow(InteriorError);
+  });
+
+  it('同じマスのゲート重複を弾く', () => {
+    expect(() => setInteriors([room()], [
+      { from: { mapId: WORLD_MAP_ID, x: 1, y: 1 }, to: { mapId: 'in-1', x: 2, y: 2 } },
+      { from: { mapId: WORLD_MAP_ID, x: 1, y: 1 }, to: { mapId: 'in-1', x: 3, y: 3 } },
+    ])).toThrow(InteriorError);
+  });
+
+  it('壊れたゲート 1 本で全体を落とす (マップも入らない)', () => {
+    expect(() => setInteriors([room()], [
+      { from: { mapId: WORLD_MAP_ID, x: 1, y: 1 }, to: { mapId: 'ghost', x: 0, y: 0 } },
+    ])).toThrow(InteriorError);
+    expect(allInteriors()).toHaveLength(0);
+  });
+});
+
+describe('通行判定', () => {
+  it('床は歩けて外周の壁は歩けない', () => {
+    const m = room();
+    expect(interiorWalkableAt(m, 4, 4)).toBe(true);
+    expect(interiorWalkableAt(m, 0, 4)).toBe(false);
+  });
+
+  it('**範囲外は歩けない** (内部マップは端で折り返さない)', () => {
+    const m = room();
+    expect(interiorWalkableAt(m, -1, 4)).toBe(false);
+    expect(interiorWalkableAt(m, m.size, 4)).toBe(false);
+    expect(interiorWalkableAt(m, 4, -1)).toBe(false);
+    expect(interiorWalkableAt(m, 4, m.size)).toBe(false);
+  });
+
+  it('範囲外の地形は壁 (歩けない地形) 扱い', () => {
+    expect(interiorTerrainAt(room(), -1, 0)).toBe('mountain');
+  });
+
+  it('walkableIn は内部なら内部の判定、それ以外はフィールドの判定に委ねる', () => {
+    setInteriors([room()], []);
+    const worldWalkable = () => true; // フィールドは何でも歩ける、という代役
+    expect(walkableIn('in-1', 4, 4, worldWalkable)).toBe(true);
+    expect(walkableIn('in-1', 0, 0, worldWalkable)).toBe(false); // 壁
+    expect(walkableIn(WORLD_MAP_ID, 0, 0, worldWalkable)).toBe(true); // 代役が答える
+    expect(walkableIn('unknown-map', 0, 0, worldWalkable)).toBe(true); // 未知はフィールド扱い
+  });
+
+  it('パーツ自身の通行値がタイルの地形より優先される', () => {
+    const tiles = new Uint8Array(16).fill(0);
+    const m: InteriorMap = {
+      id: 'in-x', name: 'x', size: 4, tiles,
+      // index 0 = 見た目は山だが通れる隘路
+      parts: [{ terrain: 'mountain', name: 'ぬけみち', walkable: true }],
+    };
+    setInteriors([m], []);
+    expect(interiorWalkableAt(interiorById('in-x')!, 1, 1)).toBe(true);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,4 +27,5 @@ export * from './npc-data.js';
 export * from './quest-data.js';
 export * from './part-presets.js';
 export * from './job-data.js';
+export * from './interior.js';
 export * from './equipment.js';

--- a/packages/core/src/interior.ts
+++ b/packages/core/src/interior.ts
@@ -112,6 +112,17 @@ export function setInteriors(list: readonly InteriorMap[] | null, gateList: read
         }
       }
     }
+    // **入口タイルが歩けないとそのゲートは永久に踏めない。** ゲートは通行判定の後に
+    // 見る設計なので、壁の上のゲートは「入ったら出られない一方通行の罠」になる
+    // (エディタの既定値が実際に壁を指していた。レビュー ★★★)。
+    // フィールド側は地図の読み込み状況に依存するのでここでは見ない (内部だけ検証)。
+    if (g.from.mapId !== WORLD_MAP_ID) {
+      const fm = nextMaps.get(g.from.mapId);
+      if (!fm) throw new InteriorError(`${where}: 入口の内部マップが存在しない (${g.from.mapId})`);
+      if (!interiorWalkableAt(fm, g.from.x, g.from.y)) {
+        throw new InteriorError(`${where}: 入口が歩けないマス (壁の上のゲートは踏めない)`);
+      }
+    }
     const k = gateKey(g.from.mapId, g.from.x, g.from.y);
     // 同じマスに 2 つのゲートがあると、踏んだときどちらへ行くのか決められない。
     if (nextGates.has(k)) throw new InteriorError(`同じマスにゲートが重複 ${where}`);

--- a/packages/core/src/interior.ts
+++ b/packages/core/src/interior.ts
@@ -1,0 +1,195 @@
+/**
+ * **内部マップ** (#424)。街の中・城・ダンジョンを、フィールドとは別のマップ空間に持つ。
+ *
+ * ## なぜマップ空間を分けるか (案 A)
+ *
+ * 1024×1024 のフィールドの空き地に内部を描き込む案 (DQ1 方式) もあったが、
+ * オーナー判断で**マップ空間の分離**を採った。内部の広さがフィールドの地形配置に
+ * 縛られず、「城の中だけ危険度を上げる」「同じ間取りを複数の街で使う」も後から効く。
+ *
+ * ## 位置は `(mapId, x, y)` の 3 つ組
+ *
+ * `mapId` は `'world'` (フィールド) か内部マップの id。**省略 = 'world'** として
+ * 既存の位置 (GameState.x/y・位置トークン) を無移行で通す。
+ *
+ * ## ゲート (出入口)
+ *
+ * 「入口タイルを踏んだら別マップの出口へ移る」という対応表を別に持つ。地形に
+ * 埋め込まないのは、**同じ絵のパーツを複数の入口に使う**ため (城のパーツを 2 つ
+ * 置いたら 2 つとも同じ城に入る、では困る)。
+ *
+ * 移動判定と遷移は **edge が権威** (docs/21)。web も同じ表を読む — 片方だけが
+ * ゲートを知っていると「画面では入れるのにサーバーが弾く」になる。
+ */
+import type { Terrain } from './world.js';
+import { isWalkable } from './world.js';
+import { BASE_PALETTE, partWalkable as worldPartWalkable, type WorldPart } from './world-map.js';
+
+export class InteriorError extends Error {}
+
+/** フィールドを表す mapId。内部マップはこれ以外の id を持つ。 */
+export const WORLD_MAP_ID = 'world';
+
+export interface InteriorMap {
+  /** 一意な id (ゲートの参照先)。 */
+  id: string;
+  /** 表示名 (「ふたばの村」「魔王の城 1F」など)。 */
+  name: string;
+  /** 一辺のタイル数 (正方形)。フィールドと違い小さい。 */
+  size: number;
+  /** タイル (1 バイト = パーツ index)。長さは size×size。 */
+  tiles: Uint8Array;
+  /** パーツ表。省略時はフィールドのパーツ表を使う (絵と通行判定を共用する)。 */
+  parts?: WorldPart[];
+  /** 遭遇の危険度 tier。**省略 = 敵が出ない** (街の中・城の広間)。 */
+  encounterTier?: number;
+}
+
+/** 出入口 1 つ。踏んだ瞬間に `to` へ移る (一方通行。往復は 2 本書く)。 */
+export interface Gate {
+  from: { mapId: string; x: number; y: number };
+  to: { mapId: string; x: number; y: number };
+}
+
+export interface InteriorsRecord {
+  interiors: Array<Omit<InteriorMap, 'tiles'> & { gz: string }>;
+  gates: Gate[];
+  updatedAt: string;
+}
+
+/** 内部マップの一辺の上限 (レコードサイズと編集のしやすさの現実的な範囲)。 */
+export const MAX_INTERIOR_SIZE = 128;
+export const MAX_INTERIORS = 100;
+export const MAX_GATES = 500;
+
+let interiors = new Map<string, InteriorMap>();
+let gates = new Map<string, Gate>();
+
+const gateKey = (mapId: string, x: number, y: number) => `${mapId}:${x},${y}`;
+
+/**
+ * 内部マップとゲートを差し替える。`null` で全解除。
+ * **壊れた 1 件で全体を落とす** (部分適用しない。他エディタと同じ流儀)。
+ */
+export function setInteriors(list: readonly InteriorMap[] | null, gateList: readonly Gate[] | null): void {
+  const nextMaps = new Map<string, InteriorMap>();
+  for (const m of list ?? []) {
+    const where = m?.id ?? '(id なし)';
+    if (!m || typeof m.id !== 'string' || m.id.trim() === '') throw new InteriorError('内部マップの id が空');
+    if (m.id === WORLD_MAP_ID) throw new InteriorError(`id に ${WORLD_MAP_ID} は使えない (フィールドの予約語)`);
+    if (nextMaps.has(m.id)) throw new InteriorError(`内部マップの id が重複 (${m.id})`);
+    if (typeof m.name !== 'string' || m.name.trim() === '') throw new InteriorError(`${where}: 名前が空`);
+    if (!Number.isInteger(m.size) || m.size < 4 || m.size > MAX_INTERIOR_SIZE) {
+      throw new InteriorError(`${where}: おおきさは 4〜${MAX_INTERIOR_SIZE}`);
+    }
+    if (!(m.tiles instanceof Uint8Array) || m.tiles.length !== m.size * m.size) {
+      throw new InteriorError(`${where}: タイル数が合わない (${m.tiles?.length} ≠ ${m.size}×${m.size})`);
+    }
+    if (m.encounterTier !== undefined && (!Number.isInteger(m.encounterTier) || m.encounterTier < 1 || m.encounterTier > 8)) {
+      throw new InteriorError(`${where}: 危険度は 1〜8 (省略で敵が出ない)`);
+    }
+    nextMaps.set(m.id, { ...m, tiles: new Uint8Array(m.tiles), ...(m.parts ? { parts: m.parts.map((p) => ({ ...p })) } : {}) });
+  }
+  if (nextMaps.size > MAX_INTERIORS) throw new InteriorError(`内部マップが多すぎる (${nextMaps.size} > ${MAX_INTERIORS})`);
+
+  const nextGates = new Map<string, Gate>();
+  for (const g of gateList ?? []) {
+    const where = g ? `(${g.from?.mapId} ${g.from?.x},${g.from?.y})` : '(空)';
+    if (!g?.from || !g.to) throw new InteriorError(`ゲートの形が不正 ${where}`);
+    for (const p of [g.from, g.to]) {
+      if (typeof p.mapId !== 'string' || !Number.isInteger(p.x) || !Number.isInteger(p.y)) {
+        throw new InteriorError(`ゲートの座標が不正 ${where}`);
+      }
+      // **行き先の実在を確かめる。** 存在しない内部マップへのゲートを踏むと、
+      // その場から出られなくなる (どこにも居ない状態になる)。
+      if (p.mapId !== WORLD_MAP_ID && !nextMaps.has(p.mapId)) {
+        throw new InteriorError(`${where}: 内部マップが存在しない (${p.mapId})`);
+      }
+      if (p.mapId !== WORLD_MAP_ID) {
+        const m = nextMaps.get(p.mapId)!;
+        if (p.x < 0 || p.y < 0 || p.x >= m.size || p.y >= m.size) {
+          throw new InteriorError(`${where}: ${p.mapId} の外を指している (${p.x}, ${p.y})`);
+        }
+      }
+    }
+    const k = gateKey(g.from.mapId, g.from.x, g.from.y);
+    // 同じマスに 2 つのゲートがあると、踏んだときどちらへ行くのか決められない。
+    if (nextGates.has(k)) throw new InteriorError(`同じマスにゲートが重複 ${where}`);
+    nextGates.set(k, { from: { ...g.from }, to: { ...g.to } });
+  }
+  if (nextGates.size > MAX_GATES) throw new InteriorError(`ゲートが多すぎる (${nextGates.size} > ${MAX_GATES})`);
+
+  interiors = nextMaps;
+  gates = nextGates;
+}
+
+/** 内部マップ (無ければ undefined = フィールド扱い)。 */
+export function interiorById(id: string): InteriorMap | undefined {
+  return interiors.get(id);
+}
+
+/** 全内部マップ (エディタ用)。 */
+export function allInteriors(): readonly InteriorMap[] {
+  return [...interiors.values()];
+}
+
+/** 全ゲート (エディタ用)。 */
+export function allGates(): readonly Gate[] {
+  return [...gates.values()];
+}
+
+/** そのマスのゲート (無ければ undefined)。移動の権威判定と web の描画が共有する。 */
+export function gateAt(mapId: string, x: number, y: number): Gate | undefined {
+  return gates.get(gateKey(mapId, x, y));
+}
+
+/** そのマップが内部か (mapId が未知なら false = フィールド扱いに倒す)。 */
+export function isInterior(mapId: string | undefined): boolean {
+  return !!mapId && mapId !== WORLD_MAP_ID && interiors.has(mapId);
+}
+
+/** 内部マップのパーツ index (範囲外は undefined)。 */
+export function interiorPartAt(map: InteriorMap, x: number, y: number): number | undefined {
+  if (x < 0 || y < 0 || x >= map.size || y >= map.size) return undefined;
+  return map.tiles[y * map.size + x];
+}
+
+/** 内部マップの地形 (パーツ表 → BASE_PALETTE の順に引く)。 */
+export function interiorTerrainAt(map: InteriorMap, x: number, y: number): Terrain {
+  const idx = interiorPartAt(map, x, y);
+  if (idx === undefined) return 'mountain'; // 範囲外は壁扱い (歩けない地形)
+  const part = map.parts?.[idx];
+  return (part?.terrain ?? BASE_PALETTE[idx] ?? 'plains') as Terrain;
+}
+
+/**
+ * 内部マップの通行判定。**範囲外は歩けない** — 内部マップは端で折り返さない
+ * (フィールドの wrap と違い、外に出るのはゲートからだけ)。
+ */
+export function interiorWalkableAt(map: InteriorMap, x: number, y: number): boolean {
+  if (x < 0 || y < 0 || x >= map.size || y >= map.size) return false;
+  // NPC は内部にも置ける (#425 の座標は将来 mapId 付きにする。今はフィールド座標のみ)。
+  const idx = interiorPartAt(map, x, y);
+  if (idx !== undefined) {
+    // パーツ自身の通行値が最優先 (フィールドと同じ規則)。内部固有のパーツ表があれば
+    // それを、無ければフィールドのパーツ表を見る。
+    const own = map.parts?.[idx]?.walkable;
+    if (own !== undefined) return own;
+    if (!map.parts) {
+      const w = worldPartWalkable(idx);
+      if (w !== undefined) return w;
+    }
+  }
+  return isWalkable(interiorTerrainAt(map, x, y));
+}
+
+/**
+ * マップをまたいで通行判定する。`mapId` が内部でなければフィールドの判定に委ねる。
+ * **NPC は今のところフィールドにしか置けない** (NpcDef が mapId を持たない)。
+ * 内部に NPC を置けるようにするのは #425 の続きで、そのときここも見るようにする。
+ */
+export function walkableIn(mapId: string, x: number, y: number, worldWalkable: (x: number, y: number) => boolean): boolean {
+  const m = interiorById(mapId);
+  if (!m) return worldWalkable(x, y);
+  return interiorWalkableAt(m, x, y);
+}


### PR DESCRIPTION
Closes #424

## 概要

位置を `(mapId, x, y)` の 3 つ組にし、フィールドとは別のマップ空間に内部 (街の中・城・ダンジョン) を持つ。**mapId 省略 = `'world'`** なので既存の位置・トークン・GameState は**無移行**で通る。

## 設計

- **ゲートは対応表** (`{from:{mapId,x,y}, to:{mapId,x,y}}`)。地形に埋め込まないのは、同じ絵のパーツを複数の入口に使うため
- **内部マップは端で折り返さない** — 外へ出るのはゲートからだけなので範囲外は歩けない
- **行き先が実在しない / 入口が歩けないゲートは保存で弾く** — 前者は「どこにも居ない」状態、後者は「入ったら出られない罠」になる
- ゲート判定は通行判定の**後** — 壁の中の入口を「歩けないが入れる」にしない
- 遭遇は内部では `encounterTier` を設定したときだけ。tier もその設定値を使う (内部座標は region 0 に落ちるため地域からは引けない)
- 遭遇タイルのキーに mapId を含める (内部とフィールドの同座標が枠を共有しない)

## 変更

| レイヤー | 内容 |
|---|---|
| core | `interior.ts`: InteriorMap / Gate / setInteriors / walkableIn / gateAt |
| edge | 位置トークン・GameState・**ガードの封印**に mapId。move のゲート遷移、決着/テレポート/街回復での mapId 確定、内部の tier |
| web | mapId で描画・移動判定・HUD・NPC 描画を切替。リロードでも内部を維持 |
| エディタ | `/admin/interiors`: パーツ配置 + Shift+クリックでゲート + 往復張り (壁なら警告して塞ぐ) |

## テスト

- core: interior 17 件 / edge: ゲート遷移と詰み対策 8 件 (入る/戻る/壁は 400/折り返さない/削除済みマップからの脱出/範囲外からの脱出/遭遇時の mapId 維持/テレポートで mapId 消去)
- core 672 / edge 245 / web 360 全緑、typecheck / build 緑

## Review

3 観点 (設計/実装/UX) を実施。**3 観点が独立に同じ ★★★ を検出**したので全件 2902d71 で対応:

- **★★★ 敗北帰還・そらのはね・街回復が mapId を消さず、リロードで全方向 400 = 一歩も動けない** (復旧はワールドリセットのみ) → 位置を書く全経路で mapId を一組で書く + 範囲外 state の脱出保険
- **★★★ 遭遇時の move 応答だけ mapId が抜け、web が「内部を抜けた」と誤認** → 全 return で mapId を維持。決着はガードに封印した mapId で復元
- **★★★ encounterTier が tier に効かず、どの危険度でも tier1 の敵しか出ない** (内部座標は region 0) → sealEncounter / handleSearch に内部の設定を渡す
- **★★★ エディタの「往復を張る」既定値が戻りゲートを外周の壁に置き、入ったら出られない** → 既定位置修正 + 壁なら赤字警告してボタンを塞ぐ + core 側でも入口の通行可否を検証
- **★★ リロードで mapId を捨てて内部座標をフィールドとして描く** → initialWs に mapId
- **★★ HUD が内部でフィールドの街表・地域危険度を引く** (街と重なると「なんでも屋」が生えるのにサーバーは回復しない) → 内部ではマップ名を出し、NPC も描かない

NPC/店の mapId 対応、ゲート張り UI の改善、ちずの内部対応は **#613** に切り出し。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SpSiVHa5hXp7sEUAXAfWEE