### PR TITLE
feat: 宿屋 (有料で全回復) と街に入ったときの帰還先更新 (#624)

### DIFF
--- a/apps/edge/src/battle-resolver.ts
+++ b/apps/edge/src/battle-resolver.ts
@@ -20,6 +20,7 @@ import {
   gateHasLock,
   gateLockedNotice,
   gateOpen,
+  innAt,
   interiorById,
   interiorTerrainAt,
   isInterior,
@@ -274,6 +275,10 @@ export interface MoveResult {
   terrain: string;
   /** 街に入って全回復した (HP/MP が権威なのでサーバーが回復)。 */
   healed?: boolean;
+  /** 宿屋に泊まった (#424)。払ったパワーと残高。healed も立つ。 */
+  inn?: { name?: string; paid: number; power: number };
+  /** 宿屋に泊まれなかった理由 (パワー不足)。 */
+  innDenied?: { name?: string; price: number; power: number };
   /** 次の move に渡す新しい位置トークン (署名済み = 改竄不可)。 */
   token: string;
   /** サーバーが遭遇を判定した場合のみ。 */
@@ -337,9 +342,15 @@ export async function handleMove(env: ResolverEnv, userDid: string, dx: number, 
     // 行き先の地形は権威側で確定する。壁の中に出す設定は保存時に弾いているが、
     // 万一そうなっていても**移動そのものは通す** (出られない状態を作らない)。
     const destTerrain = dest ? interiorTerrainAt(dest, nx, ny) : terrainAt(nx, ny);
+    // **街のマスから内部へ入ったら帰還先も更新する。** ゲートは街の回復処理より先に
+    // return するので、ここで書かないと lastTown が古い街のまま残り、負けたときに
+    // 遠くへ飛ばされる (街に入る = 立ち寄った、という扱いはフィールドと揃える)。
+    const enteredFromTown = gate.from.mapId === WORLD_MAP_ID && terrainAt(gate.from.x, gate.from.y) === 'town';
     // 位置は PDS に確定させる (マップをまたぐのは稀 = 書き込みコストが乗ってよい)。
-    await readModifyWrite(env, userDid, (cur) => ({ ...cur, mapId: mapId === WORLD_MAP_ID ? undefined : mapId, x: nx, y: ny }),
-      { now, init: (d, iso) => migrateInitState(d, iso, ns, fetchImpl) });
+    await readModifyWrite(env, userDid, (cur) => ({
+      ...cur, mapId: mapId === WORLD_MAP_ID ? undefined : mapId, x: nx, y: ny,
+      ...(enteredFromTown ? { lastTown: { x: gate.from.x, y: gate.from.y } } : {}),
+    }), { now, init: (d, iso) => migrateInitState(d, iso, ns, fetchImpl) });
     const gateToken = signPosition(env, { did: userDid, mapId, x: nx, y: ny, counter: counter + 1, iat: now });
     // フィールドへ戻るときは mapId を載せない (旧 client が知らないキーを解釈しない)。
     return { ...(mapId !== WORLD_MAP_ID ? { mapId } : {}), x: nx, y: ny, terrain: destTerrain, token: gateToken };
@@ -355,6 +366,31 @@ export async function handleMove(env: ResolverEnv, userDid: string, dx: number, 
     await readModifyWrite(env, userDid, (cur) => ({ ...cur, mapId: undefined, x: nx, y: ny, carryHp: undefined, carryMp: undefined, lastTown: { x: nx, y: ny } }),
       { now, init: (d, iso) => migrateInitState(d, iso, ns, fetchImpl) });
     healed = true;
+  }
+
+  // 宿屋 (#424)。街の内部に入ると「入るだけで回復」が働かないので、回復はここで**有料**。
+  // **満タンなら課金しない** — 通り抜けるたびに取られると通行の邪魔になる。
+  let inn: MoveResult['inn'];
+  let innDenied: MoveResult['innDenied'];
+  const innHere = inside ? innAt(mapId, nx, ny) : undefined;
+  if (innHere) {
+    const rec = await readState(env, userDid);
+    const st = rec?.state ?? (await migrateInitState(userDid, new Date(now * 1000).toISOString(), ns, fetchImpl));
+    const hurt = st.carryHp !== undefined || st.carryMp !== undefined;
+    if (!hurt) {
+      // 全快で泊まる理由がない。無言だと「宿屋が壊れている」に見えるので結果は返す。
+      inn = { ...(innHere.name ? { name: innHere.name } : {}), paid: 0, power: st.power };
+    } else if (st.power < innHere.price) {
+      innDenied = { ...(innHere.name ? { name: innHere.name } : {}), price: innHere.price, power: st.power };
+    } else {
+      const after = await readModifyWrite(env, userDid, (cur) => {
+        // 残高は毎回読み直す (CAS リトライで二重に引かない)。
+        if (cur.power < innHere.price) throw new ResolverError('パワーが たりない', 400, 'inn_poor');
+        return { ...cur, power: cur.power - innHere.price, carryHp: undefined, carryMp: undefined, x: nx, y: ny, mapId };
+      }, { now, init: (d, iso) => migrateInitState(d, iso, ns, fetchImpl) });
+      inn = { ...(innHere.name ? { name: innHere.name } : {}), paid: innHere.price, power: after.power };
+      healed = true;
+    }
   }
 
   const nextToken = signPosition(env, { did: userDid, mapId, x: nx, y: ny, counter: counter + 1, iat: now });
@@ -387,7 +423,11 @@ export async function handleMove(env: ResolverEnv, userDid: string, dx: number, 
       }
     }
   }
-  return { ...(mapId !== WORLD_MAP_ID ? { mapId } : {}), x: nx, y: ny, terrain, healed: healed || undefined, token: nextToken };
+  return {
+    ...(mapId !== WORLD_MAP_ID ? { mapId } : {}), x: nx, y: ny, terrain,
+    healed: healed || undefined, token: nextToken,
+    ...(inn ? { inn } : {}), ...(innDenied ? { innDenied } : {}),
+  };
 }
 
 export interface TeleportResult { x: number; y: number; token: string; materials: Record<string, number> }

--- a/apps/edge/test/battle-resolver.test.ts
+++ b/apps/edge/test/battle-resolver.test.ts
@@ -414,3 +414,72 @@ describe('ゲートの解禁フラグ (#426)', () => {
     expect(r.mapId).toBe('in-1');
   });
 });
