### PR TITLE
feat(core): NPC を内部マップにも置けるようにする / 内部では「ちず」を出さない (#613)

### DIFF
--- a/apps/edge/test/battle-resolver.test.ts
+++ b/apps/edge/test/battle-resolver.test.ts
@@ -3,7 +3,7 @@ import { p256 } from '@noble/curves/p256';
 import { base64urlnopad } from '@scure/base';
 import { sealEncounter, handleMove, handleTeleport, handleTurn, handleReset, migrateInitState, ResolverError, GUARD_TTL_SEC, type ResolverEnv } from '../src/battle-resolver';
 import { writeServerTokens } from '../src/oauth-store';
-import { BASE_PALETTE, setInteriors, terrainAt, isWalkable, worldOverlay, type Command, type InteriorMap } from '@aozoraquest/core';
+import { BASE_PALETTE, setInteriors, setNpcs, terrainAt, isWalkable, worldOverlay, type Command, type InteriorMap } from '@aozoraquest/core';
 import { XP_EPOCH, type GameState } from '../src/game-state';
 
 const USER = 'did:plc:alice';
@@ -289,6 +289,21 @@ describe('内部マップとゲート (#424)', () => {
     // (1,1) の左と上は外周の壁
     await expect(handleMove(env, USER, -1, 0, enter.token, NOW)).rejects.toMatchObject({ status: 400 });
     await expect(handleMove(env, USER, 0, -1, enter.token, NOW)).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('内部マップの NPC が立つマスには進めない (400) — 隣は歩ける (#613)', async () => {
+    const env = await makeEnv();
+    globalThis.fetch = resolverMock({ diagnosis: DIAG, gameState: GS({ mapId: 'in-1', x: 3, y: 3 }) }).fn;
+    setInteriors([room()], []);
+    setNpcs([{ id: 'guard', name: 'ばんへい', mapId: 'in-1', x: 4, y: 3, lines: ['とまれ。'] }]);
+    try {
+      await expect(handleMove(env, USER, 1, 0, undefined, NOW)).rejects.toMatchObject({ status: 400 });
+      const r = await handleMove(env, USER, 0, 1, undefined, NOW);
+      expect(r.mapId).toBe('in-1');
+      expect(r.y).toBe(4);
+    } finally {
+      setNpcs(null);
+    }
   });
 
   it('内部マップは端で折り返さない (外周の外へは出られない)', async () => {

--- a/apps/web/src/routes/admin-npcs.tsx
+++ b/apps/web/src/routes/admin-npcs.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import {
   allInteriors,
   allNpcs,
+  facilityAt,
   gameQuests,
   interiorById,
   interiorWalkableAt,
@@ -37,15 +38,20 @@ function inMapRange(n: NpcDef, map: InteriorMap | undefined): boolean {
 }
 
 /**
- * **保存を拒む置き場所** — 存在しないマップ / マップの外。どちらも誰にも会えない NPC で、
- * core は読み込み順の都合でここを検証しない (NPC は内部マップより先に読む) のでエディタが見る。
+ * **保存を拒む置き場所** — 存在しないマップ / マップの外 / 施設 (宿屋・なんでも屋・ゲート) のマス。
+ * 前 2 つは誰にも会えない NPC。施設のマスは、移動判定が NPC を先に見る (ぶつかる = 話す) ので
+ * その施設が二度と使えなくなる。core は読み込み順の都合でここを検証しない
+ * (NPC は内部マップより先に読む) のでエディタが見る。
  */
 function placementError(n: NpcDef): string | null {
   const mapId = n.mapId ?? WORLD_MAP_ID;
-  if (mapId === WORLD_MAP_ID) return null;
-  const map = interiorById(mapId);
-  if (!map) return `「${n.name}」の内部マップ (${mapId}) が存在しない`;
-  if (!inMapRange(n, map)) return `「${n.name}」が ${map.name} の外にいる (${n.x}, ${n.y}) — 0〜${map.size - 1}`;
+  if (mapId !== WORLD_MAP_ID) {
+    const map = interiorById(mapId);
+    if (!map) return `「${n.name}」の内部マップ (${mapId}) が存在しない`;
+    if (!inMapRange(n, map)) return `「${n.name}」が ${map.name} の外にいる (${n.x}, ${n.y}) — 0〜${map.size - 1}`;
+  }
+  const facility = facilityAt(mapId, n.x, n.y);
+  if (facility) return `「${n.name}」が${facility}のマスに重なっている (${n.x}, ${n.y}) — 入口を塞ぐ`;
   return null;
 }
 
@@ -91,7 +97,9 @@ export function AdminNpcs() {
       const map = interiorById(mapId);
       let { x, y } = n;
       if (map && !inMapRange(n, map)) {
-        const taken = (px: number, py: number) => xs.some((o) => o.id !== id && (o.mapId ?? WORLD_MAP_ID) === mapId && o.x === px && o.y === py);
+        // 別の NPC と施設のマスは避ける (施設は placementError と同じ判定 = 保存で弾かれる場所)。
+        const taken = (px: number, py: number) => !!facilityAt(mapId, px, py)
+          || xs.some((o) => o.id !== id && (o.mapId ?? WORLD_MAP_ID) === mapId && o.x === px && o.y === py);
         outer: for (let py = 0; py < map.size; py++) for (let px = 0; px < map.size; px++) {
           if (interiorWalkableAt(map, px, py) && !taken(px, py)) { x = px; y = py; break outer; }
         }
@@ -157,7 +165,7 @@ export function AdminNpcs() {
   const placeNote = (n: NpcDef): string | null => {
     // 置き場所の落とし穴を可視化する。保存は拒否しない (意図的な配置がありうる) が、
     // 「海の上の人」「街の入口を塞ぐ人」は大抵ミスなので気づけるようにする。
-    // マップの外・存在しないマップは保存で拒む (placementError)。
+    // マップの外・存在しないマップ・施設のマスは保存で拒む (placementError)。
     const err = placementError(n);
     if (err) return `⚠ ${err} (保存できない)`;
     const map = n.mapId && n.mapId !== WORLD_MAP_ID ? interiorById(n.mapId) : undefined;

--- a/apps/web/src/routes/admin-npcs.tsx
+++ b/apps/web/src/routes/admin-npcs.tsx
@@ -1,14 +1,19 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import {
+  allInteriors,
   allNpcs,
   gameQuests,
+  interiorById,
+  interiorWalkableAt,
   isWalkableAt,
   npcArtKey,
   NpcDataError,
   setNpcs,
   townAt,
+  WORLD_MAP_ID,
   worldOverlay,
+  type InteriorMap,
   type NpcDef,
 } from '@aozoraquest/core';
 import { useSession } from '@/lib/session';
@@ -18,11 +23,32 @@ import { TileArtEditor, type ArtSubject } from '@/components/admin/tile-art-edit
 import { ItemReqInput } from '@/components/admin/item-req-input';
 
 /**
- * **NPC エディタ** (#425)。位置・名前・セリフ・絵。
+ * **NPC エディタ** (#425)。マップ・位置・名前・セリフ・絵。
  *
  * NPC はタイルを 1 つ占め、**歩いてぶつかると会話が始まる** (移動判定でも塞ぐ =
  * web と edge の両方が同じ一覧を読む)。絵はドット絵 (`npc:<id>`)、無ければ代替の人形。
+ * フィールドのほか内部マップ (#424) にも置ける (#613)。
  */
+
+/** そのマップの範囲内か。フィールドはトーラスなのでどの整数でも範囲内。 */
+function inMapRange(n: NpcDef, map: InteriorMap | undefined): boolean {
+  if (!map) return true;
+  return n.x >= 0 && n.y >= 0 && n.x < map.size && n.y < map.size;
+}
+
+/**
+ * **保存を拒む置き場所** — 存在しないマップ / マップの外。どちらも誰にも会えない NPC で、
+ * core は読み込み順の都合でここを検証しない (NPC は内部マップより先に読む) のでエディタが見る。
+ */
+function placementError(n: NpcDef): string | null {
+  const mapId = n.mapId ?? WORLD_MAP_ID;
+  if (mapId === WORLD_MAP_ID) return null;
+  const map = interiorById(mapId);
+  if (!map) return `「${n.name}」の内部マップ (${mapId}) が存在しない`;
+  if (!inMapRange(n, map)) return `「${n.name}」が ${map.name} の外にいる (${n.x}, ${n.y}) — 0〜${map.size - 1}`;
+  return null;
+}
+
 export function AdminNpcs() {
   const session = useSession();
   const admin = isAdminDid(session.did ?? null);
@@ -31,6 +57,8 @@ export function AdminNpcs() {
   const [note, setNote] = useState<string | null>(null);
   const [dirty, setDirty] = useState(false);
   const [drawing, setDrawing] = useState(false);
+  // 置けるマップの一覧 (内部マップは loadAuthoredWorld の後に揃う)。
+  const [interiors, setInteriorList] = useState<readonly InteriorMap[]>(() => allInteriors());
 
   const current = useMemo(() => list.find((n) => n.id === sel) ?? null, [list, sel]);
 
@@ -39,13 +67,37 @@ export function AdminNpcs() {
   useEffect(() => {
     let cancelled = false;
     void loadAuthoredWorld(session.agent ?? null).finally(() => {
-      if (!cancelled) setList(allNpcs().map((n) => ({ ...n, lines: [...n.lines] })));
+      if (cancelled) return;
+      setList(allNpcs().map((n) => ({ ...n, lines: [...n.lines] })));
+      setInteriorList(allInteriors());
     });
     return () => { cancelled = true; };
   }, [session.agent]);
 
   const update = useCallback((id: string, patch: Partial<NpcDef>) => {
     setList((xs) => xs.map((n) => (n.id === id ? { ...n, ...patch } : n)));
+    setDirty(true);
+  }, []);
+
+  /**
+   * 置くマップを切り替える。内部マップへ移すときは、そのマップで歩ける空きマスへ
+   * 置き直す (フィールドの座標をそのまま持ち込むと大抵はマップの外になる)。
+   */
+  const setMap = useCallback((id: string, mapId: string) => {
+    setList((xs) => xs.map((n) => {
+      if (n.id !== id) return n;
+      const { mapId: _old, ...rest } = n;
+      if (mapId === WORLD_MAP_ID) return rest;
+      const map = interiorById(mapId);
+      let { x, y } = n;
+      if (map && !inMapRange(n, map)) {
+        const taken = (px: number, py: number) => xs.some((o) => o.id !== id && (o.mapId ?? WORLD_MAP_ID) === mapId && o.x === px && o.y === py);
+        outer: for (let py = 0; py < map.size; py++) for (let px = 0; px < map.size; px++) {
+          if (interiorWalkableAt(map, px, py) && !taken(px, py)) { x = px; y = py; break outer; }
+        }
+      }
+      return { ...rest, mapId, x, y };
+    }));
     setDirty(true);
   }, []);
 
@@ -72,6 +124,10 @@ export function AdminNpcs() {
     if (orphan) {
       setNote(`保存できない: クエスト「${orphan.title}」が NPC (${orphan.npcId}) に発注させている。先にクエストを消すか発注者を変える`);
       return;
+    }
+    for (const n of list) {
+      const err = placementError(n);
+      if (err) { setNote(`保存できない: ${err}`); return; }
     }
     try {
       await saveNpcs(session.agent, list);
@@ -101,11 +157,21 @@ export function AdminNpcs() {
   const placeNote = (n: NpcDef): string | null => {
     // 置き場所の落とし穴を可視化する。保存は拒否しない (意図的な配置がありうる) が、
     // 「海の上の人」「街の入口を塞ぐ人」は大抵ミスなので気づけるようにする。
+    // マップの外・存在しないマップは保存で拒む (placementError)。
+    const err = placementError(n);
+    if (err) return `⚠ ${err} (保存できない)`;
+    const map = n.mapId && n.mapId !== WORLD_MAP_ID ? interiorById(n.mapId) : undefined;
+    if (map) {
+      if (!interiorWalkableAt(map, n.x, n.y)) return '⚠ 歩けないマスの上にいる (だれもぶつかれない = 話せない)';
+      return null;
+    }
     if (!isWalkableAt(n.x, n.y)) return '⚠ 歩けないマスの上にいる (だれもぶつかれない = 話せない)';
     const t = townAt(n.x, n.y);
     if (t) return `⚠ 街 (${t.name}) のマスに重なっている (入口を塞ぐ)`;
     return null;
   };
+  const mapLabel = (mapId: string | undefined): string =>
+    !mapId || mapId === WORLD_MAP_ID ? 'フィールド' : interiorById(mapId)?.name ?? mapId;
 
   return (
     <div className="admin-page" style={{ padding: '0.8em' }}>
@@ -136,7 +202,9 @@ export function AdminNpcs() {
               }}
             >
               <span style={{ flex: 1 }}>{n.name}</span>
-              <span style={{ fontSize: '0.75em', color: 'var(--color-muted)' }}>({n.x},{n.y})</span>
+              <span style={{ fontSize: '0.75em', color: 'var(--color-muted)' }}>
+                {n.mapId && n.mapId !== WORLD_MAP_ID ? `${mapLabel(n.mapId)} ` : ''}({n.x},{n.y})
+              </span>
             </button>
           ))}
           {list.length === 0 && (
@@ -169,13 +237,27 @@ export function AdminNpcs() {
               </span>
             </div>
             {field('なまえ', <input value={current.name} onChange={(e) => update(current.id, { name: e.target.value })} />)}
+            {field('マップ', (
+              <select value={current.mapId ?? WORLD_MAP_ID} onChange={(e) => setMap(current.id, e.target.value)}>
+                <option value={WORLD_MAP_ID}>フィールド</option>
+                {interiors.map((m) => <option key={m.id} value={m.id}>{m.name} ({m.id})</option>)}
+                {/* 消えたマップに居る NPC も選択肢に残す (選べないと直しようがない) */}
+                {current.mapId && current.mapId !== WORLD_MAP_ID && !interiorById(current.mapId) && (
+                  <option value={current.mapId}>{current.mapId} (存在しない)</option>
+                )}
+              </select>
+            ))}
             {field('位置', (
               <span style={{ display: 'flex', gap: '0.3em', alignItems: 'center' }}>
                 x
                 <input type="number" value={current.x} onChange={(e) => update(current.id, { x: Number(e.target.value) })} style={{ width: '5.5em' }} />
                 y
                 <input type="number" value={current.y} onChange={(e) => update(current.id, { y: Number(e.target.value) })} style={{ width: '5.5em' }} />
-                <span style={{ fontSize: '0.8em', color: 'var(--color-muted)' }}>マップエディタの座標表示と同じ</span>
+                <span style={{ fontSize: '0.8em', color: 'var(--color-muted)' }}>
+                  {current.mapId && current.mapId !== WORLD_MAP_ID
+                    ? `内部マップエディタの座標 (0〜${(interiorById(current.mapId)?.size ?? 1) - 1})`
+                    : 'マップエディタの座標表示と同じ'}
+                </span>
               </span>
             ))}
             {placeNote(current) && (

--- a/apps/web/src/routes/world.tsx
+++ b/apps/web/src/routes/world.tsx
@@ -55,7 +55,7 @@ function shopErrorText(e: unknown, fallback: string): string {
 }
 import { WORLD_PREVIEW_ENABLED } from '@/lib/world-preview';
 import { loadAuthoredWorld } from '@/lib/world-authoring';
-import { allNpcs, EQUIPMENT_BY_ID, equipHands, gameQuestById, gameQuestByNpc, gateAt, gateLockedNotice, gateOpen, interiorExitFor, interiorShopAt, itemsSatisfied, interiorById, interiorPartAt, interiorTerrainAt, npcArtKey, npcAt, npcLinesFor, walkableIn, WORLD_MAP_ID, type NpcDef } from '@aozoraquest/core';
+import { EQUIPMENT_BY_ID, equipHands, gameQuestById, gameQuestByNpc, gateAt, gateLockedNotice, gateOpen, interiorExitFor, interiorShopAt, itemsSatisfied, interiorById, interiorPartAt, interiorTerrainAt, npcArtKey, npcAt, npcLinesFor, npcsOn, walkableIn, WORLD_MAP_ID, type NpcDef } from '@aozoraquest/core';
 import { mappedPartAt } from '@aozoraquest/core';
 import { Avatar } from '@/components/avatar';
 import { WorldBattleControls, type BattlePhase } from '@/components/world-battle-controls';
@@ -577,9 +577,8 @@ export function World() {
       // **NPC にぶつかったら会話** (#425)。DQ の作法: 移動はせず、話しかける。
       // クエスト発注 NPC (#423) は状況で話が変わる: 未受注→依頼 (読了で受注)、
       // 進行中→達成を試みる (条件検証はサーバー)、達成済み→通常セリフ。
-      // NPC はフィールドにしか置けない (#425 の座標に mapId が無い)。内部で引くと
-      // 同じ座標の NPC が「幽霊」として現れ、戻りゲートを塞ぐこともある (レビュー ★★)。
-      const npc = cur ? undefined : npcAt(nx, ny);
+      // NPC は今いるマップで引く (#613)。内部マップの NPC はフィールドの同じ座標には居ない。
+      const npc = npcAt(cur?.id ?? WORLD_MAP_ID, nx, ny);
       if (npc) {
         const q0 = gameQuestByNpc(npc.id);
         // 解禁フラグ (#545) が立つまで、その NPC は依頼を話さない (通常のセリフに戻る)。
@@ -1355,7 +1354,9 @@ export function World() {
     // しらべるは街の外だけ (街=安全地帯で地方素材は出ない)。コストをラベルに明記
     ...(inTown ? [] : [{ key: 'search', label: `しらべる (パワー${SEARCH_TUNING.powerCost})`, onSelect: () => void searchHere() } as WorldMenuCommand]),
     { key: 'gear', label: 'そうび', onSelect: () => setGearOpen(true) },
-    { key: 'map', label: 'ちず', onSelect: () => setMapOpen(true) },
+    // ちずは世界地図なので内部では出さない (#613)。内部の座標を世界地図に重ねると
+    // 現在地マーカーが region 0 (左上) に出る誤表示になる。
+    ...(insideHere ? [] : [{ key: 'map', label: 'ちず', onSelect: () => setMapOpen(true) } as WorldMenuCommand]),
     { key: 'inventory', label: 'もちもの', onSelect: () => setInvOpen(true) },
     // 使えないコマンドはグレーで残さず消す (なんでも屋と同じポリシー — レビュー ★★)
     ...(statusReady ? [{ key: 'status', label: 'つよさ', onSelect: () => setStatusOpen(true) } as WorldMenuCommand] : []),
@@ -1423,11 +1424,11 @@ export function World() {
 
   // ビューポート内の NPC (#425)。ドット絵 (npc:<id>) → 代替の見た目 (人form) に倒す。
   const npcSprites = [];
-  // NPC はフィールド専用 (#425 の座標に mapId が無い)。内部では描かない。
-  for (const n of insideHere ? [] : allNpcs()) {
-    const vx = wrap(n.x - (ws.x - HALF));
-    const vy = wrap(n.y - (ws.y - HALF));
-    if (vx >= VIEW || vy >= VIEW) continue;
+  // 今いるマップの NPC だけ描く (#613)。内部マップは端で折り返さないので wrap しない。
+  for (const n of npcsOn(insideHere?.id ?? WORLD_MAP_ID)) {
+    const vx = insideHere ? n.x - (ws.x - HALF) : wrap(n.x - (ws.x - HALF));
+    const vy = insideHere ? n.y - (ws.y - HALF) : wrap(n.y - (ws.y - HALF));
+    if (vx < 0 || vy < 0 || vx >= VIEW || vy >= VIEW) continue;
     const art = pixelTile(npcArtKey(n.id));
     npcSprites.push(
       <g key={`npc-${n.id}`} transform={`translate(${vx * TILE},${vy * TILE})`}>

--- a/packages/core/src/__tests__/interior.test.ts
+++ b/packages/core/src/__tests__/interior.test.ts
@@ -29,7 +29,8 @@ import {
   type InteriorMap,
 } from '../interior.js';
 import { BASE_PALETTE } from '../world-map.js';
-import { worldOverlay } from '../world.js';
+import { isWalkableAt, worldOverlay } from '../world.js';
+import { allNpcs, npcAt, npcsOn, setNpcs, NpcDataError } from '../npc-data.js';
 import { starterTownInterior, starterTownGates } from '../interior-samples.js';
 
 const FLOOR = BASE_PALETTE.indexOf('plains');
@@ -346,5 +347,57 @@ describe('端から出る (#626)', () => {
 
   it('出る先が存在しない内部マップだと保存できない', () => {
     expect(() => setInteriors([{ ...v3, exitTo: { mapId: 'ghost', x: 0, y: 0 } }], [])).toThrow(InteriorError);
+  });
+});
+
+describe('内部マップの NPC (#613)', () => {
+  afterEach(() => { setInteriors(null, null); setNpcs(null); });
+
+  it('内部マップに置いた NPC のマスは walkableIn で塞がり、隣接から npcAt で引ける', () => {
+    setInteriors([room()], []);
+    expect(walkableIn('in-1', 3, 3, isWalkableAt)).toBe(true);
+    setNpcs([{ id: 'n', name: 'ばんへい', mapId: 'in-1', x: 3, y: 3, lines: ['とまれ。'] }]);
+    expect(walkableIn('in-1', 3, 3, isWalkableAt), 'NPC のマスは塞がる').toBe(false);
+    expect(walkableIn('in-1', 4, 3, isWalkableAt), '隣のマスは歩ける').toBe(true);
+    // 隣から「ぶつかる」= その先のマスを引く
+    expect(npcAt('in-1', 3, 3)?.name).toBe('ばんへい');
+    expect(npcAt('in-1', 4, 3)).toBeUndefined();
+    // 内部マップの NPC はフィールドの同じ座標には現れない (幽霊にならない)
+    expect(npcAt(WORLD_MAP_ID, 3, 3)).toBeUndefined();
+    expect(npcsOn('in-1').map((n) => n.id)).toEqual(['n']);
+    expect(npcsOn(WORLD_MAP_ID)).toEqual([]);
+    // 宿屋・店・ゲート入口の検証に使う interiorWalkableAt は NPC を見ない
+    expect(interiorWalkableAt(interiorById('in-1')!, 3, 3)).toBe(true);
+  });
+
+  it('mapId の無い旧レコードはフィールドの NPC として読める', () => {
+    setInteriors([room()], []);
+    // フィールドで歩けるマスを探す
+    let X = 0, Y = 0;
+    outer: for (let y = 300; y < 340; y++) for (let x = 200; x < 240; x++) {
+      if (isWalkableAt(x, y)) { X = x; Y = y; break outer; }
+    }
+    setNpcs([{ id: 'old', name: 'むらびと', x: X, y: Y, lines: ['やあ。'] }]);
+    expect(allNpcs()[0]?.mapId).toBeUndefined();
+    expect(npcAt(WORLD_MAP_ID, X, Y)?.id).toBe('old');
+    expect(walkableIn(WORLD_MAP_ID, X, Y, isWalkableAt)).toBe(false);
+    expect(npcsOn(WORLD_MAP_ID).map((n) => n.id)).toEqual(['old']);
+    // 同じ座標でも内部マップには居ない
+    expect(npcAt('in-1', X, Y)).toBeUndefined();
+    expect(walkableIn('in-1', Math.min(X, 6), Math.min(Y, 6), isWalkableAt)).toBe(true);
+  });
+
+  it('内部マップの座標は折り返さない (フィールドと別の規則)', () => {
+    setInteriors([room()], []);
+    setNpcs([{ id: 'n', name: 'ばんへい', mapId: 'in-1', x: 3, y: 3, lines: ['とまれ。'] }]);
+    expect(npcAt('in-1', 3 + 1024, 3)).toBeUndefined();
+    expect(npcAt('in-1', 3, 3 - 1024)).toBeUndefined();
+  });
+
+  it('同じマスでもマップが違えば別の NPC を置ける / 同じマップの同じマスは弾く', () => {
+    const a = { id: 'a', name: 'あ', mapId: 'in-1', x: 3, y: 3, lines: ['や'] };
+    expect(() => setNpcs([a, { ...a, id: 'b', mapId: 'in-2' }])).not.toThrow();
+    expect(() => setNpcs([a, { ...a, id: 'b' }])).toThrow(NpcDataError);
+    expect(() => setNpcs([{ ...a, mapId: ' ' }])).toThrow(NpcDataError);
   });
 });

--- a/packages/core/src/__tests__/interior.test.ts
+++ b/packages/core/src/__tests__/interior.test.ts
@@ -12,6 +12,7 @@ import {
   WORLD_MAP_ID,
   allGates,
   allInteriors,
+  facilityAt,
   gateAt,
   gateOpen,
   innAt,
@@ -368,6 +369,26 @@ describe('内部マップの NPC (#613)', () => {
     expect(npcsOn(WORLD_MAP_ID)).toEqual([]);
     // 宿屋・店・ゲート入口の検証に使う interiorWalkableAt は NPC を見ない
     expect(interiorWalkableAt(interiorById('in-1')!, 3, 3)).toBe(true);
+  });
+
+  it('施設 (宿屋 / なんでも屋 / ゲート) のマスを facilityAt で引ける — NPC を置くと施設が使えなくなるのでエディタが避ける', () => {
+    const town = worldOverlay().towns[0]!;
+    setInteriors(
+      [{ ...room(), inn: { x: 2, y: 2, price: 5 }, shop: { x: 3, y: 2, town: { x: town.x, y: town.y } } }],
+      [{ from: { mapId: 'in-1', x: 4, y: 4 }, to: { mapId: WORLD_MAP_ID, x: town.x, y: town.y } },
+       { from: { mapId: WORLD_MAP_ID, x: town.x, y: town.y }, to: { mapId: 'in-1', x: 5, y: 5 } }],
+    );
+    expect(facilityAt('in-1', 2, 2)).toBe('宿屋');
+    expect(facilityAt('in-1', 3, 2)).toBe('なんでも屋');
+    expect(facilityAt('in-1', 4, 4)).toBe('ゲート');
+    expect(facilityAt(WORLD_MAP_ID, town.x, town.y)).toBe('ゲート');
+    expect(facilityAt('in-1', 5, 5)).toBeUndefined(); // ゲートの出口は施設ではない
+    expect(facilityAt('in-1', 3, 3)).toBeUndefined();
+    // 施設のマスに NPC が立つと、移動判定は NPC が先に当たる (= 施設が使えない)。
+    // core はこれを弾かない (読み込み順の都合) ので、エディタが facilityAt で避ける。
+    setNpcs([{ id: 'n', name: 'じゃま', mapId: 'in-1', x: 2, y: 2, lines: ['…'] }]);
+    expect(walkableIn('in-1', 2, 2, isWalkableAt)).toBe(false);
+    expect(innAt('in-1', 2, 2)).toBeDefined();
   });
 
   it('mapId の無い旧レコードはフィールドの NPC として読める', () => {

--- a/packages/core/src/__tests__/monster-data.test.ts
+++ b/packages/core/src/__tests__/monster-data.test.ts
@@ -340,7 +340,7 @@ describe('NPC (#425)', () => {
     }
     expect(core.isWalkableAt(X, Y)).toBe(true);
     core.setNpcs([{ id: 'v1', name: 'むらびと', x: X, y: Y, lines: ['こんにちは。'] }]);
-    expect(core.npcAt(X, Y)?.name).toBe('むらびと');
+    expect(core.npcAt(core.WORLD_MAP_ID, X, Y)?.name).toBe('むらびと');
     expect(core.isWalkableAt(X, Y), 'NPC のマスは塞がるはず').toBe(false);
     core.setNpcs(null);
     expect(core.isWalkableAt(X, Y)).toBe(true);
@@ -358,6 +358,6 @@ describe('NPC (#425)', () => {
 
   it('座標はトーラスで引ける', () => {
     core.setNpcs([{ id: 'w', name: 'はし', x: 1024 + 3, y: -2, lines: ['まるまる。'] }]);
-    expect(core.npcAt(3, 1022)?.id).toBe('w');
+    expect(core.npcAt(core.WORLD_MAP_ID, 3, 1022)?.id).toBe('w');
   });
 });

--- a/packages/core/src/interior.ts
+++ b/packages/core/src/interior.ts
@@ -27,11 +27,12 @@ import { BASE_PALETTE, partWalkable as worldPartWalkable, type WorldPart } from 
 import { assertItemRequirements, isFlagName, itemsSatisfied, type ItemRequirement } from './scenario.js';
 import { ITEMS } from './battle.js';
 import { townAt } from './world.js';
+import { npcAt } from './npc-data.js';
+import { WORLD_MAP_ID } from './map-id.js';
+
+export { WORLD_MAP_ID };
 
 export class InteriorError extends Error {}
-
-/** フィールドを表す mapId。内部マップはこれ以外の id を持つ。 */
-export const WORLD_MAP_ID = 'world';
 
 export interface InteriorMap {
   /** 一意な id (ゲートの参照先)。 */
@@ -303,7 +304,8 @@ export function interiorTerrainAt(map: InteriorMap, x: number, y: number): Terra
  */
 export function interiorWalkableAt(map: InteriorMap, x: number, y: number): boolean {
   if (x < 0 || y < 0 || x >= map.size || y >= map.size) return false;
-  // NPC は内部にも置ける (#425 の座標は将来 mapId 付きにする。今はフィールド座標のみ)。
+  // NPC はここでは見ない (walkableIn が見る)。この関数は宿屋・店・ゲート入口の
+  // 「歩けるマスか」の検証にも使うので、NPC が立っているだけで保存を弾かない。
   const idx = interiorPartAt(map, x, y);
   if (idx !== undefined) {
     // パーツ自身の通行値が最優先 (フィールドと同じ規則)。内部固有のパーツ表があれば
@@ -320,11 +322,15 @@ export function interiorWalkableAt(map: InteriorMap, x: number, y: number): bool
 
 /**
  * マップをまたいで通行判定する。`mapId` が内部でなければフィールドの判定に委ねる。
- * **NPC は今のところフィールドにしか置けない** (NpcDef が mapId を持たない)。
- * 内部に NPC を置けるようにするのは #425 の続きで、そのときここも見るようにする。
+ *
+ * **NPC の立っているマスは内部でも塞ぐ** (#613)。フィールドは `isWalkableAt` が
+ * 同じ `npcAt` を見るので、移動判定はどのマップでもここ 1 本を通せばよい
+ * (web と edge の両方がこれを使う。片方だけだと画面では人がいるのにサーバーは
+ * 素通りさせる、という食い違いになる)。
  */
 export function walkableIn(mapId: string, x: number, y: number, worldWalkable: (x: number, y: number) => boolean): boolean {
   const m = interiorById(mapId);
   if (!m) return worldWalkable(x, y);
+  if (npcAt(m.id, x, y)) return false;
   return interiorWalkableAt(m, x, y);
 }

--- a/packages/core/src/interior.ts
+++ b/packages/core/src/interior.ts
@@ -279,6 +279,23 @@ export function interiorShopAt(mapId: string, x: number, y: number): NonNullable
   return m.shop.x === x && m.shop.y === y ? m.shop : undefined;
 }
 
+/** そのマスにある施設の名前 (エディタの警告文にそのまま使う)。 */
+export type FacilityName = '宿屋' | 'なんでも屋' | 'ゲート';
+
+/**
+ * **そのマスの施設** (宿屋 / なんでも屋 / ゲート)。無ければ undefined。
+ *
+ * 移動判定は NPC を施設より先に見る (ぶつかる = 話す) ので、施設のマスに NPC を
+ * 置くとその施設は二度と使えない。NPC エディタが置き場所を避ける判定をここ 1 か所に持つ
+ * (フィールドのゲートも同じ理由で塞がる)。
+ */
+export function facilityAt(mapId: string, x: number, y: number): FacilityName | undefined {
+  if (innAt(mapId, x, y)) return '宿屋';
+  if (interiorShopAt(mapId, x, y)) return 'なんでも屋';
+  if (gateAt(mapId, x, y)) return 'ゲート';
+  return undefined;
+}
+
 /** そのマップが内部か (mapId が未知なら false = フィールド扱いに倒す)。 */
 export function isInterior(mapId: string | undefined): boolean {
   return !!mapId && mapId !== WORLD_MAP_ID && interiors.has(mapId);

--- a/packages/core/src/map-id.ts
+++ b/packages/core/src/map-id.ts
@@ -1,0 +1,8 @@
+/**
+ * **フィールドを表す mapId** (#424)。位置は `(mapId, x, y)` の 3 つ組で、
+ * 省略 = フィールド。内部マップはこれ以外の id を持つ。
+ *
+ * interior.ts と npc-data.ts の両方が使うので、どちらにも属さない場所に置く
+ * (npc-data → interior → world → npc-data の循環 import を作らない)。
+ */
+export const WORLD_MAP_ID = 'world';

--- a/packages/core/src/npc-data.ts
+++ b/packages/core/src/npc-data.ts
@@ -12,6 +12,7 @@
 
 import { assertItemRequirements, isFlagName, itemsSatisfied, type ItemRequirement } from './scenario.js';
 import { ITEMS } from './battle.js';
+import { WORLD_MAP_ID } from './map-id.js';
 
 export class NpcDataError extends Error {}
 
@@ -19,7 +20,12 @@ export interface NpcDef {
   id: string;
   /** 名前 (会話の話者として出る)。 */
   name: string;
-  /** 立ち位置 (ワールド座標)。 */
+  /**
+   * **立っているマップ** (#613)。内部マップ (#424) の id、**省略 = フィールド**
+   * (`WORLD_MAP_ID`)。mapId の無い旧レコードは無移行でフィールドの NPC として読める。
+   */
+  mapId?: string;
+  /** 立ち位置 (そのマップの座標。フィールドはトーラスで丸める)。 */
   x: number;
   y: number;
   /** セリフ (1 要素 = 1 窓)。ぶつかるたびに先頭から流す。 */
@@ -52,10 +58,18 @@ export const MAX_NPC_LINE = 120;
 export const MAX_NPCS = 500;
 
 let npcList: NpcDef[] = [];
-let byKey = new Map<number, NpcDef>();
+let byKey = new Map<string, NpcDef>();
 
 const WORLD = 1024;
-const key = (x: number, y: number) => (((y % WORLD) + WORLD) % WORLD) * WORLD + (((x % WORLD) + WORLD) % WORLD);
+const wrapW = (v: number) => ((v % WORLD) + WORLD) % WORLD;
+/** その NPC のマップ (省略 = フィールド)。 */
+const mapOf = (n: Pick<NpcDef, 'mapId'>): string => n.mapId ?? WORLD_MAP_ID;
+/**
+ * マスのキー。フィールドはトーラスで丸め、内部マップは折り返さない (#424 と同じ規則。
+ * 内部で丸めると、範囲外の座標が別のマスに化けて見つからない NPC になる)。
+ */
+const key = (mapId: string, x: number, y: number) =>
+  mapId === WORLD_MAP_ID ? `${WORLD_MAP_ID}:${wrapW(x)},${wrapW(y)}` : `${mapId}:${x},${y}`;
 
 /**
  * NPC 一覧を差し替える。`null` / 空で全解除。
@@ -65,7 +79,7 @@ export function setNpcs(list: readonly NpcDef[] | null): void {
   const next = list ?? [];
   if (next.length > MAX_NPCS) throw new NpcDataError(`NPC が多すぎる (${next.length} > ${MAX_NPCS})`);
   const ids = new Set<string>();
-  const spots = new Set<number>();
+  const spots = new Set<string>();
   for (const n of next) {
     const where = n?.id ?? '(id なし)';
     if (!n || typeof n.id !== 'string' || n.id.trim() === '') throw new NpcDataError('NPC の id が空');
@@ -73,7 +87,12 @@ export function setNpcs(list: readonly NpcDef[] | null): void {
     ids.add(n.id);
     if (typeof n.name !== 'string' || n.name.trim() === '') throw new NpcDataError(`${where}: 名前が空`);
     if (!Number.isInteger(n.x) || !Number.isInteger(n.y)) throw new NpcDataError(`${where}: 座標が整数でない`);
-    const k = key(n.x, n.y);
+    // マップの実在・範囲はここでは見ない — NPC は内部マップより先に読み込まれる
+    // (読み込み順に依存する検証は、順序が変わった日に全 NPC を落とす)。エディタが見る。
+    if (n.mapId !== undefined && (typeof n.mapId !== 'string' || n.mapId.trim() === '')) {
+      throw new NpcDataError(`${where}: マップ id が不正`);
+    }
+    const k = key(mapOf(n), n.x, n.y);
     // **同じマスに 2 人は立てない。** ぶつかったときどちらと話すのか決められない。
     if (spots.has(k)) throw new NpcDataError(`${where}: 同じマスに別の NPC がいる (${n.x}, ${n.y})`);
     spots.add(k);
@@ -102,17 +121,22 @@ export function setNpcs(list: readonly NpcDef[] | null): void {
     }
   }
   npcList = next.map((n) => ({ ...n, lines: [...n.lines], ...(n.altLines ? { altLines: n.altLines.map((a) => ({ ...a, lines: [...a.lines], ...(a.items ? { items: a.items.map((r) => ({ ...r })) } : {}) })) } : {}) }));
-  byKey = new Map(npcList.map((n) => [key(n.x, n.y), n]));
+  byKey = new Map(npcList.map((n) => [key(mapOf(n), n.x, n.y), n]));
 }
 
-/** そのマスの NPC (居なければ undefined)。移動判定と会話の両方が使う。 */
-export function npcAt(x: number, y: number): NpcDef | undefined {
-  return byKey.get(key(x, y));
+/** そのマップ・そのマスの NPC (居なければ undefined)。移動判定と会話の両方が使う。 */
+export function npcAt(mapId: string, x: number, y: number): NpcDef | undefined {
+  return byKey.get(key(mapId, x, y));
 }
 
-/** 全 NPC (描画・エディタ用)。 */
+/** 全 NPC (エディタ用)。 */
 export function allNpcs(): readonly NpcDef[] {
   return npcList;
+}
+
+/** そのマップに立っている NPC (描画用)。フィールドは `WORLD_MAP_ID`。 */
+export function npcsOn(mapId: string): readonly NpcDef[] {
+  return npcList.filter((n) => mapOf(n) === mapId);
 }
 
 /**

--- a/packages/core/src/world.ts
+++ b/packages/core/src/world.ts
@@ -19,6 +19,7 @@ import { MAX_POPULATED_TIER, type Tier } from './battle.js';
 import { WORLD_DATA } from './world-data.js';
 import { mappedPartAt, mappedTerrainAt, partWalkable, registerWorldMapInvalidator, worldTownOverrides } from './world-map.js';
 import { npcAt } from './npc-data.js';
+import { WORLD_MAP_ID } from './map-id.js';
 
 // ─── 定数 ───────────────────────────────────────────────────
 
@@ -91,7 +92,8 @@ export function isWalkableAt(xIn: number, yIn: number): boolean {
   // **NPC の立っているマスは塞ぐ** (#425)。DQ の作法で、ぶつかる = 話しかける。
   // ここ (web/edge 共通の判定) に入れないと、画面では人がいるのにサーバーは素通り
   // させる、という食い違いになる。
-  if (npcAt(x, y)) return false;
+  // 内部マップ側は walkableIn が同じ npcAt を見る (#613)。
+  if (npcAt(WORLD_MAP_ID, x, y)) return false;
   const pi = mappedPartAt(x, y);
   if (pi !== undefined) {
     const w = partWalkable(pi);


### PR DESCRIPTION
Refs #613 (残件があるので Closes にしない)

## A. NPC の mapId 対応

- `NpcDef.mapId?: string` を足す。**省略 = フィールド** (`WORLD_MAP_ID`) なので既存レコードは無移行で読める
- `npcAt(mapId, x, y)` に変更。呼び出し元 (core `isWalkableAt` の通行判定、web `world.tsx` の「ぶつかると話す」) を追随。内部マップでも NPC にぶつかれば話せる
- 内部マップの座標は**折り返さない** (#424 と同じ規則。内部で wrap すると範囲外の座標が別マスに化ける)
- **通行判定は `walkableIn` 1 本に寄せる**: 内部は `walkableIn` が `npcAt` を見る、フィールドは `isWalkableAt` が同じ `npcAt` を見る。edge は `walkableIn` 経由なので追随する (edge に独自の NPC 判定は無いことを確認)
- `interiorWalkableAt` は NPC を見ない — 宿屋・店・ゲート入口の「歩けるマスか」の検証に使うので、NPC が立っているだけで内部マップの保存を落とさない
- core の `setNpcs` はマップの実在・範囲を検証しない — NPC は内部マップより先に読み込まれる (web/edge とも) ので、読み込み順に依存する検証は順序が変わった日に全 NPC を落とす。範囲の検証は `/admin/npcs` が持つ
- `WORLD_MAP_ID` を `packages/core/src/map-id.ts` に出す (npc-data → interior → world → npc-data の循環 import を作らないため。`interior.ts` から再 export しているので import 元は変わらない)
- web: 今いるマップの NPC だけ描く (`npcsOn(mapId)`)。内部では wrap せず、ビューポート外は描かない
- `/admin/npcs`: 「マップ」セレクト (フィールド / 内部マップ一覧)。内部へ移すとそのマップの歩ける空きマスに置き直す。**マップの外・存在しないマップは保存で拒む**。歩けないマスは従来どおり警告のみ。一覧に内部マップ名を出す

## B. ちず (WorldMapModal)

内部マップに居るときはメニューに「ちず」を出さない (内部座標を世界地図に重ねると現在地マーカーが region 0 に出る誤表示になっていた)。

## C. ゲート張り UI (Shift+クリックの linking 中に普通のクリックで塗る)

**現状コードでは再現しない (既に直っている)。** `admin-interiors.tsx` の `onPointerDown` は
`if (linking && !e.shiftKey) { setLinking(null); ...; return; }` を `paintAt` より前に持ち、linking 中の普通のクリックは「行き先選びをやめる」で終わる (塗らない)。`onPointerMove` も `painting.current` が立たない限り塗らない。`git log -S` でこの分岐は #612 のマージコミット (239140a) に含まれており、issue の記述は #612 のレビュー時点のもの。コードは変更していない。

## テスト

- core: `interior.test.ts` に「内部マップの NPC (#613)」4 件 (walkableIn で塞がる / 隣接で npcAt が引ける / mapId 無しの旧レコードがフィールド扱い / 内部座標は折り返さない / 別マップの同座標は共存・同マップの同座標は弾く)。既存の `npcAt` 呼び出しをシグネチャ変更に追随
- edge: `battle-resolver.test.ts` に「内部マップの NPC が立つマスには進めない (400) — 隣は歩ける」1 件
- `pnpm --filter @aozoraquest/core typecheck && test`: 802 passed
- `pnpm --filter @aozoraquest/edge typecheck && test`: 258 passed
- `pnpm --filter @aozoraquest/web typecheck && test`: 394 passed。eslint (変更ファイル) に新規警告なし

## Review

1 観点 (実装) を実施。

- **★★ 内部マップの宿屋・なんでも屋・ゲートのマスに NPC を置いても警告が出ず保存も通る** — 移動判定は NPC を施設より先に見るので、その施設が二度と使えない (core で実測: inn のマスに NPC を置くと walkableIn=false / npcAt=true / innAt=true、setInteriors も弾かない) → **f169e86 で対応**。core に `facilityAt(mapId, x, y)` (宿屋 / なんでも屋 / ゲート) を足してテストを付け、`/admin/npcs` の `placeNote` (警告)・`setMap` (自動配置の候補から除外)・保存時の拒否の 3 か所が同じ関数を使う。フィールドのゲートも同じ理由で塞がるのでマップを問わず見る。core 803 / web 394 緑

## 残

- 残: フィールド側ゲート UI (マップエディタ #421 側に「ここにゲートを張る」)
- 内部の店を店主 NPC に置く形 (issue の「内部の店」) はこの PR では触っていない (今は `InteriorMap.shop` の座標方式のまま)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXHZbULKCqUhgx1NCi6kZ7

