### PR TITLE
fix(edge,web): 重複 XP 申告を書かず、落ちた投稿申告の保留を 1 か所に寄せる (Refs #548)

### DIFF
--- a/apps/edge/src/game-state.ts
+++ b/apps/edge/src/game-state.ts
@@ -185,7 +185,16 @@ export interface RmwOptions {
  * InvalidSwap (別リクエストが割り込んで CID が変わった) の時は最新を読み直して mutate をやり直す。
  * → 「古い意思決定のまま上書き」して二重報酬/二重消費が通るのを防ぐ (§4.1 の契約)。
  * mutate は**副作用を持たず**、毎回新しい state を返す純関数であること (リトライで複数回呼ばれる)。
- * 書き込みトークンが無い/失効は server-pds が ServerWriteError で fail-closed に倒す。
+ * 書き込みトークンが無い/失効は server-pds が fail-closed に倒す (ServerWriteError)。
+ *
+ * **変更なしの契約 (#548)**: mutate が**受け取った state をそのまま返した**ら「何もしない」の合図で、
+ * PDS には書かない (既存の state をそのまま返す)。重複申告・再受注・処理済みの店操作など、
+ * 冪等に弾く経路はすべて `return cur` で表す。判定はここ 1 か所 — 各 mutate に個別の
+ * 「書かない」分岐を持たせない。
+ * 書かない理由は書き込み量: 1 put = サーバーアカウント repo への 1 コミットで、repo 単位で
+ * 直列化される。localStorage が消えた端末が `/me` を開くたびに重複申告が最大 10 件飛ぶと、
+ * 中身の変わらないコミットが 10 個積まれていた。
+ * state がまだ無いとき (init から作った直後) は「変更なし」でも書く — レコードの作成自体が変更。
  */
 export async function readModifyWrite(
   env: GameStateEnv,
@@ -200,7 +209,9 @@ export async function readModifyWrite(
   for (let attempt = 0; attempt <= retries; attempt++) {
     const existing = await readState(env, targetDid);
     const current = existing?.state ?? (await init(targetDid, nowIso));
-    const next: GameState = { ...mutate(current), did: targetDid, version: GAME_STATE_VERSION, updatedAt: nowIso };
+    const mutated = mutate(current);
+    if (existing && mutated === current) return current; // 変更なし: 書かない (契約は doc 参照)
+    const next: GameState = { ...mutated, did: targetDid, version: GAME_STATE_VERSION, updatedAt: nowIso };
     // 既存があればその CID を期待 (CAS)、無ければ null (新規作成のみ) で二重作成も防ぐ。
     const swap = existing ? existing.cid : null;
     try {

--- a/apps/edge/test/game-state.test.ts
+++ b/apps/edge/test/game-state.test.ts
@@ -162,6 +162,30 @@ describe('game-state (OAuth 権威書き込み)', () => {
     expect(puts).toBe(2); // 1回目 InvalidSwap で再試行 → 2回目 401 で打ち止め (spin しない)
   });
 
+  it('mutate が受け取った state をそのまま返したら書かない (変更なしの契約 #548)', async () => {
+    const env = await makeEnv();
+    let puts = 0;
+    globalThis.fetch = (async (url: string) => {
+      if (url.includes('getRecord')) return jsonRes(200, { uri: 'x', cid: 'cidA', value: existingRec });
+      puts++;
+      return jsonRes(200, { uri: 'x', cid: 'cidB' });
+    }) as unknown as typeof fetch;
+    const out = await readModifyWrite(env, DID, (c) => c, { now: NOW });
+    expect(puts).toBe(0);
+    expect(out.power).toBe(5); // 既存の state をそのまま返す
+    // 同じ内容でも**別オブジェクト**を返したら書く (同一参照だけが合図。深い比較はしない)
+    await readModifyWrite(env, DID, (c) => ({ ...c }), { now: NOW });
+    expect(puts).toBe(1);
+  });
+
+  it('state が無いときは変更なしでも作成する (レコードの作成自体が変更)', async () => {
+    const env = await makeEnv();
+    const m = statefulPds();
+    globalThis.fetch = m.fn;
+    await readModifyWrite(env, DID, (c) => c, { now: NOW });
+    expect(m.store.get(rkeyForDid(DID))).toBeTruthy();
+  });
+
   it('書き込みトークン未 bootstrap は fail-closed (ServerWriteError)', async () => {
     const env = await makeEnv();
     (env as { OAUTH_TOKENS?: KVNamespace }).OAUTH_TOKENS = mockKv(); // 空 = 未 bootstrap

--- a/apps/edge/test/xp-claim.test.ts
+++ b/apps/edge/test/xp-claim.test.ts
@@ -142,10 +142,26 @@ describe('claimXp (投稿の申告)', () => {
     const store = new Map<string, { value: unknown; cid: string }>();
     globalThis.fetch = pdsWithPost(store);
     const first = await claimXp(env, DID, { archetype: 'warrior', postUri: postUri('a') }, NOW);
+    const cidAfterFirst = store.get(rkeyForDid(DID))!.cid;
     const again = await claimXp(env, DID, { archetype: 'warrior', postUri: postUri('a') }, NOW);
     expect(again.granted).toBe(0);
     expect(again.duplicate).toBe(true);
     expect(again.jobXp).toBe(first.jobXp);
+    // **重複は書かない** (#548)。localStorage を失った端末が /me を開くたびに同じ申告を
+    // 最大 10 件送るので、中身の変わらないコミットをサーバー repo に積まない。
+    expect(store.get(rkeyForDid(DID))!.cid).toBe(cidAfterFirst);
+  });
+
+  it('新しい投稿の申告は書く (変更なし判定が本物の申告を落とさない)', async () => {
+    const env = await makeEnv();
+    const store = new Map<string, { value: unknown; cid: string }>();
+    globalThis.fetch = pdsWithPost(store);
+    await claimXp(env, DID, { archetype: 'warrior', postUri: postUri('a') }, NOW);
+    const cidAfterA = store.get(rkeyForDid(DID))!.cid;
+    const b = await claimXp(env, DID, { archetype: 'warrior', postUri: postUri('b') }, NOW);
+    expect(b.granted).toBe(XP_REWARDS.postMatch);
+    expect(store.get(rkeyForDid(DID))!.cid).not.toBe(cidAfterA);
+    expect(stored(store).xpClaims).toContain(`post:${postUri('b')}`);
   });
 
   it('連続日数はサーバーが数える (client の申告を使わない)', async () => {

--- a/apps/web/src/lib/__tests__/pending-claims.test.ts
+++ b/apps/web/src/lib/__tests__/pending-claims.test.ts
@@ -7,7 +7,7 @@ const mem = new Map<string, string>();
   setItem: (k: string, v: string) => { mem.set(k, v); },
   removeItem: (k: string) => { mem.delete(k); },
 } as Storage;
-import { rememberPendingClaim, forgetPendingClaim, pendingClaims, flushPendingClaims, clearPendingClaims } from '../pending-claims';
+import { rememberPendingClaim, forgetPendingClaim, pendingClaims, flushPendingClaims, clearPendingClaims, claimPostXp } from '../pending-claims';
 
 describe('申告できなかった投稿の出し直し (#551)', () => {
   beforeEach(() => clearPendingClaims());
@@ -44,6 +44,43 @@ describe('申告できなかった投稿の出し直し (#551)', () => {
 
   it('古すぎるものは捨てる (サーバーの年齢制限に当たるので送っても無駄)', () => {
     rememberPendingClaim({ postUri: 'at://me/app.bsky.feed.post/old', archetype: 'warrior', at: Date.now() - 5 * 24 * 3600 * 1000 });
+    expect(pendingClaims()).toHaveLength(0);
+  });
+
+  it('申告が落ちたら保留に残り、次の申告機会で出し直され、成功で保留から消える (#548)', async () => {
+    const sent: string[] = [];
+    let online = false;
+    const send = async (c: { postUri: string; archetype: string }) => {
+      sent.push(c.postUri);
+      if (!online) throw new Error('edge down');
+      return { granted: 10, jobXp: 10, duplicate: false, power: 1, streakDays: 1 };
+    };
+    // 1 回目: edge が落ちている → null を返して (投稿処理は続く) 保留に残る
+    const r1 = await claimPostXp(send, { postUri: 'at://me/app.bsky.feed.post/a', archetype: 'warrior' });
+    expect(r1).toBeNull();
+    expect(pendingClaims().map((c) => c.postUri)).toEqual(['at://me/app.bsky.feed.post/a']);
+    // 2 回目 (次の投稿): 復旧している → 先に a を出し直し、b も申告し、保留は空になる
+    online = true;
+    sent.length = 0;
+    const r2 = await claimPostXp(send, { postUri: 'at://me/app.bsky.feed.post/b', archetype: 'warrior' });
+    expect(r2?.granted).toBe(10);
+    expect(sent).toEqual(['at://me/app.bsky.feed.post/a', 'at://me/app.bsky.feed.post/b']);
+    expect(pendingClaims()).toHaveLength(0);
+  });
+
+  it('出し直しが失敗しても今回の申告は試み、落ちたら両方を保留に残す', async () => {
+    rememberPendingClaim({ postUri: 'at://me/app.bsky.feed.post/a', archetype: 'warrior', at: Date.now() });
+    const r = await claimPostXp(async () => { throw new Error('edge down'); }, { postUri: 'at://me/app.bsky.feed.post/b', archetype: 'warrior' });
+    expect(r).toBeNull();
+    expect(pendingClaims().map((c) => c.postUri).sort()).toEqual(['at://me/app.bsky.feed.post/a', 'at://me/app.bsky.feed.post/b']);
+  });
+
+  it('投稿 URI が無くても溜まっている申告は出し直す', async () => {
+    rememberPendingClaim({ postUri: 'at://me/app.bsky.feed.post/a', archetype: 'warrior', at: Date.now() });
+    const sent: string[] = [];
+    const r = await claimPostXp(async (c) => { sent.push(c.postUri); return 1; }, null);
+    expect(r).toBeNull();
+    expect(sent).toEqual(['at://me/app.bsky.feed.post/a']);
     expect(pendingClaims()).toHaveLength(0);
   });
 

--- a/apps/web/src/lib/pending-claims.ts
+++ b/apps/web/src/lib/pending-claims.ts
@@ -78,6 +78,31 @@ export async function flushPendingClaims(
   return done;
 }
 
+/**
+ * **投稿の XP を申告する唯一の入口。** 前に落ちた申告を先に出し直し、今回の申告が落ちたら
+ * 覚えておく。post-processor はこれを呼ぶだけで、保留の出し入れを自分では触らない
+ * (申告の経路が増えても保留の扱いが 1 か所に留まる)。
+ *
+ * `send` が投げたら null (投稿処理は続ける — edge が落ちている間でも投稿は成立させたい)。
+ * `c` が null なら出し直しだけ行う。
+ */
+export async function claimPostXp<T>(
+  send: (c: Pick<PendingClaim, 'postUri' | 'archetype'>) => Promise<T>,
+  c: Pick<PendingClaim, 'postUri' | 'archetype'> | null,
+): Promise<T | null> {
+  await flushPendingClaims((p) => send(p).then(() => undefined));
+  if (!c) return null;
+  try {
+    const r = await send(c);
+    forgetPendingClaim(c.postUri);
+    return r;
+  } catch (e) {
+    console.warn('xp claim failed', c.postUri, e);
+    rememberPendingClaim({ ...c, at: Date.now() });
+    return null;
+  }
+}
+
 /** テスト用: 記録を消す。 */
 export function clearPendingClaims(): void {
   try { localStorage.removeItem(KEY); } catch { /* no-op */ }

--- a/apps/web/src/lib/post-processor.ts
+++ b/apps/web/src/lib/post-processor.ts
@@ -34,7 +34,7 @@ import { classifyCognitiveFromVec } from './cognitive-classifier';
 import { Embedder } from './embedder';
 import { getRecord, putRecord } from './atproto';
 import { serverClaimXp } from './world-server';
-import { flushPendingClaims, forgetPendingClaim, rememberPendingClaim } from './pending-claims';
+import { claimPostXp } from './pending-claims';
 import { deriveActionTypes, type PostStructure } from './structural-action';
 
 export interface QuestLogEntry {
@@ -270,25 +270,16 @@ export async function processSelfPost(
       // 認知スコアのブレンド・streak・playerLevel の更新ごと失われる。
       claim = async () => {
         const arch = analysis.archetype;
-        // 前に落ちた申告があれば先に出し直す (サーバーは冪等なので安全)。
-        await flushPendingClaims((c) => serverClaimXp(agent, { archetype: c.archetype, postUri: c.postUri }).then(() => undefined));
-        if (!postUri) return;
-        try {
-          // **額は送らない。** サーバーが投稿の実在を確かめてから決める (#551)。
-          const r = await serverClaimXp(agent, { archetype: arch, postUri });
-          forgetPendingClaim(postUri);
-          if (r.granted > 0) {
-            // レベルアップ判定は**権威 state の値**で行う。
-            const before = jobLevelFromXp(r.jobXp - r.granted, arch);
-            const after = jobLevelFromXp(r.jobXp, arch);
-            if (after > before) jobLeveledUp = { from: before, to: after };
-            finalJobLevel = { archetype: arch, xp: r.jobXp, joinedAt: oldJob.joinedAt };
-          }
-        } catch (e) {
-          console.warn('xp claim failed', e);
-          // **覚えておいて次の投稿で出し直す。** ここで諦めると、PDS の一時障害だけで
-          // その投稿の XP が永久に消える (申告は投稿時にしか走らないため)。
-          rememberPendingClaim({ postUri, archetype: arch, at: Date.now() });
+        // **額は送らない。** サーバーが投稿の実在を確かめてから決める (#551)。
+        // 落ちた申告の保留と出し直しは claimPostXp が持つ (#548)。ここで諦めると、
+        // PDS の一時障害だけでその投稿の XP が永久に消える (申告は投稿時にしか走らないため)。
+        const r = await claimPostXp((c) => serverClaimXp(agent, c), postUri ? { archetype: arch, postUri } : null);
+        if (r && r.granted > 0) {
+          // レベルアップ判定は**権威 state の値**で行う。
+          const before = jobLevelFromXp(r.jobXp - r.granted, arch);
+          const after = jobLevelFromXp(r.jobXp, arch);
+          if (after > before) jobLeveledUp = { from: before, to: after };
+          finalJobLevel = { archetype: arch, xp: r.jobXp, joinedAt: oldJob.joinedAt };
         }
       };
 


### PR DESCRIPTION
Refs #548 (投稿の実在検証は #555 で対応済み。本 PR は残りのうち A/B の 2 点)

## A. 重複申告でも CAS 書き込みが走る (edge)

- `readModifyWrite` に **「mutate が受け取った state をそのまま (同一参照で) 返したら PDS に書かない」** の契約を 1 か所で入れた (`apps/edge/src/game-state.ts`)。各 mutate に個別の分岐は足していない — 既存の `return cur` (重複申告・再受注・処理済みの店操作・処理済みの探索) がそのまま「書かない」の合図になる。
- state がまだ無いとき (init 直後) は「変更なし」でも作成する (レコードの作成自体が変更)。
- 他の mutate は毎回スプレッドで新しいオブジェクトを返しているので挙動は変わらない。`lastPostAt` 等の副作用フィールドは新規申告のときだけ更新されており、重複時は触っていない (確認済み)。
- テスト: `game-state.test.ts` (同一参照 → put 0 回 / 別オブジェクト → put する / state 無し → 作成する)、`xp-claim.test.ts` (同じ申告 2 回目は CID が変わらない / 新規申告は書かれる)。

## B. 投稿 XP 申告のリトライ (web)

- 保留機構 `pending-claims.ts` (#555 で入っていた) に申告の入口 `claimPostXp(send, claim)` を足し、**前に落ちた申告の出し直し → 今回の申告 → 失敗なら保留 / 成功なら保留から消す** をそこに集約。`post-processor.ts` はこれを呼ぶだけになった (保留の出し入れを自分で触らない)。
- テスト: `pending-claims.test.ts` (申告失敗 → 保留に残る → 次の申告機会で先に出し直される → 成功で保留から消える / 出し直しも今回も落ちたら両方保留 / 投稿 URI 無しでも出し直しはする)。

## 残件 (別 PR)

- `xpClaims` キーの sha256 化 (権威 state の形式変更を伴う)
- レート制限本体 (docs/21 §10 の権威 state 内カウンタ)

## テスト

- `pnpm --filter @aozoraquest/edge typecheck && test`: 22 files / 260 tests 緑
- `pnpm --filter @aozoraquest/web typecheck && test`: 43 files / 397 tests 緑

## Review

subagent 1 観点 (実装)。**指摘なし** (★★★ / ★★ とも 0 件)。確認された点: 同一参照を返す mutate は全て冪等に弾く意図の経路で書かれるべきものは無い / in-place 変更は edge/src に 0 件 / state 未作成時は作成する / 戻り値の updatedAt・version を読む側は無い / claimPostXp は旧 post-processor と 1 対 1 で同じ挙動 / 削除・置換されたテスト無し / 保留機構は 1 つ。