+
+describe('宿屋 (#424)', () => {
+  const orig = globalThis.fetch;
+  afterEach(() => { globalThis.fetch = orig; setInteriors(null, null); });
+
+  const F = BASE_PALETTE.indexOf('plains');
+  const W = BASE_PALETTE.indexOf('mountain');
+  const innRoom = (): InteriorMap => {
+    const size = 8;
+    const tiles = new Uint8Array(size * size).fill(F);
+    for (let k = 0; k < size; k++) { tiles[k] = W; tiles[(size-1)*size+k] = W; tiles[k*size] = W; tiles[k*size+size-1] = W; }
+    return { id: 'in-1', name: 'むら', size, tiles, inn: { x: 5, y: 4, price: 3, name: 'やど' } };
+  };
+
+  it('傷ついていれば パワーを払って全回復する', async () => {
+    const env = await makeEnv();
+    const m = resolverMock({ diagnosis: DIAG, gameState: GS({ mapId: 'in-1', x: 4, y: 4, power: 10, carryHp: 5 }) });
+    globalThis.fetch = m.fn;
+    setInteriors([innRoom()], []);
+    const r = await handleMove(env, USER, 1, 0, undefined, NOW); // (5,4) = 宿屋
+    expect(r.inn).toMatchObject({ paid: 3, power: 7 });
+    expect(r.healed).toBe(true);
+    const st = m.store.get('gs')!.value as GameState;
+    expect(st.power).toBe(7);
+    expect(st.carryHp).toBeUndefined(); // 全回復 = carry を消す
+  });
+
+  it('満タンなら課金しない (通り抜けても取られない)', async () => {
+    const env = await makeEnv();
+    const m = resolverMock({ diagnosis: DIAG, gameState: GS({ mapId: 'in-1', x: 4, y: 4, power: 10 }) });
+    globalThis.fetch = m.fn;
+    setInteriors([innRoom()], []);
+    const r = await handleMove(env, USER, 1, 0, undefined, NOW);
+    expect(r.inn).toMatchObject({ paid: 0, power: 10 });
+    expect((m.store.get('gs')!.value as GameState).power).toBe(10);
+  });
+
+  it('パワーが足りなければ泊まれない (回復も課金もしない)', async () => {
+    const env = await makeEnv();
+    const m = resolverMock({ diagnosis: DIAG, gameState: GS({ mapId: 'in-1', x: 4, y: 4, power: 1, carryHp: 5 }) });
+    globalThis.fetch = m.fn;
+    setInteriors([innRoom()], []);
+    const r = await handleMove(env, USER, 1, 0, undefined, NOW);
+    expect(r.innDenied).toMatchObject({ price: 3, power: 1 });
+    expect(r.healed).toBeUndefined();
+    expect((m.store.get('gs')!.value as GameState).carryHp).toBe(5); // 傷は残る
+  });
+});
+
+describe('街の内部へ入ると帰還先も更新する (#424)', () => {
+  const orig = globalThis.fetch;
+  afterEach(() => { globalThis.fetch = orig; setInteriors(null, null); });
+
+  it('街のマスからゲートで入ると lastTown がその街になる', async () => {
+    // ゲートは街の回復処理より先に return するので、ここで書かないと lastTown が
+    // 古い街のまま残り、負けたときに遠くへ飛ばされる。
+    const env = await makeEnv();
+    const town = worldOverlay().towns[0]!;
+    const m = resolverMock({ diagnosis: DIAG, gameState: GS({ x: town.x, y: town.y - 1, lastTown: { x: 1, y: 1 } }) });
+    globalThis.fetch = m.fn;
+    const size = 8;
+    const tiles = new Uint8Array(size * size).fill(BASE_PALETTE.indexOf('plains'));
+    setInteriors([{ id: 'in-1', name: 'むら', size, tiles }],
+      [{ from: { mapId: 'world', x: town.x, y: town.y }, to: { mapId: 'in-1', x: 4, y: 4 } }]);
+    const r = await handleMove(env, USER, 0, 1, undefined, NOW);
+    expect(r.mapId).toBe('in-1');
+    expect((m.store.get('gs')!.value as GameState).lastTown).toEqual({ x: town.x, y: town.y });
+  });
+});

