### PR TITLE
fix(web): 書けなかった記帳を保留して書き直す (#642)

### DIFF
--- a/apps/web/src/components/shop-modal.tsx
+++ b/apps/web/src/components/shop-modal.tsx
@@ -89,6 +89,7 @@ export function ShopModal({
   busy,
   lastAction,
   errorText,
+  noticeText,
   onCraft,
   onForge,
   onSell,
@@ -108,6 +109,8 @@ export function ShopModal({
   /** 失敗の理由 (#551)。**モーダル内に出す** — ページ本体の通知行に出しても、
    *  この全画面オーバーレイの背面に描かれてプレイヤーには見えない。 */
   errorText: string | null;
+  /** 記帳だけ落ちたときの控えめな知らせ (#642)。品もパワーも動いていないので赤字にしない。 */
+  noticeText?: string | null;
   onCraft: (def: EquipmentDef) => void;
   onForge: (def: EquipmentDef, level: number, rkeys: [string, string]) => void;
   /** 素材のひきとり (count は materialsPerPower の倍数) */
@@ -248,6 +251,14 @@ export function ShopModal({
         >
           {errorText}
         </p>
+        {noticeText && (
+          <p
+            aria-live="polite"
+            style={{ margin: '0 0 0.5em', fontSize: '0.8em', color: 'var(--color-muted)' }}
+          >
+            {noticeText}
+          </p>
+        )}
         <div style={{ overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 6 }}>
           {stock.equipment.map((id) => {
             const def = EQUIPMENT_BY_ID[id];

--- a/apps/web/src/components/shop-modal.tsx
+++ b/apps/web/src/components/shop-modal.tsx
@@ -251,14 +251,19 @@ export function ShopModal({
         >
           {errorText}
         </p>
-        {noticeText && (
-          <p
-            aria-live="polite"
-            style={{ margin: '0 0 0.5em', fontSize: '0.8em', color: 'var(--color-muted)' }}
-          >
-            {noticeText}
-          </p>
-        )}
+        {/* live region は**常設**して中身だけ差し替える (条件付きマウントは初回読み上げが
+            落ちることがある — 上のエラー行と同じ理由。レビュー ★★) */}
+        <p
+          aria-live="polite"
+          style={{
+            margin: noticeText ? '0 0 0.5em' : 0,
+            fontSize: '0.8em',
+            minHeight: noticeText ? '1.3em' : 0,
+            color: 'var(--color-muted)',
+          }}
+        >
+          {noticeText}
+        </p>
         <div style={{ overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 6 }}>
           {stock.equipment.map((id) => {
             const def = EQUIPMENT_BY_ID[id];

--- a/apps/web/src/lib/craft-log-queue.test.ts
+++ b/apps/web/src/lib/craft-log-queue.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { craftItem, sellMaterials, CraftLogError } from './crafting';
-import { enqueueCraftLog, flushCraftLogs, pendingCraftLogs } from './craft-log-queue';
+import { clearCraftLogQueue, enqueueCraftLog, flushCraftLogs, pendingCraftLogs } from './craft-log-queue';
 
 /**
  * 記帳 (ユーザー PDS の履歴) が書けなかったときの保留と再送 (#642)。
@@ -23,8 +23,20 @@ beforeEach(() => {
 });
 
 const DID = 'did:test';
-const agentWith = (createRecord: ReturnType<typeof vi.fn>): never =>
-  ({ assertDid: DID, com: { atproto: { repo: { createRecord } } } } as never);
+/** getRecord は既定で「無い」を返す (= 書けていない)。既に在る状況だけ差し替える。 */
+const agentWith = (createRecord: ReturnType<typeof vi.fn>, getRecord?: ReturnType<typeof vi.fn>): never =>
+  ({
+    assertDid: DID,
+    com: {
+      atproto: {
+        repo: { createRecord, getRecord: getRecord ?? vi.fn(async () => { throw new Error('Could not locate record'); }) },
+      },
+    },
+  } as never);
+
+/** 同 rkey の createRecord で PDS が実際に返す文言 (atproto の mst.ts)。
+ *  "already exists" ではないので、文言 grep では重複を検出できない。 */
+const DUPLICATE = 'There is already a value at key: app.aozoraquest.craft/s-1';
 
 describe('記帳の失敗を保留する', () => {
   test('craftItem が落ちたら rkey と record を持った CraftLogError になる', async () => {
@@ -41,11 +53,22 @@ describe('記帳の失敗を保留する', () => {
     expect(e.record['power']).toBe(4);
   });
 
-  test('「既にある」は成功として扱う (応答だけ落ちた再送で永久に詰まらせない)', async () => {
-    const createRecord = vi.fn(async () => { throw new Error('Record already exists'); });
+  test('既に書けていたら成功として扱う (応答だけ落ちた再送で永久に詰まらせない)', async () => {
+    // PDS の文言に依存せず、同 rkey の record が実在するかで判定する
+    const createRecord = vi.fn(async () => { throw new Error(DUPLICATE); });
+    const getRecord = vi.fn(async () => ({ data: { uri: 'at://x', cid: 'c', value: {} } }));
     await expect(
-      sellMaterials(agentWith(createRecord), { materialId: 'slime-drop', materialCount: 30 }, 's-1'),
+      sellMaterials(agentWith(createRecord, getRecord), { materialId: 'slime-drop', materialCount: 30 }, 's-1'),
     ).resolves.toBeTruthy();
+    expect(getRecord).toHaveBeenCalledTimes(1);
+  });
+
+  test('書けていなければ CraftLogError (取りにいけない時も保留に残す)', async () => {
+    const createRecord = vi.fn(async () => { throw new Error('offline'); });
+    const getRecord = vi.fn(async () => { throw new Error('offline'); });
+    await expect(
+      sellMaterials(agentWith(createRecord, getRecord), { materialId: 'slime-drop', materialCount: 30 }, 's-2'),
+    ).rejects.toBeInstanceOf(CraftLogError);
   });
 
   test('保留に積むと DID 単位で残り、同じ rkey は二重に積まれない', () => {
@@ -90,5 +113,50 @@ describe('保留した記帳を書き直す', () => {
     const createRecord = vi.fn(async () => ({ data: { uri: 'at://x', cid: 'c' } }));
     expect(await flushCraftLogs(agentWith(createRecord), DID)).toBe(0);
     expect(createRecord).not.toHaveBeenCalled();
+  });
+});
+
+describe('取りこぼさない / 詰まらない', () => {
+  test('再送の往復中に積まれた保留を消さない', async () => {
+    enqueueCraftLog(DID, new CraftLogError('c-old', { itemId: 'a' }, new Error('x')), 'now');
+    // 1 件目を送っている最中に、店で作った記帳が落ちて積まれる状況を再現する
+    const createRecord = vi.fn(async () => {
+      enqueueCraftLog(DID, new CraftLogError('c-new', { itemId: 'b' }, new Error('x')), 'now');
+      return { data: { uri: 'at://x', cid: 'c' } };
+    });
+    expect(await flushCraftLogs(agentWith(createRecord), DID)).toBe(1);
+    expect(pendingCraftLogs(DID).map((e) => e.rkey)).toEqual(['c-new']);
+  });
+
+  test('何度送っても通らない 1 件は上限で捨て、後続が書けるようになる', async () => {
+    enqueueCraftLog(DID, new CraftLogError('c-poison', { itemId: 'bad' }, new Error('x')), 'now');
+    enqueueCraftLog(DID, new CraftLogError('c-ok', { itemId: 'good' }, new Error('x')), 'now');
+    const createRecord = vi.fn(async (a: unknown) => {
+      if ((a as { rkey: string }).rkey === 'c-poison') throw new Error('InvalidRequest');
+      return { data: { uri: 'at://x', cid: 'c' } };
+    });
+    const agent = agentWith(createRecord);
+    // 4 回は先頭で止まったまま (試行回数を数えている)
+    for (let i = 0; i < 4; i += 1) expect(await flushCraftLogs(agent, DID)).toBe(0);
+    expect(pendingCraftLogs(DID).map((e) => e.rkey)).toEqual(['c-poison', 'c-ok']);
+    // 5 回目で諦めて捨て、後続が書ける
+    expect(await flushCraftLogs(agent, DID)).toBe(0);
+    expect(pendingCraftLogs(DID).map((e) => e.rkey)).toEqual(['c-ok']);
+    expect(await flushCraftLogs(agent, DID)).toBe(1);
+    expect(pendingCraftLogs(DID)).toHaveLength(0);
+  });
+
+  test('積み直しても試行回数は 0 に戻らない', () => {
+    const e = new CraftLogError('c-1', { itemId: 'a' }, new Error('x'));
+    enqueueCraftLog(DID, e, 'now');
+    localStorage.setItem(`aq.craftlog.pending.${DID}`, JSON.stringify([{ rkey: 'c-1', record: { itemId: 'a' }, queuedAt: 'now', attempts: 3 }]));
+    enqueueCraftLog(DID, e, 'later');
+    expect(pendingCraftLogs(DID)[0]!.attempts).toBe(3);
+  });
+
+  test('ワールドリセットで保留を捨てる (消した記録が書き戻らない)', () => {
+    enqueueCraftLog(DID, new CraftLogError('c-1', { itemId: 'a' }, new Error('x')), 'now');
+    clearCraftLogQueue(DID);
+    expect(pendingCraftLogs(DID)).toHaveLength(0);
   });
 });

--- a/apps/web/src/lib/craft-log-queue.test.ts
+++ b/apps/web/src/lib/craft-log-queue.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { craftItem, sellMaterials, CraftLogError } from './crafting';
+import { enqueueCraftLog, flushCraftLogs, pendingCraftLogs } from './craft-log-queue';
+
+/**
+ * 記帳 (ユーザー PDS の履歴) が書けなかったときの保留と再送 (#642)。
+ *
+ * 所持の権威はサーバーなので記帳の失敗で品は消えないが、黙って捨てると履歴が永久に欠け、
+ * パワー会計 (points.ts は craft コレクションを再スキャンして消費/獲得を出す) もずれる。
+ */
+
+const store = new Map<string, string>();
+beforeEach(() => {
+  store.clear();
+  (globalThis as unknown as { localStorage: Storage }).localStorage = {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+    key: () => null,
+    length: 0,
+  } as Storage;
+});
+
+const DID = 'did:test';
+const agentWith = (createRecord: ReturnType<typeof vi.fn>): never =>
+  ({ assertDid: DID, com: { atproto: { repo: { createRecord } } } } as never);
+
+describe('記帳の失敗を保留する', () => {
+  test('craftItem が落ちたら rkey と record を持った CraftLogError になる', async () => {
+    const createRecord = vi.fn(async () => { throw new Error('upstream 502'); });
+    const err = await craftItem(
+      agentWith(createRecord),
+      { itemId: 'wp-knife', materialId: 'slime-drop', materialCount: 1, power: 4, luk: 0 },
+      'c-fixed',
+    ).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(CraftLogError);
+    const e = err as CraftLogError;
+    expect(e.rkey).toBe('c-fixed');
+    expect(e.record['itemId']).toBe('wp-knife');
+    expect(e.record['power']).toBe(4);
+  });
+
+  test('「既にある」は成功として扱う (応答だけ落ちた再送で永久に詰まらせない)', async () => {
+    const createRecord = vi.fn(async () => { throw new Error('Record already exists'); });
+    await expect(
+      sellMaterials(agentWith(createRecord), { materialId: 'slime-drop', materialCount: 30 }, 's-1'),
+    ).resolves.toBeTruthy();
+  });
+
+  test('保留に積むと DID 単位で残り、同じ rkey は二重に積まれない', () => {
+    const e = new CraftLogError('c-1', { itemId: 'wp-knife' }, new Error('x'));
+    enqueueCraftLog(DID, e, '2026-08-03T00:00:00.000Z');
+    enqueueCraftLog(DID, e, '2026-08-03T00:01:00.000Z');
+    expect(pendingCraftLogs(DID)).toHaveLength(1);
+    expect(pendingCraftLogs('did:other')).toHaveLength(0);
+  });
+});
+
+describe('保留した記帳を書き直す', () => {
+  test('同じ rkey・同じ内容で書き直し、書けたら保留から消える', async () => {
+    enqueueCraftLog(DID, new CraftLogError('c-1', { itemId: 'wp-knife', power: 4 }, new Error('x')), 'now');
+    const createRecord = vi.fn(async (_a: unknown) => ({ data: { uri: 'at://x', cid: 'c' } }));
+    const done = await flushCraftLogs(agentWith(createRecord), DID);
+    expect(done).toBe(1);
+    const arg = createRecord.mock.calls[0]![0] as { rkey: string; record: Record<string, unknown> };
+    expect(arg.rkey).toBe('c-1');
+    expect(arg.record['itemId']).toBe('wp-knife');
+    expect(pendingCraftLogs(DID)).toHaveLength(0);
+  });
+
+  test('途中で落ちたら書けた分だけ消し、残りは次の機会に持ち越す', async () => {
+    enqueueCraftLog(DID, new CraftLogError('c-1', { itemId: 'a' }, new Error('x')), 'now');
+    enqueueCraftLog(DID, new CraftLogError('c-2', { itemId: 'b' }, new Error('x')), 'now');
+    enqueueCraftLog(DID, new CraftLogError('c-3', { itemId: 'c' }, new Error('x')), 'now');
+    let n = 0;
+    const createRecord = vi.fn(async () => {
+      n += 1;
+      if (n === 2) throw new Error('offline');
+      return { data: { uri: 'at://x', cid: 'c' } };
+    });
+    const done = await flushCraftLogs(agentWith(createRecord), DID);
+    expect(done).toBe(1);
+    // 落ちた 1 件で打ち切る (落ちている相手に残り全部を投げない)
+    expect(createRecord).toHaveBeenCalledTimes(2);
+    expect(pendingCraftLogs(DID).map((e) => e.rkey)).toEqual(['c-2', 'c-3']);
+  });
+
+  test('保留が無ければ書きにいかない', async () => {
+    const createRecord = vi.fn(async () => ({ data: { uri: 'at://x', cid: 'c' } }));
+    expect(await flushCraftLogs(agentWith(createRecord), DID)).toBe(0);
+    expect(createRecord).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/craft-log-queue.ts
+++ b/apps/web/src/lib/craft-log-queue.ts
@@ -22,12 +22,19 @@ import { CraftLogError, writeCraftLog } from './crafting';
 export interface PendingCraftLog {
   rkey: string;
   record: Record<string, unknown>;
-  /** 保留に入れた時刻 (古いものから捨てるため) */
+  /** 保留に入れた時刻 (診断用。捨てる判断は attempts と MAX_PENDING で行う) */
   queuedAt: string;
+  /** 書き直しを試した回数。上限を超えたら諦めて捨てる (下の MAX_ATTEMPTS 参照) */
+  attempts?: number;
 }
 
 /** 端末に貯める上限。壊れた repo 相手に無限に積まないための単純な上限。 */
 const MAX_PENDING = 20;
+
+/** 1 件あたりの再送上限。**これが無いと先頭で詰まる** — lexicon 検証エラーのように
+ *  何度送っても通らない record が先頭に来ると、後続の正常な記帳が永久に書かれない
+ *  (レビュー ★★)。上限で捨てれば、失う履歴はその 1 件だけで済む。 */
+const MAX_ATTEMPTS = 5;
 
 function keyFor(did: string): string {
   return `aq.craftlog.pending.${did}`;
@@ -59,9 +66,12 @@ function save(did: string, list: PendingCraftLog[]): void {
 
 /** 記帳の失敗を保留に積む。同じ rkey が既にあれば入れ替える (再送で同じ物を二重に積まない)。 */
 export function enqueueCraftLog(did: string, e: CraftLogError, at: string): void {
-  const list = pendingCraftLogs(did).filter((x) => x.rkey !== e.rkey);
-  list.push({ rkey: e.rkey, record: e.record, queuedAt: at });
-  save(did, list);
+  const list = pendingCraftLogs(did);
+  // 試行回数は引き継ぐ (同じ rkey を積み直すたびに 0 に戻ると上限が効かない)
+  const attempts = list.find((x) => x.rkey === e.rkey)?.attempts;
+  const rest = list.filter((x) => x.rkey !== e.rkey);
+  rest.push({ rkey: e.rkey, record: e.record, queuedAt: at, ...(attempts ? { attempts } : {}) });
+  save(did, rest);
 }
 
 /**
@@ -69,20 +79,49 @@ export function enqueueCraftLog(did: string, e: CraftLogError, at: string): void
  *
  * 1 件でも失敗したら**そこで止める** (残りは次の機会へ)。落ちている相手に
  * 20 件連続で投げても通らないし、レート制限を悪化させるだけなので。
+ * ただし同じ 1 件で止まり続けないよう試行回数を数え、MAX_ATTEMPTS で諦めて捨てる。
  */
 export async function flushCraftLogs(agent: Agent, did: string): Promise<number> {
   const list = pendingCraftLogs(did);
   if (list.length === 0) return 0;
+  /** 保留から外す rkey (書けた or 諦めた) */
+  const settled = new Set<string>();
+  /** 残すが試行回数だけ進める rkey */
+  const bumped = new Map<string, number>();
   let done = 0;
   for (const entry of list) {
     try {
       await writeCraftLog(agent, entry.rkey, entry.record);
+      settled.add(entry.rkey);
       done += 1;
     } catch (e) {
-      console.warn('[craftlog] retry failed', entry.rkey, e);
+      const attempts = (entry.attempts ?? 0) + 1;
+      if (attempts >= MAX_ATTEMPTS) {
+        console.warn('[craftlog] giving up after retries', entry.rkey, e);
+        settled.add(entry.rkey);
+      } else {
+        console.warn('[craftlog] retry failed', entry.rkey, e);
+        bumped.set(entry.rkey, attempts);
+      }
       break;
     }
   }
-  if (done > 0) save(did, list.slice(done));
+  // **書き戻す直前に読み直す**。開始時のスナップショットで上書きすると、
+  // 再送の往復中に積まれた保留 (店を開いた直後に作って記帳が落ちた等) を
+  // 一度も送らないまま消してしまう (レビュー ★★★)。
+  const latest = pendingCraftLogs(did)
+    .filter((e) => !settled.has(e.rkey))
+    .map((e) => {
+      const n = bumped.get(e.rkey);
+      return n === undefined ? e : { ...e, attempts: n };
+    });
+  save(did, latest);
   return done;
+}
+
+/** 保留を丸ごと捨てる。ワールドリセット (完全ワイプ) から呼ぶ — 消したはずの制作レコードが
+ *  保留から書き戻されると、幽霊個体が並び、0 に戻したパワー消費も再集計で復活する
+ *  (レビュー ★★)。 */
+export function clearCraftLogQueue(did: string): void {
+  save(did, []);
 }

--- a/apps/web/src/lib/craft-log-queue.ts
+++ b/apps/web/src/lib/craft-log-queue.ts
@@ -1,0 +1,88 @@
+import type { Agent } from '@atproto/api';
+import { CraftLogError, writeCraftLog } from './crafting';
+
+/**
+ * **書けなかった記帳をあとで書き直すための保留キュー** (#642)。
+ *
+ * なんでも屋の制作・合成・ひきとり・すてるは、サーバーが結果を確定したあとで
+ * ユーザー PDS に履歴を書く。所持の権威はサーバーなのでこの書き込みが落ちても
+ * 品は消えないが、黙って捨てると
+ *
+ *   - 履歴が永久に欠ける (サーバーから所持個体が取れないときの表示フォールバックにも出ない)
+ *   - パワー会計がずれる (points.ts は craft コレクションを再スキャンして
+ *     消費 `craftPowerSpent` / 獲得 `salePowerEarned` を出す)
+ *
+ * ので、**同じ rkey のまま**保留して次の機会に書き直す。createRecord は同 rkey で
+ * 衝突するため、二重記帳は構造的に起きない (既に書けていた場合は成功として捨てる)。
+ *
+ * リロードを跨いで消えないよう localStorage に置く。DID ごとに分けるのは、同じ端末で
+ * 別アカウントに切り替えたときに他人の repo へ書きにいかないため。
+ */
+
+export interface PendingCraftLog {
+  rkey: string;
+  record: Record<string, unknown>;
+  /** 保留に入れた時刻 (古いものから捨てるため) */
+  queuedAt: string;
+}
+
+/** 端末に貯める上限。壊れた repo 相手に無限に積まないための単純な上限。 */
+const MAX_PENDING = 20;
+
+function keyFor(did: string): string {
+  return `aq.craftlog.pending.${did}`;
+}
+
+export function pendingCraftLogs(did: string): PendingCraftLog[] {
+  try {
+    const raw = localStorage.getItem(keyFor(did));
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (e): e is PendingCraftLog =>
+        !!e && typeof e === 'object' && typeof (e as PendingCraftLog).rkey === 'string' && !!(e as PendingCraftLog).record,
+    );
+  } catch {
+    return []; // private mode / 壊れた JSON。履歴の再送は best-effort なので黙って諦める
+  }
+}
+
+function save(did: string, list: PendingCraftLog[]): void {
+  try {
+    if (list.length === 0) localStorage.removeItem(keyFor(did));
+    else localStorage.setItem(keyFor(did), JSON.stringify(list.slice(-MAX_PENDING)));
+  } catch {
+    /* private mode。保留できないだけで、その場の操作は成立している */
+  }
+}
+
+/** 記帳の失敗を保留に積む。同じ rkey が既にあれば入れ替える (再送で同じ物を二重に積まない)。 */
+export function enqueueCraftLog(did: string, e: CraftLogError, at: string): void {
+  const list = pendingCraftLogs(did).filter((x) => x.rkey !== e.rkey);
+  list.push({ rkey: e.rkey, record: e.record, queuedAt: at });
+  save(did, list);
+}
+
+/**
+ * 保留を古い順に書き直す。返り値は書けた件数。
+ *
+ * 1 件でも失敗したら**そこで止める** (残りは次の機会へ)。落ちている相手に
+ * 20 件連続で投げても通らないし、レート制限を悪化させるだけなので。
+ */
+export async function flushCraftLogs(agent: Agent, did: string): Promise<number> {
+  const list = pendingCraftLogs(did);
+  if (list.length === 0) return 0;
+  let done = 0;
+  for (const entry of list) {
+    try {
+      await writeCraftLog(agent, entry.rkey, entry.record);
+      done += 1;
+    } catch (e) {
+      console.warn('[craftlog] retry failed', entry.rkey, e);
+      break;
+    }
+  }
+  if (done > 0) save(did, list.slice(done));
+  return done;
+}

--- a/apps/web/src/lib/crafting.ts
+++ b/apps/web/src/lib/crafting.ts
@@ -88,15 +88,26 @@ export async function writeCraftLog(agent: Agent, rkey: string, record: Record<s
   try {
     await agent.com.atproto.repo.createRecord({ repo: agent.assertDid, collection: COL.craft, rkey, record });
   } catch (e) {
-    // 既に書けている (応答だけ落ちた再送) は成功と同じ。ここで捨てないと永久に再送し続ける。
-    if (isAlreadyExists(e)) return;
+    // **既に書けている (応答だけ落ちた再送) は成功と同じ**。ここで成功と判定できないと、
+    // その 1 件が保留の先頭に居座って後続の記帳が永久に書かれない。
+    // エラー文言では判定しない — 同 rkey の createRecord で PDS が返すのは
+    // 「There is already a value at key: …」であって "already exists" ではなく、
+    // 経路によっては generic な 5xx で届く。**実際に在るかどうか**を見るのが確実
+    // (レビュー ★★★: 文言 grep は本番のどのメッセージにも一致していなかった)。
+    if (await craftLogExists(agent, rkey)) return;
     throw new CraftLogError(rkey, record, e);
   }
 }
 
-function isAlreadyExists(e: unknown): boolean {
-  const msg = e instanceof Error ? `${e.message}` : String(e);
-  return /already exists|RecordAlreadyExists/i.test(msg);
+/** 同じ rkey の記帳が既に repo にあるか。取りにいけなかった場合は「無い」と答える
+ *  (= 保留に残して次の機会に試す。取りこぼすより二重に試すほうが安全)。 */
+async function craftLogExists(agent: Agent, rkey: string): Promise<boolean> {
+  try {
+    await agent.com.atproto.repo.getRecord({ repo: agent.assertDid, collection: COL.craft, rkey });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /** 新しい craft rkey を採番する (再試行の冪等化のため、確定は呼び出し側で行う)。 */

--- a/apps/web/src/lib/crafting.ts
+++ b/apps/web/src/lib/crafting.ts
@@ -68,6 +68,37 @@ export interface ForgeRecord {
   via: string;
 }
 
+/**
+ * 記帳が書けなかったことを、**再送に必要な材料ごと**呼び出し側へ渡す (#642)。
+ *
+ * 所持の権威はサーバーなので記帳の失敗で品は消えないが、黙って捨てると履歴が欠け、
+ * パワー会計 (points.ts は craft コレクションを再スキャンして消費/獲得を出す) もずれる。
+ * rkey と record をそのまま持たせておけば、あとで**同じ rkey**で書き直せる
+ * (createRecord は同 rkey で衝突するので二重記帳にならない)。
+ */
+export class CraftLogError extends Error {
+  constructor(readonly rkey: string, readonly record: Record<string, unknown>, override readonly cause: unknown) {
+    super('craft log write failed');
+    this.name = 'CraftLogError';
+  }
+}
+
+/** craft コレクションへの記帳はすべてここを通す (失敗を CraftLogError に揃えるため)。 */
+export async function writeCraftLog(agent: Agent, rkey: string, record: Record<string, unknown>): Promise<void> {
+  try {
+    await agent.com.atproto.repo.createRecord({ repo: agent.assertDid, collection: COL.craft, rkey, record });
+  } catch (e) {
+    // 既に書けている (応答だけ落ちた再送) は成功と同じ。ここで捨てないと永久に再送し続ける。
+    if (isAlreadyExists(e)) return;
+    throw new CraftLogError(rkey, record, e);
+  }
+}
+
+function isAlreadyExists(e: unknown): boolean {
+  const msg = e instanceof Error ? `${e.message}` : String(e);
+  return /already exists|RecordAlreadyExists/i.test(msg);
+}
+
 /** 新しい craft rkey を採番する (再試行の冪等化のため、確定は呼び出し側で行う)。 */
 export function newCraftRkey(): string {
   return `c-${Date.now().toString(36)}-${Math.floor(Math.random() * 1e6).toString(36)}`;
@@ -85,20 +116,14 @@ export async function craftItem(
   },
   rkeyIn?: string,
 ): Promise<CraftedPiece> {
-  const did = agent.assertDid;
   const rkey = rkeyIn ?? newCraftRkey();
   const { level: serverLevel, ...record } = input;
-  await agent.com.atproto.repo.createRecord({
-    repo: did,
-    collection: COL.craft,
-    rkey,
-    record: {
-      $type: COL.craft,
-      ...record,
-      at: new Date().toISOString(),
-      via: VIA,
-    } satisfies CraftRecord,
-  });
+  await writeCraftLog(agent, rkey, {
+    $type: COL.craft,
+    ...record,
+    at: new Date().toISOString(),
+    via: VIA,
+  } satisfies CraftRecord);
   return {
     rkey,
     itemId: input.itemId,
@@ -119,21 +144,15 @@ export async function forgeItems(
   input: { itemId: string; resultLevel: number; consumed: [string, string] },
   rkeyIn?: string,
 ): Promise<CraftedPiece> {
-  const did = agent.assertDid;
   const rkey = rkeyIn ?? newForgeRkey();
-  await agent.com.atproto.repo.createRecord({
-    repo: did,
-    collection: COL.craft,
-    rkey,
-    record: {
-      $type: COL.craft,
-      itemId: input.itemId,
-      level: Math.min(CRAFT_TUNING.levelMax, input.resultLevel),
-      consumed: input.consumed,
-      at: new Date().toISOString(),
-      via: VIA,
-    } satisfies ForgeRecord,
-  });
+  await writeCraftLog(agent, rkey, {
+    $type: COL.craft,
+    itemId: input.itemId,
+    level: Math.min(CRAFT_TUNING.levelMax, input.resultLevel),
+    consumed: input.consumed,
+    at: new Date().toISOString(),
+    via: VIA,
+  } satisfies ForgeRecord);
   return { rkey, itemId: input.itemId, level: Math.min(CRAFT_TUNING.levelMax, input.resultLevel), at: new Date().toISOString() };
 }
 
@@ -159,23 +178,17 @@ export async function sellMaterials(
   input: { materialId: string; materialCount: number },
   rkeyIn?: string,
 ): Promise<{ powerGained: number; materialCount: number }> {
-  const did = agent.assertDid;
   const powerGained = salePowerFor(input.materialCount);
   const materialCount = powerGained * SALE_TUNING.materialsPerPower;
   const rkey = rkeyIn ?? newSaleRkey();
-  await agent.com.atproto.repo.createRecord({
-    repo: did,
-    collection: COL.craft,
-    rkey,
-    record: {
-      $type: COL.craft,
-      materialId: input.materialId,
-      materialCount,
-      powerGained,
-      at: new Date().toISOString(),
-      via: VIA,
-    } satisfies SaleRecord,
-  });
+  await writeCraftLog(agent, rkey, {
+    $type: COL.craft,
+    materialId: input.materialId,
+    materialCount,
+    powerGained,
+    at: new Date().toISOString(),
+    via: VIA,
+  } satisfies SaleRecord);
   return { powerGained, materialCount };
 }
 
@@ -193,19 +206,13 @@ export interface CraftInventory {
  */
 /** すてた記録を書く。権威は既にサーバー側で減っているので、これは表示の整合のため。 */
 export async function discardItems(agent: Agent, rkeys: string[], rkeyIn?: string): Promise<void> {
-  const did = agent.assertDid;
   const rkey = rkeyIn ?? newDiscardRkey();
-  await agent.com.atproto.repo.createRecord({
-    repo: did,
-    collection: COL.craft,
-    rkey,
-    record: {
-      $type: COL.craft,
-      discarded: rkeys,
-      at: new Date().toISOString(),
-      via: VIA,
-    } satisfies DiscardRecord,
-  });
+  await writeCraftLog(agent, rkey, {
+    $type: COL.craft,
+    discarded: rkeys,
+    at: new Date().toISOString(),
+    via: VIA,
+  } satisfies DiscardRecord);
 }
 
 /** 新しい すてる rkey を採番する。 */

--- a/apps/web/src/lib/onboarding-reset.ts
+++ b/apps/web/src/lib/onboarding-reset.ts
@@ -19,6 +19,7 @@
 import type { Agent } from '@atproto/api';
 import { getRecord, putRecord } from './atproto';
 import { COL } from './collections';
+import { clearCraftLogQueue } from './craft-log-queue';
 import { resetWorldPower } from './points';
 import { serverReset } from './world-server';
 
@@ -126,6 +127,9 @@ export async function resetOnboarding(agent: Agent, did: string): Promise<void> 
       throw new Error(`${label}: ${e instanceof Error ? e.message : String(e)}`);
     }
   };
+  // 書けなかった記帳の保留も捨てる。残すと、消した制作レコードが次の入場で
+  // 書き戻されて幽霊個体が並び、0 に戻したパワー消費も再集計で復活する。
+  clearCraftLogQueue(did);
   await step('craft', () => deleteAllRecords(agent, did, COL.craft));
   await step('battle', () => deleteAllRecords(agent, did, COL.battle));
   await step('gear', () => deleteSelf(agent, did, COL.gear));

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -41,7 +41,8 @@ import { serverMove, serverTurn, serverState, serverTeleport, serverItem, server
   serverQuestAccept,
   serverQuestComplete,
 } from '@/lib/world-server';
-import { craftItem, discardItems, forgeItems, loadCraftInventory, newCraftRkey, newDiscardRkey, newForgeRkey, newSaleRkey, sellMaterials, type CraftedPiece } from '@/lib/crafting';
+import { CraftLogError, craftItem, discardItems, forgeItems, loadCraftInventory, newCraftRkey, newDiscardRkey, newForgeRkey, newSaleRkey, sellMaterials, type CraftedPiece } from '@/lib/crafting';
+import { enqueueCraftLog, flushCraftLogs } from '@/lib/craft-log-queue';
 import { ShopModal, type LastShopAction } from '@/components/shop-modal';
 import { GearModal } from '@/components/gear-modal';
 import { loadGearRefs, resolveGear, saveGearRefs, type GearRefs } from '@/lib/gear';
@@ -299,6 +300,22 @@ export function World() {
   const [craftBusy, setCraftBusy] = useState(false);
   /** お店の失敗理由 (#551)。ページ本体の通知行はモーダルの背面に隠れるので、モーダル内に出す。 */
   const [shopError, setShopError] = useState<string | null>(null);
+  /** 記帳だけ落ちたときの控えめな知らせ (#642)。品もパワーも動いていないので赤字にしない。 */
+  const [shopNotice, setShopNotice] = useState<string | null>(null);
+
+  /** 記帳 (ユーザー PDS の履歴) の失敗を保留に積む (#642)。所持の権威はサーバーなので
+   *  品もパワーも動かないが、黙って捨てると履歴が永久に欠け、パワー会計もずれる。 */
+  const keepCraftLog = useCallback((where: string, e: unknown) => {
+    console.warn(`[world] ${where} log failed`, e);
+    if (did && e instanceof CraftLogError) enqueueCraftLog(did, e, new Date().toISOString());
+  }, [did]);
+
+  /** 保留した記帳を書き直す。店を開いたときと世界に入ったときに 1 回ずつ試す。 */
+  const flushCraftLog = useCallback(() => {
+    if (!agent || !did) return;
+    void flushCraftLogs(agent, did).catch((e) => console.warn('[world] craft log flush failed', e));
+  }, [agent, did]);
+
   const [lastShopAction, setLastShopAction] = useState<LastShopAction | null>(null);
   /** 再試行の冪等化: 失敗した制作/合成/ひきとりの rkey を保持し、同条件の再試行で
    *  使い回す (createRecord は同 rkey で衝突するため 2 重記帳が構造的に起きない) */
@@ -493,9 +510,12 @@ export function World() {
       // 取れなかったときの表示フォールバックだけ (装備しても edge が弾く)。
       if (!serverInv) setCraftedPieces(craftInv.pieces);
       setGearRefs(refs);
+      // 前のセッションで書けなかった記帳をここで書き直す (#642)。保留は localStorage に
+      // 残るので、リロードや翌日の起動でも拾える。
+      flushCraftLog();
     })();
     return () => { cancelled = true; };
-  }, [session.status, agent, did, retryNonce]);
+  }, [session.status, agent, did, retryNonce, flushCraftLog]);
 
   // タイル実寸の追従 (アバターオーバーレイ用)
   useEffect(() => {
@@ -664,7 +684,9 @@ export function World() {
             if (sp) {
               setLastShopAction(null);
               setShopError(null);
+              setShopNotice(null);
               setMaterialsView({ ...materialsRef.current });
+              flushCraftLog(); // 前に書けなかった記帳をここで書き直す (#642)
               setShopOpen(true);
               setNotice(null);
             }
@@ -726,7 +748,7 @@ export function World() {
         }
       })();
     },
-    [scheduleSave, agent],
+    [scheduleSave, agent, flushCraftLog],
   );
 
   // 戦闘コマンドも**毎回サーバーが解決する** (docs/21 §5)。クライアントは battleId + turn + command を送るだけ。
@@ -1111,6 +1133,7 @@ export function World() {
       const rkey = pendingCraftRef.current?.defId === def.id ? pendingCraftRef.current.rkey : newCraftRkey();
       pendingCraftRef.current = { defId: def.id, rkey };
       setShopError(null);
+      setShopNotice(null);
       setCraftBusy(true);
       try {
         // **費用の支払いと強化値の抽選はサーバー** (#551)。素材もパワーも権威側から引かれ、
@@ -1134,8 +1157,10 @@ export function World() {
           },
           rkey,
         ).catch((e) => {
-          console.warn('[world] craft log failed', e);
-          setShopError('つくれたが、記録に失敗した (もちものには入っている)。');
+          keepCraftLog('craft', e);
+          // 品もパワーも既にサーバー側で確定しているので、失敗として赤字で出さない (#642)。
+          // 欠けたのは履歴だけで、それは保留してあとで書き直す。
+          setShopNotice('記録はあとで残す (品は もちものに入っている)。');
           return { rkey, itemId: def.id, level: res.level ?? 0, at: new Date().toISOString() };
         });
         pendingCraftRef.current = null;
@@ -1150,7 +1175,7 @@ export function World() {
         setCraftBusy(false);
       }
     },
-    [agent, did, craftBusy, combat, subtractMaterial, shopTownAt],
+    [agent, did, craftBusy, combat, subtractMaterial, shopTownAt, keepCraftLog],
   );
 
   // 合成 (きたえる): 同アイテム・同強化値 2 個体 → +1。素材もパワーも不要
@@ -1162,6 +1187,7 @@ export function World() {
       const frkey = pendingForgeRef.current?.key === forgeKey ? pendingForgeRef.current.rkey : newForgeRkey();
       pendingForgeRef.current = { key: forgeKey, rkey: frkey };
       setShopError(null);
+      setShopNotice(null);
       setCraftBusy(true);
       try {
         // **合成もサーバー** (#551 段階 2)。消費する個体は権威側の所持から探すので、
@@ -1172,7 +1198,7 @@ export function World() {
         const piece: CraftedPiece = { rkey: frkey, itemId: def.id, level: res.level ?? resultLevel, at: new Date().toISOString() };
         // 記帳 (履歴)。所持の根拠ではないので、失敗しても進める。
         void forgeItems(agent, { itemId: def.id, resultLevel: piece.level, consumed: rkeys }, frkey)
-          .catch((e) => console.warn('[world] forge log failed', e));
+          .catch((e) => keepCraftLog('forge', e));
         setLastShopAction({ piece, kind: 'forge' });
       } catch (e) {
         console.warn('[world] forge failed', e);
@@ -1182,7 +1208,7 @@ export function World() {
         setCraftBusy(false);
       }
     },
-    [agent, did, craftBusy],
+    [agent, did, craftBusy, keepCraftLog],
   );
 
   // 素材のひきとり (素材 → パワー。docs/20 の低レート変換)
@@ -1194,6 +1220,7 @@ export function World() {
       const srkey = pendingSaleRef.current?.key === saleKey ? pendingSaleRef.current.rkey : newSaleRkey();
       pendingSaleRef.current = { key: saleKey, rkey: srkey };
       setShopError(null);
+      setShopNotice(null);
       setCraftBusy(true);
       try {
         // **在庫と残高の増減はサーバー** (#551)。client 台帳だけだと「パワーが 5 ふえた!」と
@@ -1203,7 +1230,7 @@ export function World() {
         setServerPower(res.power);
         applyServerMaterials(res.materials);
         // 記帳 (履歴)。数量とパワーはサーバーが確定した値で書く。
-        await sellMaterials(agent, { materialId, materialCount: count }, srkey).catch((e) => console.warn('[world] sale log failed', e));
+        await sellMaterials(agent, { materialId, materialCount: count }, srkey).catch((e) => keepCraftLog('sale', e));
         // 結果はモーダル内のセリフ窓で出す (#607)。世界の通知行はモーダルの背面で見えない。
         setLastShopAction({ kind: 'sell', materialId, count, powerGained: res.powerGained ?? 0 });
       } catch (e) {
@@ -1213,7 +1240,7 @@ export function World() {
         setCraftBusy(false);
       }
     },
-    [agent, did, craftBusy, subtractMaterial],
+    [agent, did, craftBusy, subtractMaterial, keepCraftLog],
   );
 
   // 装備の着脱 (gear/self は rkey 参照 — 強化値は直書きしない。docs/20 W6c 契約)
@@ -1336,7 +1363,9 @@ export function World() {
       ? [{ key: 'shop', label: 'なんでも屋', onSelect: () => {
           setLastShopAction(null);
           setShopError(null);
+          setShopNotice(null);
           setMaterialsView({ ...materialsRef.current });
+          flushCraftLog(); // 前に書けなかった記帳をここで書き直す (#642)
           // 入場時に serverState が落ちていると残高が null のまま復旧経路が無く、
           // 店が「パワー 0」で全品グレーアウトして死んで見える (#551 レビュー指摘)。
           // 開くたびに取り直す。
@@ -1714,7 +1743,7 @@ export function World() {
                 if (res.pieces) setCraftedPieces(res.pieces.map((x) => ({ rkey: x.rkey, itemId: x.itemId, level: x.level, at: '' })));
                 // PDS 側にも墓標を残す (/me の集計が捨てた装備を数えたままにならないように)。
                 // 権威は既にサーバーで減っているので、失敗しても進める。
-                void discardItems(agent, [rkey], dkey).catch((e) => console.warn('[world] discard log failed', e));
+                void discardItems(agent, [rkey], dkey).catch((e) => keepCraftLog('discard', e));
               } catch (e) {
                 console.warn('[world] discard failed', e);
                 setShopError(shopErrorText(e, 'すてられなかった'));
@@ -1758,6 +1787,7 @@ export function World() {
           busy={craftBusy}
           lastAction={lastShopAction}
           errorText={shopError}
+          noticeText={shopNotice}
           onCraft={(def) => void onCraft(def)}
           onForge={(def, level, rkeys) => void onForge(def, level, rkeys)}
           onSell={(materialId, count) => void onSell(materialId, count)}


### PR DESCRIPTION
Closes #642

## いま起きていたこと

なんでも屋の制作・合成・ひきとり・すてるは、サーバーが結果を確定した**あと**に
ユーザー PDS へ履歴を書く。この書き込みが落ちると console に出して捨てていた
(制作だけ赤字で「つくれたが、記録に失敗した」と表示)。

所持の権威はサーバーなので品もパワーも失われないが、捨てると

- 履歴が永久に欠ける (サーバーから所持個体が取れないときの表示フォールバックにも出ない)
- 本体側のパワー会計がずれる — `points.ts` は craft コレクションを再スキャンして
  消費 `craftPowerSpent` / 獲得 `salePowerEarned` を出すので、記帳が無い分は計上されない

## 直し方

- 記帳はすべて `writeCraftLog` を通し、失敗を **rkey と record ごと** `CraftLogError` で持ち上げる
- localStorage の保留キューに積む (DID 単位。別アカウントの repo に書きにいかないため)
- **世界に入ったとき**と**店を開いたとき**に同じ rkey で書き直す。`createRecord` は同 rkey で
  衝突するので二重記帳にならない (既存の冪等設計にそのまま乗る)
- 既に書けていた (応答だけ落ちた再送) 場合は成功として保留から外す
- 落ちたら 1 件で打ち切って次の機会へ。ただし試行回数を数え、5 回で諦めて捨てる
- 文言を実害に合わせる。赤字の「失敗した」は品かパワーを失ったように読めるので、
  控えめな知らせ (`noticeText`) にした

## テスト

`src/lib/craft-log-queue.test.ts` (11 件、実コードで実測)。主なもの:

- 落ちたら rkey と record を持った `CraftLogError` になる
- **実際に PDS が返す重複エラー文言**で、既に書けていれば成功として扱う / 取りにいけなければ保留に残す
- 書き直しは同じ rkey・同じ内容で送られ、成功したら保留から消える
- 途中で落ちたら書けた分だけ消し、残り (`c-2`, `c-3`) は次の機会に持ち越す
- 再送の往復中に積まれた保留を消さない
- 何度送っても通らない 1 件は 5 回で捨て、後続が書けるようになる
- 積み直しても試行回数は 0 に戻らない
- ワールドリセットで保留を捨てる

## Review

subagent 3 観点 (実装 / 設計・データ整合 / UX)。**★★★ 2 件・★★ 3 件をすべて PR 内で修正**。

- **★★★ 重複判定が実 PDS のエラー文言に一致していなかった** (実装・設計の 2 観点が独立に検出) —
  同 rkey の `createRecord` で返るのは `There is already a value at key: …` で、`already exists` ではない。
  判定できないとその 1 件が保留の先頭に居座り、**後続の記帳が永久に書かれない** (PR 前より悪い)。
  文言 grep をやめ、同 rkey の record が実在するかで判定するようにした。テストも実際の文言に差し替え。
- **★★★ flush 中に積まれた保留が消える** (実装・UX の 2 観点が独立に検出) — 開始時のスナップショットで
  localStorage を上書きしていた。書き戻す直前に読み直し、書けた rkey だけを引くようにした。
- **★★ 恒久的に書けない 1 件で後続が詰まる** — 試行回数を数え、5 回で諦めて捨てる。
- **★★ ワールドリセットが保留を掃除しない** — 消した制作レコードが次の入場で書き戻され、
  幽霊個体が並び、0 に戻したパワー消費も再集計で復活する。`resetOnboarding` で保留を捨てる。
- **★★ 知らせの live region が条件付きマウント** — 初回読み上げが落ちるので常設にした
  (同じ落とし穴が上のエラー行のコメントに記録されていた)。

問題なしと確認された点: `at` は失敗時刻のまま保持され再送時刻に化けない / 多重計上は起きない
(同 rkey で衝突するため) / `loadCraftInventory` の合成検証は不動点ループなので遅れて書かれても壊れない /
localStorage 不可・壊れた JSON でも例外は漏れない / TDZ も `move` の再生成も起きない /
赤字と知らせが同時に出る経路は無い。

## 確認

- [x] typecheck 緑
- [x] unit 394 passed (43 files)
- [x] lint 緑 (error 0、既存 warning 8 件のまま)
- [x] build 緑