### PR TITLE
fix: 管理エディタ横断の逆参照ガードと読み込み前上書きの防止 (#603)

### DIFF
--- a/apps/web/src/components/admin/authored-world-gate.tsx
+++ b/apps/web/src/components/admin/authored-world-gate.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from 'react';
+
+/**
+ * **保存済みレコードを読み込むまで、エディタの全操作を止める** (#603)。
+ *
+ * `useAuthoredWorld` は読み込み完了で一覧を現物から取り直す (reset)。その前に
+ * 始めた編集は reset で黙って消えるので、完了までは入力欄もボタンも触らせない。
+ * `fieldset[disabled]` は中の input / select / button を一括で無効にする
+ * (エディタごとに `disabled={!loaded}` を配って回らない)。リンクは効いたまま。
+ */
+export function AuthoredWorldGate({ loaded, children }: { loaded: boolean; children: ReactNode }) {
+  return (
+    <fieldset className="admin-gate" disabled={!loaded}>
+      {!loaded && <p style={{ fontSize: '0.8em', color: 'var(--color-muted)', margin: '0 0 0.4em' }}>保存済みの定義を読み込み中…</p>}
+      {children}
+    </fieldset>
+  );
+}

--- a/apps/web/src/lib/use-authored-world.test.tsx
+++ b/apps/web/src/lib/use-authored-world.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useAuthoredWorld } from './use-authored-world';
+import { loadAuthoredWorld } from './world-authoring';
+import type { Agent } from '@atproto/api';
+
+vi.mock('./world-authoring', () => ({ loadAuthoredWorld: vi.fn() }));
+
+/**
+ * **管理エディタは保存済みレコードを読み込むまで保存させない** (#603)。
+ *
+ * エディタを URL 直打ちで開くと、メモリの定義は空/コード直書きのまま。その状態で
+ * 保存すると PDS レコードを丸ごと上書きして既存の編集が消える。読み込みが終わるまで
+ * `false` を返し、終わった瞬間に `reset` で一覧を現物から取り直させる。
+ */
+describe('useAuthoredWorld', () => {
+  const load = vi.mocked(loadAuthoredWorld);
+  let resolve: () => void;
+
+  beforeEach(() => {
+    load.mockReset();
+    load.mockImplementation(() => new Promise<void>((r) => { resolve = r; }));
+  });
+
+  it('読み込みが終わるまで false、終わると reset を呼んで true', async () => {
+    const reset = vi.fn();
+    const agent = {} as Agent;
+    const { result } = renderHook(() => useAuthoredWorld(agent, reset));
+    expect(result.current).toBe(false);
+    expect(load).toHaveBeenCalledWith(agent);
+    expect(reset).not.toHaveBeenCalled();
+
+    await act(async () => { resolve(); });
+    expect(reset).toHaveBeenCalledTimes(1);
+    expect(result.current).toBe(true);
+  });
+
+  it('読み込みに失敗しても reset を呼んで true (loadAuthoredWorld は失敗を握り潰す前提)', async () => {
+    let reject: (e: unknown) => void = () => {};
+    load.mockImplementation(() => new Promise<void>((_, rj) => { reject = rj; }));
+    const reset = vi.fn();
+    const { result } = renderHook(() => useAuthoredWorld(null, reset));
+    await act(async () => { reject(new Error('x')); });
+    expect(reset).toHaveBeenCalledTimes(1);
+    expect(result.current).toBe(true);
+  });
+
+  it('agent が変わったら読み直し、その間は false に戻る', async () => {
+    const reset = vi.fn();
+    const a1 = {} as Agent;
+    const a2 = {} as Agent;
+    const { result, rerender } = renderHook(({ agent }) => useAuthoredWorld(agent, reset), { initialProps: { agent: a1 } });
+    await act(async () => { resolve(); });
+    expect(result.current).toBe(true);
+
+    rerender({ agent: a2 });
+    expect(result.current).toBe(false);
+    expect(load).toHaveBeenLastCalledWith(a2);
+    await act(async () => { resolve(); });
+    expect(reset).toHaveBeenCalledTimes(2);
+    expect(result.current).toBe(true);
+  });
+
+  it('アンマウント後に読み込みが終わっても reset を呼ばない', async () => {
+    const reset = vi.fn();
+    const { unmount } = renderHook(() => useAuthoredWorld(null, reset));
+    unmount();
+    await act(async () => { resolve(); });
+    expect(reset).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/use-authored-world.ts
+++ b/apps/web/src/lib/use-authored-world.ts
@@ -23,11 +23,14 @@ export function useAuthoredWorld(agent: Agent | null, reset: () => void): boolea
   useEffect(() => {
     let cancelled = false;
     setLoaded(false);
-    void loadAuthoredWorld(agent).finally(() => {
+    // 失敗しても編集は始めさせる (loadAuthoredWorld は失敗を握り潰す前提だが、
+    // `.finally` は reject を伝播するので、ここで吸収しないと未処理の reject になる)。
+    const done = () => {
       if (cancelled) return;
       resetRef.current();
       setLoaded(true);
-    });
+    };
+    void loadAuthoredWorld(agent).then(done, done);
     return () => { cancelled = true; };
   }, [agent]);
 

--- a/apps/web/src/lib/use-authored-world.ts
+++ b/apps/web/src/lib/use-authored-world.ts
@@ -1,0 +1,35 @@
+import { useEffect, useRef, useState } from 'react';
+import type { Agent } from '@atproto/api';
+import { loadAuthoredWorld } from './world-authoring';
+
+/**
+ * **管理エディタは保存済みレコードを読み込んでから編集させる** (#603)。
+ *
+ * 各エディタの初期値はメモリ (`activeMonsters()` 等) から取るが、それが埋まるのは
+ * /world か /admin/map を先に開いたときだけ。エディタを URL 直打ち・リロードで開くと
+ * 空/コード直書きの状態から編集が始まり、保存すると PDS レコードを丸ごと上書きして
+ * 既存の編集が消える。
+ *
+ * マウント時 (と agent が変わったとき) に `loadAuthoredWorld` を回し、終わるまで
+ * `false` を返す。エディタは読み込み完了で `reset` を呼ばれて一覧を現物から取り直し、
+ * `false` の間は保存ボタンを無効にする。
+ */
+export function useAuthoredWorld(agent: Agent | null, reset: () => void): boolean {
+  const [loaded, setLoaded] = useState(false);
+  // 最新の reset を効果から呼ぶ (deps に入れるとレンダーごとに読み直してしまう)。
+  const resetRef = useRef(reset);
+  resetRef.current = reset;
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoaded(false);
+    void loadAuthoredWorld(agent).finally(() => {
+      if (cancelled) return;
+      resetRef.current();
+      setLoaded(true);
+    });
+    return () => { cancelled = true; };
+  }, [agent]);
+
+  return loaded;
+}

--- a/apps/web/src/routes/admin-items.tsx
+++ b/apps/web/src/routes/admin-items.tsx
@@ -5,11 +5,9 @@ import {
   GEAR_SLOT_LABELS,
   activeEquipment,
   activeItems,
-  allGates,
-  allNpcs,
-  gameQuests,
-  scenarioEvents,
   canEquip,
+  danglingRefs,
+  describeDanglingRef,
   ItemDataError,
   JOBS,
   JOB_EQUIP_KINDS,
@@ -19,6 +17,7 @@ import {
 import { useSession } from '@/lib/session';
 import { isAdminDid } from '@/lib/runtime-config';
 import { saveItems } from '@/lib/world-authoring';
+import { useAuthoredWorld } from '@/lib/use-authored-world';
 
 /**
  * **アイテムエディタ** (#420)。そうび / どうぐ・素材 の 2 タブ。
@@ -42,6 +41,11 @@ export function AdminItems() {
   const [sel, setSel] = useState<string | null>(null);
   const [note, setNote] = useState<string | null>(null);
   const [dirty, setDirty] = useState(false);
+  // 保存済みレコードを読み込むまで保存させない (直接開いて保存すると保存済みの編集を上書きする。#603)。
+  const loaded = useAuthoredWorld(session.agent ?? null, () => {
+    setEquipment(activeEquipment().map((e) => ({ ...e, bonus: { ...e.bonus }, price: { ...e.price } })));
+    setItems(activeItems());
+  });
 
   const current = useMemo(() => equipment.find((e) => e.id === sel) ?? null, [equipment, sel]);
 
@@ -81,20 +85,13 @@ export function AdminItems() {
   const save = useCallback(async () => {
     if (!session.agent) return;
     try {
-      // 参照しているアイテムを消させない (#426)。参照切れが 1 件あると
-      // setInteriors/setGameQuests/setScenario が全体を落とし、edge のコールドスタート後に
-      // ゲート・クエスト・シナリオがまとめて読み込まれなくなる (レビュー ★★)。
-      const ids = new Set(items.map((it) => it.id));
-      const missing = (req?: readonly { itemId: string }[]) => (req ?? []).find((r) => !ids.has(r.itemId))?.itemId;
-      const refs: Array<[string, string | undefined]> = [
-        ...allGates().map((g) => [`ゲート (${g.from.mapId} ${g.from.x},${g.from.y})`, missing(g.requireItems)] as [string, string | undefined]),
-        ...gameQuests().map((q) => [`クエスト「${q.title}」`, missing(q.requireItems)] as [string, string | undefined]),
-        ...allNpcs().flatMap((n) => (n.altLines ?? []).map((a) => [`NPC「${n.name}」のセリフ`, missing(a.items)] as [string, string | undefined])),
-        ...scenarioEvents().flatMap((e) => e.when.map((c) => [`シナリオ「${e.title}」`, c.kind === 'itemCount' && !ids.has(c.itemId) ? c.itemId : undefined] as [string, string | undefined])),
-      ];
-      const hit = refs.find(([, id]) => id);
-      if (hit) {
-        setNote(`保存できない: ${hit[0]} が「${hit[1]}」を参照している。先にそちらを直す`);
+      // 参照しているアイテム・装備を消させない (#426 / #603)。参照切れが 1 件あると
+      // setInteriors/setGameQuests/setScenario/setShopOverrides が全体を落とし、edge の
+      // コールドスタート後にゲート・クエスト・シナリオ・店がまとめて読み込まれなくなる。
+      const dangling = danglingRefs('item', items.map((it) => it.id))[0]
+        ?? danglingRefs('equipment', equipment.map((e) => e.id))[0];
+      if (dangling) {
+        setNote(describeDanglingRef(dangling));
         return;
       }
       await saveItems(session.agent, items, equipment);
@@ -140,7 +137,7 @@ export function AdminItems() {
             {label}
           </button>
         ))}
-        <button type="button" onClick={() => void save()} disabled={!session.agent || !dirty} style={{ marginLeft: 'auto', fontSize: '0.85em' }}>
+        <button type="button" onClick={() => void save()} disabled={!session.agent || !dirty || !loaded} style={{ marginLeft: 'auto', fontSize: '0.85em' }}>
           保存
         </button>
       </div>

--- a/apps/web/src/routes/admin-items.tsx
+++ b/apps/web/src/routes/admin-items.tsx
@@ -18,6 +18,7 @@ import { useSession } from '@/lib/session';
 import { isAdminDid } from '@/lib/runtime-config';
 import { saveItems } from '@/lib/world-authoring';
 import { useAuthoredWorld } from '@/lib/use-authored-world';
+import { AuthoredWorldGate } from '@/components/admin/authored-world-gate';
 
 /**
  * **アイテムエディタ** (#420)。そうび / どうぐ・素材 の 2 タブ。
@@ -125,6 +126,7 @@ export function AdminItems() {
 
   return (
     <div className="admin-page" style={{ padding: '0.8em' }}>
+      <AuthoredWorldGate loaded={loaded}>
       <div className="admin-head">
         <Link to="/admin" style={{ fontSize: '0.8em' }}>← 管理</Link>
         {([['equipment', 'そうび'], ['items', 'どうぐ・素材']] as const).map(([k, label]) => (
@@ -343,6 +345,7 @@ export function AdminItems() {
           )}
         </div>
       )}
+      </AuthoredWorldGate>
     </div>
   );
 }

--- a/apps/web/src/routes/admin-monsters.tsx
+++ b/apps/web/src/routes/admin-monsters.tsx
@@ -8,6 +8,8 @@ import {
   runAutoBattle,
   startBattle,
   setMonsterOverrides,
+  danglingRefs,
+  describeDanglingRef,
   MonsterDataError,
   JOBS,
   ITEMS,
@@ -18,6 +20,7 @@ import {
 import { useSession } from '@/lib/session';
 import { isAdminDid } from '@/lib/runtime-config';
 import { saveMonsters } from '@/lib/world-authoring';
+import { useAuthoredWorld } from '@/lib/use-authored-world';
 import { MonsterSvg, bodyFor } from '@/components/monster-svg';
 import { TileArtEditor, type ArtSubject } from '@/components/admin/tile-art-editor';
 import { monsterArtKey } from '@aozoraquest/core';
@@ -25,9 +28,9 @@ import { monsterArtKey } from '@aozoraquest/core';
 /**
  * **モンスターエディタ** (#419)。一覧・編集・複製・削除と、保存前の検証・模擬戦。
  *
- * 保存先は管理者 PDS の `world.monsters` (#537)。読み込みは `loadAuthoredWorld` が
- * 起動時に済ませているので、この画面は `activeMonsters()` (= 差し替え済みの現物) から
- * 始めればよい。保存はレコード全置換 (壊れた 1 体で全体を落とす検証つき)。
+ * 保存先は管理者 PDS の `world.monsters` (#537)。マウント時に `loadAuthoredWorld` を回し、
+ * 読み込めるまで保存させない (直接開いて保存すると保存済みの編集を上書きする。#603)。
+ * 保存はレコード全置換 (壊れた 1 体で全体を落とす検証つき)。
  */
 
 const ABILITY_LABELS: Record<string, string> = {
@@ -48,6 +51,7 @@ export function AdminMonsters() {
   const [dirty, setDirty] = useState(false);
   // 絵を描くモード (ドット絵エディタを開く)。下敷きは従来の SVG。
   const [drawing, setDrawing] = useState(false);
+  const loaded = useAuthoredWorld(session.agent ?? null, () => setList(activeMonsters().map((m) => ({ ...m }))));
 
   const current = useMemo(() => list.find((m) => m.id === sel) ?? null, [list, sel]);
   /** 単数 (旧) と複数 (新) を吸収した現在の能力列。 */
@@ -99,6 +103,13 @@ export function AdminMonsters() {
 
   const save = useCallback(async () => {
     if (!session.agent) return;
+    // クエストが討伐対象にしているモンスターを消させない (#603) — 参照切れが 1 体でもあると
+    // setGameQuests が全体を落とし、消した敵と無関係な全クエストまで web/edge から消える。
+    const dangling = danglingRefs('monster', list.map((m) => m.id))[0];
+    if (dangling) {
+      setNote(describeDanglingRef(dangling));
+      return;
+    }
     try {
       const n = await saveMonsters(session.agent, list);
       setDirty(false);
@@ -179,7 +190,7 @@ export function AdminMonsters() {
         <span style={{ fontSize: '0.75em', color: 'var(--color-muted)' }}>
           {([1, 2, 3, 4, 5, 6] as Tier[]).map((t) => `t${t}:${counts[t] ?? 0}`).join(' ')}
         </span>
-        <button type="button" onClick={() => void save()} disabled={!session.agent || !dirty} style={{ marginLeft: 'auto', fontSize: '0.85em' }}>
+        <button type="button" onClick={() => void save()} disabled={!session.agent || !dirty || !loaded} style={{ marginLeft: 'auto', fontSize: '0.85em' }}>
           保存
         </button>
       </div>

--- a/apps/web/src/routes/admin-monsters.tsx
+++ b/apps/web/src/routes/admin-monsters.tsx
@@ -21,6 +21,7 @@ import { useSession } from '@/lib/session';
 import { isAdminDid } from '@/lib/runtime-config';
 import { saveMonsters } from '@/lib/world-authoring';
 import { useAuthoredWorld } from '@/lib/use-authored-world';
+import { AuthoredWorldGate } from '@/components/admin/authored-world-gate';
 import { MonsterSvg, bodyFor } from '@/components/monster-svg';
 import { TileArtEditor, type ArtSubject } from '@/components/admin/tile-art-editor';
 import { monsterArtKey } from '@aozoraquest/core';
@@ -184,6 +185,7 @@ export function AdminMonsters() {
 
   return (
     <div className="admin-page" style={{ padding: '0.8em' }}>
+      <AuthoredWorldGate loaded={loaded}>
       <div className="admin-head">
         <Link to="/admin" style={{ fontSize: '0.8em' }}>← 管理</Link>
         <strong>モンスター</strong>
@@ -452,6 +454,7 @@ export function AdminMonsters() {
           <div style={{ fontSize: '0.85em', color: 'var(--color-muted)' }}>左の一覧から選ぶ。増やすときは近い敵を選んで「複製」。</div>
         )}
       </div>
+      </AuthoredWorldGate>
     </div>
   );
 }

--- a/apps/web/src/routes/admin-quests.tsx
+++ b/apps/web/src/routes/admin-quests.tsx
@@ -16,6 +16,7 @@ import { useSession } from '@/lib/session';
 import { isAdminDid } from '@/lib/runtime-config';
 import { saveGameQuests } from '@/lib/world-authoring';
 import { useAuthoredWorld } from '@/lib/use-authored-world';
+import { AuthoredWorldGate } from '@/components/admin/authored-world-gate';
 import { ItemReqInput } from '@/components/admin/item-req-input';
 
 /**
@@ -146,6 +147,7 @@ export function AdminQuests() {
 
   return (
     <div className="admin-page" style={{ padding: '0.8em' }}>
+      <AuthoredWorldGate loaded={loaded}>
       <div className="admin-head">
         <Link to="/admin" style={{ fontSize: '0.8em' }}>← 管理</Link>
         <strong>クエスト</strong>
@@ -346,6 +348,7 @@ export function AdminQuests() {
           <div style={{ fontSize: '0.85em', color: 'var(--color-muted)' }}>左の一覧から選ぶか「＋クエスト」。</div>
         )}
       </div>
+      </AuthoredWorldGate>
     </div>
   );
 }

--- a/apps/web/src/routes/admin-quests.tsx
+++ b/apps/web/src/routes/admin-quests.tsx
@@ -1,19 +1,21 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import {
   allNpcs,
+  danglingRefs,
+  describeDanglingRef,
   gameQuests,
   ITEMS,
   MONSTERS,
   QuestDataError,
-  scenarioEvents,
   setGameQuests,
   type GameQuestDef,
   type QuestObjective,
 } from '@aozoraquest/core';
 import { useSession } from '@/lib/session';
 import { isAdminDid } from '@/lib/runtime-config';
-import { loadAuthoredWorld, saveGameQuests } from '@/lib/world-authoring';
+import { saveGameQuests } from '@/lib/world-authoring';
+import { useAuthoredWorld } from '@/lib/use-authored-world';
 import { ItemReqInput } from '@/components/admin/item-req-input';
 
 /**
@@ -31,20 +33,12 @@ export function AdminQuests() {
   const [sel, setSel] = useState<string | null>(null);
   const [note, setNote] = useState<string | null>(null);
   const [dirty, setDirty] = useState(false);
-  const [loaded, setLoaded] = useState(false);
 
-  // **保存済みレコードを必ず読み込んでから編集させる** (実装レビュー ★★)。
-  // メモリの gameQuests() は /world か /admin/map を先に開いた時しか埋まっておらず、
-  // この画面を直接開いて保存すると空リストで world.quests を上書き = 既存クエスト全損する。
-  useEffect(() => {
-    let cancelled = false;
-    void loadAuthoredWorld(session.agent ?? null).finally(() => {
-      if (cancelled) return;
-      setList(gameQuests().map((q) => ({ ...q, intro: [...q.intro], done: [...q.done], ...(q.progress ? { progress: [...q.progress] } : {}) })));
-      setLoaded(true);
-    });
-    return () => { cancelled = true; };
-  }, [session.agent]);
+  // 保存済みレコードを読み込むまで保存させない (この画面を直接開いて保存すると
+  // 空リストで world.quests を上書き = 既存クエスト全損する)。
+  const loaded = useAuthoredWorld(session.agent ?? null, () => {
+    setList(gameQuests().map((q) => ({ ...q, intro: [...q.intro], done: [...q.done], ...(q.progress ? { progress: [...q.progress] } : {}) })));
+  });
 
   const npcs = useMemo(() => allNpcs(), [loaded]);
   const monsters = useMemo(() => [...MONSTERS].sort((a, b) => a.tier - b.tier), [loaded]);
@@ -77,11 +71,9 @@ export function AdminQuests() {
     if (!session.agent) return;
     // シナリオ (#545) が条件にしているクエストを消させない — 参照切れが 1 件でもあると
     // setScenario が全体を落とし、**フラグが二度と立たなくなる** (解禁クエストも永久ロック)。
-    const orphan = scenarioEvents().find((e) =>
-      e.when.some((c) => c.kind === 'questDone' && !list.some((q) => q.id === c.questId)),
-    );
-    if (orphan) {
-      setNote(`保存できない: シナリオ「${orphan.title}」が消したクエストを条件にしている。先にシナリオを直す`);
+    const dangling = danglingRefs('quest', list.map((q) => q.id))[0];
+    if (dangling) {
+      setNote(describeDanglingRef(dangling));
       return;
     }
     try {

--- a/apps/web/src/routes/admin-shops.tsx
+++ b/apps/web/src/routes/admin-shops.tsx
@@ -17,6 +17,7 @@ import {
 import { useSession } from '@/lib/session';
 import { isAdminDid } from '@/lib/runtime-config';
 import { saveShops } from '@/lib/world-authoring';
+import { useAuthoredWorld } from '@/lib/use-authored-world';
 
 /**
  * **お店のラインナップエディタ** (#422)。
@@ -28,11 +29,14 @@ import { saveShops } from '@/lib/world-authoring';
 export function AdminShops() {
   const session = useSession();
   const admin = isAdminDid(session.did ?? null);
-  const towns = useMemo(() => worldOverlay().towns, []);
   const [overrides, setOverrides] = useState<ShopOverride[]>(() => shopOverrides());
   const [sel, setSel] = useState<Town | null>(null);
   const [note, setNote] = useState<string | null>(null);
   const [dirty, setDirty] = useState(false);
+  // 保存済みレコードを読み込むまで保存させない (直接開いて保存すると上書き中の店が全部消える。#603)。
+  const loaded = useAuthoredWorld(session.agent ?? null, () => setOverrides(shopOverrides()));
+  // 街の一覧も地図の読み込みで変わる (直接開くと読み込み前は空)。
+  const towns = useMemo(() => worldOverlay().towns, [loaded]);
 
   const equipment = activeEquipment();
   const items = activeItems();
@@ -100,7 +104,7 @@ export function AdminShops() {
         <Link to="/admin" style={{ fontSize: '0.8em' }}>← 管理</Link>
         <strong>お店のラインナップ</strong>
         <span style={{ fontSize: '0.75em', color: 'var(--color-muted)' }}>{overrides.length} 店を上書き中</span>
-        <button type="button" onClick={() => void save()} disabled={!session.agent || !dirty} style={{ marginLeft: 'auto', fontSize: '0.85em' }}>
+        <button type="button" onClick={() => void save()} disabled={!session.agent || !dirty || !loaded} style={{ marginLeft: 'auto', fontSize: '0.85em' }}>
           保存
         </button>
       </div>

--- a/apps/web/src/routes/admin-shops.tsx
+++ b/apps/web/src/routes/admin-shops.tsx
@@ -18,6 +18,7 @@ import { useSession } from '@/lib/session';
 import { isAdminDid } from '@/lib/runtime-config';
 import { saveShops } from '@/lib/world-authoring';
 import { useAuthoredWorld } from '@/lib/use-authored-world';
+import { AuthoredWorldGate } from '@/components/admin/authored-world-gate';
 
 /**
  * **お店のラインナップエディタ** (#422)。
@@ -100,6 +101,7 @@ export function AdminShops() {
 
   return (
     <div className="admin-page" style={{ padding: '0.8em' }}>
+      <AuthoredWorldGate loaded={loaded}>
       <div className="admin-head">
         <Link to="/admin" style={{ fontSize: '0.8em' }}>← 管理</Link>
         <strong>お店のラインナップ</strong>
@@ -246,6 +248,7 @@ export function AdminShops() {
           </div>
         )}
       </div>
+      </AuthoredWorldGate>
     </div>
   );
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2102,6 +2102,17 @@ p { margin: 0.4em 0; }
   flex-wrap: wrap;
   margin-bottom: 0.4em;
 }
+/* 保存済みレコードを読み込むまで全操作を止める枠 (fieldset の見た目を消す) */
+.admin-gate {
+  display: block;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  min-width: 0;
+}
+.admin-gate:disabled {
+  opacity: 0.6;
+}
 /* 一覧 + フォームの 2 カラム */
 .admin-cols {
   display: grid;

--- a/packages/core/src/__tests__/world-refs.test.ts
+++ b/packages/core/src/__tests__/world-refs.test.ts
@@ -13,14 +13,20 @@ import { setInteriors, WORLD_MAP_ID } from '../interior.js';
 import { setScenario } from '../scenario.js';
 import { MONSTERS, ITEMS } from '../battle.js';
 import { EQUIPMENT } from '../equipment.js';
+import { activeEquipment, activeItems, setItemOverrides } from '../item-data.js';
 
 const MON = MONSTERS[0]!.id;
 const MON2 = MONSTERS[1]!.id;
-const [ITEM, ITEM2, ITEM3, ITEM4, ITEM5, ITEM6] = Object.keys(ITEMS) as [string, string, string, string, string, string];
+/** テスト専用の品 (誰もドロップしない = 参照元がこのテストの定義だけになる)。 */
+const TEST_ITEMS = ['t-item-1', 't-item-2', 't-item-3', 't-item-4', 't-item-5', 't-item-6'] as const;
+const [ITEM, ITEM2, ITEM3, ITEM4, ITEM5, ITEM6] = TEST_ITEMS;
+const DROPPER = MONSTERS.find((m) => m.drops.length > 0)!;
+const DROP_ITEM = DROPPER.drops[0]!.item;
 const EQ = EQUIPMENT[0]!.id;
 const EQ2 = EQUIPMENT[1]!.id;
 
 beforeEach(() => {
+  setItemOverrides({ items: [...activeItems(), ...TEST_ITEMS.map((id) => ({ id, name: id }))], equipment: [...activeEquipment()] });
   setNpcs([
     { id: 'n1', name: 'そんちょう', x: 1, y: 1, lines: ['やあ'] },
     { id: 'n2', name: 'むらびと', x: 2, y: 1, lines: ['やあ'], altLines: [{ items: [{ itemId: ITEM4 }], lines: ['それを持っているのか'] }] },
@@ -44,6 +50,7 @@ afterEach(() => {
   setShopOverrides(null);
   setGameQuests(null);
   setNpcs(null);
+  setItemOverrides(null);
 });
 
 const froms = (kind: Parameters<typeof worldRefs>[0], id: string) => worldRefs(kind).filter((r) => r.id === id).map((r) => r.from);
@@ -66,6 +73,10 @@ describe('worldRefs: 参照の種類ごとに全部挙がる', () => {
     expect(froms('item', ITEM4)).toEqual(['NPC「むらびと」のセリフ', 'シナリオ「はじまり」']);
     expect(froms('item', ITEM5)).toEqual(['店 (10, 10)']);
     expect(froms('item', ITEM6)).toEqual(['店 (10, 10)']);
+  });
+
+  it('アイテム ← モンスターのドロップ', () => {
+    expect(froms('item', DROP_ITEM)).toContain(`モンスター「${DROPPER.name}」のドロップ`);
   });
 
   it('装備 ← 店のラインナップ', () => {
@@ -105,6 +116,12 @@ describe('danglingRefs: 残す id への参照は挙がらない', () => {
       [ITEM5, '店 (10, 10)'],
       [ITEM3, `ゲート (${WORLD_MAP_ID} 1,1)`],
     ]);
+  });
+
+  it('ドロップ先のアイテムを消すと、そのモンスターが挙がる', () => {
+    const refs = danglingRefs('item', Object.keys(ITEMS).filter((id) => id !== DROP_ITEM));
+    expect(refs.map((r) => r.from)).toContain(`モンスター「${DROPPER.name}」のドロップ`);
+    expect(refs.every((r) => r.id === DROP_ITEM)).toBe(true);
   });
 
   it('参照されている装備を消すと、その店が挙がる', () => {

--- a/packages/core/src/__tests__/world-refs.test.ts
+++ b/packages/core/src/__tests__/world-refs.test.ts
@@ -1,0 +1,115 @@
+/**
+ * ワールド定義どうしの逆参照 (#603)。守るべき不変条件:
+ * - **参照されている id は「切れる参照」として全部挙がる** (参照の種類ごとに 1 件も抜けない)
+ * - 残す id への参照は挙がらない (消していないのに保存を拒否しない)
+ * - 参照元の説明はエディタにそのまま出せる
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { danglingRefs, describeDanglingRef, worldRefs } from '../world-refs.js';
+import { setGameQuests } from '../quest-data.js';
+import { setNpcs } from '../npc-data.js';
+import { setShopOverrides } from '../shop-data.js';
+import { setInteriors, WORLD_MAP_ID } from '../interior.js';
+import { setScenario } from '../scenario.js';
+import { MONSTERS, ITEMS } from '../battle.js';
+import { EQUIPMENT } from '../equipment.js';
+
+const MON = MONSTERS[0]!.id;
+const MON2 = MONSTERS[1]!.id;
+const [ITEM, ITEM2, ITEM3, ITEM4, ITEM5, ITEM6] = Object.keys(ITEMS) as [string, string, string, string, string, string];
+const EQ = EQUIPMENT[0]!.id;
+const EQ2 = EQUIPMENT[1]!.id;
+
+beforeEach(() => {
+  setNpcs([
+    { id: 'n1', name: 'そんちょう', x: 1, y: 1, lines: ['やあ'] },
+    { id: 'n2', name: 'むらびと', x: 2, y: 1, lines: ['やあ'], altLines: [{ items: [{ itemId: ITEM4 }], lines: ['それを持っているのか'] }] },
+  ]);
+  setGameQuests([
+    { id: 'q1', title: 'たいじ', npcId: 'n1', intro: ['たのむ'], done: ['ありがとう'], objective: { kind: 'defeat', monsterId: MON, count: 3 } },
+    {
+      id: 'q2', title: 'あつめ', npcId: 'n2', intro: ['たのむ'], done: ['ありがとう'],
+      objective: { kind: 'collect', itemId: ITEM, count: 2 },
+      reward: { itemId: ITEM2, count: 1 },
+      requireItems: [{ itemId: ITEM3 }],
+    },
+  ]);
+  setShopOverrides([{ x: 10, y: 10, equipment: [EQ], consumables: [ITEM5], materialId: ITEM6 }]);
+  setInteriors([], [{ from: { mapId: WORLD_MAP_ID, x: 1, y: 1 }, to: { mapId: WORLD_MAP_ID, x: 2, y: 2 }, requireItems: [{ itemId: ITEM3, count: 2 }] }]);
+  setScenario([{ id: 'e1', title: 'はじまり', when: [{ kind: 'questDone', questId: 'q1' }, { kind: 'itemCount', itemId: ITEM4, count: 1 }], setFlags: ['started'] }]);
+});
+afterEach(() => {
+  setScenario(null);
+  setInteriors(null, null);
+  setShopOverrides(null);
+  setGameQuests(null);
+  setNpcs(null);
+});
+
+const froms = (kind: Parameters<typeof worldRefs>[0], id: string) => worldRefs(kind).filter((r) => r.id === id).map((r) => r.from);
+
+describe('worldRefs: 参照の種類ごとに全部挙がる', () => {
+  it('NPC ← クエストの発注者', () => {
+    expect(froms('npc', 'n1')).toEqual(['クエスト「たいじ」']);
+    expect(froms('npc', 'n2')).toEqual(['クエスト「あつめ」']);
+  });
+
+  it('モンスター ← クエストの討伐条件', () => {
+    expect(froms('monster', MON)).toEqual(['クエスト「たいじ」']);
+    expect(froms('monster', MON2)).toEqual([]);
+  });
+
+  it('アイテム ← クエスト (収集/報酬/解禁)・店 (どうぐ/素材)・ゲート・NPC のセリフ・シナリオ', () => {
+    expect(froms('item', ITEM)).toEqual(['クエスト「あつめ」']);
+    expect(froms('item', ITEM2)).toEqual(['クエスト「あつめ」']);
+    expect(froms('item', ITEM3)).toEqual(['クエスト「あつめ」', `ゲート (${WORLD_MAP_ID} 1,1)`]);
+    expect(froms('item', ITEM4)).toEqual(['NPC「むらびと」のセリフ', 'シナリオ「はじまり」']);
+    expect(froms('item', ITEM5)).toEqual(['店 (10, 10)']);
+    expect(froms('item', ITEM6)).toEqual(['店 (10, 10)']);
+  });
+
+  it('装備 ← 店のラインナップ', () => {
+    expect(froms('equipment', EQ)).toEqual(['店 (10, 10)']);
+    expect(froms('equipment', EQ2)).toEqual([]);
+  });
+
+  it('クエスト ← シナリオの達成条件', () => {
+    expect(froms('quest', 'q1')).toEqual(['シナリオ「はじまり」']);
+    expect(froms('quest', 'q2')).toEqual([]);
+  });
+});
+
+describe('danglingRefs: 残す id への参照は挙がらない', () => {
+  it('全部残せば空', () => {
+    expect(danglingRefs('monster', MONSTERS.map((m) => m.id))).toEqual([]);
+    expect(danglingRefs('item', Object.keys(ITEMS))).toEqual([]);
+    expect(danglingRefs('equipment', EQUIPMENT.map((e) => e.id))).toEqual([]);
+    expect(danglingRefs('npc', ['n1', 'n2'])).toEqual([]);
+    expect(danglingRefs('quest', ['q1', 'q2'])).toEqual([]);
+  });
+
+  it('参照されているモンスターを消すと、そのクエストが挙がる', () => {
+    const refs = danglingRefs('monster', MONSTERS.filter((m) => m.id !== MON).map((m) => m.id));
+    expect(refs).toEqual([{ kind: 'monster', id: MON, from: 'クエスト「たいじ」' }]);
+    expect(describeDanglingRef(refs[0]!)).toBe(`保存できない: クエスト「たいじ」がモンスター「${MON}」を参照している。先にそちらを直す`);
+  });
+
+  it('参照されていないモンスターを消しても空', () => {
+    expect(danglingRefs('monster', MONSTERS.filter((m) => m.id !== MON2).map((m) => m.id))).toEqual([]);
+  });
+
+  it('参照されているアイテムを消すと、参照元が全部挙がる (店のラインナップ含む)', () => {
+    const keep = Object.keys(ITEMS).filter((id) => id !== ITEM3 && id !== ITEM5);
+    expect(danglingRefs('item', keep).map((r) => [r.id, r.from])).toEqual([
+      [ITEM3, 'クエスト「あつめ」'],
+      [ITEM5, '店 (10, 10)'],
+      [ITEM3, `ゲート (${WORLD_MAP_ID} 1,1)`],
+    ]);
+  });
+
+  it('参照されている装備を消すと、その店が挙がる', () => {
+    expect(danglingRefs('equipment', EQUIPMENT.filter((e) => e.id !== EQ).map((e) => e.id))).toEqual([
+      { kind: 'equipment', id: EQ, from: '店 (10, 10)' },
+    ]);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,7 @@ export * from './item-data.js';
 export * from './shop-data.js';
 export * from './npc-data.js';
 export * from './quest-data.js';
+export * from './world-refs.js';
 export * from './part-presets.js';
 export * from './job-data.js';
 export * from './interior.js';

--- a/packages/core/src/world-refs.ts
+++ b/packages/core/src/world-refs.ts
@@ -10,6 +10,7 @@
  * どの定義がどの id を参照するかの知識は**このファイルだけ**が持つ — 各エディタに
  * 同じ列挙を書くと、参照の種類が増えたときに片方だけ抜ける。
  */
+import { MONSTERS } from './battle.js';
 import { allGates } from './interior.js';
 import { allNpcs } from './npc-data.js';
 import { gameQuests } from './quest-data.js';
@@ -59,6 +60,10 @@ export function worldRefs(kind: WorldRefKind): WorldRef[] {
     }
   }
   if (kind === 'item') {
+    // ドロップ先が消えると、勝利のたびに存在しない id が素材に入る (検証は id の実在を見ない)。
+    for (const m of MONSTERS) {
+      for (const d of m.drops) push(d.item, `モンスター「${m.name}」のドロップ`);
+    }
     for (const g of allGates()) {
       for (const r of g.requireItems ?? []) push(r.itemId, `ゲート (${g.from.mapId} ${g.from.x},${g.from.y})`);
     }

--- a/packages/core/src/world-refs.ts
+++ b/packages/core/src/world-refs.ts
@@ -1,0 +1,91 @@
+/**
+ * **ワールド定義どうしの逆参照** (#603)。「この id を消したら誰が困るか」を 1 か所で答える。
+ *
+ * 各定義の検証 (setGameQuests / setShopOverrides / setInteriors / setNpcs / setScenario) は
+ * **参照切れが 1 件でもあると全体を落とす**。そのため参照されている定義をエディタで
+ * 消して保存すると、次の読み込みで参照元のセットが web / edge からまるごと消える
+ * (モンスターを 1 体消したら全クエストが消える、など)。
+ *
+ * エディタは保存前にここで逆参照を引き、参照が残っていれば保存を拒否する。
+ * どの定義がどの id を参照するかの知識は**このファイルだけ**が持つ — 各エディタに
+ * 同じ列挙を書くと、参照の種類が増えたときに片方だけ抜ける。
+ */
+import { allGates } from './interior.js';
+import { allNpcs } from './npc-data.js';
+import { gameQuests } from './quest-data.js';
+import { scenarioEvents } from './scenario.js';
+import { shopOverrides } from './shop-data.js';
+
+/** 参照される側の種類。 */
+export type WorldRefKind = 'npc' | 'monster' | 'item' | 'equipment' | 'quest';
+
+/** 参照 1 本。`from` はエディタにそのまま出せる参照元の説明。 */
+export interface WorldRef {
+  kind: WorldRefKind;
+  id: string;
+  from: string;
+}
+
+const KIND_LABELS: Record<WorldRefKind, string> = {
+  npc: 'NPC',
+  monster: 'モンスター',
+  item: 'アイテム',
+  equipment: '装備',
+  quest: 'クエスト',
+};
+
+/** 読み込み済みの定義から、その種類への参照をすべて列挙する。 */
+export function worldRefs(kind: WorldRefKind): WorldRef[] {
+  const out: WorldRef[] = [];
+  const push = (id: string | undefined, from: string) => {
+    if (id !== undefined) out.push({ kind, id, from });
+  };
+  for (const q of gameQuests()) {
+    const from = `クエスト「${q.title}」`;
+    if (kind === 'npc') push(q.npcId, from);
+    if (kind === 'monster' && q.objective.kind === 'defeat') push(q.objective.monsterId, from);
+    if (kind === 'item') {
+      if (q.objective.kind === 'collect') push(q.objective.itemId, from);
+      push(q.reward?.itemId, from);
+      for (const r of q.requireItems ?? []) push(r.itemId, from);
+    }
+  }
+  for (const s of shopOverrides()) {
+    const from = `店 (${s.x}, ${s.y})`;
+    if (kind === 'equipment') for (const id of s.equipment ?? []) push(id, from);
+    if (kind === 'item') {
+      for (const id of s.consumables ?? []) push(id, from);
+      push(s.materialId, from);
+    }
+  }
+  if (kind === 'item') {
+    for (const g of allGates()) {
+      for (const r of g.requireItems ?? []) push(r.itemId, `ゲート (${g.from.mapId} ${g.from.x},${g.from.y})`);
+    }
+    for (const n of allNpcs()) {
+      for (const a of n.altLines ?? []) for (const r of a.items ?? []) push(r.itemId, `NPC「${n.name}」のセリフ`);
+    }
+  }
+  for (const e of scenarioEvents()) {
+    const from = `シナリオ「${e.title}」`;
+    for (const c of e.when) {
+      if (kind === 'item' && c.kind === 'itemCount') push(c.itemId, from);
+      if (kind === 'quest' && c.kind === 'questDone') push(c.questId, from);
+    }
+  }
+  return out;
+}
+
+/**
+ * `keep` に無い id への参照 = **保存すると切れる参照**。エディタは削除後の一覧を渡し、
+ * 1 件でも返ったら保存を拒否する。
+ */
+export function danglingRefs(kind: WorldRefKind, keep: Iterable<string>): WorldRef[] {
+  const ids = new Set(keep);
+  return worldRefs(kind).filter((r) => !ids.has(r.id));
+}
+
+/** エディタの拒否メッセージ (どこが・何を参照しているか)。 */
+export function describeDanglingRef(r: WorldRef): string {
+  return `保存できない: ${r.from}が${KIND_LABELS[r.kind]}「${r.id}」を参照している。先にそちらを直す`;
+}


### PR DESCRIPTION
Refs #603 (admin-npcs への展開が残るため Closes にしない)

## 概要

管理エディタ横断の 2 つの穴を塞ぐ。

### A. 逆参照チェック (保存時)

- **core に 1 か所**: `packages/core/src/world-refs.ts` の `worldRefs(kind)` / `danglingRefs(kind, keep)` / `describeDanglingRef(ref)`。「この id を誰が参照しているか」の列挙はここだけが持つ
  - `npc` ← クエストの発注者
  - `monster` ← クエストの討伐条件
  - `item` ← クエスト (収集 / 報酬 / 解禁)・店 (どうぐ / 値札の素材)・ゲート・NPC のセリフ・シナリオ・**モンスターのドロップ**
  - `equipment` ← 店のラインナップ
  - `quest` ← シナリオの達成条件
- **admin-monsters**: 削除するモンスターがクエストの討伐条件なら保存を拒否し、どのクエストかを出す
- **admin-items**: 削除するアイテムがクエストの収集/報酬、店のラインナップ、モンスターのドロップから参照されていたら拒否。従来の手書き列挙 (requireItems だけ見ていた) を `danglingRefs('item')` + `danglingRefs('equipment')` に置き換え (装備 ← 店 も新たに塞がる)
- **admin-quests**: シナリオ参照チェックも同じ関数に寄せる (契約を 2 か所に置かない)
- core テスト 12 件 (種類ごとの列挙が抜けない / 残す id は挙がらない / メッセージ)

### B. 読み込み前上書きの防止

- `apps/web/src/lib/use-authored-world.ts` に「マウント時 (と agent 変化時) に `loadAuthoredWorld` → 完了まで `false`、完了で `reset` を呼んで一覧を現物から取り直す」を切り出し
- `apps/web/src/components/admin/authored-world-gate.tsx` (`fieldset[disabled]`) で **完了までエディタの全操作を止め「読み込み中」を出す** (完了前に始めた編集が reset で消えない)
- admin-monsters / admin-items / admin-shops / admin-quests の 4 画面に適用 (admin-quests の既存 useEffect も同じ hook に寄せる)
- admin-shops は街の一覧 (`worldOverlay().towns`) も読み込み後に取り直す (直接開くと空だった)
- hook テスト 4 件 (jsdom: 完了前 false / 失敗でも true / agent 変化で読み直し / アンマウント後は reset しない)

### 残件

- **admin-npcs への展開は #613 マージ後に追う** (別 PR が同時に編集中で衝突するため触っていない)。同じ hook + gate と `danglingRefs('npc')` に寄せるだけ
- レコード読み込みが 1 本でも失敗すると (`getRecord` 5xx → `console.warn` で握り潰し) `loaded=true` になりコード直書き状態で保存できる → **#652**

## Review

1 観点 (実装) で実施。222683e で対応:

**★★★ (PR 内で修正)**
- web-ci 赤: `use-authored-world.ts` の `void loadAuthoredWorld(agent).finally(...)` が reject を伝播し、テストの reject ケースが Unhandled Rejection → vitest exit 1。hook 側で `.then(done, done)` として吸収 (テストは残す) → 222683e

**★★ (PR 内で修正)**
- 読み込み完了前に始めた編集が `reset` で黙って消える (URL 直打ちの数秒間は入力欄が有効): `AuthoredWorldGate` (`fieldset[disabled]`) で完了まで全操作を止め「読み込み中」を表示。4 画面共通 → 222683e
- 逆参照の漏れ: `worldRefs('item')` にモンスターのドロップ (`MONSTERS[].drops[].item`) が無く、ドロップ先の品を消して保存できた: drops を追加 (from は「モンスター『名前』のドロップ」)。core テスト 2 件追加 → 222683e

**★★ (issue 化)**
- レコード読み込みが 1 本でも失敗すると `loaded=true` になりコード直書き状態で保存できる (PDS の保存済み編集が全消し) → #652

## テスト

- `pnpm --filter @aozoraquest/core typecheck` exit 0 / `test` exit 0 (39 files)
- `pnpm --filter @aozoraquest/web typecheck` exit 0 / `test` exit 0 (44 files、Unhandled Rejection なし)
- eslint: 0 errors (`useMemo` の `loaded` 依存 warning は admin-quests の既存パターンと同じ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXHZbULKCqUhgx1NCi6kZ7
