### PR TITLE
fix: 「同梱の絵に戻す」でたての橋が横になる (#615)

### DIFF
--- a/apps/web/src/components/admin/tile-art-editor.tsx
+++ b/apps/web/src/components/admin/tile-art-editor.tsx
@@ -13,6 +13,8 @@ import {
   emptyTileArt,
   loadTileArts,
   bundledTileArtFor,
+  partPresetByName,
+  presetArt,
   setTileArt,
   tileArtColorAt,
   tileArtFor,
@@ -129,7 +131,11 @@ export function TileArtEditor({ parts: partsIn, subjects: subjectsIn }: { parts?
    * 登録簿から消して保存すると、以後は同梱の絵が使われる。
    */
   const resetToBundled = useCallback(async () => {
-    const bundled = bundledTileArtFor(subject.legacyKey ?? subject.key);
+    // **プリセットのパーツを先に見る。** 「たての橋」は地形が bridge なので、
+    // 地形の既定に戻すと**横の橋**になってしまう (実際に起きた)。パーツ自身の
+    // 同梱の絵があるならそれが戻し先。
+    const preset = partPresetByName(subject.name);
+    const bundled = preset ? presetArt(preset) : bundledTileArtFor(subject.legacyKey ?? subject.key);
     if (!bundled) { setNote('この部位には同梱の絵が無い'); return; }
     if (!window.confirm(`${subject.name} を同梱の絵に戻す？\n自分で描いた絵は消える`)) return;
     try {

--- a/packages/core/src/__tests__/part-presets.test.ts
+++ b/packages/core/src/__tests__/part-presets.test.ts
@@ -3,8 +3,9 @@
  * エディタで追加した瞬間に落ちるので、データの健全性をここで固定する。
  */
 import { describe, it, expect } from 'vitest';
-import { PART_PRESETS, presetArt } from '../part-presets.js';
-import { assertTileArt, TILE_ART_MAX_COLORS } from '../tile-art.js';
+import { PART_PRESETS, partPresetByName, presetArt } from '../part-presets.js';
+import { assertTileArt, decodeTileArt, TILE_ART_MAX_COLORS } from '../tile-art.js';
+import { DEFAULT_TERRAIN_ARTS } from '../terrain-art-data.js';
 import { BASE_PALETTE, setWorldParts, worldParts } from '../world-map.js';
 
 describe('PART_PRESETS', () => {
@@ -36,5 +37,20 @@ describe('PART_PRESETS', () => {
     } finally {
       setWorldParts(before);
     }
+  });
+});
+
+describe('partPresetByName (#615 戻し先)', () => {
+  it('名前でプリセットを引ける', () => {
+    expect(partPresetByName('たての橋')?.terrain).toBe('bridge');
+    expect(partPresetByName('城')?.walkable).toBe(false);
+    expect(partPresetByName('ない名前')).toBeUndefined();
+  });
+
+  it('たての橋の戻し先が地形 (bridge) の既定と違う絵である', () => {
+    // 地形の既定に戻すと**横の橋**になってしまう (実際に起きた退行)。
+    const vertical = presetArt(partPresetByName('たての橋')!);
+    const bridgeDefault = decodeTileArt(DEFAULT_TERRAIN_ARTS['bridge']!);
+    expect(vertical.pixels).not.toEqual(bridgeDefault.pixels);
   });
 });

--- a/packages/core/src/part-presets.ts
+++ b/packages/core/src/part-presets.ts
@@ -53,6 +53,15 @@ export const PART_PRESETS: readonly PartPreset[] = [
   { name: 'たての橋', terrain: 'bridge', walkable: true, art: VBRIDGE_ART },
 ];
 
+/**
+ * 名前でプリセットを引く (#615)。**「同梱の絵に戻す」の戻し先**に使う —
+ * たての橋のように「地形 (bridge) の既定の絵」とパーツの絵が別のものは、
+ * 地形の既定に戻すと**横の橋になってしまう** (実際に起きた)。
+ */
+export function partPresetByName(name: string): PartPreset | undefined {
+  return PART_PRESETS.find((p) => p.name === name);
+}
+
 /** プリセットの絵をメモリ形式に (エディタが setTileArt に渡す)。 */
 export function presetArt(p: PartPreset): TileArt {
   return decodeTileArt(p.art);


### PR DESCRIPTION
Refs #615

## なぜ

オーナー報告 (実機): たての橋を「同梱の絵に戻す」と**横の橋**になってしまった。

たての橋は地形が `bridge` なので、戻し先を `bundledTileArtFor(legacyKey='bridge')` で引くと地形の既定 = 横断の橋が返っていた。

## 変更

- `partPresetByName`: 名前でパーツプリセットを引く
- 「同梱の絵に戻す」は**プリセットを先に見る**。無ければ従来どおり地形の既定へ
- 回帰テスト: たての橋の戻し先が `bridge` の既定と別の絵であること

## テスト

- core 699 / web 377 全緑、typecheck / build 緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SpSiVHa5hXp7sEUAXAfWEE