### PR TITLE
fix: 店の操作で位置トークンを送る (村のなんでも屋で作れない) (#636)

### DIFF
--- a/apps/edge/test/shop.test.ts
+++ b/apps/edge/test/shop.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { p256 } from '@noble/curves/p256';
 import { base64urlnopad } from '@scure/base';
-import { EQUIPMENT_BY_ID, SALE_TUNING, townShopStock, worldOverlay } from '@aozoraquest/core';
+import { EQUIPMENT_BY_ID, SALE_TUNING, townShopStock, worldOverlay, BASE_PALETTE, setInteriors, type InteriorMap } from '@aozoraquest/core';
 import { shopCraft, shopSell, shopForge, shopDiscard, ShopError, MAX_SHOP_OPS, MAX_OWNED_PIECES } from '../src/shop';
 import { sanitizeGear } from '../src/battle-resolver';
 import { rkeyForDid, XP_EPOCH, type GameState, type GameStateEnv } from '../src/game-state';
@@ -384,5 +384,36 @@ describe('所持上限と すてる (#575)', () => {
     const env = await makeEnv();
     await shopDiscard(env, DID, { rkeys: ['junk'], rkey: 'd10' }, NOW);
     expect(stored(store).gearSel).toEqual({});
+  });
+});
+
+describe('村の中のなんでも屋 (#424/#636)', () => {
+  const orig = globalThis.fetch;
+  afterEach(() => { globalThis.fetch = orig; setInteriors(null, null); });
+
+  const SIZE = 8;
+  const SHOP_TILE = { x: 5, y: 4 };
+  const village = (): InteriorMap => ({
+    id: 'in-town', name: 'むら', size: SIZE,
+    tiles: new Uint8Array(SIZE * SIZE).fill(BASE_PALETTE.indexOf('plains')),
+    shop: { ...SHOP_TILE, town: { x: TOWN.x, y: TOWN.y } },
+  });
+
+  it('店のマスに立っていれば、村の中でも作ってもらえる', async () => {
+    setInteriors([village()], []);
+    const m = statefulPds(stateAt({ mapId: 'in-town', x: 1, y: 1 })); // state の座標は入口のまま
+    globalThis.fetch = m.fn;
+    // **位置は token が正**。店のマスを指すトークンを渡す。
+    const res = await shopCraft(await makeEnv(), DID,
+      { itemId: ITEM.id, rkey: 'r1', luk: 0, pos: { ...SHOP_TILE, mapId: 'in-town' } }, NOW);
+    expect(res.pieces).toEqual([{ rkey: 'r1', itemId: ITEM.id, level: res.level }]);
+  });
+
+  it('村の中でも店のマス以外では買えない', async () => {
+    setInteriors([village()], []);
+    globalThis.fetch = statefulPds(stateAt({ mapId: 'in-town', x: 1, y: 1 })).fn;
+    await expect(shopCraft(await makeEnv(), DID,
+      { itemId: ITEM.id, rkey: 'r2', luk: 0, pos: { x: 1, y: 1, mapId: 'in-town' } }, NOW),
+    ).rejects.toMatchObject({ code: 'not_in_town' });
   });
 });

