### PR TITLE
style(web): セリフ窓にモーダル感を出す (#640)

### DIFF
--- a/apps/web/src/components/dialogue-window.tsx
+++ b/apps/web/src/components/dialogue-window.tsx
@@ -122,7 +122,7 @@ export function DialogueWindow({
 
   return (
     <>
-      {/* 送り面: **常に画面全体を覆う** 透明レイヤー。どこをタップしても会話が進み、footer や
+      {/* 送り面: **常に画面全体を覆う** レイヤー。どこをタップしても会話が進み、footer や
           スティック等の背後 UI への誤タップ・誤遷移を防ぐ。anchor='map' で窓を地図に貼っても
           この送り面は viewport 全面のままなので、画面下端 (footer 際) を送ろうとしても効く
           (地図枠だけを覆うと footer 遷移で会話が中断する回帰があった — レビュー ★★)。 */}
@@ -139,7 +139,10 @@ export function DialogueWindow({
           }
         }}
         tabIndex={0}
-        style={{ position: 'fixed', inset: 0, zIndex: DIALOGUE_BACKDROP_Z, cursor: 'pointer', background: 'transparent' }}
+        // 背後をわずかに暗くする (#640)。全画面が当たり判定なのに見た目が素通しだと
+        // 「いま会話中で、ほかは触れない」ことが伝わらない (実機で存在感が薄いと指摘)。
+        className="aq-dialogue-backdrop"
+        style={{ position: 'fixed', inset: 0, zIndex: DIALOGUE_BACKDROP_Z, cursor: 'pointer' }}
       />
       {/* 窓本体: 'viewport' は footer 際に固定、'map' は直近の position:relative 祖先
           (ワールドの地図枠) の下端に貼る (DQ 風)。送り面より上 (z)。 */}
@@ -158,7 +161,7 @@ export function DialogueWindow({
       >
         {line.speaker && (
           <div
-            className="dq-window"
+            className="dq-window aq-dialogue-pane"
             style={{
               display: 'inline-flex',
               alignItems: 'center',
@@ -177,7 +180,7 @@ export function DialogueWindow({
           </div>
         )}
         <div
-          className="dq-window"
+          className="dq-window aq-dialogue-pane"
           // maxHeight/overflowY: 将来の長い NPC セリフでも窓がアバターに被らないよう上限を設ける
           //   (DQ も 1 窓は数行で固定 — レビュー ★★)。marginBottom:0: dq-window 既定の 0.9em を
           //   打ち消し、地図枠の下端 (bottom:0.5em) にぴったり寄せる (レビュー ★)。

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2174,3 +2174,32 @@ p { margin: 0.4em 0; }
 @media (prefers-reduced-motion: reduce) {
   .door-fade-in, .door-fade-out { animation-duration: 1ms; }
 }
+
+/* ── セリフ窓のモーダル感 (#640) ────────────────────────────────
+   会話は「送るまで先へ進めない」= 実質モーダルなのに、窓が半透明 (--color-window-bg は
+   rgba .78) で下の UI が透け、送り面も素通しだったため存在感が無かった。
+   なんでも屋では品物カードやボタンが窓ごしに見えて、どれが手前か分からない。 */
+
+/* 送り面: 背後をわずかに暗くして後退させる。会話を送るタップ層そのものなので、
+   見た目 (暗い) と当たり判定 (全画面) が一致する。 */
+.aq-dialogue-backdrop {
+  background: rgba(0, 0, 0, 0.5);
+  animation: aq-dialogue-dim 140ms ease-out;
+}
+@keyframes aq-dialogue-dim {
+  from { background: rgba(0, 0, 0, 0); }
+}
+
+/* 窓本体と話者プレート: **不透明**にして浮かせる。--color-window-solid は
+   カラムのドリルダウンで同じ目的 (下が透けると読めない) に使っている既存トークン。 */
+.aq-dialogue-pane {
+  background: var(--color-window-solid);
+  box-shadow:
+    inset 0 0 0 1px var(--color-window-inner-border),
+    0 4px 0 rgba(0, 0, 0, 0.35),
+    0 10px 26px rgba(0, 0, 0, 0.55);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .aq-dialogue-backdrop { animation-duration: 1ms; }
+}


### PR DESCRIPTION
Closes #640

## 症状

なんでも屋のセリフ窓が、下の店の内容 (品物カードや「ひきとり」ボタン) が透けて見えるため
「いま会話中で、ほかは触れない」ことが伝わらない。実機で存在感が薄いという指摘。

## 直し方

- 窓本体と話者プレートを**不透明**にする (`--color-window-solid`。カラムのドリルダウンで
  「下が透けると読めない」という同じ目的に使っている既存トークン) + 影を足して浮かせる
- 送り面をわずかに暗くして背後を後退させる。送り面は元から画面全体が当たり判定なので、
  暗くすることで見た目と当たり判定が一致する

`prefers-reduced-motion` ではフェードを実質ゼロ時間にする (戦闘ワイプ・扉フェードと同じ方針)。

## 確認

実コンポーネントの DOM を jsdom で描き出し、本番の `styles.css` を当てて
なんでも屋と同じ重なり (半透明オーバーレイ + 品物カード) の上で実際にスクリーンショットを撮って確認。
窓ごしに品物が透けないこと、背後が暗く後退することを目視済み。

- [x] typecheck 緑
- [x] unit 383 passed
- [x] build 緑

## Review

CSS の値・色のみ (詳細度・レイアウト計算・DOM 構造は不変) なので §1.5 の高速パス。