### PR TITLE
chore(ci): エッジ Worker を dev/main push で自動デプロイする (#549)

### DIFF
--- a/.github/workflows/edge-deploy.yml
+++ b/.github/workflows/edge-deploy.yml
@@ -50,9 +50,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup pnpm
+        # version は指定せず package.json の packageManager を単一の出所にする
+        # (明示 version と衝突すると ERR_PNPM_BAD_PM_VERSION になる。ci.yml と同じ)
         uses: pnpm/action-setup@v4
-        with:
-          version: 9.15.0
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/edge-deploy.yml
+++ b/.github/workflows/edge-deploy.yml
@@ -1,0 +1,83 @@
+name: edge-deploy
+
+# エッジ Worker (apps/edge) を dev / main への push で自動デプロイする。
+#
+# なぜ: web は Cloudflare Workers Builds が push で自動デプロイされるのに、エッジは手動
+# `wrangler deploy` だけだった。デプロイ漏れで戦闘の権威計算が数週間前のコードのまま動き、
+# 画面 (最新の成長モデル) と戦闘 (旧モデル) の数値がずれた (#549)。片方だけ自動の非対称を無くす。
+#
+# デプロイ先は **ブランチが決める** (docs/22-edge-env-separation.md):
+#   dev  → `wrangler deploy --env dev` → aozoraquest-edge-dev
+#   main → `wrangler deploy`           → aozoraquest-edge (本番)
+# workflow_dispatch は Actions タブの branch 選択がそのまま環境選択になる (dev / main 以外は拒否)。
+#
+# 必要な設定 (GitHub → Settings → Secrets and variables → Actions → Repository secrets、
+# または Environments の main / dev それぞれの secrets):
+#   CLOUDFLARE_API_TOKEN   Cloudflare API トークン (権限: Workers Scripts:Edit)
+#   CLOUDFLARE_ACCOUNT_ID  Cloudflare アカウント ID
+# 未設定のうちはこの workflow は失敗する (= エッジは従来どおり手動 deploy のまま)。
+# Worker Secrets (SERVER_DID / OAUTH_*_JWK / WORLD_TOKEN_SECRET / KUDA_API_KEY 等) と KV は
+# `wrangler deploy` で消えないので、自動化後も再設定は不要。
+#
+# 本番 (main) に承認を挟みたいときは GitHub Environment `main` に Required reviewers を付ける
+# (このジョブは main では environment: main を使う)。
+
+on:
+  push:
+    branches: [dev, main]
+    # core はエッジの依存 (@aozoraquest/core = workspace:*) なので含める。
+    paths:
+      - 'apps/edge/**'
+      - 'packages/core/**'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/edge-deploy.yml'
+  workflow_dispatch: {}
+
+# 同じブランチへの連続 push は最後の 1 つだけ出す。古い run が後から完走して新しいコードを
+# 上書きする逆転を防ぐ (wrangler deploy 自体は CF 側で原子的なので途中キャンセルは安全)。
+concurrency:
+  group: edge-deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    # dev / main 以外 (dispatch で feature ブランチを選んだ等) は出さない。
+    if: github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    # ci.yml / directory-refresh.yml と同じ Environment 名を使う (承認ルール・secrets の置き場を 1 つに)。
+    environment: ${{ github.ref == 'refs/heads/main' && 'main' || 'dev' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      # ci.yml はエッジの typecheck / test を回していない (web typecheck と core/web test のみ)。
+      # 壊れたエッジを出すと全ユーザーの戦闘が止まるので、deploy 直前にここで最低限を通す。
+      - name: Typecheck (edge)
+        run: pnpm --filter @aozoraquest/edge typecheck
+
+      - name: Unit tests (edge)
+        run: pnpm --filter @aozoraquest/edge test
+
+      - name: Deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: apps/edge
+          # pnpm-lock.yaml は repo root にあり workingDirectory から自動検出されないので明示。
+          # wrangler 本体は上の pnpm install で入った apps/edge の devDependency (lockfile 固定) を使う。
+          packageManager: pnpm
+          command: ${{ github.ref == 'refs/heads/main' && 'deploy' || 'deploy --env dev' }}

--- a/docs/13-ops.md
+++ b/docs/13-ops.md
@@ -4,7 +4,9 @@
 
 Aozora Quest は**バックエンドレス**のため、運用は以下だけに絞られる:
 
-1. **CI/CD**: GitHub → Cloudflare Workers Builds の自動デプロイ (本体 PWA + 管理画面、2 プロジェクト)
+1. **CI/CD**: GitHub → Cloudflare Workers Builds の自動デプロイ (本体 PWA + 管理画面、2 プロジェクト)。
+   エッジ Worker (`apps/edge`) は GitHub Actions `.github/workflows/edge-deploy.yml` が dev / main への
+   push で自動デプロイ (22-edge-env-separation.md §自動デプロイ)
 2. **モニタリング**: 解析サービス無し (Cloudflare ダッシュボードの基本ログのみ)
 3. **シークレット管理**: 管理者の OAuth クレデンシャルのみ (ユーザー側で保管する API キーは無い)
 4. **法務**: 商標性のある性格類型論表記を使わない、AT Protocol ToS、Cloudflare ToS
@@ -113,8 +115,11 @@ GitHub Actions repository secrets に登録:
 
 | 名前 | 用途 |
 |---|---|
-| `CLOUDFLARE_API_TOKEN` | Workers Builds デプロイ (Edit スコープのみ) |
-| `CLOUDFLARE_ACCOUNT_ID` | 同上 |
+| `CLOUDFLARE_API_TOKEN` | エッジ Worker の自動デプロイ (`edge-deploy.yml`)。権限は **Workers Scripts:Edit** のみ |
+| `CLOUDFLARE_ACCOUNT_ID` | 同上 (Cloudflare アカウント ID) |
+
+web (Workers Builds) は Cloudflare 側が GitHub を直接 pull するので GitHub Secrets は不要。
+エッジの Worker Secrets (`SERVER_DID` 等) は `wrangler deploy` で消えないので、上記 2 つだけで足りる。
 
 **ローテーション**: 年 1 回程度の見直しで十分 (ボトルネックではない)。漏洩が判明したら即座に revoke、新規発行。
 

--- a/docs/22-edge-env-separation.md
+++ b/docs/22-edge-env-separation.md
@@ -14,6 +14,8 @@ dev は本番に**一切**触れられないのが原則。Web アプリが `aoz
 
 - **本番エッジ**: `aozoraquest-edge` (top-level wrangler config)。`wrangler deploy` (main リリース時)。
 - **dev エッジ**: `aozoraquest-edge-dev` (`[env.dev]`)。`wrangler deploy --env dev`。
+- **どちらも push で自動デプロイ** (`.github/workflows/edge-deploy.yml`、§自動デプロイ参照)。
+  手動 `wrangler deploy` は自動デプロイが使えないときの迂回路。
   URL は worker 名から自動: `https://aozoraquest-edge-dev.kojiran.workers.dev`。
 - **サーバーアカウントは同じでよい**。dev エッジは別 client_id (= dev の `/client-metadata.json` URL) で
   同じアカウントを認可するので、**独立した OAuth grant / 独立した refresh チェーン**になり本番と干渉しない。
@@ -68,6 +70,8 @@ API キー必須 (429lab/kuda 新仕様、`Authorization: Bearer`)。キー未�
 (fail-safe) が、物理乱数エントロピーを混ぜたいなら prod/dev 両方に set すること。
 
 ### 3. dev エッジをデプロイ
+通常は dev への push で自動デプロイされる (§自動デプロイ)。初回セットアップや GitHub Actions が
+使えないときだけ手動で:
 ```
 wrangler deploy --env dev
 ```
@@ -113,8 +117,27 @@ VITE_EDGE_DID=did:web:aozoraquest-edge-dev.kojiran.workers.dev
   `DEV_EDGE_URL`/`DEV_EDGE_DID` 定数と `.env.development` の VITE_EDGE_URL/DID も直す
   (dev は VITE_NSID_ENV=dev のときコード側の定数でエッジを強制しているため)。
 
-## 再発防止
+## 自動デプロイ (`.github/workflows/edge-deploy.yml`)
 
-- dev エッジは dev push で自動デプロイする仕組み (GitHub Actions or CF Workers Build) を検討 (#TODO)。
-  それまでは dev エッジのコード変更は `wrangler deploy --env dev` を手動で回す (docs に明記)。
-- 本番エッジは main リリース時のみ `wrangler deploy` (top-level)。誤って本番へ出さない運用を徹底。
+web は Cloudflare Workers Builds が push で自動デプロイされるのに、エッジは手動 `wrangler deploy`
+だけだった。デプロイ漏れで戦闘の権威計算が数週間前のコードのまま動き、画面 (最新) と戦闘 (旧) の
+数値がずれた (#549)。片方だけ自動の非対称を無くすため、エッジも GitHub Actions で push デプロイする。
+
+- **トリガー**: `dev` / `main` への push で `apps/edge/**`・`packages/core/**` (エッジの依存)・
+  `pnpm-lock.yaml`・workflow 自身のどれかが変わったとき。Actions タブの手動実行 (workflow_dispatch)
+  も可で、そのとき選んだブランチがそのままデプロイ先になる (dev / main 以外は拒否)。
+- **デプロイ先はブランチが決める**: `dev` → `wrangler deploy --env dev` (`aozoraquest-edge-dev`)、
+  `main` → `wrangler deploy` (`aozoraquest-edge`)。本番へ出るのは main リリース (dev → main の PR
+  マージ) のときだけ。
+- **デプロイ前ゲート**: エッジの typecheck と unit test (ci.yml はエッジを回していない)。
+  壊れたエッジを出すと全ユーザーの戦闘が止まるので落ちたら出さない。
+- **必要な GitHub Secrets** (Settings → Secrets and variables → Actions → Repository secrets):
+  - `CLOUDFLARE_API_TOKEN` — Cloudflare API トークン (権限: **Workers Scripts:Edit**)
+  - `CLOUDFLARE_ACCOUNT_ID` — Cloudflare アカウント ID
+
+  未設定のうちは workflow が失敗する (= 従来どおり手動 deploy)。
+- **Worker Secrets (`SERVER_DID` / `OAUTH_*_JWK` / `WORLD_TOKEN_SECRET` / `KUDA_API_KEY` 等) と KV は
+  `wrangler deploy` で消えない**。自動化後も再設定は不要。
+- 本番 (main) に承認を挟みたければ GitHub Environment `main` に Required reviewers を設定する
+  (workflow は main で `environment: main` を使う。ci.yml / directory-refresh.yml と同じ名前)。
+- **dev エッジをリネームした時**は上記「補足」の world-server.ts 定数の更新も忘れないこと。


### PR DESCRIPTION
Closes #549

## なぜ

web は Cloudflare Workers Builds が push で自動デプロイされるのに、エッジ Worker (`apps/edge`) は手動 `wrangler deploy` だけだった。デプロイ漏れで戦闘の権威計算が数週間前のコードのまま動き続け、画面 (最新の成長モデル) と戦闘 (旧モデル) の数値がずれた (#549: HP 73 = 現行モデルでは出ない奇数、ヒカリダケ HP 62、レベルが上がらない)。core を直しても戦闘には届いていなかった。片方だけ自動の非対称を無くす。

## ⚠️ オーナーが設定する GitHub Secrets (これが無いと workflow は失敗し続ける)

GitHub → **Settings → Secrets and variables → Actions → Repository secrets** に 2 つ:

| 名前 | 値 |
|---|---|
| **`CLOUDFLARE_API_TOKEN`** | Cloudflare API トークン。権限は **Workers Scripts:Edit** (Account 単位) だけでよい |
| **`CLOUDFLARE_ACCOUNT_ID`** | Cloudflare アカウント ID (dashboard の Workers & Pages 右側 / `wrangler whoami`) |

- 未設定のうちは dev / main への push で `edge-deploy` が **赤くなる** (エッジは従来どおり手動 deploy のまま、web の CI には影響しない)。
- Repository secrets でなく Environment (`main` / `dev`) ごとの secrets に置いても動く (job が `environment:` を指定している)。
- **Worker Secrets (`SERVER_DID` / `OAUTH_*_JWK` / `WORLD_TOKEN_SECRET` / `KUDA_API_KEY` 等) と KV は `wrangler deploy` で消えない**。再設定は不要。
- 本番 (main) デプロイに承認を挟みたければ Environment `main` に Required reviewers を付ける (任意)。

## 変更

- `.github/workflows/edge-deploy.yml` (新規)
  - **trigger**: `dev` / `main` への push で `apps/edge/**`・`packages/core/**` (エッジの依存)・`pnpm-lock.yaml`・workflow 自身が変わったとき。`workflow_dispatch` も可
  - **デプロイ先はブランチが決める**: `dev` → `wrangler deploy --env dev` (`aozoraquest-edge-dev`) / `main` → `wrangler deploy` (`aozoraquest-edge`)。dispatch では Actions タブで選んだブランチがそのままデプロイ先、dev / main 以外は job の `if` で拒否 (feature ブランチから本番へ出せない)
  - **deploy 前ゲート**: エッジの typecheck + unit test (ci.yml はエッジを回していない。壊れたエッジを出すと全ユーザーの戦闘が止まる)。ローカル実測: typecheck OK、257 tests 0.8s
  - **concurrency**: 同一ブランチの古い run をキャンセル (古いコードが後から上書きする逆転を防ぐ)
  - **environment**: ci.yml / directory-refresh.yml と同じ `main` / `dev` を使う (既存の Environment 2 つを再利用。`production` を新設しない)
  - pnpm は ci.yml と同じく `pnpm/action-setup@v4` に version を渡さず、root `package.json` の `packageManager` を単一の出所にする
  - `cloudflare/wrangler-action@v3` + `packageManager: pnpm`。`wranglerVersion` は指定せず、`pnpm install --frozen-lockfile` で入った apps/edge の devDependency (lockfile 固定) を再利用する (v3.15.0 の dist で「pre-installed wrangler を使う」分岐を確認済み)
  - secrets は `${{ secrets.CLOUDFLARE_API_TOKEN }}` / `${{ secrets.CLOUDFLARE_ACCOUNT_ID }}` の参照のみ (CLAUDE.md §4)
- `docs/22-edge-env-separation.md`: 「再発防止 (#TODO)」を実際の仕組みに置き換え。必要な secrets、Worker Secrets / KV が消えないこと、手動 deploy は迂回路であることを明記
- `docs/13-ops.md`: CI/CD 方針と secrets 表をエッジ自動デプロイに合わせる (従来の表は「Workers Builds デプロイ用」と書いていたが、Workers Builds は GitHub Secrets を使わない)

`packages/lexicons` は issue に挙がっているが、edge / core のどちらも import していないので paths に含めていない。

## 検証

- YAML 構文: pyyaml で parse し、`on` / `paths` / `concurrency` / `if` / `environment` / steps / deploy inputs が意図どおりであることを確認 (actionlint は未インストールのため未実施)
- `pnpm --filter @aozoraquest/edge typecheck` / `test`: 緑 (22 files, 257 tests)
- 実際のデプロイは secrets 設定後の dev push で初めて走る。**マージ後、最初の `edge-deploy` run が緑になり、Cloudflare dashboard の `aozoraquest-edge-dev` の最新デプロイがそのコミットになっていることを確認する**のがこの PR の完了条件

## Review

1 観点 (実装) レビュー。★★★ 1 件、★★ 0 件。

- **★★★ `pnpm/action-setup@v4` に `with: version: 9.15.0` があり、root `package.json` の `packageManager` (`pnpm@10.34.5`) と食い違う** → v4 は両方指定で版が違うと `ERR_PNPM_BAD_PM_VERSION` ("Multiple versions of pnpm specified") で throw するため、secrets を入れても全 run が Setup pnpm で落ちる。ci.yml が #344 で同じ事故を踏んで `version` を外している。
  **対応**: `923635c` で `with: version` を削除し、ci.yml と同じく `packageManager` を単一の出所にした (Node 22 / `cache: pnpm` は据え置き)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXHZbULKCqUhgx1NCi6kZ7