--- a/apps/web/src/lib/world-server.ts
+++ b/apps/web/src/lib/world-server.ts
@@ -196,14 +196,16 @@ export interface ServerShopResult {
 
 /** なんでも屋: 装備を作ってもらう (#551)。**費用も強化値もサーバーが決める**。
  *  client は返ってきた level を craft レコードに記帳するだけ。 */
-export function serverShopCraft(agent: Agent, itemId: string, rkey: string): Promise<ServerShopResult> {
-  return callEdge<ServerShopResult>(agent, LXM_SHOP_CRAFT, '/api/shop/craft', { itemId, rkey });
+export function serverShopCraft(agent: Agent, itemId: string, rkey: string, token?: string): Promise<ServerShopResult> {
+  // **位置トークンを送る** (#636)。サーバーは token の座標で店を判定する。送らないと
+  // state の座標に倒れ、村の中では入口の座標のままなので「店の外」と判定される。
+  return callEdge<ServerShopResult>(agent, LXM_SHOP_CRAFT, '/api/shop/craft', { itemId, rkey, ...(token ? { token } : {}) });
 }
 
 /** なんでも屋: きたえる (#551 段階 2)。同じ品・同じ強化値の 2 個体 → +1。
  *  消費する個体は**権威側の所持から**探すので、持っていない rkey は通らない。 */
-export function serverShopForge(agent: Agent, rkeys: [string, string], rkey: string): Promise<ServerShopResult> {
-  return callEdge<ServerShopResult>(agent, LXM_SHOP_FORGE, '/api/shop/forge', { rkeys, rkey });
+export function serverShopForge(agent: Agent, rkeys: [string, string], rkey: string, token?: string): Promise<ServerShopResult> {
+  return callEdge<ServerShopResult>(agent, LXM_SHOP_FORGE, '/api/shop/forge', { rkeys, rkey, ...(token ? { token } : {}) });
 }
 
 /**
@@ -241,8 +243,8 @@ export function serverQuestComplete(agent: Agent, questId: string): Promise<Serv
 }
 
 /** なんでも屋: 素材のひきとり (#551)。権威側の在庫と残高を動かす。 */
-export function serverShopSell(agent: Agent, materialId: string, count: number, rkey: string): Promise<ServerShopResult> {
-  return callEdge<ServerShopResult>(agent, LXM_SHOP_SELL, '/api/shop/sell', { materialId, count, rkey });
+export function serverShopSell(agent: Agent, materialId: string, count: number, rkey: string, token?: string): Promise<ServerShopResult> {
+  return callEdge<ServerShopResult>(agent, LXM_SHOP_SELL, '/api/shop/sell', { materialId, count, rkey, ...(token ? { token } : {}) });
 }
 
 /** あおぞらパワーを消費する (#551)。**値段はサーバーが決める** — client が金額を送らない。

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -1101,7 +1101,7 @@ export function World() {
       try {
         // **費用の支払いと強化値の抽選はサーバー** (#551)。素材もパワーも権威側から引かれ、
         // 結果の在庫がそのまま返る (client の減算だけでは、リロードで素材が戻る = 複製できた)。
-        const res = await serverShopCraft(agent, def.id, rkey);
+        const res = await serverShopCraft(agent, def.id, rkey, tokenRef.current);
         setServerPower(res.power);
         applyServerMaterials(res.materials);
         // 個体そのもの (強化値つきレコード) はまだユーザー PDS。サーバーが決めた level を記帳する。
@@ -1152,7 +1152,7 @@ export function World() {
       try {
         // **合成もサーバー** (#551 段階 2)。消費する個体は権威側の所持から探すので、
         // 持っていない rkey や強化値の食い違いは通らない。
-        const res = await serverShopForge(agent, rkeys, frkey);
+        const res = await serverShopForge(agent, rkeys, frkey, tokenRef.current);
         pendingForgeRef.current = null;
         if (res.pieces) setCraftedPieces(res.pieces.map((p) => ({ rkey: p.rkey, itemId: p.itemId, level: p.level, at: '' })));
         const piece: CraftedPiece = { rkey: frkey, itemId: def.id, level: res.level ?? resultLevel, at: new Date().toISOString() };
@@ -1184,7 +1184,7 @@ export function World() {
       try {
         // **在庫と残高の増減はサーバー** (#551)。client 台帳だけだと「パワーが 5 ふえた!」と
         // 出ても権威側は動かず、戦闘の報酬にも効かなかった。
-        const res = await serverShopSell(agent, materialId, count, srkey);
+        const res = await serverShopSell(agent, materialId, count, srkey, tokenRef.current);
         pendingSaleRef.current = null;
         setServerPower(res.power);
         applyServerMaterials(res.materials);


### PR DESCRIPTION
Closes #636

## なぜ

#633 を直した後も、村のなんでも屋でアイテムが作れなかった。

サーバーは**位置トークンの座標**で店を判定する作り (`positionFrom(env, body.token, did)`) なのに、**クライアントが token を送っていなかった**。送られないと `state` の座標に倒れる。

| | state の座標 | 結果 |
|---|---|---|
| フィールドの街 | 街に入ると街の座標になる | たまたま一致して動いていた |
| **村の中** | 歩行は**トークンだけ**更新、state は入口のまま | 店のマスに立っていても `not_in_town` |

## 変更

つくる / きたえる / ひきとり の 3 経路で位置トークンを送る。サーバー側の判定 (`shopAt`) は #626 で内部マップ対応済み。

## テスト

- edge 2 件: 「店のマスなら村の中でも作れる」「店のマス以外では作れない」
- edge 256 / web 381 全緑、typecheck / build 緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SpSiVHa5hXp7sEUAXAfWEE