### PR TITLE
fix: 移動もワールドの読み込みを待つ (街に入れない) (#424)

### DIFF
--- a/apps/edge/src/router.ts
+++ b/apps/edge/src/router.ts
@@ -175,6 +175,11 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
         return cors(json(await handleTurn(env, did, body.battleId, body.turn, body.command as Command, nowSec(), nsFromOrigin(req), skillIndex)), allowedOrigin);
       }
       if (typeof body.dx !== 'number' || typeof body.dy !== 'number') return cors(json({ error: 'bad_request' }, 400), allowedOrigin);
+      // **移動もワールドの読み込みを待つ。** ゲート (#424)・NPC (#425)・地図はここで効くので、
+      // コールド isolate で index.ts の waitUntil が間に合っていないと「街に入れない」
+      // 「人がいない」が無言で起きる (実際に踏んだ)。ロード済みならキャッシュ即返しで
+      // コストは乗らない。
+      await ensureAuthoredWorld(env, nsFromOrigin(req), nowSec());
       return cors(json(await handleMove(env, did, body.dx, body.dy, typeof body.token === 'string' ? body.token : undefined, nowSec(), nsFromOrigin(req))), allowedOrigin);
     } catch (e) {
       return cors(battleError(e), allowedOrigin);


### PR DESCRIPTION
Refs #424

## なぜ

オーナー報告「街に入れない」の調査。

保存済みレコードは正しかった (`world.interiors` にふたばの村とゲート 2 本を確認)。原因は edge 側で、ゲート・NPC・手編集の地図は移動判定で効くのに **`/api/world/move` だけ `ensureAuthoredWorld` を待っていなかった**。

`index.ts` の `ctx.waitUntil` が間に合っていないコールド isolate では、ゲートが無いものとして扱われ「街に入れない」「NPC が居ない」が無言で起きる。

戦闘ターン (#423 の討伐カウント) とクエストは既に同じ理由で待つようにしてあり、移動だけ取り残されていた。

## 変更

move の直前で `await ensureAuthoredWorld(...)`。ロード済みならキャッシュ即返し (`loadedAt` が TTL 内なら `Promise.resolve()`) なので、歩行のホットパスにコストは乗らない。

## テスト

edge 250 全緑、typecheck 緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SpSiVHa5hXp7sEUAXAfWEE