### PR TITLE
feat: シナリオ (イベント列 + 進行フラグ) とエディタ (#545)

### DIFF
--- a/apps/edge/src/battle-resolver.ts
+++ b/apps/edge/src/battle-resolver.ts
@@ -517,6 +517,11 @@ export interface TurnResult {
   materials?: Record<string, number>;
   carryHp?: number;
   carryMp?: number;
+  /** 進行フラグ (#545)。決着でシナリオが進むと増える。 */
+  flags?: string[];
+  /** シナリオのお知らせ (一度だけ)。**発火済みは二度と返らない**ので、
+   *  client がここで拾わないと永久に失われる。 */
+  scenarioNotices?: string[];
 }
 
 /**

--- a/apps/edge/src/battle-resolver.ts
+++ b/apps/edge/src/battle-resolver.ts
@@ -25,6 +25,7 @@ import {
 import { entropyU32 } from './kuda';
 import { readGuard, createGuard, advanceGuard, deleteGuard, type BattleGuard } from './battle-guard';
 import { readState, readModifyWrite, emptyState, rkeyForDid, GAME_STATE_COLLECTION, type GameStateEnv, type GameState } from './game-state';
+import { advanceScenario } from './scenario-progress';
 import { SEARCH_POWER_COST, MAX_SHOP_OPS } from './shop';
 import { sanitizeGear } from './game-state';
 // sanitizeGear は game-state へ移した (shop からも使うため。shop → battle-resolver は循環)。
@@ -564,6 +565,7 @@ export async function handleTurn(env: ResolverEnv, userDid: string, battleId: st
     let awarded: AwardBreakdown = {};
     let finalPos = { x: 0, y: 0 };
     let finalMapId: string = WORLD_MAP_ID;
+    const noticeBox: { v: string[] } = { v: [] };
     const window = enemyWindow(now);
     const written = await readModifyWrite(env, userDid, (cur: GameState): GameState => {
       // 戦闘中に消費したやくそう/しずくを materials に反映してから報酬 (ドロップ/ロス) を適用。
@@ -596,8 +598,13 @@ export async function handleTurn(env: ResolverEnv, userDid: string, battleId: st
       // ここで mapId を扱わないと、内部マップの座標のままフィールドに放り出される /
       // 内部の範囲外に立って全方向「進めない」になる (レビュー ★★★)。
       finalMapId = decision === 'lose' ? WORLD_MAP_ID : (guard.sealed.mapId ?? parsed?.mapId ?? WORLD_MAP_ID);
+      // ジョブ Lv 条件のシナリオ (#545) は決着でしか動かないのでここで見る。
+      // mutate は純関数なので、CAS リトライで複数回走っても同じ結果になる。
+      const advanced = advanceScenario({ ...cur, ...r.next } as GameState);
+      noticeBox.v = advanced?.notices ?? [];
       return {
         ...r.next,
+        ...(advanced ? { flags: advanced.flags } : {}),
         mapId: finalMapId === WORLD_MAP_ID ? undefined : finalMapId,
         x: finalPos.x,
         y: finalPos.y,
@@ -616,7 +623,9 @@ export async function handleTurn(env: ResolverEnv, userDid: string, battleId: st
     // 決着後の位置に対応する新トークンを発行 (敗北帰還で位置が変わるので client はこれで同期)。
     const token = signPosition(env, { did: userDid, ...(finalMapId !== WORLD_MAP_ID ? { mapId: finalMapId } : {}), x: finalPos.x, y: finalPos.y, counter: 0, iat: now });
     return { state: stripState(next), events: next.lastEvents, outcome: next.outcome, awarded, position: finalPos, token,
-      materials: written.materials, carryHp: written.carryHp, carryMp: written.carryMp };
+      materials: written.materials, carryHp: written.carryHp, carryMp: written.carryMp,
+      ...(written.flags ? { flags: written.flags } : {}),
+      ...(noticeBox.v.length ? { scenarioNotices: noticeBox.v } : {}) };
   }
 
   // ── 未決着: turn+1・新 pendingTurnSeed を CAS で確定してから応答 (並行二重解決/引き直しを弾く) ──

--- a/apps/edge/src/game-quest.ts
+++ b/apps/edge/src/game-quest.ts
@@ -10,6 +10,7 @@
  */
 import { gameQuestById, MAX_QUEST_REWARD_POWER } from '@aozoraquest/core';
 import { readModifyWrite, type GameState, type GameStateEnv } from './game-state';
+import { advanceScenario, type ScenarioResult } from './scenario-progress';
 
 export class GameQuestError extends Error {
   constructor(
@@ -30,6 +31,10 @@ export interface QuestStateResult {
   materials: Record<string, number>;
   /** 達成時のみ: 付与した報酬。 */
   rewarded?: { power?: number; itemId?: string; count?: number };
+  /** 進行フラグ (#545)。達成でシナリオが進むと増える。 */
+  flags?: string[];
+  /** シナリオのお知らせ (「東の橋が直ったらしい」)。一度だけ出す。 */
+  notices?: string[];
 }
 
 export async function handleQuestAccept(
@@ -46,6 +51,12 @@ export async function handleQuestAccept(
     did,
     (cur) => {
       if ((cur.questsDone ?? []).includes(questId)) throw new GameQuestError('もう達成している', 400, 'already_done');
+      // **解禁フラグ** (#545)。立っていないクエストはサーバーが受け付けない
+      // (client が NPC の分岐を無視して直接 POST しても通らない)。
+      const need = def.requireFlags ?? [];
+      if (need.some((f) => !(cur.flags ?? []).includes(f))) {
+        throw new GameQuestError('まだ その たのまれごとは 出ていない', 400, 'locked');
+      }
       if (cur.quest?.id === questId) return cur; // 再受注は no-op (連打・再送で壊れない)
       // **1 つずつ。** 同時進行を許すと「どの敵を数えるか」が曖昧になる (将来 quests[] 化も可能)。
       // ただし定義が消された孤児クエスト (管理者がエディタで削除) は無かったことにする —
@@ -55,7 +66,7 @@ export async function handleQuestAccept(
     },
     init ? { now, init } : { now },
   );
-  return { quest: next.quest, questsDone: next.questsDone, power: next.power, materials: next.materials };
+  return { quest: next.quest, questsDone: next.questsDone, power: next.power, materials: next.materials, ...(next.flags ? { flags: next.flags } : {}) };
 }
 
 export async function handleQuestComplete(
@@ -70,6 +81,7 @@ export async function handleQuestComplete(
   // 報酬の再検証 (定義レコードが壊れても暴走しない最後の砦)
   const rewardPower = Math.min(def.reward?.power ?? 0, MAX_QUEST_REWARD_POWER);
   let rewarded: QuestStateResult['rewarded'];
+  const scenarioBox: { v: ScenarioResult | null } = { v: null };
   const next = await readModifyWrite(
     env,
     did,
@@ -101,15 +113,24 @@ export async function handleQuestComplete(
         ...(rewardPower > 0 ? { power: rewardPower } : {}),
         ...(def.reward?.itemId ? { itemId: def.reward.itemId, count: def.reward.count ?? 0 } : {}),
       };
-      return {
+      const done: GameState = {
         ...cur,
         quest: undefined,
         questsDone: [...(cur.questsDone ?? []), questId].slice(-MAX_DONE),
         power: cur.power + rewardPower,
         materials,
       };
+      // 達成はシナリオが動く主な経路 (#545)。フラグと お知らせ をここで確定する。
+      // mutate は純関数なので、リトライで複数回走っても同じ結果になる。
+      scenarioBox.v = advanceScenario(done);
+      return scenarioBox.v ? { ...done, flags: scenarioBox.v.flags } : done;
     },
     init ? { now, init } : { now },
   );
-  return { quest: next.quest, questsDone: next.questsDone, power: next.power, materials: next.materials, ...(rewarded ? { rewarded } : {}) };
+  return {
+    quest: next.quest, questsDone: next.questsDone, power: next.power, materials: next.materials,
+    ...(rewarded ? { rewarded } : {}),
+    ...(next.flags ? { flags: next.flags } : {}),
+    ...(scenarioBox.v?.notices.length ? { notices: scenarioBox.v.notices } : {}),
+  };
 }

--- a/apps/edge/src/game-state.ts
+++ b/apps/edge/src/game-state.ts
@@ -104,6 +104,9 @@ export interface GameState {
   pieces?: OwnedPiece[];
   /** 今いるマップ (#424)。省略 = フィールド ('world')。内部マップ (街の中・城) に居るとき id が入る。 */
   mapId?: string;
+  /** 進行フラグ (#545/#426)。**サーバーだけが立てる** — client の自己申告で章が進むと
+   *  クエスト解禁も報酬も破られる。シナリオのイベント条件が揃うと edge が追加する。 */
+  flags?: string[];
   /** 進行中のゲーム内クエスト (#423)。討伐数は勝利時に edge が数える。 */
   quest?: { id: string; progress: number };
   /** 達成済みクエスト id (再受注させない)。直近 200 件のリング。 */

--- a/apps/edge/src/scenario-progress.ts
+++ b/apps/edge/src/scenario-progress.ts
@@ -1,0 +1,40 @@
+/**
+ * **シナリオの進行判定** (#545)。フラグを立てるのは edge だけ。
+ *
+ * client の自己申告でフラグが立つと、クエストの解禁も NPC の分岐も破られる
+ * (「章 3 のフラグ」を POST すれば終盤のクエストが受け放題になる)。条件の判定も
+ * 付与もここでやり、client は結果を受け取るだけにする。
+ *
+ * 呼ぶのは**進行が動く経路** (クエスト達成・戦闘決着) の後。毎移動では見ない —
+ * 条件が満たされるのはこの 2 つの後だけで、歩くたびに PDS を読むのは高すぎる。
+ */
+import { jobLevelFromXp, pendingScenario, type ScenarioEvent } from '@aozoraquest/core';
+import type { GameState } from './game-state';
+
+/** 立てたフラグと、一度だけ出すお知らせ。 */
+export interface ScenarioResult {
+  flags: string[];
+  notices: string[];
+  fired: string[];
+}
+
+/**
+ * その state で新しく発火するイベントを解決する。**state は書き換えない** (純関数) —
+ * readModifyWrite の mutate から呼ぶので、リトライで複数回走っても同じ結果になる必要がある。
+ */
+export function advanceScenario(state: GameState): ScenarioResult | null {
+  const jobXpLevels: Record<string, number> = {};
+  for (const [job, xp] of Object.entries(state.jobXp ?? {})) jobXpLevels[job] = jobLevelFromXp(xp, job);
+  const { fired, flags } = pendingScenario({
+    flags: state.flags ?? [],
+    questsDone: state.questsDone ?? [],
+    jobXpLevels,
+    materials: state.materials ?? {},
+  });
+  if (fired.length === 0) return null;
+  return {
+    flags,
+    notices: fired.map((e: ScenarioEvent) => e.notice).filter((n): n is string => !!n),
+    fired: fired.map((e: ScenarioEvent) => e.id),
+  };
+}

--- a/apps/edge/src/world-authoring.ts
+++ b/apps/edge/src/world-authoring.ts
@@ -1,4 +1,4 @@
-import { decodeWorldMap, loadStaticWorldMap, loadTileArts, setGameQuests, setInteriors, setItemOverrides, setJobOverrides, setMonsterOverrides, setNpcs, setShopOverrides, setTownOverrides, setWorldMap, WORLD_SIZE, type EquipmentDef, type Gate, type GameQuestDef, type InteriorMap, type ItemDefData, type JobOverride, type MonsterDef, type NpcDef, type ShopOverride, type TownOverride, type WorldPart } from '@aozoraquest/core';
+import { decodeWorldMap, loadStaticWorldMap, loadTileArts, setGameQuests, setInteriors, setScenario, setItemOverrides, setJobOverrides, setMonsterOverrides, setNpcs, setShopOverrides, setTownOverrides, setWorldMap, WORLD_SIZE, type EquipmentDef, type Gate, type GameQuestDef, type ScenarioEvent, type InteriorMap, type ItemDefData, type JobOverride, type MonsterDef, type NpcDef, type ShopOverride, type TownOverride, type WorldPart } from '@aozoraquest/core';
 import { getRecord } from './pds';
 import { resolveDidDocument } from './service-auth';
 import { pdsEndpointFromDoc } from './oauth-metadata';
@@ -122,6 +122,10 @@ export function ensureAuthoredWorld(env: WorldAuthoringEnv, nsid: string, now: n
     // **空配列も適用する** (length で弾かない) — 全クエスト削除の保存が {quests: []} になるので、
     // スキップすると warm isolate に削除済みクエストが残り続け、受注も報酬も通ってしまう。
     if (quests?.value?.quests) setGameQuests(quests.value.quests);
+    // シナリオ (#545)。**フラグを立てるのは edge** なので必須。条件が questId を引くため
+    // クエストより後に読む。
+    const scenario = await getRecord<{ events?: ScenarioEvent[] }>(pds, did, `${nsid}.world.scenario`, RKEY);
+    if (scenario?.value?.events) setScenario(scenario.value.events);
   })()
     .catch((e) => {
       // **落ちてもゲームは続く** (同梱の地図 or ノイズ生成に倒れる)。次の TTL で再試行。

--- a/apps/edge/test/game-quest.test.ts
+++ b/apps/edge/test/game-quest.test.ts
@@ -10,7 +10,7 @@
 import { describe, it, expect, afterEach, beforeAll } from 'vitest';
 import { p256 } from '@noble/curves/p256';
 import { base64urlnopad } from '@scure/base';
-import { MONSTERS, setGameQuests, setNpcs, type GameQuestDef } from '@aozoraquest/core';
+import { MONSTERS, setGameQuests, setNpcs, setScenario, type GameQuestDef } from '@aozoraquest/core';
 import { handleQuestAccept, handleQuestComplete, GameQuestError } from '../src/game-quest';
 import { applyBattleOutcome } from '../src/battle-reward';
 import { rkeyForDid, XP_EPOCH, type GameState, type GameStateEnv } from '../src/game-state';
@@ -226,5 +226,40 @@ describe('applyBattleOutcome の討伐カウント', () => {
     const s = stateAt({ quest: { id: 'q-collect', progress: 0 } });
     const { next } = win(s, [MON.id]);
     expect(next.quest).toEqual({ id: 'q-collect', progress: 0 });
+  });
+});
+
+describe('シナリオ連動 (#545)', () => {
+  const orig = globalThis.fetch;
+  afterEach(() => { globalThis.fetch = orig; setScenario(null); });
+
+  it('クエスト達成でフラグが立ち、お知らせが返る', async () => {
+    setScenario([{ id: 'e1', title: '第1章', when: [{ kind: 'questDone', questId: 'q-defeat' }], setFlags: ['ch1'], notice: '東の橋が なおったらしい' }]);
+    const m = statefulPds(stateAt({ quest: { id: 'q-defeat', progress: 2 } }));
+    globalThis.fetch = m.fn;
+    const res = await handleQuestComplete(await makeEnv(), DID, 'q-defeat', NOW);
+    expect(res.flags).toContain('ch1');
+    expect(res.notices).toEqual(['東の橋が なおったらしい']);
+    expect((stored(m.store) as GameState).flags).toContain('ch1');
+  });
+
+  it('解禁フラグが立っていないクエストはサーバーが受け付けない (直 POST でも)', async () => {
+    // NPC の分岐を無視して直接叩いても通らないことを確かめる。
+    setGameQuests([{ ...DEFEAT_Q, requireFlags: ['ch1'] }, COLLECT_Q]);
+    globalThis.fetch = statefulPds(stateAt()).fn;
+    await expect(handleQuestAccept(await makeEnv(), DID, 'q-defeat', NOW)).rejects.toMatchObject({ code: 'locked' });
+    // フラグが立っていれば通る
+    globalThis.fetch = statefulPds(stateAt({ flags: ['ch1'] })).fn;
+    const ok = await handleQuestAccept(await makeEnv(), DID, 'q-defeat', NOW);
+    expect(ok.quest).toEqual({ id: 'q-defeat', progress: 0 });
+    setGameQuests([DEFEAT_Q, COLLECT_Q]);
+  });
+
+  it('既にフラグが立っていれば同じお知らせを二度出さない', async () => {
+    setScenario([{ id: 'e1', title: '第1章', when: [{ kind: 'questDone', questId: 'q-collect' }], setFlags: ['ch1'], notice: 'もう出ない' }]);
+    const m = statefulPds(stateAt({ materials: { herb: 5 }, quest: { id: 'q-collect', progress: 0 }, flags: ['ch1'] }));
+    globalThis.fetch = m.fn;
+    const res = await handleQuestComplete(await makeEnv(), DID, 'q-collect', NOW);
+    expect(res.notices).toBeUndefined();
   });
 });

--- a/apps/web/src/lib/collections.ts
+++ b/apps/web/src/lib/collections.ts
@@ -99,6 +99,8 @@ export const ADMIN_COL = {
   jobs: `${ROOT}.world.jobs`,
   /** 内部マップ (街の中・城・ダンジョン) とゲート。#424 */
   interiors: `${ROOT}.world.interiors`,
+  /** シナリオ (イベント列 + フラグ)。#545 */
+  scenario: `${ROOT}.world.scenario`,
   /** 依頼クエスト集約 (docs/15-user-quest.md §集約インフラ)。
    *  Worker が主管理者 PDS に書く。env 別に rkey を分ける (dev→'dev', prod→'self')。 */
   questIndex: `${ROOT}.questIndex`,

--- a/apps/web/src/lib/world-authoring.ts
+++ b/apps/web/src/lib/world-authoring.ts
@@ -7,6 +7,7 @@ import {
   loadTileArts,
   setGameQuests,
   setInteriors,
+  setScenario,
   setJobOverrides,
   setItemOverrides,
   setMonsterOverrides,
@@ -23,6 +24,7 @@ import {
   type Gate,
   type GameQuestDef,
   type InteriorMap,
+  type ScenarioEvent,
   type JobOverride,
   type ItemDefData,
   type MonsterDef,
@@ -209,6 +211,13 @@ export async function loadAuthoredWorld(agent: Agent | null): Promise<void> {
     } catch (e) {
       console.warn('[world] quests load failed', e);
     }
+    try {
+      // シナリオ (#545)。条件が questId を引くので**クエストより後**に読む。
+      const rec = await getRecord<{ events?: ScenarioEvent[] }>(agent, adminDid, ADMIN_COL.scenario, RKEY);
+      if (rec?.events) setScenario(rec.events);
+    } catch (e) {
+      console.warn('[world] scenario load failed', e);
+    }
     return;
   }
   await loadStaticWorldMap().catch((e) => console.warn('[world] static map load failed', e));
@@ -299,6 +308,20 @@ export async function loadInteriorsRecord(agent: Agent, adminDid: string): Promi
   const gates = rec?.gates ?? [];
   setInteriors(maps, gates);
   return { maps, gates };
+}
+
+/** シナリオ (#545)。setScenario が先に検証で落とす (存在しないクエストを条件にさせない)。 */
+export async function saveScenario(agent: Agent, events: ScenarioEvent[]): Promise<void> {
+  setScenario(events);
+  await putRecord(agent, ADMIN_COL.scenario, RKEY, { events, updatedAt: new Date().toISOString() });
+}
+
+/** シナリオだけを読む (エディタ用。読めたかどうかを返す = 上書き事故を防ぐ)。 */
+export async function loadScenarioRecord(agent: Agent, adminDid: string): Promise<ScenarioEvent[]> {
+  const rec = await getRecord<{ events?: ScenarioEvent[] }>(agent, adminDid, ADMIN_COL.scenario, RKEY);
+  const events = rec?.events ?? [];
+  setScenario(events);
+  return events;
 }
 
 /** ジョブのパラメータ (#544)。setJobOverrides が先に検証で落とす。 */

--- a/apps/web/src/lib/world-server.ts
+++ b/apps/web/src/lib/world-server.ts
@@ -95,7 +95,7 @@ export interface ServerMoveResult {
 /** 権威 GameState (パワー/XP/素材/位置/carry HP-MP 等)。表示はこれを正とする。 */
 /** 所持装備の 1 個体 (#551 段階 2)。**権威側が唯一の正**で、ここに無い個体は装備できない。 */
 export interface ServerOwnedPiece { rkey: string; itemId: string; level: number }
-export interface ServerGameState { did: string; power: number; playerXp: number; jobXp: Record<string, number>; materials: Record<string, number>; gear: string[]; pieces?: ServerOwnedPiece[]; x: number; y: number; carryHp?: number; carryMp?: number; herbs?: number; tonics?: number; mapId?: string; quest?: { id: string; progress: number }; questsDone?: string[]; version: number; updatedAt: string }
+export interface ServerGameState { did: string; power: number; playerXp: number; jobXp: Record<string, number>; materials: Record<string, number>; gear: string[]; pieces?: ServerOwnedPiece[]; x: number; y: number; carryHp?: number; carryMp?: number; herbs?: number; tonics?: number; mapId?: string; flags?: string[]; quest?: { id: string; progress: number }; questsDone?: string[]; version: number; updatedAt: string }
 export interface ServerStateResult { state: ServerGameState; initialized: boolean; token?: string }
 export interface ServerAward {
   /** パワー不足で報酬対象外だった (勝っても逃げても XP・素材が入らない)。 */
@@ -220,6 +220,10 @@ export interface ServerQuestResult {
   materials: Record<string, number>;
   /** 達成時のみ: 付与された報酬。 */
   rewarded?: { power?: number; itemId?: string; count?: number };
+  /** 進行フラグ (#545)。サーバーが立てた結果。 */
+  flags?: string[];
+  /** シナリオのお知らせ (一度だけ)。 */
+  notices?: string[];
 }
 
 /** ゲーム内クエスト (#423): 受注。進行は GameState に積まれ、討伐は勝利時にサーバーが数える。 */

--- a/apps/web/src/lib/world-server.ts
+++ b/apps/web/src/lib/world-server.ts
@@ -114,7 +114,7 @@ export interface ServerAward {
     learned?: string[];
   };
 }
-export interface ServerTurnResult { state: ServerBattleState; events: { actor: string; text: string }[]; outcome: string; awarded?: ServerAward; position?: { x: number; y: number }; token?: string; materials?: Record<string, number>; carryHp?: number; carryMp?: number }
+export interface ServerTurnResult { state: ServerBattleState; events: { actor: string; text: string }[]; outcome: string; awarded?: ServerAward; position?: { x: number; y: number }; token?: string; materials?: Record<string, number>; carryHp?: number; carryMp?: number; flags?: string[]; scenarioNotices?: string[] }
 export interface ServerItemResult { carryHp?: number; carryMp?: number; materials: Record<string, number>; healed: number }
 export interface ServerTeleportResult { x: number; y: number; token: string; materials: Record<string, number> }
 

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -27,6 +27,7 @@ const AdminNpcs = lazy(() => import('@/routes/admin-npcs').then(m => ({ default:
 const AdminQuests = lazy(() => import('@/routes/admin-quests').then(m => ({ default: m.AdminQuests })));
 const AdminJobs = lazy(() => import('@/routes/admin-jobs').then(m => ({ default: m.AdminJobs })));
 const AdminInteriors = lazy(() => import('@/routes/admin-interiors').then(m => ({ default: m.AdminInteriors })));
+const AdminScenario = lazy(() => import('@/routes/admin-scenario').then(m => ({ default: m.AdminScenario })));
 const World = lazy(() => import('@/routes/world').then(m => ({ default: m.World })));
 const Onboarding = lazy(() => import('@/routes/onboarding').then(m => ({ default: m.Onboarding })));
 const OAuthCallback = lazy(() => import('@/routes/oauth-callback').then(m => ({ default: m.OAuthCallback })));
@@ -95,6 +96,7 @@ const router = createBrowserRouter([
       { path: 'admin/quests', element: <AdminQuests /> },
       { path: 'admin/jobs', element: <AdminJobs /> },
       { path: 'admin/interiors', element: <AdminInteriors /> },
+      { path: 'admin/scenario', element: <AdminScenario /> },
       { path: 'world', element: <World /> },
       { path: 'onboarding', element: <Onboarding /> },
       { path: 'oauth/callback', element: <OAuthCallback /> },

--- a/apps/web/src/routes/admin-dashboard.tsx
+++ b/apps/web/src/routes/admin-dashboard.tsx
@@ -40,7 +40,7 @@ const CONTENT_SECTIONS: Section[] = [
   { key: 'npc', title: 'NPC', desc: '位置・名前・セリフ・絵 (フラグ制御は #425 で続き)', to: '/admin/npcs', issue: 425 },
   { key: 'quest', title: 'クエスト', desc: 'NPC 発注・達成条件 (討伐/収集)・報酬', to: '/admin/quests', issue: 423 },
   { key: 'places', title: '街 / ダンジョン / 城', desc: '内部マップとゲート (出入口) の編集', to: '/admin/interiors', issue: 424 },
-  { key: 'scenario', title: 'シナリオ', desc: '進行の筋書き', issue: 545 },
+  { key: 'scenario', title: 'シナリオ', desc: 'イベント列 + 進行フラグ (NPC セリフ/クエスト解禁のゲート)', to: '/admin/scenario', issue: 545 },
   { key: 'items', title: 'アイテム', desc: 'そうび・どうぐ・素材の編集', to: '/admin/items', issue: 420 },
   { key: 'shops', title: 'お店', desc: '店ごとのラインナップ・値札の素材 (セリフは #422 で続き)', to: '/admin/shops', issue: 422 },
   { key: 'flags', title: 'フラグ', desc: '進行フラグでゲート', issue: 426 },

--- a/apps/web/src/routes/admin-npcs.tsx
+++ b/apps/web/src/routes/admin-npcs.tsx
@@ -197,6 +197,82 @@ export function AdminNpcs() {
                 ＋セリフ
               </button>
             </div>
+            {/* フラグ別セリフ (#545)。上から見て最初に条件を満たしたものを話す。 */}
+            <div style={{ fontSize: '0.8em' }}>
+              <span style={{ color: 'var(--color-muted)' }}>
+                フラグ別セリフ (上から見て最初に条件を満たしたもの。どれも満たさなければ上のセリフ)
+              </span>
+              {(current.altLines ?? []).map((alt, ai) => (
+                <div key={ai} style={{ border: '1px solid var(--color-border)', padding: '0.3em', margin: '0.2em 0' }}>
+                  <div style={{ display: 'flex', gap: '0.3em', alignItems: 'center', flexWrap: 'wrap' }}>
+                    <span style={{ color: 'var(--color-muted)' }}>立っている</span>
+                    <input
+                      value={(alt.flags ?? []).join(' ')}
+                      placeholder="flag_a flag_b"
+                      onChange={(e) => {
+                        const flags = e.target.value.split(/\s+/).filter(Boolean);
+                        update(current.id, { altLines: (current.altLines ?? []).map((x, j) => (j === ai ? { ...x, flags } : x)) });
+                      }}
+                      style={{ width: '11em', fontFamily: 'ui-monospace, monospace' }}
+                    />
+                    <span style={{ color: 'var(--color-muted)' }}>立っていない</span>
+                    <input
+                      value={(alt.notFlags ?? []).join(' ')}
+                      placeholder="flag_c"
+                      onChange={(e) => {
+                        const notFlags = e.target.value.split(/\s+/).filter(Boolean);
+                        update(current.id, { altLines: (current.altLines ?? []).map((x, j) => (j === ai ? { ...x, notFlags } : x)) });
+                      }}
+                      style={{ width: '9em', fontFamily: 'ui-monospace, monospace' }}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => update(current.id, { altLines: (current.altLines ?? []).filter((_, j) => j !== ai) })}
+                      style={{ marginLeft: 'auto', fontSize: '0.8em' }}
+                    >
+                      この分岐を消す
+                    </button>
+                  </div>
+                  {alt.lines.map((l, li) => (
+                    <div key={li} style={{ display: 'flex', gap: '0.3em', margin: '0.15em 0' }}>
+                      <input
+                        value={l}
+                        onChange={(e) => update(current.id, {
+                          altLines: (current.altLines ?? []).map((x, j) => (j === ai ? { ...x, lines: x.lines.map((y, k) => (k === li ? e.target.value : y)) } : x)),
+                        })}
+                        style={{ flex: 1 }}
+                      />
+                      <button
+                        type="button"
+                        disabled={alt.lines.length <= 1}
+                        onClick={() => update(current.id, {
+                          altLines: (current.altLines ?? []).map((x, j) => (j === ai ? { ...x, lines: x.lines.filter((_, k) => k !== li) } : x)),
+                        })}
+                        style={{ fontSize: '0.8em' }}
+                      >
+                        ×
+                      </button>
+                    </div>
+                  ))}
+                  <button
+                    type="button"
+                    onClick={() => update(current.id, {
+                      altLines: (current.altLines ?? []).map((x, j) => (j === ai ? { ...x, lines: [...x.lines, ''] } : x)),
+                    })}
+                    style={{ fontSize: '0.8em' }}
+                  >
+                    ＋セリフ
+                  </button>
+                </div>
+              ))}
+              <button
+                type="button"
+                onClick={() => update(current.id, { altLines: [...(current.altLines ?? []), { flags: [], lines: ['…'] }] })}
+                style={{ fontSize: '0.8em', marginTop: '0.2em' }}
+              >
+                ＋フラグ別セリフ
+              </button>
+            </div>
             {drawing && (
               <TileArtEditor
                 subjects={[{

--- a/apps/web/src/routes/admin-quests.tsx
+++ b/apps/web/src/routes/admin-quests.tsx
@@ -6,6 +6,7 @@ import {
   ITEMS,
   MONSTERS,
   QuestDataError,
+  scenarioEvents,
   setGameQuests,
   type GameQuestDef,
   type QuestObjective,
@@ -73,6 +74,15 @@ export function AdminQuests() {
 
   const save = useCallback(async () => {
     if (!session.agent) return;
+    // シナリオ (#545) が条件にしているクエストを消させない — 参照切れが 1 件でもあると
+    // setScenario が全体を落とし、**フラグが二度と立たなくなる** (解禁クエストも永久ロック)。
+    const orphan = scenarioEvents().find((e) =>
+      e.when.some((c) => c.kind === 'questDone' && !list.some((q) => q.id === c.questId)),
+    );
+    if (orphan) {
+      setNote(`保存できない: シナリオ「${orphan.title}」が消したクエストを条件にしている。先にシナリオを直す`);
+      return;
+    }
     try {
       await saveGameQuests(session.agent, list);
       setDirty(false);

--- a/apps/web/src/routes/admin-quests.tsx
+++ b/apps/web/src/routes/admin-quests.tsx
@@ -303,6 +303,25 @@ export function AdminQuests() {
                 )}
               </span>
             ))}
+            {field('解禁フラグ', (
+              <span style={{ display: 'flex', gap: '0.3em', alignItems: 'center', flex: 1 }}>
+                <input
+                  value={(current.requireFlags ?? []).join(' ')}
+                  placeholder="(なし) 空白区切り。立つまで NPC は依頼を話さない"
+                  onChange={(e) => {
+                    const flags = e.target.value.split(/\s+/).filter(Boolean);
+                    setList((xs) => xs.map((x) => {
+                      if (x.id !== current.id) return x;
+                      if (flags.length === 0) { const { requireFlags: _f, ...rest } = x; return rest as GameQuestDef; }
+                      return { ...x, requireFlags: flags };
+                    }));
+                    setDirty(true);
+                  }}
+                  style={{ flex: 1, fontFamily: 'ui-monospace, monospace' }}
+                />
+                <Link to="/admin/scenario" style={{ fontSize: '0.85em' }}>シナリオ</Link>
+              </span>
+            ))}
             {lineEditor(current, 'intro', '依頼のセリフ', '読み終えると受注する')}
             {lineEditor(current, 'progress', '進行中のセリフ', '空なら既定「たのんだよ。」+ サーバーの「まだ n/m」')}
             {lineEditor(current, 'done', '達成のセリフ', 'お礼。この後に報酬が出る')}

--- a/apps/web/src/routes/admin-scenario.tsx
+++ b/apps/web/src/routes/admin-scenario.tsx
@@ -14,7 +14,7 @@ import {
 } from '@aozoraquest/core';
 import { useSession } from '@/lib/session';
 import { getPrimaryAdminDid, isAdminDid } from '@/lib/runtime-config';
-import { loadScenarioRecord, saveScenario } from '@/lib/world-authoring';
+import { loadAuthoredWorld, loadScenarioRecord, saveScenario } from '@/lib/world-authoring';
 
 /**
  * **シナリオエディタ** (#545)。進行を「条件が揃ったらフラグが立つ」の列で書く。
@@ -52,7 +52,10 @@ export function AdminScenario() {
     const agent = session.agent;
     const adminDid = getPrimaryAdminDid();
     if (!agent || !adminDid) { setLoadState('failed'); return; }
-    void loadScenarioRecord(agent, adminDid)
+    // **クエストを先に読む** — 条件が questId の実在を引くので、直接開くと
+    // 「クエストが存在しない」で読み込みが落ち、正常なレコードなのに保存不能になる。
+    void loadAuthoredWorld(agent)
+      .then(() => loadScenarioRecord(agent, adminDid))
       .then((events) => {
         if (cancelled) return;
         setList(events.map((e) => ({ ...e, when: e.when.map((c) => ({ ...c })), setFlags: [...e.setFlags] })));

--- a/apps/web/src/routes/admin-scenario.tsx
+++ b/apps/web/src/routes/admin-scenario.tsx
@@ -1,0 +1,303 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  ITEMS,
+  JOBS,
+  MAX_NOTICE_LEN,
+  ScenarioError,
+  gameQuests,
+  jobDisplayName,
+  scenarioEvents,
+  type Archetype,
+  type ScenarioCondition,
+  type ScenarioEvent,
+} from '@aozoraquest/core';
+import { useSession } from '@/lib/session';
+import { getPrimaryAdminDid, isAdminDid } from '@/lib/runtime-config';
+import { loadScenarioRecord, saveScenario } from '@/lib/world-authoring';
+
+/**
+ * **シナリオエディタ** (#545)。進行を「条件が揃ったらフラグが立つ」の列で書く。
+ *
+ * 粒度はオーナー判断で **(a) イベント列**。立ったフラグで NPC のセリフ (altLines) と
+ * クエストの解禁 (requireFlags) が変わる。選択肢つき会話や章ごとの地域解禁は
+ * この土台の上に後から乗せる。
+ *
+ * **フラグを立てるのはサーバー** — ここは「いつ立つか」の定義を書くだけ。
+ */
+
+const KIND_LABELS: Record<ScenarioCondition['kind'], string> = {
+  questDone: 'クエスト達成',
+  flag: 'フラグが立っている',
+  notFlag: 'フラグが立っていない',
+  jobLevel: 'ジョブ Lv 以上',
+  itemCount: 'アイテム所持',
+};
+
+export function AdminScenario() {
+  const session = useSession();
+  const admin = isAdminDid(session.did ?? null);
+  const [list, setList] = useState<ScenarioEvent[]>([]);
+  const [sel, setSel] = useState<string | null>(null);
+  const [note, setNote] = useState<string | null>(null);
+  const [dirty, setDirty] = useState(false);
+  const [loadState, setLoadState] = useState<'loading' | 'ok' | 'failed'>('loading');
+
+  const quests = useMemo(() => gameQuests(), [loadState]);
+  const items = useMemo(() => Object.entries(ITEMS).map(([id, v]) => ({ id, name: v.name })), []);
+
+  // 保存済みを読めなければ保存させない (空で上書きすると全部消える)。
+  useEffect(() => {
+    let cancelled = false;
+    const agent = session.agent;
+    const adminDid = getPrimaryAdminDid();
+    if (!agent || !adminDid) { setLoadState('failed'); return; }
+    void loadScenarioRecord(agent, adminDid)
+      .then((events) => {
+        if (cancelled) return;
+        setList(events.map((e) => ({ ...e, when: e.when.map((c) => ({ ...c })), setFlags: [...e.setFlags] })));
+        setLoadState('ok');
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        console.warn('[admin] scenario load failed', e);
+        setLoadState('failed');
+        setNote('保存済みのシナリオを読み込めなかった。上書きで消える恐れがあるので保存できない');
+      });
+    return () => { cancelled = true; };
+  }, [session.agent]);
+
+  const current = useMemo(() => list.find((e) => e.id === sel) ?? null, [list, sel]);
+  const update = useCallback((id: string, patch: Partial<ScenarioEvent>) => {
+    setList((xs) => xs.map((e) => (e.id === id ? { ...e, ...patch } : e)));
+    setDirty(true);
+  }, []);
+
+  /** 既に定義されているフラグ (打ち間違い防止に候補として出す)。 */
+  const knownFlags = useMemo(() => [...new Set(list.flatMap((e) => e.setFlags))].sort(), [list]);
+
+  const add = useCallback(() => {
+    let i = list.length + 1;
+    while (list.some((e) => e.id === `ev-${i}`)) i++;
+    const ev: ScenarioEvent = { id: `ev-${i}`, title: 'あたらしいイベント', when: [], setFlags: [`flag_${i}`] };
+    setList((xs) => [...xs, ev]);
+    setSel(ev.id);
+    setDirty(true);
+  }, [list]);
+
+  const save = useCallback(async () => {
+    if (!session.agent) return;
+    try {
+      await saveScenario(session.agent, list);
+      setDirty(false);
+      setNote(`${list.length} 件を保存した。サーバーは最大 5 分で拾う`);
+    } catch (e) {
+      setNote(e instanceof ScenarioError ? `保存できない: ${e.message}` : `保存できなかった: ${String(e)}`);
+    }
+  }, [session.agent, list]);
+
+  if (!admin) {
+    return (
+      <div style={{ padding: '1em' }}>
+        <p>この画面は管理者だけが使えます。</p>
+        <Link to="/admin">管理ダッシュボードへ</Link>
+      </div>
+    );
+  }
+
+  const field = (label: string, input: React.ReactNode) => (
+    <label style={{ display: 'flex', alignItems: 'center', gap: '0.4em', fontSize: '0.8em' }}>
+      <span style={{ width: '6em', color: 'var(--color-muted)' }}>{label}</span>
+      {input}
+    </label>
+  );
+
+  /** 条件 1 行の編集 UI。種類で必要な入力が変わる。 */
+  const condRow = (ev: ScenarioEvent, c: ScenarioCondition, i: number) => {
+    const setCond = (next: ScenarioCondition) => update(ev.id, { when: ev.when.map((x, j) => (j === i ? next : x)) });
+    return (
+      <div key={i} style={{ display: 'flex', gap: '0.3em', alignItems: 'center', flexWrap: 'wrap', margin: '0.15em 0' }}>
+        <select
+          value={c.kind}
+          onChange={(e) => {
+            const kind = e.target.value as ScenarioCondition['kind'];
+            // 種類を変えたら、その種類に要るフィールドだけを持つ条件に作り直す
+            // (古いフィールドが残ると検証で落ちる)。
+            if (kind === 'questDone') setCond({ kind, questId: quests[0]?.id ?? '' });
+            else if (kind === 'flag' || kind === 'notFlag') setCond({ kind, flag: knownFlags[0] ?? 'flag_1' });
+            else if (kind === 'jobLevel') setCond({ kind, job: JOBS[0]!.id, level: 5 });
+            else setCond({ kind, itemId: items[0]?.id ?? '', count: 1 });
+          }}
+        >
+          {(Object.keys(KIND_LABELS) as ScenarioCondition['kind'][]).map((k) => (
+            <option key={k} value={k}>{KIND_LABELS[k]}</option>
+          ))}
+        </select>
+
+        {c.kind === 'questDone' && (
+          <select value={c.questId} onChange={(e) => setCond({ ...c, questId: e.target.value })}>
+            {quests.length === 0 && <option value="">(クエストが無い)</option>}
+            {quests.map((q) => <option key={q.id} value={q.id}>{q.title}</option>)}
+          </select>
+        )}
+        {(c.kind === 'flag' || c.kind === 'notFlag') && (
+          <input
+            value={c.flag}
+            list="known-flags"
+            onChange={(e) => setCond({ ...c, flag: e.target.value })}
+            style={{ width: '11em', fontFamily: 'ui-monospace, monospace' }}
+          />
+        )}
+        {c.kind === 'jobLevel' && (
+          <>
+            <select value={c.job} onChange={(e) => setCond({ ...c, job: e.target.value as Archetype })}>
+              {JOBS.map((j) => <option key={j.id} value={j.id}>{jobDisplayName(j.id, 'default')}</option>)}
+            </select>
+            Lv<input type="number" min={1} max={99} value={c.level} onChange={(e) => setCond({ ...c, level: Number(e.target.value) })} style={{ width: '4.5em' }} />
+          </>
+        )}
+        {c.kind === 'itemCount' && (
+          <>
+            <select value={c.itemId} onChange={(e) => setCond({ ...c, itemId: e.target.value })}>
+              {items.map((it) => <option key={it.id} value={it.id}>{it.name}</option>)}
+            </select>
+            ×<input type="number" min={1} value={c.count} onChange={(e) => setCond({ ...c, count: Number(e.target.value) })} style={{ width: '4.5em' }} />
+          </>
+        )}
+        <button type="button" onClick={() => update(ev.id, { when: ev.when.filter((_, j) => j !== i) })} style={{ fontSize: '0.8em' }}>×</button>
+      </div>
+    );
+  };
+
+  return (
+    <div style={{ padding: '0.8em', maxWidth: 900 }}>
+      <datalist id="known-flags">
+        {knownFlags.map((f) => <option key={f} value={f} />)}
+      </datalist>
+
+      <div style={{ display: 'flex', gap: '0.6em', alignItems: 'center', marginBottom: '0.4em' }}>
+        <Link to="/admin" style={{ fontSize: '0.8em' }}>← 管理</Link>
+        <strong>シナリオ</strong>
+        <span style={{ fontSize: '0.75em', color: 'var(--color-muted)' }}>{list.length} 件 / フラグ {knownFlags.length}</span>
+        <button type="button" onClick={add} style={{ fontSize: '0.85em' }}>＋イベント</button>
+        <button type="button" onClick={() => void save()} disabled={!session.agent || !dirty || loadState !== 'ok'} style={{ marginLeft: 'auto', fontSize: '0.85em' }}>
+          保存
+        </button>
+      </div>
+
+      {note && <p style={{ fontSize: '0.8em', color: 'var(--color-accent)', margin: '0 0 0.4em' }}>{note}</p>}
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'minmax(160px, 1fr) 2fr', gap: '0.8em' }}>
+        <div style={{ maxHeight: '72vh', overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 2 }}>
+          {list.map((e) => (
+            <button
+              key={e.id}
+              type="button"
+              onClick={() => setSel(e.id)}
+              style={{
+                display: 'flex', gap: '0.3em', width: '100%', padding: '0.2em 0.4em', fontSize: '0.85em', textAlign: 'left',
+                border: sel === e.id ? '2px solid var(--color-accent)' : '1px solid var(--color-border)', background: 'transparent',
+              }}
+            >
+              <span style={{ flex: 1 }}>{e.title}</span>
+              <span style={{ fontSize: '0.7em', color: 'var(--color-muted)' }}>{e.when.length}条件</span>
+            </button>
+          ))}
+          {list.length === 0 && <span style={{ fontSize: '0.8em', color: 'var(--color-muted)' }}>まだ無い。「＋イベント」で作る</span>}
+        </div>
+
+        {current ? (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.35em' }}>
+            <div style={{ display: 'flex', gap: '0.4em', alignItems: 'center' }}>
+              <strong>{current.title}</strong>
+              <code style={{ fontSize: '0.75em', color: 'var(--color-muted)' }}>{current.id}</code>
+              <button
+                type="button"
+                className="secondary"
+                onClick={() => {
+                  if (!window.confirm(`「${current.title}」を消す？`)) return;
+                  setList((xs) => xs.filter((e) => e.id !== current.id));
+                  setSel(null);
+                  setDirty(true);
+                }}
+                style={{ marginLeft: 'auto', fontSize: '0.8em' }}
+              >
+                削除
+              </button>
+            </div>
+            {field('見出し', <input value={current.title} onChange={(e) => update(current.id, { title: e.target.value })} style={{ flex: 1 }} />)}
+
+            <div style={{ fontSize: '0.8em' }}>
+              <span style={{ color: 'var(--color-muted)' }}>
+                条件 (すべて満たすと発火。空なら最初から発火)
+              </span>
+              {current.when.map((c, i) => condRow(current, c, i))}
+              <button
+                type="button"
+                onClick={() => update(current.id, { when: [...current.when, { kind: 'questDone', questId: quests[0]?.id ?? '' }] })}
+                style={{ fontSize: '0.8em', marginTop: '0.2em' }}
+                disabled={quests.length === 0}
+              >
+                ＋条件
+              </button>
+              {quests.length === 0 && (
+                <span style={{ marginLeft: '0.4em', color: 'var(--color-muted)' }}>
+                  <Link to="/admin/quests">クエスト</Link>を作ると条件に使える
+                </span>
+              )}
+            </div>
+
+            <div style={{ fontSize: '0.8em' }}>
+              <span style={{ color: 'var(--color-muted)' }}>立てるフラグ (NPC のセリフ・クエストの解禁がこれで変わる)</span>
+              {current.setFlags.map((f, i) => (
+                <div key={i} style={{ display: 'flex', gap: '0.3em', margin: '0.15em 0' }}>
+                  <input
+                    value={f}
+                    onChange={(e) => update(current.id, { setFlags: current.setFlags.map((x, j) => (j === i ? e.target.value : x)) })}
+                    style={{ width: '14em', fontFamily: 'ui-monospace, monospace' }}
+                  />
+                  <button
+                    type="button"
+                    disabled={current.setFlags.length <= 1}
+                    onClick={() => update(current.id, { setFlags: current.setFlags.filter((_, j) => j !== i) })}
+                    style={{ fontSize: '0.8em' }}
+                  >
+                    ×
+                  </button>
+                </div>
+              ))}
+              <button type="button" onClick={() => update(current.id, { setFlags: [...current.setFlags, ''] })} style={{ fontSize: '0.8em' }}>
+                ＋フラグ
+              </button>
+            </div>
+
+            {field('お知らせ', (
+              <input
+                value={current.notice ?? ''}
+                maxLength={MAX_NOTICE_LEN}
+                placeholder="(なし) 例: 東の橋が なおったらしい"
+                onChange={(e) => {
+                  const v = e.target.value;
+                  // exactOptionalPropertyTypes: 空ならキーごと消す
+                  setList((xs) => xs.map((x) => {
+                    if (x.id !== current.id) return x;
+                    if (v.trim() === '') { const { notice: _n, ...rest } = x; return rest as ScenarioEvent; }
+                    return { ...x, notice: v };
+                  }));
+                  setDirty(true);
+                }}
+                style={{ flex: 1 }}
+              />
+            ))}
+
+            <p style={{ fontSize: '0.75em', color: 'var(--color-muted)', margin: '0.3em 0 0' }}>
+              使い道: <Link to="/admin/npcs">NPC</Link> のフラグ別セリフ / <Link to="/admin/quests">クエスト</Link>の解禁フラグ
+            </p>
+          </div>
+        ) : (
+          <div style={{ fontSize: '0.85em', color: 'var(--color-muted)' }}>左の一覧から選ぶか「＋イベント」。</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -157,6 +157,19 @@ export function World() {
   const questRef = useRef<{ active?: { id: string; progress: number }; done: string[] }>({ done: [] });
   /** 進行フラグ (#545)。**サーバーが正** — 立てるのは edge だけで、ここは表示用の写し。 */
   const flagsRef = useRef<string[]>([]);
+  /** 戦闘中に届いたシナリオのお知らせ (#545)。戦闘の窓は使えないので、
+   *  リザルトを閉じてマップに戻ってから出す。 */
+  const pendingNoticesRef = useRef<string[]>([]);
+  /** 溜まったシナリオのお知らせをマップの窓で出す。**戦闘を閉じた直後に呼ぶ** —
+   *  戦闘中に出しても窓が描画されず、発火済みのお知らせは二度と返らないので消える。 */
+  const flushScenarioNotices = useCallback(() => {
+    const list = pendingNoticesRef.current;
+    if (list.length === 0) return;
+    pendingNoticesRef.current = [];
+    setScenarioTalk(list);
+  }, []);
+  /** シナリオのお知らせ窓 (話者なしの地の文)。 */
+  const [scenarioTalk, setScenarioTalk] = useState<string[] | null>(null);
   const [onboarding, setOnboarding] = useState(false);
   const onboardingRef = useRef(false);
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
@@ -688,6 +701,10 @@ export function World() {
             ...(res.position ? { resultPos: res.position } : {}),
             ...(res.token ? { resultToken: res.token } : {}),
             ...(res.materials ? { resultMaterials: res.materials, resultCarryHp: res.carryHp, resultCarryMp: res.carryMp } : {}) };
+          // シナリオ (#545) は決着でも進む (ジョブ Lv 条件はここでしか動かない)。
+          // **拾わないと永久に失われる** — 発火済みのお知らせは二度と返らない。
+          if (res.flags) flagsRef.current = res.flags;
+          if (res.scenarioNotices?.length) pendingNoticesRef.current = [...pendingNoticesRef.current, ...res.scenarioNotices];
           battleRef.current = acting;
           setBattle(acting);
         } catch (e) {
@@ -718,6 +735,7 @@ export function World() {
       if (b.phase === 'result') {
         battleRef.current = null;
         setBattle(null);
+        flushScenarioNotices();
         return;
       }
       // agent/did は決着の確定処理 (レコード/XP) だけに要るので、ここでは要求しない。
@@ -820,6 +838,7 @@ export function World() {
       if (resultLines.length === 0) {
         battleRef.current = null;
         setBattle(null);
+        flushScenarioNotices();
       } else {
         const done = { ...b, state: next, busy: false, phase: 'result' as BattlePhase, resultLines };
         battleRef.current = done;
@@ -1474,6 +1493,13 @@ export function World() {
                   })
                   .catch((e) => setNotice(e instanceof WorldServerError ? e.message : 'うけおいに しっぱいした…'));
               }}
+            />
+          )}
+          {!battle && scenarioTalk && !npcTalk && !onboarding && (
+            <DialogueWindow
+              anchor="map"
+              lines={scenarioTalk.map((text) => ({ text }))}
+              onDone={() => setScenarioTalk(null)}
             />
           )}
           {!battle && onboarding && (

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -54,7 +54,7 @@ function shopErrorText(e: unknown, fallback: string): string {
 }
 import { WORLD_PREVIEW_ENABLED } from '@/lib/world-preview';
 import { loadAuthoredWorld } from '@/lib/world-authoring';
-import { allNpcs, EQUIPMENT_BY_ID, equipHands, gameQuestById, gameQuestByNpc, interiorById, interiorPartAt, interiorTerrainAt, npcArtKey, npcAt, walkableIn, WORLD_MAP_ID, type NpcDef } from '@aozoraquest/core';
+import { allNpcs, EQUIPMENT_BY_ID, equipHands, gameQuestById, gameQuestByNpc, interiorById, interiorPartAt, interiorTerrainAt, npcArtKey, npcAt, npcLinesFor, walkableIn, WORLD_MAP_ID, type NpcDef } from '@aozoraquest/core';
 import { mappedPartAt } from '@aozoraquest/core';
 import { Avatar } from '@/components/avatar';
 import { WorldBattleControls, type BattlePhase } from '@/components/world-battle-controls';
@@ -155,6 +155,8 @@ export function World() {
   const [npcTalk, setNpcTalk] = useState<{ npc: NpcDef; lines: string[]; acceptQuestId?: string } | null>(null);
   /** ゲーム内クエストの進行 (#423)。**サーバーが正** — 受注/達成の応答と serverState だけが書く。 */
   const questRef = useRef<{ active?: { id: string; progress: number }; done: string[] }>({ done: [] });
+  /** 進行フラグ (#545)。**サーバーが正** — 立てるのは edge だけで、ここは表示用の写し。 */
+  const flagsRef = useRef<string[]>([]);
   const [onboarding, setOnboarding] = useState(false);
   const onboardingRef = useRef(false);
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
@@ -368,6 +370,7 @@ export function World() {
             serverInv = { materials: ss.state.materials ?? {}, carryHp: ss.state.carryHp, carryMp: ss.state.carryMp };
             setServerPower(ss.state.power ?? 0);
             questRef.current = { ...(ss.state.quest ? { active: ss.state.quest } : {}), done: ss.state.questsDone ?? [] };
+            flagsRef.current = ss.state.flags ?? [];
             serverMapId = ss.state.mapId;
             // **所持個体もサーバーが正** (#551 段階 2)。ユーザー PDS の craft レコードは
             // 記帳 (履歴) であって所持の根拠ではない。
@@ -542,14 +545,17 @@ export function World() {
       // 同じ座標の NPC が「幽霊」として現れ、戻りゲートを塞ぐこともある (レビュー ★★)。
       const npc = cur ? undefined : npcAt(nx, ny);
       if (npc) {
-        const q = gameQuestByNpc(npc.id);
+        const q0 = gameQuestByNpc(npc.id);
+        // 解禁フラグ (#545) が立つまで、その NPC は依頼を話さない (通常のセリフに戻る)。
+        const q = q0 && (q0.requireFlags ?? []).every((f) => flagsRef.current.includes(f)) ? q0 : undefined;
         const qs = questRef.current;
+        const npcLines = npcLinesFor(npc, flagsRef.current);
         // 進行中クエストの定義が消されていたら (管理者が削除)、無かったことにする。
         // 放置すると「べつの たのまれごと」で全クエストが永久に受けられない (UX レビュー ★★★)。
         // サーバー側 (handleQuestAccept) も同じ判断で孤児クエストを落とす。
         const active = qs.active && gameQuestById(qs.active.id) ? qs.active : undefined;
         if (!q || qs.done.includes(q.id)) {
-          setNpcTalk({ npc, lines: npc.lines });
+          setNpcTalk({ npc, lines: npcLines });
         } else if (active?.id === q.id) {
           // 達成試行はサーバー往復。**往復中は移動もバンプも塞ぐ** (moveBusyRef) —
           // 塞がないとキー押しっぱなしで並行リクエストが飛び、成功の報酬ダイアログを
@@ -559,6 +565,7 @@ export function World() {
             try {
               const res = await serverQuestComplete(agent, q.id);
               questRef.current = { ...(res.quest ? { active: res.quest } : {}), done: res.questsDone ?? [] };
+              if (res.flags) flagsRef.current = res.flags;
               setServerPower(res.power);
               applyServerMaterials(res.materials);
               const r = res.rewarded;
@@ -566,7 +573,8 @@ export function World() {
                 r?.power ? `あおぞらパワー ${r.power}` : null,
                 r?.itemId ? `${ITEMS[r.itemId]?.name ?? r.itemId} ×${r.count}` : null,
               ].filter(Boolean).join(' と ');
-              setNpcTalk({ npc, lines: [...q.done, ...(got ? [`${got} を もらった!`] : [])] });
+              // シナリオのお知らせ (#545) はお礼の後に続けて出す (別の窓にすると流れが切れる)。
+              setNpcTalk({ npc, lines: [...q.done, ...(got ? [`${got} を もらった!`] : []), ...(res.notices ?? [])] });
             } catch (e) {
               if (e instanceof WorldServerError && e.code === 'not_ready') {
                 // 「まだ n/m」はサーバーの言い分をそのまま出す (進行数はサーバーが正)。
@@ -574,7 +582,7 @@ export function World() {
               } else if (e instanceof WorldServerError && e.code === 'already_done') {
                 // 並行達成の敗者 (レース)。done に積んで通常セリフへ。
                 questRef.current = { done: [...qs.done, q.id] };
-                setNpcTalk({ npc, lines: npc.lines });
+                setNpcTalk({ npc, lines: npcLines });
               } else {
                 // 通信失敗を進行セリフの顔で出さない — 条件を満たしているのに
                 // 「まだ頼み中」に見えると、達成済みなのに狩り続けてしまう (UX レビュー ★★)。

--- a/packages/core/src/__tests__/scenario.test.ts
+++ b/packages/core/src/__tests__/scenario.test.ts
@@ -186,3 +186,40 @@ describe('レビュー指摘の回帰 (#545)', () => {
     expect(() => setNpcs([ok])).not.toThrow();
   });
 });
+
+describe('notFlag の順序独立性 (#545 レビュー ★★)', () => {
+  /** 同じ回に両方の条件が揃うケース。定義の並び順で結果が変わってはいけない。 */
+  const pair = (order: 'aFirst' | 'bFirst'): ScenarioEvent[] => {
+    const a: ScenarioEvent = { id: 'A', title: '第2章へ', when: [{ kind: 'itemCount', itemId: 'herb', count: 1 }], setFlags: ['ch2'] };
+    const b: ScenarioEvent = {
+      id: 'B', title: '第2章前だけの噂',
+      when: [{ kind: 'itemCount', itemId: 'herb', count: 1 }, { kind: 'notFlag', flag: 'ch2' }],
+      setFlags: ['rumor'], notice: 'いまだけの うわさ',
+    };
+    return order === 'aFirst' ? [a, b] : [b, a];
+  };
+
+  it('定義の並び順に関わらず、同じ回に条件が揃えば両方発火する', () => {
+    for (const order of ['aFirst', 'bFirst'] as const) {
+      setScenario(pair(order));
+      const r = pendingScenario(progress({ materials: { herb: 1 } }));
+      expect(r.fired.map((e) => e.id).sort(), order).toEqual(['A', 'B']);
+    }
+  });
+
+  it('既にフラグが立っている状態なら notFlag のイベントは発火しない', () => {
+    setScenario(pair('aFirst'));
+    const r = pendingScenario(progress({ materials: { herb: 1 }, flags: ['ch2'] }));
+    expect(r.fired.map((e) => e.id)).toEqual([]); // A は発火済み、B は notFlag が成立しない
+  });
+
+  it('連鎖 (次の周で発火) は引き続き 1 回の呼び出しで解決する', () => {
+    setScenario([
+      { id: 'e3', title: '3', when: [{ kind: 'flag', flag: 'f2' }], setFlags: ['f3'] },
+      { id: 'e1', title: '1', when: [], setFlags: ['f1'] },
+      { id: 'e2', title: '2', when: [{ kind: 'flag', flag: 'f1' }], setFlags: ['f2'] },
+    ]);
+    const r = pendingScenario(progress());
+    expect(r.fired.map((e) => e.id).sort()).toEqual(['e1', 'e2', 'e3']);
+  });
+});

--- a/packages/core/src/__tests__/scenario.test.ts
+++ b/packages/core/src/__tests__/scenario.test.ts
@@ -163,3 +163,26 @@ describe('フラグによる出し分け', () => {
     expect(npcLinesFor(npc, ['ch1'])).toEqual(['ふつう']);
   });
 });
+
+describe('レビュー指摘の回帰 (#545)', () => {
+  it('フラグ総数が上限を超える定義は保存で弾く (切り捨てで章が巻き戻らない)', () => {
+    // 上限を超えると pendingScenario の slice が古いフラグを捨て、そのイベントが
+    // 「未発火」に戻って毎回再発火する。定義側で超えさせないのが唯一の確実な防ぎ方。
+    const many: ScenarioEvent[] = Array.from({ length: 200 }, (_, i) => ({
+      id: `e${i}`, title: `e${i}`, when: [], setFlags: [`a${i}`, `b${i}`, `c${i}`],
+    }));
+    expect(() => setScenario(many)).toThrow(ScenarioError); // 600 > 500
+  });
+
+  it('クエストの解禁フラグもシナリオと同じ書式で弾く (typo が永久ロックにならない)', () => {
+    expect(() => setGameQuests([{ ...QUEST, requireFlags: ['Chapter2'] }])).toThrow();
+    expect(() => setGameQuests([{ ...QUEST, requireFlags: ['chapter2'] }])).not.toThrow();
+  });
+
+  it('NPC のフラグ別セリフも同じ書式で弾く', () => {
+    const bad: NpcDef = { id: 'n9', name: 'x', x: 9, y: 9, lines: ['a'], altLines: [{ flags: ['UPPER'], lines: ['b'] }] };
+    expect(() => setNpcs([bad])).toThrow();
+    const ok: NpcDef = { ...bad, altLines: [{ flags: ['upper'], lines: ['b'] }] };
+    expect(() => setNpcs([ok])).not.toThrow();
+  });
+});

--- a/packages/core/src/__tests__/scenario.test.ts
+++ b/packages/core/src/__tests__/scenario.test.ts
@@ -1,0 +1,165 @@
+/**
+ * シナリオ (イベント列 + フラグ) (#545)。守るべき不変条件:
+ * - **発火済み (全フラグが立っている) イベントは二度と出さない** (お知らせが毎回出る事故)
+ * - 連鎖 (A のフラグで B が発火) を 1 回の呼び出しで解決する
+ * - 存在しないクエスト・ジョブ・アイテムを条件にさせない
+ * - 壊れた 1 件で全体を落とす
+ */
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import {
+  ScenarioError,
+  flagsSatisfied,
+  pendingScenario,
+  scenarioEvents,
+  setScenario,
+  type ScenarioEvent,
+  type ScenarioProgress,
+} from '../scenario.js';
+import { setGameQuests, type GameQuestDef } from '../quest-data.js';
+import { setNpcs, npcLinesFor, type NpcDef } from '../npc-data.js';
+import { MONSTERS } from '../battle.js';
+
+const MON = MONSTERS[0]!.id;
+const QUEST: GameQuestDef = {
+  id: 'q1', title: 'たいじ', npcId: 'n1',
+  intro: ['たのむ'], done: ['ありがとう'],
+  objective: { kind: 'defeat', monsterId: MON, count: 1 },
+};
+
+const progress = (over: Partial<ScenarioProgress> = {}): ScenarioProgress => ({
+  flags: [], questsDone: [], jobXpLevels: {}, materials: {}, ...over,
+});
+
+beforeEach(() => {
+  setNpcs([{ id: 'n1', name: 'そんちょう', x: 1, y: 1, lines: ['やあ'] }]);
+  setGameQuests([QUEST]);
+});
+afterEach(() => {
+  setScenario(null);
+  setGameQuests(null);
+  setNpcs(null);
+});
+
+describe('setScenario の検証', () => {
+  const base: ScenarioEvent = { id: 'e1', title: '第1章', when: [{ kind: 'questDone', questId: 'q1' }], setFlags: ['ch1_done'] };
+
+  it('正常な定義を受け付ける', () => {
+    setScenario([base]);
+    expect(scenarioEvents()).toHaveLength(1);
+  });
+
+  it('存在しないクエスト・ジョブ・アイテムを弾く', () => {
+    expect(() => setScenario([{ ...base, when: [{ kind: 'questDone', questId: 'ghost' }] }])).toThrow(ScenarioError);
+    expect(() => setScenario([{ ...base, when: [{ kind: 'jobLevel', job: 'nobody' as never, level: 5 }] }])).toThrow(ScenarioError);
+    expect(() => setScenario([{ ...base, when: [{ kind: 'itemCount', itemId: 'ghost', count: 1 }] }])).toThrow(ScenarioError);
+  });
+
+  it('フラグ名の書式を強制する (空白・大文字・長すぎを弾く)', () => {
+    for (const flag of ['', 'A B', 'UPPER', 'x'.repeat(60)]) {
+      expect(() => setScenario([{ ...base, setFlags: [flag] }]), flag).toThrow(ScenarioError);
+    }
+  });
+
+  it('立てるフラグが無いイベントを弾く (何も起きないイベントは書き間違い)', () => {
+    expect(() => setScenario([{ ...base, setFlags: [] }])).toThrow(ScenarioError);
+  });
+
+  it('自分が立てるフラグを自分の条件にできない (一度発火したら二度と成立しない)', () => {
+    expect(() => setScenario([{ ...base, when: [{ kind: 'flag', flag: 'ch1_done' }], setFlags: ['ch1_done'] }])).toThrow(ScenarioError);
+  });
+
+  it('id 重複・お知らせの長さを弾く', () => {
+    expect(() => setScenario([base, base])).toThrow(ScenarioError);
+    expect(() => setScenario([{ ...base, notice: 'x'.repeat(200) }])).toThrow(ScenarioError);
+  });
+
+  it('壊れた 1 件で全体を落とす', () => {
+    setScenario([base]);
+    expect(() => setScenario([{ ...base, id: 'ok' }, { ...base, id: 'bad', setFlags: [''] }])).toThrow(ScenarioError);
+    expect(scenarioEvents().map((e) => e.id)).toEqual(['e1']); // 前の状態のまま
+  });
+});
+
+describe('pendingScenario', () => {
+  it('条件を満たすと発火してフラグが立つ', () => {
+    setScenario([{ id: 'e1', title: '第1章', when: [{ kind: 'questDone', questId: 'q1' }], setFlags: ['ch1'], notice: '橋が なおった' }]);
+    expect(pendingScenario(progress()).fired).toHaveLength(0); // まだ達成していない
+    const r = pendingScenario(progress({ questsDone: ['q1'] }));
+    expect(r.fired.map((e) => e.id)).toEqual(['e1']);
+    expect(r.flags).toContain('ch1');
+  });
+
+  it('**発火済みは二度と出さない** (毎回同じお知らせが出ない)', () => {
+    setScenario([{ id: 'e1', title: '第1章', when: [{ kind: 'questDone', questId: 'q1' }], setFlags: ['ch1'] }]);
+    const r = pendingScenario(progress({ questsDone: ['q1'], flags: ['ch1'] }));
+    expect(r.fired).toHaveLength(0);
+  });
+
+  it('連鎖を 1 回で解決する (1 歩ごとに 1 段ずつ進まない)', () => {
+    setScenario([
+      { id: 'e2', title: '第2章', when: [{ kind: 'flag', flag: 'ch1' }], setFlags: ['ch2'] },
+      { id: 'e1', title: '第1章', when: [{ kind: 'questDone', questId: 'q1' }], setFlags: ['ch1'] },
+    ]);
+    const r = pendingScenario(progress({ questsDone: ['q1'] }));
+    expect(r.fired.map((e) => e.id).sort()).toEqual(['e1', 'e2']);
+    expect(r.flags).toEqual(expect.arrayContaining(['ch1', 'ch2']));
+  });
+
+  it('notFlag で「まだ〜していない」を表せる', () => {
+    setScenario([{ id: 'e1', title: '未着手', when: [{ kind: 'notFlag', flag: 'ch1' }], setFlags: ['hint'] }]);
+    expect(pendingScenario(progress()).fired).toHaveLength(1);
+    expect(pendingScenario(progress({ flags: ['ch1'] })).fired).toHaveLength(0);
+  });
+
+  it('jobLevel / itemCount は閾値以上で成立する', () => {
+    setScenario([
+      { id: 'lv', title: 'Lv', when: [{ kind: 'jobLevel', job: 'warrior', level: 5 }], setFlags: ['lv5'] },
+      { id: 'it', title: '素材', when: [{ kind: 'itemCount', itemId: 'herb', count: 3 }], setFlags: ['herb3'] },
+    ]);
+    expect(pendingScenario(progress({ jobXpLevels: { warrior: 4 }, materials: { herb: 2 } })).fired).toHaveLength(0);
+    const r = pendingScenario(progress({ jobXpLevels: { warrior: 5 }, materials: { herb: 3 } }));
+    expect(r.fired.map((e) => e.id).sort()).toEqual(['it', 'lv']);
+  });
+
+  it('条件が空なら最初から発火する (導入イベント)', () => {
+    setScenario([{ id: 'e0', title: '開始', when: [], setFlags: ['started'] }]);
+    expect(pendingScenario(progress()).fired.map((e) => e.id)).toEqual(['e0']);
+  });
+
+  it('条件が永久に満たされないイベントは発火しない (無限ループしない)', () => {
+    setScenario([{ id: 'e1', title: '不能', when: [{ kind: 'flag', flag: 'never_set' }], setFlags: ['x'] }]);
+    expect(pendingScenario(progress()).fired).toHaveLength(0);
+  });
+});
+
+describe('フラグによる出し分け', () => {
+  it('flagsSatisfied は required を全部・forbidden を 1 つも満たさないときだけ true', () => {
+    expect(flagsSatisfied(['a'], undefined, ['a', 'b'])).toBe(true);
+    expect(flagsSatisfied(['a', 'c'], undefined, ['a', 'b'])).toBe(false);
+    expect(flagsSatisfied(undefined, ['b'], ['a', 'b'])).toBe(false);
+    expect(flagsSatisfied(undefined, undefined, [])).toBe(true);
+  });
+
+  it('npcLinesFor は最初に条件を満たす分岐を返し、無ければ既定のセリフ', () => {
+    const npc: NpcDef = {
+      id: 'n2', name: 'むらびと', x: 2, y: 2, lines: ['ふつうの はなし'],
+      altLines: [
+        { flags: ['ch2'], lines: ['第2章の はなし'] },
+        { flags: ['ch1'], lines: ['第1章の はなし'] },
+      ],
+    };
+    expect(npcLinesFor(npc, [])).toEqual(['ふつうの はなし']);
+    expect(npcLinesFor(npc, ['ch1'])).toEqual(['第1章の はなし']);
+    // 上から順なので、両方立っていれば ch2 (後の章) が勝つ
+    expect(npcLinesFor(npc, ['ch1', 'ch2'])).toEqual(['第2章の はなし']);
+  });
+
+  it('notFlags で「まだ〜していない間だけ」のセリフを書ける', () => {
+    const npc: NpcDef = {
+      id: 'n3', name: 'むらびと', x: 3, y: 3, lines: ['ふつう'],
+      altLines: [{ notFlags: ['ch1'], lines: ['はやく たすけて'] }],
+    };
+    expect(npcLinesFor(npc, [])).toEqual(['はやく たすけて']);
+    expect(npcLinesFor(npc, ['ch1'])).toEqual(['ふつう']);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,4 +28,5 @@ export * from './quest-data.js';
 export * from './part-presets.js';
 export * from './job-data.js';
 export * from './interior.js';
+export * from './scenario.js';
 export * from './equipment.js';

--- a/packages/core/src/npc-data.ts
+++ b/packages/core/src/npc-data.ts
@@ -21,6 +21,19 @@ export interface NpcDef {
   y: number;
   /** セリフ (1 要素 = 1 窓)。ぶつかるたびに先頭から流す。 */
   lines: string[];
+  /**
+   * **進行フラグで変わるセリフ** (#545)。上から順に見て、条件を満たす最初のものを話す。
+   * どれも満たさなければ `lines` (既定のセリフ)。
+   *
+   * 「橋を直したら村人の話が変わる」を、NPC を作り直さずに書けるようにする。
+   */
+  altLines?: Array<{
+    /** すべて立っていること。 */
+    flags?: string[];
+    /** どれも立っていないこと。 */
+    notFlags?: string[];
+    lines: string[];
+  }>;
 }
 
 export interface NpcsRecord {
@@ -65,8 +78,20 @@ export function setNpcs(list: readonly NpcDef[] | null): void {
         throw new NpcDataError(`${where}: セリフが不正 (空 or ${MAX_NPC_LINE} 文字超)`);
       }
     }
+    for (const alt of n.altLines ?? []) {
+      if (!alt || !Array.isArray(alt.lines) || alt.lines.length === 0) throw new NpcDataError(`${where}: フラグ別セリフが空`);
+      for (const l of alt.lines) {
+        if (typeof l !== 'string' || l.trim() === '' || l.length > MAX_NPC_LINE) {
+          throw new NpcDataError(`${where}: フラグ別セリフが不正`);
+        }
+      }
+      // 条件の無い分岐は既定のセリフと同じなので、書き間違い (フラグ名の打ち漏らし) を疑う。
+      if ((alt.flags?.length ?? 0) === 0 && (alt.notFlags?.length ?? 0) === 0) {
+        throw new NpcDataError(`${where}: フラグ別セリフに条件が無い`);
+      }
+    }
   }
-  npcList = next.map((n) => ({ ...n, lines: [...n.lines] }));
+  npcList = next.map((n) => ({ ...n, lines: [...n.lines], ...(n.altLines ? { altLines: n.altLines.map((a) => ({ ...a, lines: [...a.lines] })) } : {}) }));
   byKey = new Map(npcList.map((n) => [key(n.x, n.y), n]));
 }
 
@@ -78,6 +103,19 @@ export function npcAt(x: number, y: number): NpcDef | undefined {
 /** 全 NPC (描画・エディタ用)。 */
 export function allNpcs(): readonly NpcDef[] {
   return npcList;
+}
+
+/**
+ * その NPC が今話すセリフ (#545)。フラグ別の分岐を上から見て、
+ * 最初に条件を満たしたものを返す。満たすものが無ければ既定のセリフ。
+ */
+export function npcLinesFor(npc: NpcDef, flags: readonly string[]): string[] {
+  for (const alt of npc.altLines ?? []) {
+    if (alt.flags?.some((f) => !flags.includes(f))) continue;
+    if (alt.notFlags?.some((f) => flags.includes(f))) continue;
+    return alt.lines;
+  }
+  return npc.lines;
 }
 
 /** NPC の絵のキー (ドット絵の登録簿に相乗り)。 */

--- a/packages/core/src/npc-data.ts
+++ b/packages/core/src/npc-data.ts
@@ -10,6 +10,8 @@
  * 絵はドット絵 (`npc:<id>` キー) で、無ければ代替の見た目に倒す。
  */
 
+import { isFlagName } from './scenario.js';
+
 export class NpcDataError extends Error {}
 
 export interface NpcDef {
@@ -88,6 +90,10 @@ export function setNpcs(list: readonly NpcDef[] | null): void {
       // 条件の無い分岐は既定のセリフと同じなので、書き間違い (フラグ名の打ち漏らし) を疑う。
       if ((alt.flags?.length ?? 0) === 0 && (alt.notFlags?.length ?? 0) === 0) {
         throw new NpcDataError(`${where}: フラグ別セリフに条件が無い`);
+      }
+      // シナリオ側と同じ書式で弾く (#545)。typo したフラグの分岐は永久に選ばれない。
+      for (const f of [...(alt.flags ?? []), ...(alt.notFlags ?? [])]) {
+        if (!isFlagName(f)) throw new NpcDataError(`${where}: フラグ名が不正 (${f})`);
       }
     }
   }

--- a/packages/core/src/quest-data.ts
+++ b/packages/core/src/quest-data.ts
@@ -40,6 +40,8 @@ export interface GameQuestDef {
   objective: QuestObjective;
   /** 報酬。省略可 (お礼のセリフだけのクエストも作れる)。 */
   reward?: { power?: number; itemId?: string; count?: number };
+  /** **解禁フラグ** (#545)。すべて立つまでこのクエストは受注できない (NPC も依頼を話さない)。 */
+  requireFlags?: string[];
 }
 
 export interface GameQuestsRecord {
@@ -97,6 +99,12 @@ export function setGameQuests(list: readonly GameQuestDef[] | null): void {
       throw new QuestDataError(`${where}: 達成条件の種類が不正`);
     }
     if (!Number.isInteger(o.count) || o.count < 1 || o.count > 99) throw new QuestDataError(`${where}: 個数は 1〜99`);
+    if (q.requireFlags !== undefined) {
+      if (!Array.isArray(q.requireFlags)) throw new QuestDataError(`${where}: requireFlags が配列でない`);
+      for (const f of q.requireFlags) {
+        if (typeof f !== 'string' || f.trim() === '') throw new QuestDataError(`${where}: 解禁フラグ名が空`);
+      }
+    }
     if (q.reward) {
       if (q.reward.power !== undefined && !(Number.isInteger(q.reward.power) && q.reward.power > 0 && q.reward.power <= MAX_QUEST_REWARD_POWER)) {
         throw new QuestDataError(`${where}: 報酬パワーは 1〜${MAX_QUEST_REWARD_POWER}`);
@@ -107,7 +115,7 @@ export function setGameQuests(list: readonly GameQuestDef[] | null): void {
       }
     }
   }
-  quests = next.map((q) => ({ ...q, intro: [...q.intro], done: [...q.done], ...(q.progress ? { progress: [...q.progress] } : {}) }));
+  quests = next.map((q) => ({ ...q, intro: [...q.intro], done: [...q.done], ...(q.progress ? { progress: [...q.progress] } : {}), ...(q.requireFlags ? { requireFlags: [...q.requireFlags] } : {}) }));
   byId = new Map(quests.map((q) => [q.id, q]));
   byNpc = new Map(quests.map((q) => [q.npcId, q]));
 }

--- a/packages/core/src/quest-data.ts
+++ b/packages/core/src/quest-data.ts
@@ -18,6 +18,7 @@
  */
 import { MONSTERS_BY_ID, ITEMS } from './battle.js';
 import { allNpcs } from './npc-data.js';
+import { isFlagName } from './scenario.js';
 
 export class QuestDataError extends Error {}
 
@@ -102,7 +103,9 @@ export function setGameQuests(list: readonly GameQuestDef[] | null): void {
     if (q.requireFlags !== undefined) {
       if (!Array.isArray(q.requireFlags)) throw new QuestDataError(`${where}: requireFlags が配列でない`);
       for (const f of q.requireFlags) {
-        if (typeof f !== 'string' || f.trim() === '') throw new QuestDataError(`${where}: 解禁フラグ名が空`);
+        // シナリオ側と同じ書式で弾く (#545)。大文字などの typo を通すと、
+        // そのフラグは永久に立たず**誰も受注できないクエスト**が無言で生まれる。
+        if (!isFlagName(f)) throw new QuestDataError(`${where}: 解禁フラグ名が不正 (${f})`);
       }
     }
     if (q.reward) {

--- a/packages/core/src/scenario.ts
+++ b/packages/core/src/scenario.ts
@@ -1,0 +1,183 @@
+/**
+ * **シナリオ (イベント列 + フラグ)** (#545 / #426)。世界に筋書きを入れる。
+ *
+ * オーナー判断で粒度は **(a) イベント列**。「条件が揃ったら何が起きる」を並べ、
+ * NPC のセリフ・クエストの解禁をフラグでゲートする。選択肢つき会話ツリー (b) や
+ * 章立てによる地域解禁 (c) は、この土台の上に後から乗る。
+ *
+ * ## フラグが単一の進行状態
+ *
+ * 進行は `GameState.flags` (文字列の集合) だけで表す。**フラグを立てるのは
+ * サーバー (edge)** — 条件の判定も付与も権威側でやる (client の自己申告で
+ * 章が進むと、クエスト解禁も報酬も破られる)。
+ *
+ * ## 条件はサーバーが検証できるものだけ
+ *
+ * - questDone: そのクエストを達成済み
+ * - flag / notFlag: 別のフラグの有無 (章の順序はこれで表す)
+ * - jobLevel: そのジョブが指定 Lv 以上
+ * - itemCount: 素材を指定個数以上持っている
+ *
+ * 「特定の場所に行った」は位置を毎ターン見る必要があるので入れていない
+ * (必要になったら move の権威経路で拾う)。
+ *
+ * ## 結果もデータで表せるものだけ
+ *
+ * - flag: フラグを立てる (これが本体。NPC/クエストの出し分けが変わる)
+ * - notice: 一度だけ出すお知らせ (「東の橋が直ったらしい」)
+ *
+ * ネタバレを避けるため、定義は**コードでなく管理者 PDS** (`world.scenario`) に置く
+ * (モンスター #419 と同じ流儀)。
+ */
+import { gameQuestById } from './quest-data.js';
+import { ITEMS } from './battle.js';
+import { JOBS_BY_ID } from './jobs.js';
+import type { Archetype } from './types.js';
+
+export class ScenarioError extends Error {}
+
+export type ScenarioCondition =
+  | { kind: 'questDone'; questId: string }
+  | { kind: 'flag'; flag: string }
+  | { kind: 'notFlag'; flag: string }
+  | { kind: 'jobLevel'; job: Archetype; level: number }
+  | { kind: 'itemCount'; itemId: string; count: number };
+
+export interface ScenarioEvent {
+  id: string;
+  /** 管理画面での見出し (プレイヤーには出ない)。 */
+  title: string;
+  /** **すべて**満たしたら発火する (AND)。空なら即発火 = 開始直後のイベント。 */
+  when: ScenarioCondition[];
+  /** 発火で立てるフラグ。 */
+  setFlags: string[];
+  /** 発火時に一度だけ出すお知らせ (省略可)。 */
+  notice?: string;
+}
+
+export interface ScenarioRecord {
+  events: ScenarioEvent[];
+  updatedAt: string;
+}
+
+export const MAX_SCENARIO_EVENTS = 200;
+export const MAX_FLAGS = 500;
+export const MAX_NOTICE_LEN = 120;
+/** フラグ名に使える文字 (レコードのキーや UI で扱いやすい範囲に絞る)。 */
+const FLAG_RE = /^[a-z0-9][a-z0-9_-]{0,47}$/;
+
+let events: ScenarioEvent[] = [];
+
+/**
+ * イベント定義を差し替える。`null` で全解除。
+ * **壊れた 1 件で全体を落とす** (部分適用しない。他エディタと同じ流儀)。
+ *
+ * questId の実在を見るので、**クエスト (#423) を読んだ後に呼ぶ**こと。
+ */
+export function setScenario(list: readonly ScenarioEvent[] | null): void {
+  const next = list ?? [];
+  if (next.length > MAX_SCENARIO_EVENTS) throw new ScenarioError(`イベントが多すぎる (${next.length} > ${MAX_SCENARIO_EVENTS})`);
+  const ids = new Set<string>();
+  for (const e of next) {
+    const where = e?.id ?? '(id なし)';
+    if (!e || typeof e.id !== 'string' || e.id.trim() === '') throw new ScenarioError('イベントの id が空');
+    if (ids.has(e.id)) throw new ScenarioError(`イベントの id が重複 (${e.id})`);
+    ids.add(e.id);
+    if (typeof e.title !== 'string' || e.title.trim() === '') throw new ScenarioError(`${where}: タイトルが空`);
+    if (!Array.isArray(e.when)) throw new ScenarioError(`${where}: 条件が配列でない`);
+    for (const c of e.when) {
+      if (!c) throw new ScenarioError(`${where}: 条件が空`);
+      switch (c.kind) {
+        case 'questDone':
+          if (!gameQuestById(c.questId)) throw new ScenarioError(`${where}: クエストが存在しない (${c.questId})`);
+          break;
+        case 'flag':
+        case 'notFlag':
+          if (!FLAG_RE.test(c.flag)) throw new ScenarioError(`${where}: フラグ名が不正 (${c.flag})`);
+          break;
+        case 'jobLevel':
+          if (!JOBS_BY_ID[c.job]) throw new ScenarioError(`${where}: ジョブが存在しない (${c.job})`);
+          if (!Number.isInteger(c.level) || c.level < 1 || c.level > 99) throw new ScenarioError(`${where}: レベルは 1〜99`);
+          break;
+        case 'itemCount':
+          if (!ITEMS[c.itemId]) throw new ScenarioError(`${where}: アイテムが存在しない (${c.itemId})`);
+          if (!Number.isInteger(c.count) || c.count < 1) throw new ScenarioError(`${where}: 個数は 1 以上`);
+          break;
+        default:
+          throw new ScenarioError(`${where}: 条件の種類が不正`);
+      }
+    }
+    if (!Array.isArray(e.setFlags) || e.setFlags.length === 0) throw new ScenarioError(`${where}: 立てるフラグが無い`);
+    for (const f of e.setFlags) {
+      if (!FLAG_RE.test(f)) throw new ScenarioError(`${where}: フラグ名が不正 (${f})`);
+    }
+    if (e.notice !== undefined && (typeof e.notice !== 'string' || e.notice.trim() === '' || e.notice.length > MAX_NOTICE_LEN)) {
+      throw new ScenarioError(`${where}: お知らせが不正 (${MAX_NOTICE_LEN} 文字まで)`);
+    }
+    // **自分が立てるフラグを自分の条件にしない** (一度発火したら二度と成立しない
+    // イベントになり、書いた人の意図とほぼ確実に食い違う)。
+    for (const c of e.when) {
+      if (c.kind === 'flag' && e.setFlags.includes(c.flag)) throw new ScenarioError(`${where}: 自分が立てるフラグを条件にしている (${c.flag})`);
+    }
+  }
+  events = next.map((e) => ({ ...e, when: e.when.map((c) => ({ ...c })), setFlags: [...e.setFlags] }));
+}
+
+/** 全イベント (エディタ・判定用)。 */
+export function scenarioEvents(): readonly ScenarioEvent[] {
+  return events;
+}
+
+/** 判定に渡す進行状況 (edge の GameState から作る)。 */
+export interface ScenarioProgress {
+  flags: readonly string[];
+  questsDone: readonly string[];
+  jobXpLevels: Readonly<Record<string, number>>;
+  materials: Readonly<Record<string, number>>;
+}
+
+function meets(c: ScenarioCondition, p: ScenarioProgress): boolean {
+  switch (c.kind) {
+    case 'questDone': return p.questsDone.includes(c.questId);
+    case 'flag': return p.flags.includes(c.flag);
+    case 'notFlag': return !p.flags.includes(c.flag);
+    case 'jobLevel': return (p.jobXpLevels[c.job] ?? 0) >= c.level;
+    case 'itemCount': return (p.materials[c.itemId] ?? 0) >= c.count;
+  }
+}
+
+/**
+ * 今の進行で新しく発火するイベントを返す。**既に全フラグが立っているものは出さない**
+ * (毎回同じお知らせが出るのを防ぐ)。
+ *
+ * 連鎖 (A が立てたフラグで B が発火) も 1 回の呼び出しで解決する — そうしないと
+ * 「1 歩歩くごとに 1 段ずつ進む」という不自然な出方になる。
+ */
+export function pendingScenario(p: ScenarioProgress): { fired: ScenarioEvent[]; flags: string[] } {
+  const flags = new Set(p.flags);
+  const fired: ScenarioEvent[] = [];
+  // 連鎖の解決。イベント数を上限にすれば、どんな依存関係でも必ず止まる
+  // (フラグは増える一方なので、1 周で 1 つも発火しなければそこで終わり)。
+  for (let round = 0; round < events.length; round++) {
+    let progressed = false;
+    for (const e of events) {
+      if (fired.includes(e)) continue;
+      // 全部のフラグが既に立っている = 発火済み。
+      if (e.setFlags.every((f) => flags.has(f))) continue;
+      const cur: ScenarioProgress = { ...p, flags: [...flags] };
+      if (!e.when.every((c) => meets(c, cur))) continue;
+      fired.push(e);
+      for (const f of e.setFlags) flags.add(f);
+      progressed = true;
+    }
+    if (!progressed) break;
+  }
+  return { fired, flags: [...flags].slice(-MAX_FLAGS) };
+}
+
+/** そのフラグ条件を満たしているか (NPC のセリフ出し分け等、表示側の判定に使う)。 */
+export function flagsSatisfied(required: readonly string[] | undefined, forbidden: readonly string[] | undefined, flags: readonly string[]): boolean {
+  if (required?.some((f) => !flags.includes(f))) return false;
+  if (forbidden?.some((f) => flags.includes(f))) return false;
+  return true;
+}

--- a/packages/core/src/scenario.ts
+++ b/packages/core/src/scenario.ts
@@ -66,6 +66,12 @@ export const MAX_NOTICE_LEN = 120;
 /** フラグ名に使える文字 (レコードのキーや UI で扱いやすい範囲に絞る)。 */
 const FLAG_RE = /^[a-z0-9][a-z0-9_-]{0,47}$/;
 
+/** フラグ名として使えるか。クエストの解禁・NPC の分岐も同じ書式で検証する
+ *  (書式が揃っていないと、typo したフラグが永久に立たない設定を無言で作れる)。 */
+export function isFlagName(v: unknown): v is string {
+  return typeof v === 'string' && FLAG_RE.test(v);
+}
+
 let events: ScenarioEvent[] = [];
 
 /**
@@ -120,6 +126,11 @@ export function setScenario(list: readonly ScenarioEvent[] | null): void {
       if (c.kind === 'flag' && e.setFlags.includes(c.flag)) throw new ScenarioError(`${where}: 自分が立てるフラグを条件にしている (${c.flag})`);
     }
   }
+  // **総フラグ数を保存時に弾く。** pendingScenario は上限で古いフラグを切り捨てるが、
+  // 捨てられたフラグのイベントは「未発火」に戻り、条件を満たす限り毎回再発火して
+  // お知らせが出続ける。定義側で超えさせないのが唯一の確実な防ぎ方。
+  const allFlags = new Set(next.flatMap((e) => e.setFlags));
+  if (allFlags.size > MAX_FLAGS) throw new ScenarioError(`フラグが多すぎる (${allFlags.size} > ${MAX_FLAGS})`);
   events = next.map((e) => ({ ...e, when: e.when.map((c) => ({ ...c })), setFlags: [...e.setFlags] }));
 }
 

--- a/packages/core/src/scenario.ts
+++ b/packages/core/src/scenario.ts
@@ -170,18 +170,24 @@ export function pendingScenario(p: ScenarioProgress): { fired: ScenarioEvent[]; 
   // 連鎖の解決。イベント数を上限にすれば、どんな依存関係でも必ず止まる
   // (フラグは増える一方なので、1 周で 1 つも発火しなければそこで終わり)。
   for (let round = 0; round < events.length; round++) {
-    let progressed = false;
+    // **1 周ぶんはこの周の開始時点のフラグで判定する。** 直前に立ったフラグを
+    // 即座に反映すると、`notFlag` のイベントが「同じ回に条件を満たした別のイベント」に
+    // 潰される (「章が進む前だけ見られる話」が定義の並び順で発火したりしなかったり
+    // する)。まとめて発火 → 次の周で連鎖、なら順序に依存しない。
+    const snapshot: ScenarioProgress = { ...p, flags: [...flags] };
+    const firedThisRound: ScenarioEvent[] = [];
     for (const e of events) {
       if (fired.includes(e)) continue;
       // 全部のフラグが既に立っている = 発火済み。
       if (e.setFlags.every((f) => flags.has(f))) continue;
-      const cur: ScenarioProgress = { ...p, flags: [...flags] };
-      if (!e.when.every((c) => meets(c, cur))) continue;
+      if (!e.when.every((c) => meets(c, snapshot))) continue;
+      firedThisRound.push(e);
+    }
+    if (firedThisRound.length === 0) break;
+    for (const e of firedThisRound) {
       fired.push(e);
       for (const f of e.setFlags) flags.add(f);
-      progressed = true;
     }
-    if (!progressed) break;
   }
   return { fired, flags: [...flags].slice(-MAX_FLAGS) };
 }


### PR DESCRIPTION
Closes #545
Refs #426

## 概要

世界に筋書きを入れる。粒度はオーナー判断で **(a) イベント列**: 「条件が揃ったらフラグが立つ」を並べ、立ったフラグで NPC のセリフとクエストの解禁を出し分ける。

## 設計

- **フラグを立てるのは edge だけ** (`GameState.flags`)。client の自己申告で章が進むと、クエスト解禁も報酬も破られる
- **条件はサーバーが検証できるものだけ**: クエスト達成 / フラグの有無 / ジョブ Lv / 素材の所持数
- 判定はクエスト達成と戦闘決着の後だけ (条件が満たされるのはこの 2 つの後だけ)
- **発火済みは二度と出さない**。**連鎖は 1 回で解決**。**同じ回の発火はその周の開始時点のフラグで判定** (notFlag が定義の並び順に依存しない)
- 自分が立てるフラグを自分の条件にする定義、フラグ総数が上限超えの定義は保存で弾く
- 定義は管理者 PDS (`world.scenario`) — リポジトリ公開なのでネタバレを避ける

## 使い方

1. `/admin/scenario` でイベントを作る (条件 → 立てるフラグ → お知らせ)
2. `/admin/npcs` の「フラグ別セリフ」でセリフを出し分け
3. `/admin/quests` の「解禁フラグ」でクエストをゲート

## テスト

- core: scenario 23 件 / edge: 3 件
- core 695 / edge 248 / web 360 全緑、typecheck / build 緑

## Review

2 観点 (設計/実装)。**両者が独立に同じ ★★★ 3 件を検出**。全件対応:

- **★★★ 決着で発火したお知らせが client に届かず永久に失われる** (発火済みは二度と返らない設計なので取り戻せない。jobLevel 条件はこの経路でしか発火せず、条件種が丸ごと死んでいた) → TurnResult に flags/scenarioNotices を通し、戦闘を閉じた直後にマップの窓で出す
- **★★★ 条件のクエストを消すとシナリオが全プレイヤーで恒久停止** (edge のコールドスタート後にフラグが二度と立たず、解禁クエストが永久ロック) → クエストエディタ側で参照切れを保存時に弾く
- **★★★ /admin/scenario を直接開くと編集不能** (クエスト未ロードで読み込みが落ち、正常なレコードなのに「読み込めなかった」) → 先にワールドを読む
- **★★ フラグ総数が上限を超えると切り捨てで章が巻き戻り、お知らせが毎回鳴り続ける** (実測: 600 フラグで毎回 34 件が再発火) → 定義側で総数を検証して弾く
- **★★ 解禁フラグ・NPC のフラグ別セリフに書式検証が無く、typo が「誰も受注できないクエスト」「永久に選ばれない分岐」を無言で作れた** → 同じ isFlagName で弾く
- **★★ notFlag のイベントが定義の並び順で潰される** (同じ回に条件が揃うと直前のフラグが即座に効く) → 1 周はその周の開始時点のフラグで判定

設計レビューが実測で確認した健全な点: フラグが落ちる経路なし (全 mutate が `...state` 展開) / flags 無しの既存 state と互換 / フラグの自己申告は成立しない / questsDone リング溢れでも再発火しない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SpSiVHa5hXp7sEUAXAfWEE