### PR TITLE
feat: 3 つ繋がるシナリオのサンプル + 最初の街の中 (#545, #424)

### DIFF
--- a/apps/web/src/routes/admin-interiors.tsx
+++ b/apps/web/src/routes/admin-interiors.tsx
@@ -10,6 +10,10 @@ import {
   interiorPartAt,
   interiorWalkableAt,
   worldParts,
+  worldOverlay,
+  starterTownInterior,
+  starterTownGates,
+  STARTER_TOWN_ID,
   type Gate,
   type InteriorMap,
   type Terrain,
@@ -154,6 +158,28 @@ export function AdminInteriors() {
         <strong>内部マップ</strong>
         <span style={{ fontSize: '0.75em', color: 'var(--color-muted)' }}>{maps.length} マップ / {gates.length} ゲート</span>
         <button type="button" onClick={addMap} style={{ fontSize: '0.85em' }}>＋マップ</button>
+        <button
+          type="button"
+          onClick={() => {
+            if (maps.some((m) => m.id === STARTER_TOWN_ID)) { setNote('「ふたばの村」は既にある'); return; }
+            const spawn = worldOverlay().spawn;
+            const village = starterTownInterior();
+            // 往復 2 本まとめて張る (入る道だけだと出られない)。フィールド側の入口は
+            // 最初の街のマスそのもの。
+            const gates = starterTownGates(spawn);
+            setMaps((xs) => [...xs, village]);
+            setGates((gs) => [
+              ...gs.filter((g) => !gates.some((n) => n.from.mapId === g.from.mapId && n.from.x === g.from.x && n.from.y === g.from.y)),
+              ...gates,
+            ]);
+            setSel(village.id);
+            setDirty(true);
+            setNote(`「${village.name}」を入れた。保存するとフィールドの (${spawn.x}, ${spawn.y}) から入れる`);
+          }}
+          style={{ fontSize: '0.85em' }}
+        >
+          はじまりの村を入れる
+        </button>
         <button type="button" onClick={() => void save()} disabled={!session.agent || !dirty || loadState !== 'ok'} style={{ marginLeft: 'auto', fontSize: '0.85em' }}>
           保存
         </button>

--- a/apps/web/src/routes/admin-scenario.tsx
+++ b/apps/web/src/routes/admin-scenario.tsx
@@ -8,6 +8,7 @@ import {
   gameQuests,
   jobDisplayName,
   scenarioEvents,
+  SAMPLE_SCENARIO,
   type Archetype,
   type ScenarioCondition,
   type ScenarioEvent,
@@ -183,6 +184,27 @@ export function AdminScenario() {
         <strong>シナリオ</strong>
         <span style={{ fontSize: '0.75em', color: 'var(--color-muted)' }}>{list.length} 件 / フラグ {knownFlags.length}</span>
         <button type="button" onClick={add} style={{ fontSize: '0.85em' }}>＋イベント</button>
+        <button
+          type="button"
+          onClick={() => {
+            // 既にあるものと id が衝突しないよう連番を振り直す。
+            let n = 1;
+            const taken = new Set(list.map((e) => e.id));
+            const add = SAMPLE_SCENARIO.map((e) => {
+              let id = e.id;
+              while (taken.has(id)) id = `${e.id}-${++n}`;
+              taken.add(id);
+              return { ...e, id, when: e.when.map((c) => ({ ...c })), setFlags: [...e.setFlags] };
+            });
+            setList((xs) => [...xs, ...add]);
+            setSel(add[0]!.id);
+            setDirty(true);
+            setNote('3 つ繋がったサンプルを入れた。保存すると遊べる (NPC のセリフやクエストの解禁に ch1_start / ch2_herbs / ch3_proof を書くと続く)');
+          }}
+          style={{ fontSize: '0.85em' }}
+        >
+          サンプルを入れる
+        </button>
         <button type="button" onClick={() => void save()} disabled={!session.agent || !dirty || loadState !== 'ok'} style={{ marginLeft: 'auto', fontSize: '0.85em' }}>
           保存
         </button>

--- a/packages/core/src/__tests__/interior.test.ts
+++ b/packages/core/src/__tests__/interior.test.ts
@@ -26,6 +26,8 @@ import {
   type InteriorMap,
 } from '../interior.js';
 import { BASE_PALETTE } from '../world-map.js';
+import { worldOverlay } from '../world.js';
+import { starterTownInterior, starterTownGates } from '../interior-samples.js';
 
 const FLOOR = BASE_PALETTE.indexOf('plains');
 const WALL = BASE_PALETTE.indexOf('mountain');
@@ -209,5 +211,58 @@ describe('通れないときのことば (#426)', () => {
   it('空文字・長すぎることばを弾く', () => {
     expect(() => setInteriors([room()], [g({ lockedNotice: '  ' })])).toThrow(InteriorError);
     expect(() => setInteriors([room()], [g({ lockedNotice: 'あ'.repeat(200) })])).toThrow(InteriorError);
+  });
+});
+
+describe('同梱の村「ふたばの村」(#424)', () => {
+  const village = starterTownInterior();
+  const spawn = worldOverlay().spawn;
+
+  it('64×64 で、そのまま保存できる', () => {
+    expect(village.size).toBe(64);
+    expect(village.tiles.length).toBe(64 * 64);
+    expect(() => setInteriors([village], starterTownGates(spawn))).not.toThrow();
+  });
+
+  it('**外へ歩いて出られない** (外周が全部ふさがっている)', () => {
+    // 出るのはゲートだけ。1 マスでも開いていると村の外の座標へ出てしまう。
+    for (let i = 0; i < village.size; i++) {
+      for (const [x, y] of [[i, 0], [i, village.size - 1], [0, i], [village.size - 1, i]] as const) {
+        expect(interiorWalkableAt(village, x, y), `(${x},${y})`).toBe(false);
+      }
+    }
+  });
+
+  it('入口と戻り口が歩ける (ゲートは踏めないと機能しない)', () => {
+    const [inGate, outGate] = starterTownGates(spawn);
+    expect(interiorWalkableAt(village, inGate!.to.x, inGate!.to.y)).toBe(true);
+    expect(interiorWalkableAt(village, outGate!.from.x, outGate!.from.y)).toBe(true);
+  });
+
+  it('入口から戻り口まで歩いて行ける (閉じ込められない)', () => {
+    // 幅優先で到達性を確かめる。家や池で導線が塞がっていると詰む。
+    const [inGate, outGate] = starterTownGates(spawn);
+    const seen = new Set<number>();
+    const q = [[inGate!.to.x, inGate!.to.y] as const];
+    seen.add(inGate!.to.y * village.size + inGate!.to.x);
+    while (q.length) {
+      const [x, y] = q.shift()!;
+      for (const [dx, dy] of [[1, 0], [-1, 0], [0, 1], [0, -1]] as const) {
+        const nx = x + dx, ny = y + dy;
+        const k = ny * village.size + nx;
+        if (seen.has(k) || !interiorWalkableAt(village, nx, ny)) continue;
+        seen.add(k);
+        q.push([nx, ny]);
+      }
+    }
+    expect(seen.has(outGate!.from.y * village.size + outGate!.from.x)).toBe(true);
+    // 広場や家の前まで含め、そこそこの広さが繋がっていること
+    expect(seen.size).toBeGreaterThan(2000);
+  });
+
+  it('戻り先はフィールドの街の 1 マス下 (踏んだ瞬間にまた入らない)', () => {
+    const [inGate, outGate] = starterTownGates(spawn);
+    expect(inGate!.from).toEqual({ mapId: 'world', x: spawn.x, y: spawn.y });
+    expect(outGate!.to).toEqual({ mapId: 'world', x: spawn.x, y: spawn.y + 1 });
   });
 });

--- a/packages/core/src/__tests__/scenario.test.ts
+++ b/packages/core/src/__tests__/scenario.test.ts
@@ -18,6 +18,7 @@ import {
 } from '../scenario.js';
 import { setGameQuests, gameQuestById, type GameQuestDef } from '../quest-data.js';
 import { setNpcs, npcLinesFor, type NpcDef } from '../npc-data.js';
+import { SAMPLE_SCENARIO, SAMPLE_FLAGS } from '../scenario-samples.js';
 import { ITEMS, MONSTERS, rollDefeatLoss } from '../battle.js';
 import { setItemOverrides } from '../item-data.js';
 import { isSellableMaterial } from '../equipment.js';
@@ -286,5 +287,47 @@ describe('レビュー指摘の回帰 (#426)', () => {
     } finally {
       setItemOverrides(null);
     }
+  });
+});
+
+describe('サンプルシナリオ (#545)', () => {
+  it('そのまま保存できる (何も用意していない環境でも通る)', () => {
+    // クエストや NPC を条件にすると、それらが無い環境では保存できない。
+    setGameQuests(null);
+    setNpcs(null);
+    expect(() => setScenario(SAMPLE_SCENARIO)).not.toThrow();
+  });
+
+  it('3 つが順に繋がる (前が発火しないと次は発火しない)', () => {
+    setScenario(SAMPLE_SCENARIO);
+    // 1 段目: 条件なしなので最初から発火する
+    const r1 = pendingScenario(progress());
+    expect(r1.fired.map((e) => e.id)).toEqual(['sample-1']);
+    expect(r1.flags).toEqual(['ch1_start']);
+
+    // 2 段目: 1 段目のフラグ + やくそう 3 つ。**前のフラグが無ければ発火しない** —
+    // ここは 2 段目だけを定義に置いて確かめる (同じ呼び出しで 1 段目が発火すると
+    // その場で連鎖してしまい、依存の有無が見えない)。
+    setScenario([SAMPLE_SCENARIO[1]!]);
+    expect(pendingScenario(progress({ materials: { herb: 3 } })).fired).toHaveLength(0);
+    expect(pendingScenario(progress({ flags: ['ch1_start'] })).fired).toHaveLength(0); // 素材も要る
+    expect(pendingScenario(progress({ flags: ['ch1_start'], materials: { herb: 3 } })).fired.map((e) => e.id)).toEqual(['sample-2']);
+    setScenario(SAMPLE_SCENARIO);
+
+    // 3 段目: 2 段目のフラグ + しずく
+    setScenario([SAMPLE_SCENARIO[2]!]);
+    expect(pendingScenario(progress({ materials: { 'slime-drop': 1 } })).fired).toHaveLength(0);
+    expect(pendingScenario(progress({ flags: ['ch2_herbs'], materials: { 'slime-drop': 1 } })).fired.map((e) => e.id)).toEqual(['sample-3']);
+  });
+
+  it('条件が一度に揃えば 3 つまとめて発火する (連鎖が 1 回で解ける)', () => {
+    setScenario(SAMPLE_SCENARIO);
+    const r = pendingScenario(progress({ materials: { herb: 3, 'slime-drop': 1 } }));
+    expect(r.fired.map((e) => e.id)).toEqual(['sample-1', 'sample-2', 'sample-3']);
+    expect(r.flags).toEqual([...SAMPLE_FLAGS]);
+  });
+
+  it('全部のお知らせが書かれている (何が起きたか分かる)', () => {
+    for (const e of SAMPLE_SCENARIO) expect(e.notice, e.id).toBeTruthy();
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,6 +28,7 @@ export * from './quest-data.js';
 export * from './part-presets.js';
 export * from './job-data.js';
 export * from './interior.js';
+export * from './interior-samples.js';
 export * from './scenario.js';
 export * from './scenario-samples.js';
 export * from './equipment.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,4 +29,5 @@ export * from './part-presets.js';
 export * from './job-data.js';
 export * from './interior.js';
 export * from './scenario.js';
+export * from './scenario-samples.js';
 export * from './equipment.js';

--- a/packages/core/src/interior-samples.ts
+++ b/packages/core/src/interior-samples.ts
@@ -1,0 +1,140 @@
+/**
+ * **同梱の内部マップ** (#424)。最初の街「ふたばの村」の中。
+ *
+ * 内部マップを 1 つも作っていない状態からだと、エディタで 64×64 を手で塗るところから
+ * 始まって重い。**入って歩ける村**を 1 つ同梱し、そこから直せるようにする。
+ *
+ * ## タイルは**フィールドのパーツ番号に合わせる**
+ *
+ * 絵は `part:<index>` → 地形名 の順で引かれる (`partArtFor`)。番号を
+ * `BASE_PALETTE` と同じ並びにしておけば、フィールドで使っている絵がそのまま出る
+ * (草地・木・池・岩・家・橋)。独自の番号を振ると絵の無いタイルになる。
+ *
+ * 通行だけは村用に上書きする — フィールドの「街」タイルは歩けるが、村の中では
+ * **家は入れない壁**にしたい (中に入る導線はゲートで別途作る)。
+ */
+import type { Gate, InteriorMap } from './interior.js';
+import type { WorldPart } from './world-map.js';
+
+export const STARTER_TOWN_ID = 'futaba-village';
+export const STARTER_TOWN_SIZE = 64;
+
+/** タイル番号 (BASE_PALETTE と同じ並び)。 */
+const GROUND = 0; // 草地 = 歩ける地面
+const GROVE = 1; // 低い草。地面の変化づけ
+const TREE = 2; // 木 (通れない)
+const POND = 3; // 池 (通れない)
+const ROCK = 5; // 岩・石垣 (通れない)
+const HOUSE = 6; // 家 (通れない。絵はフィールドの街タイル)
+const PATH = 7; // 道 (橋の絵を石畳として使う)
+
+/**
+ * 村のパーツ表。**通行だけ**をフィールドと変えている (家と木は入れない)。
+ * terrain はフィールドと同じにしておく — 絵の探索が地形名に落ちるため。
+ */
+const PARTS: WorldPart[] = [
+  { terrain: 'plains', name: 'じめん', walkable: true },
+  { terrain: 'grove', name: 'くさむら', walkable: true },
+  { terrain: 'forest', name: 'き', walkable: false },
+  { terrain: 'pond', name: 'いけ', walkable: false },
+  { terrain: 'water', name: 'みず', walkable: false },
+  { terrain: 'mountain', name: 'いしがき', walkable: false },
+  { terrain: 'town', name: 'いえ', walkable: false },
+  { terrain: 'bridge', name: 'みち', walkable: true },
+];
+
+/** フィールドから入ったときの降り立つ場所 (村の南の通り)。 */
+export const STARTER_TOWN_ENTRANCE = { x: 32, y: 59 };
+/** フィールドへ戻るマス (南の石垣の内側)。**壁は開けない** — 出るのはここだけ。 */
+export const STARTER_TOWN_EXIT = { x: 32, y: 61 };
+
+/**
+ * 64×64 の村を組み立てる。**手で塗った 4096 タイルを埋め込むより、組み立てる**
+ * ほうが読めて直せる (家を 1 軒足すのが 1 行)。
+ */
+export function buildStarterTownTiles(): Uint8Array {
+  const S = STARTER_TOWN_SIZE;
+  const t = new Uint8Array(S * S).fill(GROUND);
+  const set = (x: number, y: number, v: number) => {
+    if (x < 0 || y < 0 || x >= S || y >= S) return;
+    t[y * S + x] = v;
+  };
+  const rect = (x0: number, y0: number, w: number, h: number, v: number) => {
+    for (let y = y0; y < y0 + h; y++) for (let x = x0; x < x0 + w; x++) set(x, y, v);
+  };
+
+  // 外周は石垣で囲う。**外へ歩いて出られないようにする** (出るのはゲートだけ)。
+  rect(0, 0, S, 2, ROCK);
+  rect(0, S - 2, S, 2, ROCK);
+  rect(0, 0, 2, S, ROCK);
+  rect(S - 2, 0, 2, S, ROCK);
+
+  // 村を囲む林 (石垣の内側)。奥行きを出しつつ、端に寄りすぎないようにする。
+  for (let x = 3; x < S - 3; x++) {
+    if (x % 3 !== 0) continue;
+    set(x, 3, TREE);
+    set(x, S - 4, TREE);
+  }
+  for (let y = 4; y < S - 4; y++) {
+    if (y % 3 !== 0) continue;
+    set(3, y, TREE);
+    set(S - 4, y, TREE);
+  }
+
+  // 目抜き通り (縦) と 広場へ抜ける横道。石畳で導線を示す。
+  rect(30, 6, 4, S - 8, PATH); // 南の石垣ぎわ (y=61) まで通す = 戻り口へ繋ぐ
+  rect(8, 30, S - 16, 3, PATH);
+
+  // 中央の広場と井戸がわりの池。
+  rect(26, 26, 12, 11, PATH);
+  rect(30, 29, 4, 4, POND);
+
+  /** 家を 1 軒置く (左上から w×h)。前に石畳の踏み段を敷いて入口を示す。 */
+  const house = (x: number, y: number, w = 5, h = 4) => {
+    rect(x, y, w, h, HOUSE);
+    rect(x + Math.floor(w / 2) - 1, y + h, 2, 1, PATH); // 玄関前
+  };
+
+  // 通りの西側 4 軒 / 東側 4 軒。広場を挟んで上下に分ける。
+  house(18, 10); house(18, 18);
+  house(18, 40); house(18, 48);
+  house(40, 10); house(40, 18);
+  house(40, 40); house(40, 48);
+  // 村長の家 (少し大きい)。広場の北。
+  house(28, 12, 8, 6);
+
+  // 畑まわりのくさむら (歩ける。見た目の変化づけ)。
+  rect(8, 8, 6, 8, GROVE);
+  rect(50, 44, 6, 8, GROVE);
+
+  // **石垣は開けない。** 開けると村の外 (マップの外) に立てるマスができる。
+  // 出入りはゲートだけなので、戻り口のまわりを石畳にして「ここから出る」と分かるようにする。
+  rect(STARTER_TOWN_EXIT.x - 1, STARTER_TOWN_EXIT.y - 1, 2, 2, PATH);
+
+  return t;
+}
+
+/** 同梱の村 (エディタから差し込む)。 */
+export function starterTownInterior(): InteriorMap {
+  return {
+    id: STARTER_TOWN_ID,
+    name: 'ふたばの村',
+    size: STARTER_TOWN_SIZE,
+    tiles: buildStarterTownTiles(),
+    parts: PARTS.map((p) => ({ ...p })),
+    // 街の中なので敵は出さない (encounterTier を設定しない)。
+  };
+}
+
+/**
+ * フィールドの街タイル ⇄ 村の入口 を繋ぐ**往復 2 本**。
+ *
+ * 入る側はフィールドの街タイルそのもの、戻る側は村の入口の 1 マス下 (石垣の切れ目)。
+ * 戻り先をフィールドの街タイルにすると**踏んだ瞬間にまた入る**ので、街の 1 マス下に出す。
+ */
+export function starterTownGates(town: { x: number; y: number }): Gate[] {
+  return [
+    { from: { mapId: 'world', x: town.x, y: town.y }, to: { mapId: STARTER_TOWN_ID, ...STARTER_TOWN_ENTRANCE } },
+    { from: { mapId: STARTER_TOWN_ID, ...STARTER_TOWN_EXIT }, to: { mapId: 'world', x: town.x, y: town.y + 1 } },
+  ];
+}

--- a/packages/core/src/scenario-samples.ts
+++ b/packages/core/src/scenario-samples.ts
@@ -1,0 +1,53 @@
+/**
+ * **シナリオのサンプル** (#545)。3 つが順に繋がる最小の筋書き。
+ *
+ * 「フラグをどう繋ぐか」は文章で説明するより**動くものを 1 つ入れて触る**ほうが早い。
+ * エディタの「サンプルを入れる」から差し込み、そのまま保存して遊べる。
+ *
+ * ## 繋がり方
+ *
+ * 1. `ch1_start` — 条件なし = 全員が最初から。ものがたりの起点
+ * 2. `ch2_herbs`  — 1 の後に **やくそうを 3 つ**持つと発火
+ * 3. `ch3_proof`  — 2 の後に **スライムのしずくを 1 つ**持つと発火
+ *
+ * ## 参照を持たない作りにしてある
+ *
+ * クエストや NPC を条件にすると、それらが無い環境では**保存できない**
+ * (検証が実在を見る)。サンプルは最初から在る素材だけを条件にしてあるので、
+ * 何も用意していなくても入る。繋いだ先 (NPC のセリフ・クエストの解禁・ゲートの解錠) は
+ * 立ったフラグ名を書くだけで足せる。
+ */
+import type { ScenarioEvent } from './scenario.js';
+
+export const SAMPLE_SCENARIO: readonly ScenarioEvent[] = [
+  {
+    id: 'sample-1',
+    title: '1. たびだち',
+    when: [], // 条件なし = 最初から発火する (導入)
+    setFlags: ['ch1_start'],
+    notice: 'ふしぎな よかんが した。なにかが はじまろうとしている…',
+  },
+  {
+    id: 'sample-2',
+    title: '2. やくそうを あつめる',
+    when: [
+      { kind: 'flag', flag: 'ch1_start' },
+      { kind: 'itemCount', itemId: 'herb', count: 3 },
+    ],
+    setFlags: ['ch2_herbs'],
+    notice: 'やくそうが 3つ そろった。むらの ひとが よろこびそうだ。',
+  },
+  {
+    id: 'sample-3',
+    title: '3. まもののあかし',
+    when: [
+      { kind: 'flag', flag: 'ch2_herbs' },
+      { kind: 'itemCount', itemId: 'slime-drop', count: 1 },
+    ],
+    setFlags: ['ch3_proof'],
+    notice: 'スライムのしずくを 手に入れた。これで みとめてもらえるはずだ。',
+  },
+];
+
+/** サンプルが立てるフラグ (エディタの案内に出す)。 */
+export const SAMPLE_FLAGS = ['ch1_start', 'ch2_herbs', 'ch3_proof'] as const;


### PR DESCRIPTION
Refs #545
Refs #424

## 1. 3 つ繋がるシナリオのサンプル (#545)

シナリオエディタの「サンプルを入れる」から差し込み、そのまま保存して遊べる。

| # | 見出し | 条件 | 立てるフラグ |
|---|---|---|---|
| 1 | たびだち | (なし = 最初から) | `ch1_start` |
| 2 | やくそうを あつめる | `ch1_start` + やくそう 3 | `ch2_herbs` |
| 3 | まもののあかし | `ch2_herbs` + スライムのしずく 1 | `ch3_proof` |

**クエストや NPC を条件にしていない**のが要点。参照すると、それらが無い環境では検証で保存できない。最初から在る素材だけで組んであるので何も用意していなくても入る。

## 2. 最初の街「ふたばの村」の中 (#424)

64×64。内部マップエディタの「はじまりの村を入れる」で、村と往復ゲートをまとめて差し込む。保存するとフィールドの (211, 340) から入れる。

- タイル番号を `BASE_PALETTE` に合わせ、フィールドの絵をそのまま使う
- 通行だけ村用に上書き — **家と木は入れない壁** (街タイルは本来歩けるが、村の中で家をすり抜けるのは変)
- **石垣は開けない** — 開けると村の外 (マップの範囲外) に立てるマスができる。出入りはゲートだけ
- 戻り先はフィールドの街の 1 マス下 (街タイルに戻すと踏んだ瞬間にまた入る)
- 4096 タイルを埋め込まず**組み立てる** (家を 1 軒足すのが 1 行)

## テスト

- シナリオ 4 件 (何も無い環境で保存できる / 段ごとの依存 / 一度に揃えば 3 つまとめて発火 / お知らせが全段にある)
- 村 5 件 (64×64 で保存できる / 外周が全部ふさがっている / 入口と戻り口が歩ける / **入口から戻り口まで歩いて行ける** / 戻り先が街の 1 マス下)
- core 722 / edge 250 / web 377 全緑、typecheck / build 緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SpSiVHa5hXp7sEUAXAfWEE