### PR TITLE
refactor(core,web): プレイヤー Lv 廃止で死んだ API を撤去する (#527)

### DIFF
--- a/apps/web/src/lib/post-processor.ts
+++ b/apps/web/src/lib/post-processor.ts
@@ -28,7 +28,6 @@ import {
   cognitiveToRpg,
   determineArchetype,
   jobLevelFromXp,
-  playerLevelFromXp,
 } from '@aozoraquest/core';
 import { classifyFromVec, type ActionCategory } from './action-classifier';
 import { classifyCognitiveFromVec } from './cognitive-classifier';
@@ -85,7 +84,6 @@ export interface ProcessResult {
   jobLevel?: JobLevelState | undefined;
   playerLevel?: PlayerLevelState | undefined;
   jobLeveledUp?: { from: number; to: number } | undefined;
-  playerLeveledUp?: { from: number; to: number } | undefined;
   /** 現 archetype と異なる判定が出ている場合の候補と連続回数。 */
   pendingArchetype?: Archetype | undefined;
   pendingArchetypeStreak?: number | undefined;
@@ -228,7 +226,6 @@ export async function processSelfPost(
   let finalJobLevel: JobLevelState | undefined;
   let finalPlayerLevel: PlayerLevelState | undefined;
   let jobLeveledUp: { from: number; to: number } | undefined;
-  let playerLeveledUp: { from: number; to: number } | undefined;
   let finalPendingArchetype: Archetype | undefined;
   let finalPendingStreak: number | undefined;
   try {
@@ -341,7 +338,6 @@ export async function processSelfPost(
     jobLevel: finalJobLevel,
     playerLevel: finalPlayerLevel,
     jobLeveledUp,
-    playerLeveledUp,
     pendingArchetype: finalPendingArchetype,
     pendingArchetypeStreak: finalPendingStreak,
   };

--- a/packages/core/src/__tests__/quest.test.ts
+++ b/packages/core/src/__tests__/quest.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { DEFAULT_QUEST_TEMPLATES, JOB_XP_CURVE, PLAYER_XP_CURVE, generateDailyQuests, jobLevelFromXp, jobXpToNextLevel, levelFromXp, playerLevelFromXp, playerXpToNextLevel } from '../quest.js';
+import { DEFAULT_QUEST_TEMPLATES, JOB_XP_CURVE, generateDailyQuests, jobLevelFromXp, jobXpToNextLevel, playerLevelFromXp } from '../quest.js';
 import type { StatVector } from '../types.js';
 
 describe('DEFAULT_QUEST_TEMPLATES', () => {
@@ -181,20 +181,6 @@ describe('generateDailyQuests', () => {
   });
 });
 
-describe('levelFromXp', () => {
-  test('0 XP は LV1', () => {
-    expect(levelFromXp(0)).toBe(1);
-  });
-
-  test('100 XP は LV2', () => {
-    expect(levelFromXp(100)).toBe(2);
-  });
-
-  test('150000 XP で LV50', () => {
-    expect(levelFromXp(150_000)).toBe(50);
-  });
-});
-
 // 職ごとの曲線 (#536) は job-level-pace.test.ts で見る。ここは**基準曲線**の性質を見るので、
 // `JOB_LEVEL_PACE` に載っていない = 倍率 1.0 の archetype を渡す。
 const BASE = '__base__';
@@ -245,29 +231,21 @@ describe('playerLevelFromXp', () => {
     expect(playerLevelFromXp(10_000_000)).toBe(99);
   });
 
-  test('曲線は LV1-99 を含み単調増加', () => {
-    expect(PLAYER_XP_CURVE.length).toBe(99);
-    expect(PLAYER_XP_CURVE[0]).toEqual([1, 0]);
-    for (let i = 1; i < PLAYER_XP_CURVE.length; i++) {
-      expect(PLAYER_XP_CURVE[i]![1]).toBeGreaterThan(PLAYER_XP_CURVE[i - 1]![1]);
+  test('XP に対して LV は単調非減少 (LV1 から LV99 へ)', () => {
+    let prev = playerLevelFromXp(0);
+    expect(prev).toBe(1);
+    for (let xp = 1; xp <= 10_000_000; xp += 997) {
+      const lv = playerLevelFromXp(xp);
+      expect(lv).toBeGreaterThanOrEqual(prev);
+      prev = lv;
     }
+    expect(prev).toBe(99);
   });
 
   test('同じ XP なら Player LV は Job LV 以下 (Player の方が緩やか)', () => {
     for (const xp of [0, 100, 1000, 5000, 20000, 44000]) {
       expect(playerLevelFromXp(xp)).toBeLessThanOrEqual(jobLevelFromXp(xp, BASE));
     }
-  });
-});
-
-describe('playerXpToNextLevel', () => {
-  test('0 XP は LV1、next=60', () => {
-    expect(playerXpToNextLevel(0)).toEqual({ level: 1, current: 0, next: 60 });
-  });
-
-  test('LV99 到達後は next=0', () => {
-    const lv99 = PLAYER_XP_CURVE[98]![1];
-    expect(playerXpToNextLevel(lv99)).toMatchObject({ level: 99, next: 0 });
   });
 });
 

--- a/packages/core/src/quest.ts
+++ b/packages/core/src/quest.ts
@@ -201,19 +201,6 @@ export const MAX_DAILY_QUEST_XP: number = (() => {
   return per.slice(0, MAX_DAILY_QUEST_SLOTS).reduce((a, b) => a + b, 0);
 })();
 
-/** 累計 XP から LV を計算 (03-game-design.md §XP とレベル)。グローバル用 (現状未使用)。 */
-const XP_CURVE: Array<[number, number]> = [
-  [1, 0], [2, 100], [5, 800], [10, 3500], [20, 15000], [30, 40000], [50, 150000],
-];
-export function levelFromXp(xp: number): number {
-  let lv = 1;
-  for (const [l, threshold] of XP_CURVE) {
-    if (xp >= threshold) lv = l;
-    else break;
-  }
-  return lv;
-}
-
 /**
  * 現職 (archetype) の滞在 LV 用 XP 曲線。パラメータは tuning.JOB_LEVEL_TUNING。
  * threshold(n) = round(coef * (n - 1)^exp)、LV1 = 0。
@@ -291,8 +278,9 @@ export const JOB_XP_REWARDS = XP_REWARDS;
 
 /**
  * 個人 (プレイヤー) LV 用 XP 曲線。パラメータは tuning.PLAYER_LEVEL_TUNING。
+ * `playerLevelFromXp` の内部表だけに使う (個人 LV は戦闘力・UI から外れている。#507/#508)。
  */
-export const PLAYER_XP_CURVE: ReadonlyArray<readonly [level: number, threshold: number]> = buildXpCurve(
+const PLAYER_XP_CURVE: ReadonlyArray<readonly [level: number, threshold: number]> = buildXpCurve(
   PLAYER_LEVEL_TUNING.maxLevel,
   PLAYER_LEVEL_TUNING.coefficient,
   PLAYER_LEVEL_TUNING.exponent,
@@ -315,14 +303,4 @@ export function playerLevelFromXp(xp: number): number {
     else break;
   }
   return lv;
-}
-
-/** 個人 LV の UI 進捗バー用。 */
-export function playerXpToNextLevel(xp: number): { level: number; current: number; next: number } {
-  const level = playerLevelFromXp(xp);
-  const idx = PLAYER_XP_CURVE.findIndex((e) => e[0] === level);
-  const curThreshold = idx >= 0 ? PLAYER_XP_CURVE[idx]![1] : 0;
-  const nextEntry = idx >= 0 && idx + 1 < PLAYER_XP_CURVE.length ? PLAYER_XP_CURVE[idx + 1] : undefined;
-  if (!nextEntry) return { level, current: xp - curThreshold, next: 0 };
-  return { level, current: xp - curThreshold, next: nextEntry[1] - curThreshold };
 }


### PR DESCRIPTION
Closes #527

## なぜ

#507 / #508 でプレイヤー Lv を戦闘力と UI から外した結果、定義とテスト以外に参照の無い API が残っていた。残すと「使われている前提」で保守する手間と、将来また表示に繋ぎ戻す誤解を招くので削る。

## 撤去した識別子

| 識別子 | 場所 | 根拠 |
|---|---|---|
| `playerXpToNextLevel` | `packages/core/src/quest.ts` + `__tests__/quest.test.ts` | 定義とテスト以外の参照 0 件 (UI 進捗バーは #508 で撤去済み) |
| `PLAYER_XP_CURVE` (export) | `packages/core/src/quest.ts` + テスト | quest.ts 外の参照はテストのみ。`playerLevelFromXp` の内部表として **module 内 `const` に降格** (削除ではない)。曲線の性質テストは `playerLevelFromXp` 経由の単調性テストに置き換え |
| `levelFromXp` / `XP_CURVE` | `packages/core/src/quest.ts` + テスト | コメントに「グローバル用 (現状未使用)」と明記、参照 0 件。issue の表には無いが同じ「プレイヤー Lv の死んだ API」なので同梱 |
| `playerLeveledUp` (戻り値フィールド + ローカル変数) | `apps/web/src/lib/post-processor.ts` | `let` 宣言のまま一度も代入されず `undefined` を返していた。消費側 (UI / テスト) 0 件を grep で確認 |
| `playerLevelFromXp` の import | `apps/web/src/lib/post-processor.ts` | import されているだけで本文に使用箇所なし |

## 残した識別子 (理由)

- `playerLevelFromXp` — `apps/web/src/routes/world.tsx` と `apps/edge/src/battle-resolver.ts` が `playerCombatant` の第 3 引数に渡している (production 参照あり)。引数を呼び出し文脈として残す判断は `battle.ts` に記録済みで、issue でも「別論点」とされている。
- `buildXpCurve` — `JOB_XP_CURVE` / `PLAYER_XP_CURVE` の両方が使う内部関数。
- `PLAYER_LEVEL_TUNING` — `PLAYER_XP_CURVE` の元パラメータ。
- ジョブ側 (`JOB_XP_CURVE` / `jobLevelFromXp` / `jobXpToNextLevel` 等) — 対象外。

## 参照ゼロの確認

```
grep -rnE 'playerXpToNextLevel|PLAYER_XP_CURVE|\blevelFromXp\b|playerLeveledUp|XP_CURVE\b' packages apps \
  --include='*.ts' --include='*.tsx' --exclude-dir=node_modules --exclude-dir=dist
```

撤去後の一致は `JOB_XP_CURVE` (ジョブ側、対象外) と quest.ts 内部の `PLAYER_XP_CURVE` (非 export) のみ。docs/ にも上記識別子への言及なし。

## テスト

- `@aozoraquest/core`: typecheck OK / test 793 passed (38 files)
- `@aozoraquest/edge`: typecheck OK / test 257 passed (22 files)
- `@aozoraquest/web`: typecheck OK / test 394 passed (43 files)

## Review

(レビュー後に記入)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
