### PR TITLE
fix: 管理エディタをスマホで使えるようにする (#617)

### DIFF
--- a/apps/web/src/routes/__tests__/admin-mobile.test.ts
+++ b/apps/web/src/routes/__tests__/admin-mobile.test.ts
@@ -1,0 +1,37 @@
+/**
+ * 管理エディタのモバイル対応 (#617)。**レイアウトを共有クラスに寄せたことを固定する** —
+ * インラインで 2 カラム grid を書くと、狭い画面で右カラムが画面外へ出て入力もラベルも
+ * 切れる (実機で操作不能になった)。新しいエディタで同じ崩れを持ち込まないよう検出する。
+ */
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DIR = join(dirname(fileURLToPath(import.meta.url)), '..');
+/** ダッシュボード (カード並べ) とマップエディタ (専用レイアウト) は対象外。 */
+const EDITORS = readdirSync(DIR)
+  .filter((f) => f.startsWith('admin-') && f.endsWith('.tsx'))
+  .filter((f) => !['admin-dashboard.tsx', 'admin-map.tsx'].includes(f));
+
+describe('管理エディタのレイアウト', () => {
+  it('対象のエディタを拾えている', () => {
+    expect(EDITORS.length).toBeGreaterThanOrEqual(6);
+  });
+
+  for (const f of EDITORS) {
+    const src = readFileSync(join(DIR, f), 'utf8');
+
+    it(`${f}: ルートに admin-page が付いている (入力が枠を超えない)`, () => {
+      expect(src).toContain('className="admin-page"');
+    });
+
+    it(`${f}: 2 カラムをインラインの gridTemplateColumns で組んでいない`, () => {
+      // 共有クラス (狭い画面で 1 カラムに畳む) を使うこと。
+      // repeat(auto-fill, ...) は自動で折り返すので許容する。
+      const inline = src.match(/gridTemplateColumns: '([^']*)'/g) ?? [];
+      const twoCol = inline.filter((m) => !m.includes('repeat('));
+      expect(twoCol, `${f} は admin-cols を使う`).toEqual([]);
+    });
+  }
+});

