### PR TITLE
feat(core): はじまりの村を 32×32 に縮める (#644)

### DIFF
--- a/apps/edge/src/battle-resolver.ts
+++ b/apps/edge/src/battle-resolver.ts
@@ -291,6 +291,31 @@ export interface MoveResult {
  * 歩行では PDS を触らない (街/エンカウントの時だけ書く) = 高速。座標・遭遇・tier は署名/秘密で偽造不可。
  * token 未指定/失効時は gameState から位置を再同期する (稀な PDS 読み)。
  */
+/**
+ * 内部マップの範囲外に立ってしまったときの逃げ先を決める (#644 レビュー ★★★)。
+ *
+ * 座標をそのままフィールドに持ち越すと、村のローカル座標が海の上を指して
+ * 一歩も動けなくなる。**必ず歩ける場所**へ戻す。優先順は
+ * 出口 (exitTo) → 直前の街 (lastTown) → 初期スポーン。
+ */
+async function escapeFromOutOfRange(
+  env: ResolverEnv,
+  userDid: string,
+  here: { exitTo?: { mapId: string; x: number; y: number } },
+): Promise<{ mapId: string; x: number; y: number }> {
+  const ok = (mapId: string, x: number, y: number): boolean => {
+    if (mapId !== WORLD_MAP_ID && !isInterior(mapId)) return false;
+    return walkableIn(mapId, x, y, isWalkableAt);
+  };
+  const exit = here.exitTo;
+  if (exit && ok(exit.mapId, exit.x, exit.y)) return { mapId: exit.mapId, x: exit.x, y: exit.y };
+  const rec = await readState(env, userDid);
+  const lt = rec?.state?.lastTown;
+  if (lt && ok(WORLD_MAP_ID, lt.x, lt.y)) return { mapId: WORLD_MAP_ID, x: lt.x, y: lt.y };
+  const spawn = worldOverlay().spawn;
+  return { mapId: WORLD_MAP_ID, x: spawn.x, y: spawn.y };
+}
+
 export async function handleMove(env: ResolverEnv, userDid: string, dx: number, dy: number, token: string | undefined, now: number, ns: string = DEFAULT_NS, fetchImpl?: typeof fetch): Promise<MoveResult> {
   if (![-1, 0, 1].includes(dx) || ![-1, 0, 1].includes(dy) || (dx === 0 && dy === 0)) throw new ResolverError('不正な移動 (隣接1マスのみ)', 400);
 
@@ -309,12 +334,19 @@ export async function handleMove(env: ResolverEnv, userDid: string, dx: number, 
   }
   // 定義が消えた内部マップに取り残されない (エディタで削除された場合)。フィールドへ戻す。
   if (mapId !== WORLD_MAP_ID && !isInterior(mapId)) mapId = WORLD_MAP_ID;
-  // **範囲外に立っている state の保険** (#424 レビュー ★★★)。過去のバグや手編集で
-  // 「内部マップ × 範囲外の座標」になると全方向 400 で一歩も動けなくなるので、
-  // フィールド扱いに倒して脱出させる (位置は既に街の座標なので実害なく戻れる)。
+  // **範囲外に立っている state の保険** (#424 レビュー ★★★)。過去のバグや手編集、
+  // **内部マップを小さく作り直したとき** (#644 で村を 64→32 にした) に
+  // 「内部マップ × 範囲外の座標」になると全方向 400 で一歩も動けなくなる。
+  //
+  // **mapId だけ倒してはいけない** (#644 レビュー ★★★)。村のローカル座標がそのまま
+  // フィールド座標として解釈され、海の真ん中に置かれて 8 方向すべて「進めない地形」=
+  // そらのはね無しでは復帰不能になる。座標も一緒に安全な場所へ戻す。
   if (mapId !== WORLD_MAP_ID) {
     const here = interiorById(mapId)!;
-    if (cx < 0 || cy < 0 || cx >= here.size || cy >= here.size) mapId = WORLD_MAP_ID;
+    if (cx < 0 || cy < 0 || cx >= here.size || cy >= here.size) {
+      const back = await escapeFromOutOfRange(env, userDid, here);
+      mapId = back.mapId; cx = back.x; cy = back.y;
+    }
   }
 
   // 内部マップ (#424) は端で折り返さない (外に出るのはゲートからだけ)。

--- a/apps/edge/test/battle-resolver.test.ts
+++ b/apps/edge/test/battle-resolver.test.ts
@@ -366,13 +366,55 @@ describe('内部マップの詰み対策 (#424 レビュー)', () => {
     setInteriors([room2()], []);
     let moved = false;
     for (const [dx, dy] of [[1, 0], [0, 1], [-1, 0], [0, -1]] as const) {
-      if (!isWalkable(terrainAt(300 + dx, 300 + dy))) continue;
-      const r = await handleMove(env, USER, dx, dy, undefined, NOW);
+      const r = await handleMove(env, USER, dx, dy, undefined, NOW).catch(() => null);
+      if (!r) continue;
       expect(r.mapId).toBeUndefined(); // フィールドとして動く
       moved = true;
       break;
     }
     expect(moved).toBe(true);
+  });
+
+  /**
+   * **座標もフィールドの安全な場所へ戻す** (#644 レビュー ★★★)。
+   *
+   * mapId だけフィールドに倒すと、内部マップのローカル座標がそのままフィールド座標として
+   * 解釈される。内部マップを小さく作り直した (村を 64→32) 直後は「旧マップでは歩けたが
+   * 新マップでは範囲外」の座標に立つ人が出て、その座標が海の上だと 8 方向すべて
+   * 「進めない地形」になり、そらのはね無しでは復帰不能になる。
+   */
+  it('範囲外から戻る先が海でも詰まない (出口 → 直前の街 → スポーンの順に逃がす)', async () => {
+    const env = await makeEnv();
+    // 8 近傍すべてが歩けない座標を実地形から探す (= 昔の「mapId だけ倒す」では詰む場所)
+    let trap: { x: number; y: number } | null = null;
+    for (let y = 40; y < 400 && !trap; y += 1) {
+      for (let x = 40; x < 400; x += 1) {
+        const around = [[1, 0], [-1, 0], [0, 1], [0, -1], [1, 1], [1, -1], [-1, 1], [-1, -1]] as const;
+        if (isWalkable(terrainAt(x, y))) continue;
+        if (around.every(([dx, dy]) => !isWalkable(terrainAt(x + dx, y + dy)))) { trap = { x, y }; break; }
+      }
+    }
+    expect(trap, '海の真ん中が見つからない').not.toBeNull();
+    globalThis.fetch = resolverMock({ diagnosis: DIAG, gameState: GS({ mapId: 'in-1', x: trap!.x, y: trap!.y }) }).fn;
+    // 出口を持つ内部マップ (同梱の村と同じ形)。範囲外ならまずここへ逃がす。
+    const back = (() => {
+      for (const [dx, dy] of [[1, 0], [0, 1], [-1, 0], [0, -1]] as const) {
+        if (isWalkable(terrainAt(20 + dx, 20 + dy))) return { nx: 20 + dx, ny: 20 + dy };
+      }
+      throw new Error('歩ける隣接マスがない');
+    })();
+    setInteriors([{ ...room2(), exitTo: { mapId: 'world', x: back.nx, y: back.ny } }], []);
+    // どこかの方向へは必ず動ける (= 海に置き去りにされていない)
+    const results = await Promise.all(
+      ([[1, 0], [-1, 0], [0, 1], [0, -1]] as const).map(([dx, dy]) =>
+        handleMove(env, USER, dx, dy, undefined, NOW).catch(() => null)),
+    );
+    expect(results.some((r) => r !== null)).toBe(true);
+    // 逃げ先は出口の周り — 罠の座標をそのまま引き継いでいない
+    for (const r of results) {
+      if (!r) continue;
+      expect(Math.abs(r.x - back.nx) + Math.abs(r.y - back.ny)).toBeLessThanOrEqual(1);
+    }
   });
 });
 

--- a/apps/web/src/routes/admin-interiors.tsx
+++ b/apps/web/src/routes/admin-interiors.tsx
@@ -188,7 +188,12 @@ export function AdminInteriors() {
             setGates((gs) => [
               // 同じ入口の重複と、**この村から出る古いゲート**を落とす
               // (端から出る設計 #626 になったので戻りゲートは要らない)。
+              // **村の外を指すようになった行き先も落とす** — 村を小さく作り直すと
+              // (64→32) 旧座標を指すゲートが範囲外になり、検証で弾かれて
+              // 「保存」そのものが通らなくなる (#644 レビュー ★★)。
               ...gs.filter((g) => g.from.mapId !== village.id
+                && !(g.to.mapId === village.id
+                  && (g.to.x < 0 || g.to.y < 0 || g.to.x >= village.size || g.to.y >= village.size))
                 && !gates.some((n) => n.from.mapId === g.from.mapId && n.from.x === g.from.x && n.from.y === g.from.y)),
               ...gates,
             ]);

--- a/packages/core/src/__tests__/interior.test.ts
+++ b/packages/core/src/__tests__/interior.test.ts
@@ -222,9 +222,10 @@ describe('同梱の村「ふたばの村」(#424)', () => {
   const village = starterTownInterior(spawnTown);
   const spawn = worldOverlay().spawn;
 
-  it('64×64 で、そのまま保存できる', () => {
-    expect(village.size).toBe(64);
-    expect(village.tiles.length).toBe(64 * 64);
+  it('32×32 で、そのまま保存できる', () => {
+    // 最初は 64×64 だったが、最初の街としては歩かされる距離が長すぎた (実機で指摘)。
+    expect(village.size).toBe(32);
+    expect(village.tiles.length).toBe(32 * 32);
     expect(() => setInteriors([village], starterTownGates(spawn))).not.toThrow();
   });
 
@@ -256,8 +257,8 @@ describe('同梱の村「ふたばの村」(#424)', () => {
     }
     expect(seen.has(village.inn!.y * village.size + village.inn!.x), '宿屋').toBe(true);
     expect(seen.has(village.shop!.y * village.size + village.shop!.x), '店').toBe(true);
-    // 広場や家の前まで含め、そこそこの広さが繋がっていること
-    expect(seen.size).toBeGreaterThan(2000);
+    // 広場や家の前まで含め、そこそこの広さが繋がっていること (32×32 = 1024 マス)
+    expect(seen.size).toBeGreaterThan(700);
   });
 
   it('戻り先はフィールドの街の 1 マス下 (踏んだ瞬間にまた入らない)', () => {
@@ -310,9 +311,9 @@ describe('村のなんでも屋 (#424)', () => {
   });
 
   it('歩けないマスの店を弾く', () => {
-    // 建物の屋根の上 (囲いをやめたので外周は草地 = 歩ける)。
-    expect(interiorWalkableAt(v, 18, 18)).toBe(false);
-    expect(() => setInteriors([{ ...v, shop: { x: 18, y: 18, town: { x: spawn2.x, y: spawn2.y } } }], [])).toThrow(InteriorError);
+    // 宿屋の屋根の上 (囲いをやめたので外周は草地 = 歩ける)。
+    expect(interiorWalkableAt(v, 8, 6)).toBe(false);
+    expect(() => setInteriors([{ ...v, shop: { x: 8, y: 6, town: { x: spawn2.x, y: spawn2.y } } }], [])).toThrow(InteriorError);
   });
 
   it('宿屋と店は別のマス (同じだとどちらが開くのか決まらない)', () => {
@@ -325,19 +326,20 @@ describe('端から出る (#626)', () => {
   const v3 = starterTownInterior(spawn3);
 
   it('マップの外へ踏み出したときだけ出る先を返す', () => {
-    expect(interiorExitFor(v3, 32, 64)).toEqual({ mapId: 'world', x: spawn3.x, y: spawn3.y + 1 }); // 下の端の外
-    expect(interiorExitFor(v3, -1, 30)).toBeDefined(); // 左の端の外
-    expect(interiorExitFor(v3, 32, 30)).toBeUndefined(); // 中を歩く分には出ない
+    expect(interiorExitFor(v3, 15, 32)).toEqual({ mapId: 'world', x: spawn3.x, y: spawn3.y + 1 }); // 下の端の外
+    expect(interiorExitFor(v3, -1, 15)).toBeDefined(); // 左の端の外
+    expect(interiorExitFor(v3, 15, 30)).toBeUndefined(); // 中を歩く分には出ない
   });
 
   it('exitTo が無いマップは端で止まる (囲われた内部)', () => {
     const { exitTo: _e, ...walled } = v3;
-    expect(interiorExitFor(walled as typeof v3, 32, 64)).toBeUndefined();
+    expect(interiorExitFor(walled as typeof v3, 15, 32)).toBeUndefined();
   });
 
   it('村は囲われていない — どの端からでも出られる', () => {
     // 端の外はどこでも exitTo が返る (出口 1 マスを探させない)。
-    for (const [x, y] of [[0, -1], [63, -1], [-1, 0], [64, 63], [10, 64]] as const) {
+    const S = v3.size;
+    for (const [x, y] of [[0, -1], [S - 1, -1], [-1, 0], [S, S - 1], [10, S]] as const) {
       expect(interiorExitFor(v3, x, y), `(${x},${y})`).toBeDefined();
     }
   });

--- a/packages/core/src/interior-samples.ts
+++ b/packages/core/src/interior-samples.ts
@@ -1,8 +1,12 @@
 /**
  * **同梱の内部マップ** (#424)。最初の街「ふたばの村」の中。
  *
- * 内部マップを 1 つも作っていない状態からだと、エディタで 64×64 を手で塗るところから
- * 始まって重い。**入って歩ける村**を 1 つ同梱し、そこから直せるようにする。
+ * 内部マップを 1 つも作っていない状態からだと、エディタで手で塗るところから始まって重い。
+ * **入って歩ける村**を 1 つ同梱し、そこから直せるようにする。
+ *
+ * 広さは **32×32**。最初は 64×64 で作ったが、最初の街としては歩かされる距離が長く、
+ * 宿屋となんでも屋を往復するだけで間延びした (実機で指摘)。半分にして、入口から
+ * 数歩で看板が見える密度にしている。
  *
  * ## 専用パーツで組む
  *
@@ -23,7 +27,7 @@ import type { Gate, InteriorMap } from './interior.js';
 import type { WorldPart } from './world-map.js';
 
 export const STARTER_TOWN_ID = 'futaba-village';
-export const STARTER_TOWN_SIZE = 64;
+export const STARTER_TOWN_SIZE = 32;
 
 /** パーツ番号 (この村のパーツ表の並び)。絵は terrain 名で引く。 */
 const GRASS = 0;
@@ -56,19 +60,15 @@ const PARTS: WorldPart[] = [
 ];
 
 /** 宿屋の扉。ここに入ると あおぞらパワーを払って全回復する。 */
-export const STARTER_TOWN_INN = { x: 21, y: 22, price: 3, name: 'ふたばの宿' };
+export const STARTER_TOWN_INN = { x: 8, y: 10, price: 3, name: 'ふたばの宿' };
 /** なんでも屋の扉。ここに入ると店が開く。 */
-export const STARTER_TOWN_SHOP = { x: 43, y: 22 };
-/** フィールドから入ったときの降り立つ場所 (村の南の通り)。 */
-export const STARTER_TOWN_ENTRANCE = { x: 32, y: 56 };
-/**
- * @deprecated 端から出られるようにしたので使わない (#626)。
- * 保存済みのゲートとの互換のために残す。
- */
-export const STARTER_TOWN_EXIT = { x: 32, y: 61 };
+export const STARTER_TOWN_SHOP = { x: 23, y: 10 };
+/** フィールドから入ったときの降り立つ場所 (村の南の通り)。端から数歩内側に置く —
+ *  端に降ろすと入った瞬間に外へ出てしまう。 */
+export const STARTER_TOWN_ENTRANCE = { x: 15, y: 28 };
 
 /**
- * 64×64 の村を組み立てる。**手で塗った 4096 タイルを埋め込むより、組み立てる**
+ * 32×32 の村を組み立てる。**手で塗ったタイルを埋め込むより、組み立てる**
  * ほうが読めて直せる (家を 1 軒足すのが 1 行)。
  */
 export function buildStarterTownTiles(): Uint8Array {
@@ -89,15 +89,16 @@ export function buildStarterTownTiles(): Uint8Array {
     set(1, i, TREE); set(S - 2, i + 2, TREE);
   }
 
-  // 目抜き通り (縦) と広場へ抜ける横道。
-  rect(30, 4, 4, S - 6, PATH);
-  rect(6, 30, S - 12, 3, PATH);
-  // 建物の前を通る東西の道 (宿屋・なんでも屋へ繋ぐ)。
-  rect(6, 24, S - 12, 2, PATH);
+  // 目抜き通り (縦)。入口から北へまっすぐ伸ばし、道なりに行けば店の前に出る。
+  rect(15, 2, 2, S - 3, PATH);
+  // 建物の前を通る東西の道 (宿屋 ⇄ なんでも屋)。扉の 1 段下を通す。
+  rect(4, 11, S - 8, 1, PATH);
+  // 広場へ抜ける横道。
+  rect(4, 17, S - 8, 1, PATH);
 
   // 中央の広場と井戸。**目印になるもの**を置いて、歩いた実感が出るようにする。
-  rect(26, 34, 12, 8, PATH);
-  set(31, 37, WELL); set(32, 37, WELL);
+  rect(12, 18, 8, 5, PATH);
+  set(15, 20, WELL); set(16, 20, WELL);
 
   /**
    * 建物を 1 軒。**屋根 → 壁 → 扉**の順に積む。看板を渡すと扉の上に出る
@@ -112,30 +113,27 @@ export function buildStarterTownTiles(): Uint8Array {
     rect(dx, y + h, 1, 1, PATH); // 玄関前の石畳
   };
 
-  // 宿屋 (西) と なんでも屋 (東)。通りに面して看板を出す。
-  building(18, 18, 8, 5, 3, INN_SIGN); // 扉 (21, 22)
-  building(40, 18, 8, 5, 3, SHOP_SIGN); // 扉 (43, 22)
+  // 宿屋 (西) と なんでも屋 (東)。目抜き通りを挟んで向かい合わせに置き、
+  // 入口から北へ歩くと**両方の看板が同時に視界に入る**ようにする。
+  building(6, 6, 6, 5, 2, INN_SIGN); // 扉 (8, 10)
+  building(20, 6, 6, 5, 3, SHOP_SIGN); // 扉 (23, 10)
 
   // ふつうの家。看板なし。
-  building(8, 8, 7, 5, 3);
-  building(24, 8, 7, 5, 3);
-  building(44, 8, 7, 5, 3);
-  building(8, 44, 7, 5, 3);
-  building(22, 44, 7, 5, 3);
-  building(40, 44, 7, 5, 3);
-  building(50, 34, 7, 5, 3);
+  building(2, 13, 5, 4, 2);
+  building(25, 13, 5, 4, 2);
+  building(3, 24, 5, 4, 2);
+  building(10, 24, 5, 4, 2);
+  building(18, 24, 5, 4, 2);
+  building(25, 24, 5, 4, 2);
 
   // 目印: 花壇・柵・木を散らす (一面の草地だと動いた実感が無い)。
-  rect(6, 36, 5, 4, FLOWER);
-  rect(52, 50, 6, 4, FLOWER);
-  rect(14, 52, 8, 1, FENCE);
-  rect(44, 30, 6, 1, FENCE);
-  for (const [x, y] of [[5, 20], [5, 50], [58, 12], [58, 44], [12, 28], [50, 28], [26, 52], [38, 52]]) {
+  rect(3, 19, 4, 3, FLOWER);
+  rect(25, 19, 4, 3, FLOWER);
+  rect(9, 21, 3, 1, FENCE);
+  rect(20, 21, 3, 1, FENCE);
+  for (const [x, y] of [[4, 4], [27, 4], [12, 14], [19, 14], [7, 30], [24, 30]]) {
     set(x!, y!, TREE);
   }
-
-  // 南の通りを端まで通す (どこからでも出られるが、道なりに行けば外に出ると分かる)。
-  rect(30, S - 6, 4, 6, PATH);
 
   return t;
 }


### PR DESCRIPTION
Closes #644

## なぜ

同梱の「ふたばの村」を 64×64 で作ったが、**最初の街としては歩かされる距離が長い**。
宿屋となんでも屋を往復するだけで間延びし、目的地に着くまで何もない草地を通り続ける。

## どうしたか

32×32 に組み直して密度を上げた。

```
   01234567890123456789012345678901
 1 ..T...T...T...T...T...T...T.....   T=木立 (ここから先は外)
 6 .T....^^^^^^...==...^^^^^^......   ^=屋根
 9 ......HHIHHH...==...HHHSHH......   I=宿屋の看板  S=なんでも屋の看板
10 .T....HHDHHH...==...HHHDHH......   D=扉 (8,10) / (23,10)
11 ....========================....   建物の前を通る東西の道
17 ....========================....
20 ...****.....===OO===.....****...   O=井戸  *=花壇
27 ...HHDHH..HHDHH==.HHDHH..HHDHH..   ふつうの家
28 .....=......=..==...=......=..T.   ← 入口 (15,28)
```

- 目抜き通りを入口から北へ一直線に通す
- 宿屋となんでも屋を**通りを挟んで向かい合わせ**に (北へ歩くと両方の看板が同時に視界に入る)
- 井戸のある広場・花壇・柵・木立は残す (一面の草地だと歩いた実感が無い — #626)
- 端まで歩けば外に出る設計 (#626) はそのまま

## 確認

実際にタイルを描き出し、入口 (15,28) から幅優先で到達性を測った:

- 入口は道タイル、宿屋 (8,10) と なんでも屋 (23,10) の扉に到達可能
- 歩ける 812 マスすべてが繋がっている (孤立した歩行マスはゼロ)

座標を直に書いていたテスト 3 件は、マップサイズから導くか新しい建物の座標に直した。
到達性の閾値 2000 → 700 は、割合では 49% → 68% と**逆に厳しくなっている**
(旧: 3697/4096、新: 812/1024)。

- [x] core 798 / edge 257 / web 394 passed
- [x] typecheck 緑 / build 緑

## 反映の手順 (マージだけでは変わらない)

内部マップは管理レコード (`app.aozoraquest.world.interiors`) が正なので、**保存済みの
64×64 の村はそのまま残る**。管理エディタの「はじまりの村を入れる」→「保存」で入れ直すと、
ゲートも同時に張り直される。

## Review

subagent 1 観点 (実装)。**★★★ 1 件・★★ 1 件をすべて PR 内で修正**。

- **★★★ 村の中に立ったまま入れ直すと、海の真ん中に置かれて一歩も動けなくなる** —
  範囲外の保険 (`battle-resolver.ts`) は `mapId` をフィールドに倒すだけで**座標を戻していなかった**。
  64→32 で旧マップの 2798 マスが範囲外になり、実測で 236 マスが海の上、うち **173 マスは
  8 方向すべて「進めない地形」**。動けないので敗北で街へ戻ることもできず、そらのはね無しでは
  復帰不能だった。座標も安全な場所へ戻すよう修正 (出口 → 直前の街 → スポーンの順に、
  実際に歩けるか確かめてから使う)。**修正を外すと落ちる回帰テストを追加済み**
  (8 近傍すべてが歩けない座標を実地形から探して再現する)。
  PR description に書いていた「既存の保険でフィールドへ出される」は誤りだった。
- **★★ 村の外を指すゲートが残ると「保存」ごと失敗する** — 入れ直しは `from` が村のゲートしか
  落とさないため、別の内部マップから村の旧座標 (例 40,40) へ張ったゲートが範囲外のまま残り、
  検証で弾かれて保存が通らなくなる。行き先が村の外になったゲートも落とすようにした。

レビューで問題なしと確認された点: 新マップに袋小路・意図しない重なりは無い / 保存済み
64×64 レコードとの食い違いは入れ直すまで起きない (edge は PDS だけを読み、同梱データへの
フォールバックが無い) / 削除した `STARTER_TOWN_EXIT` の参照は残っていない /
テストは弱められていない。