### PR TITLE
feat: タイル絵に「同梱の絵に戻す」を追加 (#615)

### DIFF
--- a/apps/web/src/components/admin/tile-art-editor.tsx
+++ b/apps/web/src/components/admin/tile-art-editor.tsx
@@ -12,6 +12,7 @@ import {
   dumpTileArts,
   emptyTileArt,
   loadTileArts,
+  bundledTileArtFor,
   setTileArt,
   tileArtColorAt,
   tileArtFor,
@@ -121,6 +122,31 @@ export function TileArtEditor({ parts: partsIn, subjects: subjectsIn }: { parts?
       setNote(`保存できなかった: ${String(e)}`);
     }
   }, [session.agent, terrain, art]);
+
+  /**
+   * **同梱の絵に戻す** (#605)。一度でも自分で描くとその絵が登録簿に残って恒久的に
+   * 勝つので、既定に戻す手段が無いと「新しい同梱の絵が反映されない」ように見える。
+   * 登録簿から消して保存すると、以後は同梱の絵が使われる。
+   */
+  const resetToBundled = useCallback(async () => {
+    const bundled = bundledTileArtFor(subject.legacyKey ?? subject.key);
+    if (!bundled) { setNote('この部位には同梱の絵が無い'); return; }
+    if (!window.confirm(`${subject.name} を同梱の絵に戻す？\n自分で描いた絵は消える`)) return;
+    try {
+      // **key と legacyKey の両方を消す** — 片方が残ると探索順で古い絵が勝ち続ける。
+      setTileArt(subject.key, null);
+      if (subject.legacyKey) setTileArt(subject.legacyKey, null);
+      setArt(bundled);
+      if (session.agent) {
+        const n = await saveTileArts(session.agent);
+        setNote(`同梱の絵に戻した (${n} 件を保存。サーバーは最大 5 分で拾う)`);
+      } else {
+        setNote('同梱の絵に戻した (未ログインなので保存されていない)');
+      }
+    } catch (e) {
+      setNote(`戻せなかった: ${String(e)}`);
+    }
+  }, [subject, session.agent]);
 
   const exportJson = useCallback(() => {
     setTileArt(terrain, art);
@@ -274,6 +300,7 @@ export function TileArtEditor({ parts: partsIn, subjects: subjectsIn }: { parts?
       <div style={{ display: 'flex', gap: '0.4em', marginTop: '0.5em', flexWrap: 'wrap', alignItems: 'center' }}>
         <button type="button" onClick={save} style={{ fontSize: '0.85em' }}>この地形に反映</button>
         <button type="button" onClick={() => void publish()} disabled={!session.agent} style={{ fontSize: '0.85em' }}>保存する</button>
+        <button type="button" onClick={() => void resetToBundled()} style={{ fontSize: '0.85em' }}>同梱の絵に戻す</button>
         <button type="button" onClick={exportJson} style={{ fontSize: '0.85em' }}>すべて書き出す</button>
         <label style={{ fontSize: '0.85em' }}>
           読み込む{' '}

--- a/packages/core/src/__tests__/terrain-art.test.ts
+++ b/packages/core/src/__tests__/terrain-art.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, it, expect, afterEach } from 'vitest';
 import { DEFAULT_TERRAIN_ARTS } from '../terrain-art-data.js';
-import { assertTileArt, decodeTileArt, partArtFor, setTileArt, tileArtFor, TILE_ART_MAX_COLORS, emptyTileArt } from '../tile-art.js';
+import { assertTileArt, bundledTileArtFor, decodeTileArt, partArtFor, setTileArt, tileArtFor, TILE_ART_MAX_COLORS, emptyTileArt } from '../tile-art.js';
 import { BASE_PALETTE } from '../world-map.js';
 
 describe('DEFAULT_TERRAIN_ARTS', () => {
@@ -67,5 +67,19 @@ describe('tileArtFor / partArtFor のフォールバック', () => {
     // (絵タブだけドット絵で地図は SVG、という食い違い。レビュー ★★★ の再発防止)。
     expect(partArtFor(0, 'plains')).toBeDefined();
     expect(partArtFor(0, 'plains')!.size).toBe(16);
+  });
+});
+
+describe('bundledTileArtFor (#605 同梱に戻す)', () => {
+  afterEach(() => setTileArt('forest', null));
+
+  it('登録簿を無視して同梱の絵を返す (戻す先が取れる)', () => {
+    setTileArt('forest', emptyTileArt(8));
+    expect(tileArtFor('forest')!.size).toBe(8); // 描いた絵が勝っている
+    expect(bundledTileArtFor('forest')!.size).toBe(16); // 同梱はそのまま取れる
+  });
+
+  it('同梱に無い地形は undefined', () => {
+    expect(bundledTileArtFor('unknown-xyz')).toBeUndefined();
   });
 });

--- a/packages/core/src/tile-art.ts
+++ b/packages/core/src/tile-art.ts
@@ -134,6 +134,14 @@ export function setTileArt(terrain: string, art: TileArt | null): void {
   registry.set(terrain, art);
 }
 
+/**
+ * **同梱の既定絵だけ**を引く (登録簿を無視する)。エディタの「同梱の絵に戻す」が使う —
+ * 一度でも自分で描くとその絵が恒久的に勝つので、既定に戻す手段が要る。
+ */
+export function bundledTileArtFor(terrain: string): TileArt | undefined {
+  return bundledArtFor(terrain);
+}
+
 /** 地形のドット絵。エディタで描いたもの → **同梱の既定絵 (#605)** → undefined (代表色)。 */
 export function tileArtFor(terrain: string): TileArt | undefined {
   return registry.get(terrain) ?? bundledArtFor(terrain);


### PR DESCRIPTION
Closes #615

## なぜ

オーナー報告「地図のパーツがドット絵になってない」「森が変わって無さそう」の原因調査。

同梱のドット絵 (#605) は**エディタで描いた絵が無いときだけ**使われる (レコードが勝つ設計)。管理者 PDS の `world.tileArt` を実測したところ、過去に描いた絵が 6 件残っていた:

    forest / plains / town / part:4 (water) / part:7 (よこの橋) / part:8 (たての橋)

この 6 つは以前の絵が勝ち続けるため同梱の絵に差し替わらない (grove / pond / mountain は同梱が出ている)。森が変わって見えないのはこれが理由で、コードの不具合ではない。

## 変更

- `bundledTileArtFor`: 登録簿を無視して同梱の絵を引く
- タイル絵エディタに **「同梱の絵に戻す」** ボタン。key と legacyKey の**両方**を消して保存する (片方が残ると探索順で古い絵が勝ち続ける)

## テスト

- core: 2 件 (描いた絵が勝っていても同梱を取れる / 同梱に無い地形は undefined)
- core 697 / web 360 全緑、typecheck / build 緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SpSiVHa5hXp7sEUAXAfWEE