### PR TITLE
fix(web): NPC エディタも逆参照ガードと読み込み前ゲートに寄せる (#603)

### DIFF
--- a/apps/web/src/routes/admin-npcs.tsx
+++ b/apps/web/src/routes/admin-npcs.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import {
   allInteriors,
   allNpcs,
+  danglingRefs,
+  describeDanglingRef,
   facilityAt,
-  gameQuests,
   interiorById,
   interiorWalkableAt,
   isWalkableAt,
@@ -19,7 +20,9 @@ import {
 } from '@aozoraquest/core';
 import { useSession } from '@/lib/session';
 import { isAdminDid } from '@/lib/runtime-config';
-import { loadAuthoredWorld, saveNpcs } from '@/lib/world-authoring';
+import { saveNpcs } from '@/lib/world-authoring';
+import { useAuthoredWorld } from '@/lib/use-authored-world';
+import { AuthoredWorldGate } from '@/components/admin/authored-world-gate';
 import { TileArtEditor, type ArtSubject } from '@/components/admin/tile-art-editor';
 import { ItemReqInput } from '@/components/admin/item-req-input';
 
@@ -29,6 +32,10 @@ import { ItemReqInput } from '@/components/admin/item-req-input';
  * NPC はタイルを 1 つ占め、**歩いてぶつかると会話が始まる** (移動判定でも塞ぐ =
  * web と edge の両方が同じ一覧を読む)。絵はドット絵 (`npc:<id>`)、無ければ代替の人形。
  * フィールドのほか内部マップ (#424) にも置ける (#613)。
+ *
+ * 保存先は管理者 PDS の `world.npcs`。マウント時に `loadAuthoredWorld` を回し、読み込めるまで
+ * 編集も保存もさせない (直接開いて保存すると保存済みの編集を上書きする。#603)。
+ * アイテム・内部マップも同時に揃う (フラグ別セリフの持ち物条件と「マップ」の選択肢が引く)。
  */
 
 /** そのマップの範囲内か。フィールドはトーラスなのでどの整数でも範囲内。 */
@@ -65,20 +72,12 @@ export function AdminNpcs() {
   const [drawing, setDrawing] = useState(false);
   // 置けるマップの一覧 (内部マップは loadAuthoredWorld の後に揃う)。
   const [interiors, setInteriorList] = useState<readonly InteriorMap[]>(() => allInteriors());
+  const loaded = useAuthoredWorld(session.agent ?? null, () => {
+    setList(allNpcs().map((n) => ({ ...n, lines: [...n.lines] })));
+    setInteriorList(allInteriors());
+  });
 
   const current = useMemo(() => list.find((n) => n.id === sel) ?? null, [list, sel]);
-
-  // **アイテムを先に読む** — フラグ別セリフの持ち物条件が ITEMS を引くので、
-  // この画面を直接開くと保存が「アイテムが存在しない」で落ちる (レビュー ★★★)。
-  useEffect(() => {
-    let cancelled = false;
-    void loadAuthoredWorld(session.agent ?? null).finally(() => {
-      if (cancelled) return;
-      setList(allNpcs().map((n) => ({ ...n, lines: [...n.lines] })));
-      setInteriorList(allInteriors());
-    });
-    return () => { cancelled = true; };
-  }, [session.agent]);
 
   const update = useCallback((id: string, patch: Partial<NpcDef>) => {
     setList((xs) => xs.map((n) => (n.id === id ? { ...n, ...patch } : n)));
@@ -125,12 +124,11 @@ export function AdminNpcs() {
 
   const save = useCallback(async () => {
     if (!session.agent) return;
-    // クエストが発注させている NPC を消させない (#423。実装レビュー ★★) —
-    // 参照切れの NPC が 1 人でもいると setGameQuests が全体を落とす設計なので、
-    // 消した NPC と無関係な全クエストまで web/edge から消えてしまう。
-    const orphan = gameQuests().find((q) => !list.some((n) => n.id === q.npcId));
-    if (orphan) {
-      setNote(`保存できない: クエスト「${orphan.title}」が NPC (${orphan.npcId}) に発注させている。先にクエストを消すか発注者を変える`);
+    // クエストが発注させている NPC を消させない (#423 / #603) — 参照切れの NPC が 1 人でも
+    // いると setGameQuests が全体を落とし、消した NPC と無関係な全クエストまで web/edge から消える。
+    const dangling = danglingRefs('npc', list.map((n) => n.id))[0];
+    if (dangling) {
+      setNote(describeDanglingRef(dangling));
       return;
     }
     for (const n of list) {
@@ -183,12 +181,13 @@ export function AdminNpcs() {
 
   return (
     <div className="admin-page" style={{ padding: '0.8em' }}>
+      <AuthoredWorldGate loaded={loaded}>
       <div className="admin-head">
         <Link to="/admin" style={{ fontSize: '0.8em' }}>← 管理</Link>
         <strong>NPC</strong>
         <span style={{ fontSize: '0.75em', color: 'var(--color-muted)' }}>{list.length} 人</span>
         <button type="button" onClick={add} style={{ fontSize: '0.85em' }}>＋NPC</button>
-        <button type="button" onClick={() => void save()} disabled={!session.agent || !dirty} style={{ marginLeft: 'auto', fontSize: '0.85em' }}>
+        <button type="button" onClick={() => void save()} disabled={!session.agent || !dirty || !loaded} style={{ marginLeft: 'auto', fontSize: '0.85em' }}>
           保存
         </button>
       </div>
@@ -400,6 +399,7 @@ export function AdminNpcs() {
           <div style={{ fontSize: '0.85em', color: 'var(--color-muted)' }}>左の一覧から選ぶか「＋NPC」。</div>
         )}
       </div>
+      </AuthoredWorldGate>
     </div>
   );
 }

--- a/packages/core/src/__tests__/world-refs.test.ts
+++ b/packages/core/src/__tests__/world-refs.test.ts
@@ -105,6 +105,14 @@ describe('danglingRefs: 残す id への参照は挙がらない', () => {
     expect(describeDanglingRef(refs[0]!)).toBe(`保存できない: クエスト「たいじ」がモンスター「${MON}」を参照している。先にそちらを直す`);
   });
 
+  it('参照されている NPC を消すと、そのクエストが挙がる (NPC エディタが保存前に引く形)', () => {
+    // n2 を消す = 残すのは n1 だけ。NPC を参照するのはクエストの発注者のみ
+    // (シナリオ条件・店・ゲートに NPC 参照は無い) なので、挙がるのは q2 の 1 本。
+    const refs = danglingRefs('npc', ['n1']);
+    expect(refs).toEqual([{ kind: 'npc', id: 'n2', from: 'クエスト「あつめ」' }]);
+    expect(describeDanglingRef(refs[0]!)).toBe('保存できない: クエスト「あつめ」がNPC「n2」を参照している。先にそちらを直す');
+  });
+
   it('参照されていないモンスターを消しても空', () => {
     expect(danglingRefs('monster', MONSTERS.filter((m) => m.id !== MON2).map((m) => m.id))).toEqual([]);
   });


### PR DESCRIPTION
Closes #603 — #650 が `Refs` で残していた最後の部分 (admin-npcs への展開)。これで #603 の残件は無くなる。

## 概要

#650 で monsters / items / shops / quests の 4 画面に入れた 2 つの仕組みを、当時 #648 が同時編集中だったため見送っていた `/admin/npcs` にも適用する。

### A. 逆参照チェックを core に寄せる

- 手書きの `gameQuests().find((q) => !list.some((n) => n.id === q.npcId))` を `danglingRefs('npc', ids)` + `describeDanglingRef` に置き換え。「NPC を誰が参照するか」の契約が web と core の 2 か所にあった状態を解消する (参照の種類が増えたとき片方だけ抜ける)
- core の型を確認した範囲で NPC を参照するのは **クエストの発注者 (`GameQuestDef.npcId`) だけ**。`ScenarioCondition` (questDone / flag / notFlag / jobLevel / itemCount)・店 (座標方式)・ゲートに NPC 参照は無いので `worldRefs('npc')` は変えていない
- core テストに「参照されている NPC を消すと、そのクエストが挙がる」を 1 件追加 (danglingRefs 側に npc の切れるケースが無かった)

### B. 読み込み前の編集・保存を止める

- 自前の `useEffect` (`loadAuthoredWorld` → `setList` / `setInteriorList`) を `useAuthoredWorld` に寄せる (内部マップ一覧の取り直しも reset の中で行う)
- `AuthoredWorldGate` (`fieldset[disabled]`) で読み込み完了まで全操作を止め、保存ボタンにも `!loaded` を足す。従来は完了前に入力欄が有効で、その間に始めた編集が完了時の取り直しで黙って消えていた

## 変更ファイル

- `apps/web/src/routes/admin-npcs.tsx` (405 行)
- `packages/core/src/__tests__/world-refs.test.ts` (+1 テスト)

## テスト

- `pnpm --filter @aozoraquest/core typecheck` exit 0 / `test` exit 0 (39 files, 811 passed)
- `pnpm --filter @aozoraquest/web typecheck` exit 0 / `test` exit 0 (44 files, 401 passed)
- `eslint apps/web/src/routes/admin-npcs.tsx` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXHZbULKCqUhgx1NCi6kZ7

## Review

subagent 1 観点 (実装)。**指摘なし** (★★★ / ★★ とも 0 件)。確認: 旧手書きチェックと `danglingRefs('npc')` は同じ集合を拒否 / NPC id の参照は quest.npcId のみ (core を grep) / hook 化で落ちた挙動なし / ゲートの範囲は他 4 画面と同一 / テストは追加のみ。