--- a/apps/web/src/routes/admin-interiors.tsx
+++ b/apps/web/src/routes/admin-interiors.tsx
@@ -139,8 +139,8 @@ export function AdminInteriors() {
   const gatesHere = current ? gates.filter((g) => g.from.mapId === current.id) : [];
 
   return (
-    <div style={{ padding: '0.8em', maxWidth: 980 }}>
-      <div style={{ display: 'flex', gap: '0.6em', alignItems: 'center', marginBottom: '0.4em' }}>
+    <div className="admin-page" style={{ padding: '0.8em' }}>
+      <div className="admin-head">
         <Link to="/admin" style={{ fontSize: '0.8em' }}>← 管理</Link>
         <strong>内部マップ</strong>
         <span style={{ fontSize: '0.75em', color: 'var(--color-muted)' }}>{maps.length} マップ / {gates.length} ゲート</span>
@@ -152,7 +152,7 @@ export function AdminInteriors() {
 
       {note && <p style={{ fontSize: '0.8em', color: 'var(--color-accent)', margin: '0 0 0.4em' }}>{note}</p>}
 
-      <div style={{ display: 'grid', gridTemplateColumns: 'minmax(150px, 1fr) 3fr', gap: '0.8em' }}>
+      <div className="admin-cols">
         <div style={{ maxHeight: '75vh', overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 2 }}>
           {maps.map((m) => (
             <button
@@ -258,8 +258,6 @@ export function AdminInteriors() {
 
             <svg
               ref={svgRef}
-              width={BOX}
-              height={BOX}
               viewBox={`0 0 ${current.size * 32} ${current.size * 32}`}
               onPointerDown={(e) => {
                 e.preventDefault();
@@ -286,7 +284,12 @@ export function AdminInteriors() {
                 try { (e.currentTarget as SVGSVGElement).releasePointerCapture(e.pointerId); } catch { /* 既に外れている */ }
               }}
               onPointerCancel={() => { painting.current = false; }}
-              style={{ display: 'block', cursor: linking ? 'crosshair' : 'pointer', touchAction: 'none', userSelect: 'none' }}
+              // 固定 px だと狭い画面で画面外へ出る。**幅に追随させ、正方形は
+              // aspect-ratio で保つ** (座標はビューポート比から引くので拡縮しても合う)。
+              style={{
+                display: 'block', width: '100%', maxWidth: BOX, aspectRatio: '1 / 1', height: 'auto',
+                cursor: linking ? 'crosshair' : 'pointer', touchAction: 'none', userSelect: 'none',
+              }}
             >
               <defs>
                 {[...new Set(Array.from(current.tiles))].map((idx) => (

--- a/apps/web/src/routes/admin-items.tsx
+++ b/apps/web/src/routes/admin-items.tsx
@@ -100,15 +100,15 @@ export function AdminItems() {
   }
 
   const field = (label: string, input: React.ReactNode) => (
-    <label style={{ display: 'flex', alignItems: 'center', gap: '0.4em', fontSize: '0.8em' }}>
-      <span style={{ width: '7em', color: 'var(--color-muted)' }}>{label}</span>
+    <label className="admin-field">
+      <span>{label}</span>
       {input}
     </label>
   );
 
   return (
-    <div style={{ padding: '0.8em', maxWidth: 900 }}>
-      <div style={{ display: 'flex', gap: '0.5em', alignItems: 'center', marginBottom: '0.4em' }}>
+    <div className="admin-page" style={{ padding: '0.8em' }}>
+      <div className="admin-head">
         <Link to="/admin" style={{ fontSize: '0.8em' }}>← 管理</Link>
         {([['equipment', 'そうび'], ['items', 'どうぐ・素材']] as const).map(([k, label]) => (
           <button
@@ -163,7 +163,7 @@ export function AdminItems() {
           </button>
         </div>
       ) : (
-        <div style={{ display: 'grid', gridTemplateColumns: 'minmax(180px, 1fr) 2fr', gap: '0.8em' }}>
+        <div className="admin-cols">
           {/* 一覧 (slot → grade) */}
           <div style={{ maxHeight: '70vh', overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 2 }}>
             {GEAR_SLOTS.map((slot) => {

--- a/apps/web/src/routes/admin-jobs.tsx
+++ b/apps/web/src/routes/admin-jobs.tsx
@@ -161,15 +161,15 @@ export function AdminJobs() {
 
   const statSum = current ? (current.stats ?? [0, 0, 0, 0, 0]).reduce((a, b) => a + b, 0) : 0;
   const field = (label: string, input: React.ReactNode) => (
-    <label style={{ display: 'flex', alignItems: 'center', gap: '0.4em', fontSize: '0.8em' }}>
-      <span style={{ width: '7em', color: 'var(--color-muted)' }}>{label}</span>
+    <label className="admin-field">
+      <span>{label}</span>
       {input}
     </label>
   );
 
   return (
-    <div style={{ padding: '0.8em', maxWidth: 960 }}>
-      <div style={{ display: 'flex', gap: '0.6em', alignItems: 'center', marginBottom: '0.4em' }}>
+    <div className="admin-page" style={{ padding: '0.8em' }}>
+      <div className="admin-head">
         <Link to="/admin" style={{ fontSize: '0.8em' }}>← 管理</Link>
         <strong>ジョブ</strong>
         <button type="button" onClick={() => void save()} disabled={!session.agent || !dirty || loadState !== 'ok'} style={{ marginLeft: 'auto', fontSize: '0.85em' }}>
@@ -179,7 +179,7 @@ export function AdminJobs() {
 
       {note && <p style={{ fontSize: '0.8em', color: 'var(--color-accent)', margin: '0 0 0.4em' }}>{note}</p>}
 
-      <div style={{ display: 'grid', gridTemplateColumns: 'minmax(150px, 1fr) 2fr', gap: '0.8em' }}>
+      <div className="admin-cols">
         <div style={{ maxHeight: '70vh', overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 2 }}>
           {list.map((j) => (
             <button

--- a/apps/web/src/routes/admin-map.tsx
+++ b/apps/web/src/routes/admin-map.tsx
@@ -370,8 +370,6 @@ export function AdminMap() {
           <div style={{ overflow: 'auto', maxWidth: '100%', border: '2px solid var(--color-border)', width: 'fit-content' }}>
             <svg
               ref={svgRef}
-              width={W}
-              height={H}
               viewBox={`0 0 ${view * 32} ${view * 32}`}
               onPointerDown={(e) => {
                 e.preventDefault(); // 文字選択とスクロールを始めさせない
@@ -386,7 +384,9 @@ export function AdminMap() {
                 try { (e.currentTarget as SVGSVGElement).releasePointerCapture(e.pointerId); } catch { /* 既に外れている */ }
               }}
               onPointerCancel={() => { painting.current = false; }}
-              style={{ display: 'block', cursor: 'crosshair', touchAction: 'none' }}
+              // 固定 px だと狭い画面で画面外へ出る。幅に追随させ正方形を保つ
+              // (置く座標はビューポート比から引くので、拡縮してもマスがずれない)。
+              style={{ display: 'block', width: '100%', maxWidth: W, aspectRatio: '1 / 1', height: 'auto', cursor: 'crosshair', touchAction: 'none' }}
             >
               {/* 同じパーツは defs に 1 回だけ定義して use で参照 (#605)。全地形がドット絵に
                   なったので、マスごとの展開だと 16px 表示 (24×24 マス) で数万 rect になる。 */}

--- a/apps/web/src/routes/admin-monsters.tsx
+++ b/apps/web/src/routes/admin-monsters.tsx
@@ -165,15 +165,15 @@ export function AdminMonsters() {
   };
 
   const field = (label: string, input: React.ReactNode) => (
-    <label style={{ display: 'flex', alignItems: 'center', gap: '0.4em', fontSize: '0.8em' }}>
-      <span style={{ width: '7em', color: 'var(--color-muted)' }}>{label}</span>
+    <label className="admin-field">
+      <span>{label}</span>
       {input}
     </label>
   );
 
   return (
-    <div style={{ padding: '0.8em', maxWidth: 900 }}>
-      <div style={{ display: 'flex', gap: '0.6em', alignItems: 'center', marginBottom: '0.4em' }}>
+    <div className="admin-page" style={{ padding: '0.8em' }}>
+      <div className="admin-head">
         <Link to="/admin" style={{ fontSize: '0.8em' }}>← 管理</Link>
         <strong>モンスター</strong>
         <span style={{ fontSize: '0.75em', color: 'var(--color-muted)' }}>
@@ -186,7 +186,7 @@ export function AdminMonsters() {
 
       {note && <p style={{ fontSize: '0.8em', color: 'var(--color-accent)', margin: '0 0 0.4em' }}>{note}</p>}
 
-      <div style={{ display: 'grid', gridTemplateColumns: 'minmax(180px, 1fr) 2fr', gap: '0.8em' }}>
+      <div className="admin-cols">
         {/* 一覧 (tier ごと) */}
         <div style={{ maxHeight: '70vh', overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 2 }}>
           {([1, 2, 3, 4, 5, 6, 7, 8] as Tier[]).map((t) => {

--- a/apps/web/src/routes/admin-npcs.tsx
+++ b/apps/web/src/routes/admin-npcs.tsx
@@ -81,8 +81,8 @@ export function AdminNpcs() {
   }
 
   const field = (label: string, input: React.ReactNode) => (
-    <label style={{ display: 'flex', alignItems: 'center', gap: '0.4em', fontSize: '0.8em' }}>
-      <span style={{ width: '6em', color: 'var(--color-muted)' }}>{label}</span>
+    <label className="admin-field">
+      <span>{label}</span>
       {input}
     </label>
   );
@@ -97,8 +97,8 @@ export function AdminNpcs() {
   };
 
   return (
-    <div style={{ padding: '0.8em', maxWidth: 900 }}>
-      <div style={{ display: 'flex', gap: '0.6em', alignItems: 'center', marginBottom: '0.4em' }}>
+    <div className="admin-page" style={{ padding: '0.8em' }}>
+      <div className="admin-head">
         <Link to="/admin" style={{ fontSize: '0.8em' }}>← 管理</Link>
         <strong>NPC</strong>
         <span style={{ fontSize: '0.75em', color: 'var(--color-muted)' }}>{list.length} 人</span>
@@ -110,7 +110,7 @@ export function AdminNpcs() {
 
       {note && <p style={{ fontSize: '0.8em', color: 'var(--color-accent)', margin: '0 0 0.4em' }}>{note}</p>}
 
-      <div style={{ display: 'grid', gridTemplateColumns: 'minmax(160px, 1fr) 2fr', gap: '0.8em' }}>
+      <div className="admin-cols">
         <div style={{ maxHeight: '70vh', overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 2 }}>
           {list.map((n) => (
             <button

--- a/apps/web/src/routes/admin-quests.tsx
+++ b/apps/web/src/routes/admin-quests.tsx
@@ -105,8 +105,8 @@ export function AdminQuests() {
   }
 
   const field = (label: string, input: React.ReactNode) => (
-    <label style={{ display: 'flex', alignItems: 'center', gap: '0.4em', fontSize: '0.8em' }}>
-      <span style={{ width: '6em', color: 'var(--color-muted)' }}>{label}</span>
+    <label className="admin-field">
+      <span>{label}</span>
       {input}
     </label>
   );
@@ -152,8 +152,8 @@ export function AdminQuests() {
   const npcNameOf = (id: string) => npcs.find((n) => n.id === id)?.name ?? id;
 
   return (
-    <div style={{ padding: '0.8em', maxWidth: 900 }}>
-      <div style={{ display: 'flex', gap: '0.6em', alignItems: 'center', marginBottom: '0.4em' }}>
+    <div className="admin-page" style={{ padding: '0.8em' }}>
+      <div className="admin-head">
         <Link to="/admin" style={{ fontSize: '0.8em' }}>← 管理</Link>
         <strong>クエスト</strong>
         <span style={{ fontSize: '0.75em', color: 'var(--color-muted)' }}>{list.length} 件</span>
@@ -170,7 +170,7 @@ export function AdminQuests() {
         </p>
       )}
 
-      <div style={{ display: 'grid', gridTemplateColumns: 'minmax(160px, 1fr) 2fr', gap: '0.8em' }}>
+      <div className="admin-cols">
         <div style={{ maxHeight: '70vh', overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 2 }}>
           {list.map((q) => (
             <button

--- a/apps/web/src/routes/admin-scenario.tsx
+++ b/apps/web/src/routes/admin-scenario.tsx
@@ -109,8 +109,8 @@ export function AdminScenario() {
   }
 
   const field = (label: string, input: React.ReactNode) => (
-    <label style={{ display: 'flex', alignItems: 'center', gap: '0.4em', fontSize: '0.8em' }}>
-      <span style={{ width: '6em', color: 'var(--color-muted)' }}>{label}</span>
+    <label className="admin-field">
+      <span>{label}</span>
       {input}
     </label>
   );
@@ -173,12 +173,12 @@ export function AdminScenario() {
   };
 
   return (
-    <div style={{ padding: '0.8em', maxWidth: 900 }}>
+    <div className="admin-page" style={{ padding: '0.8em' }}>
       <datalist id="known-flags">
         {knownFlags.map((f) => <option key={f} value={f} />)}
       </datalist>
 
-      <div style={{ display: 'flex', gap: '0.6em', alignItems: 'center', marginBottom: '0.4em' }}>
+      <div className="admin-head">
         <Link to="/admin" style={{ fontSize: '0.8em' }}>← 管理</Link>
         <strong>シナリオ</strong>
         <span style={{ fontSize: '0.75em', color: 'var(--color-muted)' }}>{list.length} 件 / フラグ {knownFlags.length}</span>
@@ -190,7 +190,7 @@ export function AdminScenario() {
 
       {note && <p style={{ fontSize: '0.8em', color: 'var(--color-accent)', margin: '0 0 0.4em' }}>{note}</p>}
 
-      <div style={{ display: 'grid', gridTemplateColumns: 'minmax(160px, 1fr) 2fr', gap: '0.8em' }}>
+      <div className="admin-cols">
         <div style={{ maxHeight: '72vh', overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 2 }}>
           {list.map((e) => (
             <button

--- a/apps/web/src/routes/admin-shops.tsx
+++ b/apps/web/src/routes/admin-shops.tsx
@@ -91,8 +91,8 @@ export function AdminShops() {
   const maxGrade = maxShopGradeForTier(tier);
 
   return (
-    <div style={{ padding: '0.8em', maxWidth: 980 }}>
-      <div style={{ display: 'flex', gap: '0.6em', alignItems: 'center', marginBottom: '0.4em' }}>
+    <div className="admin-page" style={{ padding: '0.8em' }}>
+      <div className="admin-head">
         <Link to="/admin" style={{ fontSize: '0.8em' }}>← 管理</Link>
         <strong>お店のラインナップ</strong>
         <span style={{ fontSize: '0.75em', color: 'var(--color-muted)' }}>{overrides.length} 店を上書き中</span>
@@ -103,7 +103,7 @@ export function AdminShops() {
 
       {note && <p style={{ fontSize: '0.8em', color: 'var(--color-accent)', margin: '0 0 0.4em' }}>{note}</p>}
 
-      <div style={{ display: 'grid', gridTemplateColumns: 'minmax(180px, 1fr) 2fr', gap: '0.8em' }}>
+      <div className="admin-cols">
         {/* 街の一覧 (tier ごと) */}
         <div style={{ maxHeight: '75vh', overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 2 }}>
           {[1, 2, 3, 4, 5, 6].map((t) => {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2072,3 +2072,76 @@ p { margin: 0.4em 0; }
 :root[data-theme='light'] .workspace-column-resizer::after {
   background: rgba(0, 0, 0, 0.18);
 }
+
+/* ─── 管理エディタのモバイル対応 (#617) ────────────────────────────
+   全エディタが「左に一覧 / 右にフォーム」の 2 カラムをインラインで組んでいたため、
+   狭い画面で右カラムが画面外へ溢れ、入力欄もラベルも切れて操作できなかった。
+   レイアウトはここに集約し、狭いときは 1 カラムに畳む。 */
+.admin-page {
+  box-sizing: border-box;
+  max-width: 100%;
+  overflow-x: hidden;
+}
+.admin-page *,
+.admin-page *::before,
+.admin-page *::after {
+  box-sizing: border-box;
+}
+/* 入力・選択は枠を超えない。**固定 em 幅のまま溢れる**のが崩れの主因だった */
+.admin-page input,
+.admin-page select,
+.admin-page textarea {
+  max-width: 100%;
+  min-width: 0;
+}
+/* 見出し行 (戻る・タイトル・操作ボタン)。狭いと折り返す */
+.admin-head {
+  display: flex;
+  gap: 0.6em;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 0.4em;
+}
+/* 一覧 + フォームの 2 カラム */
+.admin-cols {
+  display: grid;
+  grid-template-columns: minmax(150px, 1fr) 2fr;
+  gap: 0.8em;
+  align-items: start;
+}
+/* ラベル + 入力の 1 行 */
+.admin-field {
+  display: flex;
+  align-items: center;
+  gap: 0.4em;
+  font-size: 0.8em;
+  flex-wrap: wrap;
+}
+.admin-field > span:first-child {
+  width: 7em;
+  color: var(--color-muted);
+  flex: none;
+}
+
+@media (max-width: 700px) {
+  /* **1 カラムに畳む。** 横に並べると右カラムが必ず画面外へ出る */
+  .admin-cols {
+    grid-template-columns: 1fr;
+  }
+  /* 一覧は畳んだ後に縦を食いすぎないよう低く抑える (フォームまでスクロールが遠い) */
+  .admin-cols > :first-child {
+    max-height: 30vh;
+  }
+  /* ラベルを上に置いて入力へ横幅を明け渡す */
+  .admin-field {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.15em;
+  }
+  .admin-field > span:first-child {
+    width: auto;
+  }
+  .admin-field > :not(:first-child) {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
Closes #617

## なぜ

オーナー報告 (実機スクショ): シナリオエディタを iPhone で開くと右カラムが画面外へ出て、見出しの入力欄・条件の行・お知らせ欄が切れて操作できない。見出しの「シナリオ」もボタンに押されて 2 行に割れる。

全エディタが 2 カラムを**インラインの gridTemplateColumns で固定**しており、狭い画面でも畳まれないのが原因。入力も `width: 11em` 等の固定幅で画面幅を超えても縮まなかった。

## 変更

- レイアウトを `styles.css` の共有クラスへ集約: `admin-page` / `admin-head` / `admin-cols` / `admin-field`
- **700px 以下で 1 カラムに畳む** (横に並べると右カラムは必ず画面外に出る)
- 入力・選択は `max-width: 100%`。ラベルは狭いとき上に置いて入力へ幅を明け渡す
- 編集キャンバス (マップ 384px / 内部マップ 448px) を幅に追随させ、正方形は `aspect-ratio` で保つ。座標はビューポート比から引いているので拡縮してもマスがずれない
- 対象: シナリオ / クエスト / NPC / アイテム / ジョブ / お店 / モンスター / 内部マップ / マップ

## テスト

- レイアウトの回帰テスト 17 件 (全エディタが共有クラスを使い、インラインの 2 カラム grid を持たない)。新しいエディタで同じ崩れを持ち込むと落ちる
- web 377 全緑、typecheck / build 緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SpSiVHa5hXp7sEUAXAfWEE