--- a/apps/web/src/lib/world-server.ts
+++ b/apps/web/src/lib/world-server.ts
@@ -91,7 +91,11 @@ export interface ServerBattleState { player: ServerMonster; monster: ServerMonst
 export interface ServerEncounter { battleId: string; monsterId: string; state: ServerBattleState; rewarded: boolean }
 export interface ServerMoveResult {
   /** 移動後のマップ (#424)。省略 = フィールド。 */
-  mapId?: string; x: number; y: number; terrain: string; healed?: boolean; token: string; encounter?: ServerEncounter }
+  mapId?: string; x: number; y: number; terrain: string; healed?: boolean; token: string; encounter?: ServerEncounter;
+  /** 宿屋 (#424)。払ったパワーと残高。 */
+  inn?: { name?: string; paid: number; power: number };
+  /** 宿屋に泊まれなかった (パワー不足)。 */
+  innDenied?: { name?: string; price: number; power: number } }
 /** 権威 GameState (パワー/XP/素材/位置/carry HP-MP 等)。表示はこれを正とする。 */
 /** 所持装備の 1 個体 (#551 段階 2)。**権威側が唯一の正**で、ここに無い個体は装備できない。 */
 export interface ServerOwnedPiece { rkey: string; itemId: string; level: number }

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -645,6 +645,17 @@ export function World() {
           let next: Vitals = { ...cur, x: res.x, y: res.y, ...(res.mapId ? { mapId: res.mapId } : {}) };
           if (!res.mapId) delete next.mapId;
           if (res.healed) { next.hp = null; next.mp = null; }
+          // 宿屋 (#424)。残高もサーバーが正 (payment は権威側で引かれている)。
+          if (res.inn) {
+            setServerPower(res.inn.power);
+            const who = res.inn.name ?? 'やどや';
+            setNotice(res.inn.paid > 0
+              ? `${who}に とまった (パワー -${res.inn.paid})。すっかり 元気に なった!`
+              : `「${who}」…いまは よく ねむれているようだ。`);
+          } else if (res.innDenied) {
+            const who = res.innDenied.name ?? 'やどや';
+            setNotice(`${who}「ひとばん ${res.innDenied.price} パワーだよ」… パワーが たりない (いま ${res.innDenied.power})。`);
+          }
           if (onWorld && res.terrain === 'town') {
             // ちずのかけら: 街に入るとその街の地方一帯 (3×3 リージョン) が地図に加わる。
             // 訪問済みの街 (そらのはねの行き先候補) も積む。どちらも表示用の探索メモ。

--- a/packages/core/src/__tests__/interior.test.ts
+++ b/packages/core/src/__tests__/interior.test.ts
@@ -14,6 +14,7 @@ import {
   allInteriors,
   gateAt,
   gateOpen,
+  innAt,
   gateLockedNotice,
   DEFAULT_GATE_LOCKED_NOTICE,
   interiorById,
@@ -264,5 +265,32 @@ describe('同梱の村「ふたばの村」(#424)', () => {
     const [inGate, outGate] = starterTownGates(spawn);
     expect(inGate!.from).toEqual({ mapId: 'world', x: spawn.x, y: spawn.y });
     expect(outGate!.to).toEqual({ mapId: 'world', x: spawn.x, y: spawn.y + 1 });
+  });
+});
+
+describe('宿屋 (#424)', () => {
+  const withInn = (inn: NonNullable<InteriorMap['inn']>) => ({ ...room(), inn });
+
+  it('宿屋のマスを引ける', () => {
+    setInteriors([withInn({ x: 4, y: 4, price: 3, name: 'やど' })], []);
+    expect(innAt('in-1', 4, 4)?.price).toBe(3);
+    expect(innAt('in-1', 5, 4)).toBeUndefined();
+    expect(innAt('world', 4, 4)).toBeUndefined();
+  });
+
+  it('歩けないマスの宿屋を弾く (踏めない宿屋は永久に使えない)', () => {
+    expect(() => setInteriors([withInn({ x: 0, y: 0, price: 3 })], [])).toThrow(InteriorError);
+  });
+
+  it('マップの外・宿代の範囲外を弾く', () => {
+    expect(() => setInteriors([withInn({ x: 99, y: 4, price: 3 })], [])).toThrow(InteriorError);
+    expect(() => setInteriors([withInn({ x: 4, y: 4, price: -1 })], [])).toThrow(InteriorError);
+    expect(() => setInteriors([withInn({ x: 4, y: 4, price: 999 })], [])).toThrow(InteriorError);
+  });
+
+  it('ふたばの村の宿屋は歩けるマスにある', () => {
+    const v = starterTownInterior();
+    expect(v.inn).toBeDefined();
+    expect(interiorWalkableAt(v, v.inn!.x, v.inn!.y)).toBe(true);
   });
 });

--- a/packages/core/src/interior-samples.ts
+++ b/packages/core/src/interior-samples.ts
@@ -43,6 +43,9 @@ const PARTS: WorldPart[] = [
   { terrain: 'bridge', name: 'みち', walkable: true },
 ];
 
+/** 宿屋のマス (東の家の玄関前)。ここに入ると あおぞらパワーを払って全回復する。 */
+export const STARTER_TOWN_INN = { x: 42, y: 14, price: 3, name: 'ふたばの宿' };
+
 /** フィールドから入ったときの降り立つ場所 (村の南の通り)。 */
 export const STARTER_TOWN_ENTRANCE = { x: 32, y: 59 };
 /** フィールドへ戻るマス (南の石垣の内側)。**壁は開けない** — 出るのはここだけ。 */
@@ -122,6 +125,8 @@ export function starterTownInterior(): InteriorMap {
     size: STARTER_TOWN_SIZE,
     tiles: buildStarterTownTiles(),
     parts: PARTS.map((p) => ({ ...p })),
+    // 宿屋 (#424)。街に入るだけでは回復しなくなったので、回復はここで有料。
+    inn: { ...STARTER_TOWN_INN },
     // 街の中なので敵は出さない (encounterTier を設定しない)。
   };
 }

