### PR TITLE
fix(web): マイナス補正の装備が「すばやさ +-2」と表示される (#653)

### DIFF
--- a/apps/web/src/components/gear-modal.tsx
+++ b/apps/web/src/components/gear-modal.tsx
@@ -4,6 +4,7 @@ import {
   canEquip,
   GEAR_SLOTS,
   GEAR_SLOT_LABELS,
+  bonusText,
   equipHands,
   gearBonusFromGear,
   jobDisplayName,
@@ -21,15 +22,6 @@ import { resolveGear, type GearRefs } from '@/lib/gear';
  */
 
 const SLOT_LABELS = GEAR_SLOT_LABELS;
-
-const STAT_LABELS: Record<string, string> = {
-  atk: 'こうげき',
-  def: 'まもり',
-  agi: 'すばやさ',
-  int: 'かしこさ',
-  luk: 'うん',
-  maxHp: 'さいだいHP',
-};
 
 export function GearModal({
   archetype,
@@ -76,12 +68,7 @@ export function GearModal({
   const selection: GearSelection = resolved.selection;
 
   const total = useMemo(() => (archetype ? gearBonusFromGear(archetype, selection) : null), [archetype, selection]);
-  const totalText = total
-    ? Object.entries(total)
-        .filter(([, v]) => v !== 0)
-        .map(([k, v]) => `${STAT_LABELS[k] ?? k} +${v}`)
-        .join(' ')
-    : '';
+  const totalText = total ? bonusText(total) : '';
 
   return (
     <div

--- a/apps/web/src/components/shop-modal.tsx
+++ b/apps/web/src/components/shop-modal.tsx
@@ -4,6 +4,7 @@ import {
   EQUIPMENT_BY_ID,
   ITEMS,
   SALE_TUNING,
+  bonusText,
   canEquip,
   equipHands,
   forgedLevel,
@@ -12,6 +13,7 @@ import {
   jobDisplayName,
   leveledName,
   salePowerFor,
+  signed,
   townShopStock,
   type Archetype,
   type EquipmentDef,
@@ -32,21 +34,6 @@ import type { DialogueLine } from '@/lib/dialogue';
  *   唯一の道 = 過剰なアイテムを燃やすシンク。
  * - 装備できない品も制作・所持は可能 (転職準備 / クエスト交換の材料 — docs/20)。
  */
-
-const STAT_LABELS: Record<string, string> = {
-  atk: 'こうげき',
-  def: 'まもり',
-  agi: 'すばやさ',
-  int: 'かしこさ',
-  luk: 'うん',
-  maxHp: 'さいだいHP',
-};
-
-function bonusText(def: EquipmentDef): string {
-  return Object.entries(def.bonus)
-    .map(([k, v]) => `${STAT_LABELS[k] ?? k} +${v}`)
-    .join(' ');
-}
 
 export type LastShopAction =
   | { kind: 'craft' | 'forge'; piece: CraftedPiece }
@@ -295,12 +282,12 @@ export function ShopModal({
                     {equipHands(def) === 2 && <span style={{ marginLeft: '0.3em', fontSize: '0.8em', color: 'var(--color-muted)' }}>(両手)</span>}
                     {owned.length > 0 && (
                       <span style={{ marginLeft: '0.4em', color: 'var(--color-muted)' }}>
-                        所持 {owned.length}{bestOwned !== null && bestOwned !== 0 ? ` (最高${bestOwned > 0 ? `+${bestOwned}` : bestOwned})` : ''}
+                        所持 {owned.length}{bestOwned !== null && bestOwned !== 0 ? ` (最高${signed(bestOwned)})` : ''}
                       </span>
                     )}
                   </div>
                   <div style={{ fontSize: '0.85em', color: 'var(--color-muted)' }}>
-                    {bonusText(def)}
+                    {bonusText(def.bonus)}
                     {def.jobOnly && (
                       <span style={{ marginLeft: '0.5em', color: equipable ? 'var(--color-accent)' : 'var(--color-danger)' }}>
                         (要: {jobDisplayName(def.jobOnly, 'default')})
@@ -359,7 +346,7 @@ export function ShopModal({
                       onClick={() => onForge(def, forgedLevel(forge.level), forge.rkeys)}
                       style={{ fontSize: '0.8em', padding: '0.35em 0.7em', whiteSpace: 'nowrap' }}
                     >
-                      きたえる ({forge.level > 0 ? `+${forge.level}` : forge.level}×2 → +{forgedLevel(forge.level)})
+                      きたえる ({signed(forge.level)}×2 → {signed(forgedLevel(forge.level))})
                     </button>
                   )}
                   {forgeBlockedByEquip && (

--- a/apps/web/src/components/status-modal.tsx
+++ b/apps/web/src/components/status-modal.tsx
@@ -9,6 +9,7 @@ import {
   jobXpToNextLevel,
   leveledName,
   mpGainsFor,
+  signed,
   type Archetype,
   type Combatant,
   type EquipSlot,
@@ -146,7 +147,7 @@ export function StatusModal({
                   key={key}
                   label={label}
                   value={combat[key]}
-                  note={bonus !== 0 ? `そうび ${bonus > 0 ? '+' : ''}${bonus}` : undefined}
+                  note={bonus !== 0 ? `そうび ${signed(bonus)}` : undefined}
                 />
               );
             })}
@@ -246,7 +247,7 @@ function HeroRow({ label, value, max, bonus, color }: { label: string; value: nu
           {value} <span style={{ color: 'var(--color-muted)', fontWeight: 400 }}>/ {max}</span>
           {bonus !== 0 && (
             <span style={{ fontFamily: 'inherit', fontSize: '0.68em', fontWeight: 400, color: 'var(--color-accent)', marginLeft: '0.5em' }}>
-              (そうび {bonus > 0 ? '+' : ''}{bonus})
+              (そうび {signed(bonus)})
             </span>
           )}
         </span>

--- a/apps/web/src/routes/admin-items.tsx
+++ b/apps/web/src/routes/admin-items.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import {
   GEAR_SLOTS,
+  BONUS_STAT_LABELS,
   GEAR_SLOT_LABELS,
   activeEquipment,
   activeItems,
@@ -11,6 +12,7 @@ import {
   ItemDataError,
   JOBS,
   JOB_EQUIP_KINDS,
+  type BonusStat,
   type EquipmentDef,
   type ItemDefData,
 } from '@aozoraquest/core';
@@ -28,9 +30,7 @@ import { AuthoredWorldGate } from '@/components/admin/authored-world-gate';
  */
 
 const SLOT_LABELS: Record<string, string> = GEAR_SLOT_LABELS;
-const BONUS_LABELS: Array<[keyof EquipmentDef['bonus'], string]> = [
-  ['atk', 'こうげき'], ['def', 'まもり'], ['agi', 'すばやさ'], ['int', 'かしこさ'], ['luk', 'うん'], ['maxHp', 'さいだいHP'],
-];
+const BONUS_LABELS = Object.entries(BONUS_STAT_LABELS) as Array<[BonusStat, string]>;
 const ALL_KINDS = ['common', 'cloth', 'charm', 'exclusive', ...new Set(Object.values(JOB_EQUIP_KINDS).flat())];
 
 export function AdminItems() {

--- a/packages/core/src/__tests__/equipment.test.ts
+++ b/packages/core/src/__tests__/equipment.test.ts
@@ -254,6 +254,20 @@ describe('制作の強化値 (craftLevelRoll / bonusWithLevel / 合成)', () => 
     expect(leveledName(harp, 0)).toBe('竪琴');
   });
 
+  it('signed / bonusText: 負の補正が「+-2」にならず、0 の項目は出ない', async () => {
+    const { signed, bonusText, BONUS_STAT_LABELS } = await import('../equipment.js');
+    expect(signed(12)).toBe('+12');
+    expect(signed(-2)).toBe('-2');
+    expect(signed(0)).toBe('0');
+    // 表示順は BONUS_STAT_LABELS の並び (定義側のキー順に依存しない)
+    expect(bonusText({ agi: -2, atk: 12 })).toBe('こうげき +12 すばやさ -2');
+    expect(bonusText({ atk: 0, def: 3, maxHp: -1 })).toBe('まもり +3 さいだいHP -1');
+    expect(bonusText({})).toBe('');
+    // 装備込み合計 (gearBonusFromGear の全キー入り) もそのまま通る
+    expect(bonusText({ atk: 0, def: 0, agi: 0, int: 0, luk: 0, maxHp: 0 })).toBe('');
+    expect(Object.keys(BONUS_STAT_LABELS)).toEqual(['atk', 'def', 'agi', 'int', 'luk', 'maxHp']);
+  });
+
   it('合成: +1 ずつ、上限 +10。gearBonusFromGear は強化値つき個体を受ける', async () => {
     const { canForge, forgedLevel, CRAFT_TUNING } = await import('../equipment.js');
     expect(forgedLevel(5)).toBe(6);

--- a/packages/core/src/equipment.ts
+++ b/packages/core/src/equipment.ts
@@ -65,13 +65,41 @@ export type EquipKind =
   | 'cloth' // 共用衣 (誰でも)
   | 'charm';
 
+/** 装備補正が乗るステータス。 */
+export type BonusStat = 'atk' | 'def' | 'agi' | 'int' | 'luk' | 'maxHp';
+
+/** 補正ステータスの表示名 (単一の出所)。並びは補正一覧の表示順。 */
+export const BONUS_STAT_LABELS: Record<BonusStat, string> = {
+  atk: 'こうげき',
+  def: 'まもり',
+  agi: 'すばやさ',
+  int: 'かしこさ',
+  luk: 'うん',
+  maxHp: 'さいだいHP',
+};
+
+/** 符号付き整数の表示: 正は「+3」、負は「-2」、0 は「0」。
+ *  補正・強化値・「そうび +N」内訳など差分を見せる場所は全部ここを通す
+ *  (`+${v}` の直書きは負数で「+-2」になる)。0 を出すかは呼び出し側が決める。 */
+export function signed(n: number): string {
+  return n > 0 ? `+${n}` : `${n}`;
+}
+
+/** 補正の一覧表示: 「こうげき +12 すばやさ -2」。0 の項目は出さない。 */
+export function bonusText(bonus: Partial<Record<BonusStat, number>>): string {
+  return (Object.keys(BONUS_STAT_LABELS) as BonusStat[])
+    .filter((k) => (bonus[k] ?? 0) !== 0)
+    .map((k) => `${BONUS_STAT_LABELS[k]} ${signed(bonus[k]!)}`)
+    .join(' ');
+}
+
 export interface EquipmentDef {
   id: string;
   name: string;
   slot: EquipSlot;
   kind: EquipKind;
   /** ステータス加算 (ブレンド・レベル補正の後に平坦加算)。 */
-  bonus: Partial<Record<'atk' | 'def' | 'agi' | 'int' | 'luk' | 'maxHp', number>>;
+  bonus: Partial<Record<BonusStat, number>>;
   /** 使う手の数 (#609)。武器・盾のみ意味を持つ。省略 = 1 (片手)。
    *  武器 + 盾の合計が 2 を超える組合せは装備できない (両手武器 + 盾、両手盾 + 武器)。 */
   hands?: 1 | 2;
@@ -359,7 +387,7 @@ export function isMasterwork(level: number): boolean {
 /** 表示名: 「ナイフ+3」「ナイフ-1」。±0 は素の名前。 */
 export function leveledName(def: EquipmentDef, level: number): string {
   if (level === 0) return def.name;
-  return `${def.name}${level > 0 ? `+${level}` : `${level}`}`;
+  return `${def.name}${signed(level)}`;
 }
 
 /** 装備中の個体。level 省略時は定義値そのまま (±0 相当)。


### PR DESCRIPTION
Closes #653

## なぜ

なんでも屋で「おおきづち」の補正が **「すばやさ +-2 こうげき +12」** と出る。補正文字列が `+${v}` 固定で負数の符号を見ておらず、しかも同じ組み立てと `STAT_LABELS` が shop-modal / gear-modal の 2 か所に重複していた。

## 寄せた先 (1 か所)

`packages/core/src/equipment.ts`

- `signed(n)` — 正は `+N`、負は `-N`、0 は `0` (0 を出すかは呼び出し側が決める)
- `BONUS_STAT_LABELS` — 補正ステータスの表示名 (単一の出所、並び = 表示順)
- `bonusText(bonus)` — 「こうげき +12 すばやさ -2」。0 の項目は出さない。並びは `BONUS_STAT_LABELS` 順 (定義側のキー順に依存しない)
- `leveledName` も `signed` を使うように統一

## 寄せた呼び出し元

| ファイル | 変更 |
|---|---|
| `apps/web/src/components/shop-modal.tsx` | ローカル `STAT_LABELS` / `bonusText` を削除し core を使用。「最高+N」「きたえる (+N×2 → +M)」の手書き符号判定も `signed` に |
| `apps/web/src/components/gear-modal.tsx` | ローカル `STAT_LABELS` を削除、そうび合計を `bonusText(total)` に |
| `apps/web/src/components/status-modal.tsx` | 「そうび +N」内訳 (5 ステ + HP/MP) の `bonus > 0 ? '+' : ''` を `signed` に |
| `apps/web/src/routes/admin-items.tsx` | ローカル `BONUS_LABELS` を `BONUS_STAT_LABELS` から導出 |

触っていないもの: `routes/world.tsx` のレベルアップ上昇量 (`levelUpGains` は 0.1 以上の上昇のみ返すので常に正)、`admin/power-grant-admin.tsx` の付与量 (常に正)。

## テスト

- `packages/core/src/__tests__/equipment.test.ts` に `signed` (正・負・0) と `bonusText` (負補正で `+-` が出ない / 0 項目を落とす / 並び / 空) を追加
- shop-modal / gear-modal のコンポーネントテストは存在しないため、表示文字列の契約は core 側の単体テストで固定

```
pnpm --filter @aozoraquest/core typecheck   exit 0
pnpm --filter @aozoraquest/core test        exit 0  (39 files / 811 tests)
pnpm --filter @aozoraquest/web  typecheck   exit 0
pnpm --filter @aozoraquest/web  test        exit 0  (44 files / 401 tests)
```

## Review

subagent 1 観点 (実装)。**指摘なし** (★★★ / ★★ とも 0 件)。確認: コード直書き 59 定義で旧文字列と新 `bonusText` の差分 0 / gear-modal の並びは不変 / 「最高+N」「きたえる」「そうび +N」は旧の符号判定と同値 / `BonusStat` は型の別名化のみで実行時検証は不変 / `leveledName` 同値 / テストは追加のみ。整理候補 (指摘外): `STAT_ROWS` (status-modal)、`STAT_GAIN_LABELS` (battle.ts)、admin-jobs / admin-monsters の `STAT_LABELS`、`BONUS_KEYS` (item-data.ts) に同種ラベルの別コピーが残る。