--- a/packages/core/src/interior.ts
+++ b/packages/core/src/interior.ts
@@ -45,6 +45,14 @@ export interface InteriorMap {
   parts?: WorldPart[];
   /** 遭遇の危険度 tier。**省略 = 敵が出ない** (街の中・城の広間)。 */
   encounterTier?: number;
+  /**
+   * **宿屋** (#424)。そのマスに入ると、あおぞらパワーを払って全回復する。
+   *
+   * 街の中に入れるようにすると、フィールドの街タイルはゲートに使われて
+   * 「入るだけで回復」が働かなくなる。回復の場所を村の中に置き直すのが宿屋で、
+   * **有料**にしてタダの回復をやめる (オーナー判断)。
+   */
+  inn?: { x: number; y: number; price: number; name?: string };
 }
 
 /** 出入口 1 つ。踏んだ瞬間に `to` へ移る (一方通行。往復は 2 本書く)。 */
@@ -82,6 +90,8 @@ export interface InteriorsRecord {
 export const MAX_INTERIOR_SIZE = 128;
 export const MAX_INTERIORS = 100;
 export const MAX_GATES = 500;
+/** 宿代の上限 (打ち間違いで経済を壊さない)。 */
+export const MAX_INN_PRICE = 100;
 
 let interiors = new Map<string, InteriorMap>();
 let gates = new Map<string, Gate>();
@@ -109,7 +119,19 @@ export function setInteriors(list: readonly InteriorMap[] | null, gateList: read
     if (m.encounterTier !== undefined && (!Number.isInteger(m.encounterTier) || m.encounterTier < 1 || m.encounterTier > 8)) {
       throw new InteriorError(`${where}: 危険度は 1〜8 (省略で敵が出ない)`);
     }
-    nextMaps.set(m.id, { ...m, tiles: new Uint8Array(m.tiles), ...(m.parts ? { parts: m.parts.map((p) => ({ ...p })) } : {}) });
+    if (m.inn) {
+      if (!Number.isInteger(m.inn.x) || !Number.isInteger(m.inn.y) || m.inn.x < 0 || m.inn.y < 0 || m.inn.x >= m.size || m.inn.y >= m.size) {
+        throw new InteriorError(`${where}: 宿屋がマップの外にある`);
+      }
+      if (!Number.isInteger(m.inn.price) || m.inn.price < 0 || m.inn.price > MAX_INN_PRICE) {
+        throw new InteriorError(`${where}: 宿代は 0〜${MAX_INN_PRICE}`);
+      }
+      // **歩けないマスの宿屋は永久に使えない。** 壁の上に置いた宿屋は誰も踏めない。
+      if (!interiorWalkableAt(m, m.inn.x, m.inn.y)) {
+        throw new InteriorError(`${where}: 宿屋が歩けないマスにある`);
+      }
+    }
+    nextMaps.set(m.id, { ...m, tiles: new Uint8Array(m.tiles), ...(m.parts ? { parts: m.parts.map((p) => ({ ...p })) } : {}), ...(m.inn ? { inn: { ...m.inn } } : {}) });
   }
   if (nextMaps.size > MAX_INTERIORS) throw new InteriorError(`内部マップが多すぎる (${nextMaps.size} > ${MAX_INTERIORS})`);
 
@@ -200,6 +222,13 @@ export function gateLockedNotice(gate: Gate): string {
 /** そのマスのゲート (無ければ undefined)。移動の権威判定と web の描画が共有する。 */
 export function gateAt(mapId: string, x: number, y: number): Gate | undefined {
   return gates.get(gateKey(mapId, x, y));
+}
+
+/** そのマスが宿屋か (無ければ undefined)。移動の権威判定が使う。 */
+export function innAt(mapId: string, x: number, y: number): NonNullable<InteriorMap['inn']> | undefined {
+  const m = interiors.get(mapId);
+  if (!m?.inn) return undefined;
+  return m.inn.x === x && m.inn.y === y ? m.inn : undefined;
 }
 
 /** そのマップが内部か (mapId が未知なら false = フィールド扱いに倒す)。 */


### PR DESCRIPTION
Closes #624

## なぜ

オーナーの質問「街に入ったら回復するのはどういう処理？宿屋追加したほうがいい？」の調査で、**内部マップを入れた街だけ壊れている**ことが判明した。

ゲート判定は街の回復判定より先に early return するため、村を作った街では:
- 入っても回復しない
- **`lastTown` も更新されない** (負けると遠くの街へ飛ばされる)

## 決定 (オーナー判断: 有料の宿屋)

- `InteriorMap.inn = { x, y, price, name }` — そのマスに入るとあおぞらパワーを払って全回復
- **満タンなら課金しない** (通り抜けるたびに取られると通行の邪魔)
- パワー不足なら泊まれない (回復も課金もしない)。残高は CAS 内で読み直すのでリトライで二重に引かれない
- 歩けないマス・マップ外・宿代の範囲外は保存で弾く (踏めない宿屋は永久に使えない)
- 街のマスからゲートで内部へ入ったら **lastTown も更新**
- ふたばの村に「ふたばの宿」(3 パワー) を配置
- 内部マップが無い街は従来どおり無料回復 (そうしないと回復手段が消える)

## レベル曲線の再調整は不要 (オーナー指摘)

当初 PR 本文に「連戦数の前提が変わるので #535 / JOB_LEVEL_PACE を引き直す」と書いたが**誤り**。連戦数は「全回復してから何戦もつか」の指標で、**その全回復を得る対価は測定に入らない**。ジョブ間の持久力差も宿代では変わらない。

宿代 3 パワー = 投稿 3 回 (`viaPosts: 1`)。回復の入手性が少し下がるだけで、曲線の導出元は動かない。

## テスト

- core 4 件 (宿屋を引ける / 歩けないマスを弾く / 範囲検証 / 村の宿屋が歩ける)
- edge 4 件 (傷ついていれば課金して全回復 / 満タンなら無課金 / パワー不足で泊まれない / 街に入ると lastTown 更新)
- core 726 / edge 254 / web 377 全緑、typecheck / build 緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SpSiVHa5hXp7sEUAXAfWEE