### PR TITLE
feat(core,web): ふたばの村に話しかけられる村人を同梱する (#656)

### DIFF
--- a/apps/web/src/routes/admin-npcs.tsx
+++ b/apps/web/src/routes/admin-npcs.tsx
@@ -12,6 +12,8 @@ import {
   npcArtKey,
   NpcDataError,
   setNpcs,
+  starterTownNpcs,
+  STARTER_TOWN_ID,
   townAt,
   WORLD_MAP_ID,
   worldOverlay,
@@ -122,6 +124,27 @@ export function AdminNpcs() {
     setDirty(true);
   }, [list]);
 
+  /**
+   * **同梱の村人を入れる** (#656)。admin-interiors の「はじまりの村を入れる」と同じ流儀:
+   * id が同じ村人は置き換え、他の NPC は残す。反映は「保存」(自動保存しない)。
+   * 村そのものが無いと保存が「マップが存在しない」で弾かれるので、先に村を入れさせる。
+   */
+  const insertVillagers = useCallback(() => {
+    const village = interiorById(STARTER_TOWN_ID);
+    if (!village) {
+      setNote('「ふたばの村」がまだ無い。先に内部マップで「はじまりの村を入れる」→ 保存');
+      return;
+    }
+    const villagers = starterTownNpcs();
+    const ids = new Set(villagers.map((n) => n.id));
+    const existing = list.some((n) => ids.has(n.id));
+    if (existing && !window.confirm(`「${village.name}」の村人を最新の同梱版で置き換える？\nこの村人たちに加えた編集は消える`)) return;
+    setList((xs) => [...xs.filter((n) => !ids.has(n.id)), ...villagers]);
+    setSel(villagers[0]?.id ?? null);
+    setDirty(true);
+    setNote(`「${village.name}」の村人 ${villagers.length} 人を${existing ? '入れ直した' : '入れた'}。保存すると村に立つ`);
+  }, [list]);
+
   const save = useCallback(async () => {
     if (!session.agent) return;
     // クエストが発注させている NPC を消させない (#423 / #603) — 参照切れの NPC が 1 人でも
@@ -187,6 +210,7 @@ export function AdminNpcs() {
         <strong>NPC</strong>
         <span style={{ fontSize: '0.75em', color: 'var(--color-muted)' }}>{list.length} 人</span>
         <button type="button" onClick={add} style={{ fontSize: '0.85em' }}>＋NPC</button>
+        <button type="button" onClick={insertVillagers} style={{ fontSize: '0.85em' }}>ふたばの村の村人を入れる</button>
         <button type="button" onClick={() => void save()} disabled={!session.agent || !dirty || !loaded} style={{ marginLeft: 'auto', fontSize: '0.85em' }}>
           保存
         </button>

--- a/apps/web/src/routes/admin-npcs.tsx
+++ b/apps/web/src/routes/admin-npcs.tsx
@@ -13,6 +13,7 @@ import {
   NpcDataError,
   setNpcs,
   starterTownNpcs,
+  starterTownNpcsPlacementError,
   STARTER_TOWN_ID,
   townAt,
   WORLD_MAP_ID,
@@ -127,12 +128,14 @@ export function AdminNpcs() {
   /**
    * **同梱の村人を入れる** (#656)。admin-interiors の「はじまりの村を入れる」と同じ流儀:
    * id が同じ村人は置き換え、他の NPC は残す。反映は「保存」(自動保存しない)。
-   * 村そのものが無いと保存が「マップが存在しない」で弾かれるので、先に村を入れさせる。
+   * 村が無い / 旧版 (大きさが違う) なら入れさせない — 判定は core (`starterTownNpcsPlacementError`)
+   * が 1 か所で持つ。旧版に入れると保存は通るのに村人が壁の中に立つ。
    */
   const insertVillagers = useCallback(() => {
     const village = interiorById(STARTER_TOWN_ID);
-    if (!village) {
-      setNote('「ふたばの村」がまだ無い。先に内部マップで「はじまりの村を入れる」→ 保存');
+    const blocked = starterTownNpcsPlacementError(village);
+    if (blocked || !village) {
+      setNote(blocked);
       return;
     }
     const villagers = starterTownNpcs();

--- a/packages/core/src/__tests__/interior.test.ts
+++ b/packages/core/src/__tests__/interior.test.ts
@@ -36,8 +36,10 @@ import {
   starterTownInterior,
   starterTownGates,
   starterTownNpcs,
+  starterTownNpcsPlacementError,
   STARTER_TOWN_ENTRANCE,
   STARTER_TOWN_ID,
+  STARTER_TOWN_SIZE,
 } from '../interior-samples.js';
 
 const FLOOR = BASE_PALETTE.indexOf('plains');
@@ -504,5 +506,12 @@ describe('同梱の村人 (#656)', () => {
     expect(seen.has(village.inn!.y * village.size + village.inn!.x), '宿屋').toBe(true);
     expect(seen.has(village.shop!.y * village.size + village.shop!.x), '店').toBe(true);
     expect(seen.size).toBeGreaterThan(700);
+  });
+
+  it('村が無い / 旧版 (大きさが違う) の村には入れさせない (壁の中に立つ)', () => {
+    expect(starterTownNpcsPlacementError(undefined)).toMatch(/まだ無い/);
+    expect(starterTownNpcsPlacementError({ size: 64 })).toMatch(/旧版/);
+    expect(starterTownNpcsPlacementError({ size: STARTER_TOWN_SIZE })).toBeNull();
+    expect(starterTownNpcsPlacementError(village)).toBeNull();
   });
 });

--- a/packages/core/src/__tests__/interior.test.ts
+++ b/packages/core/src/__tests__/interior.test.ts
@@ -31,8 +31,14 @@ import {
 } from '../interior.js';
 import { BASE_PALETTE } from '../world-map.js';
 import { isWalkableAt, worldOverlay } from '../world.js';
-import { allNpcs, npcAt, npcsOn, setNpcs, NpcDataError } from '../npc-data.js';
-import { starterTownInterior, starterTownGates } from '../interior-samples.js';
+import { allNpcs, npcAt, npcsOn, setNpcs, MAX_NPC_LINE, NpcDataError } from '../npc-data.js';
+import {
+  starterTownInterior,
+  starterTownGates,
+  starterTownNpcs,
+  STARTER_TOWN_ENTRANCE,
+  STARTER_TOWN_ID,
+} from '../interior-samples.js';
 
 const FLOOR = BASE_PALETTE.indexOf('plains');
 const WALL = BASE_PALETTE.indexOf('mountain');
@@ -420,5 +426,83 @@ describe('内部マップの NPC (#613)', () => {
     expect(() => setNpcs([a, { ...a, id: 'b', mapId: 'in-2' }])).not.toThrow();
     expect(() => setNpcs([a, { ...a, id: 'b' }])).toThrow(NpcDataError);
     expect(() => setNpcs([{ ...a, mapId: ' ' }])).toThrow(NpcDataError);
+  });
+});
+
+describe('同梱の村人 (#656)', () => {
+  const spawn = worldOverlay().spawn;
+  const village = starterTownInterior(spawn);
+  const villagers = starterTownNpcs();
+  afterEach(() => { setInteriors(null, null); setNpcs(null); });
+
+  it('4〜5 人いて、全員ふたばの村に立ち、id が一意', () => {
+    expect(villagers.length).toBeGreaterThanOrEqual(4);
+    expect(villagers.length).toBeLessThanOrEqual(5);
+    expect(new Set(villagers.map((n) => n.id)).size).toBe(villagers.length);
+    for (const n of villagers) expect(n.mapId, n.id).toBe(STARTER_TOWN_ID);
+  });
+
+  it('セリフは 1〜2 窓で、上限の長さに収まる (DQ の窓に入る)', () => {
+    for (const n of villagers) {
+      expect(n.lines.length, n.id).toBeGreaterThanOrEqual(1);
+      expect(n.lines.length, n.id).toBeLessThanOrEqual(2);
+      for (const l of n.lines) expect(l.length, `${n.id}: ${l}`).toBeLessThanOrEqual(MAX_NPC_LINE);
+    }
+  });
+
+  it('そのまま setNpcs に通る (壊れた 1 人で全体が落ちない)', () => {
+    expect(() => setNpcs(villagers)).not.toThrow();
+    expect(allNpcs().length).toBe(villagers.length);
+  });
+
+  it('歩けるマス / 施設の無いマス / 村の端でないマス / 互いに重ならない', () => {
+    setInteriors([village], starterTownGates(spawn));
+    const spots = new Set<string>();
+    for (const n of villagers) {
+      expect(interiorWalkableAt(village, n.x, n.y), `${n.id} が歩けないマスに立っている`).toBe(true);
+      expect(facilityAt(STARTER_TOWN_ID, n.x, n.y), `${n.id} が施設のマスに重なっている`).toBeUndefined();
+      // 外周 1 マスは歩けば外へ出る (#626)。そこに立つと出口を塞ぐ。
+      expect(n.x > 0 && n.y > 0 && n.x < village.size - 1 && n.y < village.size - 1, `${n.id} が村の端にいる`).toBe(true);
+      // 降り立つマスに立つと、入った瞬間に人と重なる。
+      expect(n.x === STARTER_TOWN_ENTRANCE.x && n.y === STARTER_TOWN_ENTRANCE.y, `${n.id} が入口に立っている`).toBe(false);
+      const k = `${n.x},${n.y}`;
+      expect(spots.has(k), `${n.id} が別の村人と同じマスにいる`).toBe(false);
+      spots.add(k);
+    }
+  });
+
+  it('村に入れると ぶつかれて (walkableIn が false)、隣から話しかけに行ける', () => {
+    setInteriors([village], starterTownGates(spawn));
+    setNpcs(villagers);
+    for (const n of villagers) {
+      expect(walkableIn(STARTER_TOWN_ID, n.x, n.y, isWalkableAt), `${n.id} のマスが塞がっていない`).toBe(false);
+      expect(npcAt(STARTER_TOWN_ID, n.x, n.y)?.id).toBe(n.id);
+      const reachable = ([[1, 0], [-1, 0], [0, 1], [0, -1]] as const)
+        .some(([dx, dy]) => walkableIn(STARTER_TOWN_ID, n.x + dx, n.y + dy, isWalkableAt));
+      expect(reachable, `${n.id} の隣に歩けるマスが無い (話しかけられない)`).toBe(true);
+    }
+  });
+
+  it('幅 1 の道 (宿屋⇄店 / 広場へ抜ける横道) の上に立たない (通せんぼにならない)', () => {
+    // 村人が道を塞ぐと、入口から宿屋・店へ行けなくなりうる。入れた状態で到達性を確かめる。
+    setInteriors([village], starterTownGates(spawn));
+    setNpcs(villagers);
+    const [inGate] = starterTownGates(spawn);
+    const seen = new Set<number>();
+    const q = [[inGate!.to.x, inGate!.to.y] as const];
+    seen.add(inGate!.to.y * village.size + inGate!.to.x);
+    while (q.length) {
+      const [x, y] = q.shift()!;
+      for (const [dx, dy] of [[1, 0], [-1, 0], [0, 1], [0, -1]] as const) {
+        const nx = x + dx, ny = y + dy;
+        const k = ny * village.size + nx;
+        if (seen.has(k) || !walkableIn(STARTER_TOWN_ID, nx, ny, isWalkableAt)) continue;
+        seen.add(k);
+        q.push([nx, ny]);
+      }
+    }
+    expect(seen.has(village.inn!.y * village.size + village.inn!.x), '宿屋').toBe(true);
+    expect(seen.has(village.shop!.y * village.size + village.shop!.x), '店').toBe(true);
+    expect(seen.size).toBeGreaterThan(700);
   });
 });

--- a/packages/core/src/interior-samples.ts
+++ b/packages/core/src/interior-samples.ts
@@ -24,6 +24,7 @@
  * 井戸・柵・花壇・木を散らして、どこにいるか分かる目印を作る。
  */
 import type { Gate, InteriorMap } from './interior.js';
+import type { NpcDef } from './npc-data.js';
 import type { WorldPart } from './world-map.js';
 
 export const STARTER_TOWN_ID = 'futaba-village';
@@ -167,5 +168,65 @@ export function starterTownGates(town: { x: number; y: number }): Gate[] {
   // 戻りは exitTo (端まで歩けば出る) が担うので、ゲートは**入る 1 本だけ**。
   return [
     { from: { mapId: 'world', x: town.x, y: town.y }, to: { mapId: STARTER_TOWN_ID, ...STARTER_TOWN_ENTRANCE } },
+  ];
+}
+
+/**
+ * **同梱の村人** (#656)。宿屋となんでも屋だけでは人がいない村になるので、
+ * 話しかけられる村人を数人置く。`/admin/npcs` の「ふたばの村の村人を入れる」で差し込み、
+ * id が同じものは置き換える (村を直したときに入れ直せる)。
+ *
+ * id は固定クエストの発注元 (`GameQuestDef.npcId`) として参照されるので**変えない**。
+ *
+ * 位置は `buildStarterTownTiles` の地形に合わせる: 歩けるマス / 施設 (宿屋・店・入口) の
+ * 無いマス / 村の端 (歩けば外へ出る外周) でないマス / 幅 1 の道 (y=11, y=17) の上でない
+ * マス (道の上に立つと通せんぼになる)。テストで固定する。
+ *
+ * セリフは既存 UI (チュートリアル・宿屋・なんでも屋) と用語を合わせる。宿代は
+ * `STARTER_TOWN_INN.price` から作る (数値を二重に持たない)。
+ */
+export function starterTownNpcs(): NpcDef[] {
+  const mapId = STARTER_TOWN_ID;
+  return [
+    {
+      // 広場の井戸のそば。村の顔。
+      id: 'futaba-elder', name: 'むらおさ', mapId, x: 14, y: 21,
+      lines: [
+        'ようこそ ふたばの村へ。わしが この村の むらおさじゃ。',
+        '村の そとには スライムが 出る。むりは するなよ。',
+      ],
+    },
+    {
+      // 宿屋の扉の右下 (東西の道は塞がない)。
+      id: 'futaba-innkeeper-wife', name: 'やどやの おかみ', mapId, x: 9, y: 12,
+      lines: [
+        `やどやは ひとばん パワー ${STARTER_TOWN_INN.price} で とまれるよ。HP も MP も ぜんかいさ。`,
+        'つかれたら いつでも おいで。',
+      ],
+    },
+    {
+      // なんでも屋の扉の左下。
+      id: 'futaba-shopfront', name: 'なんでも屋の むすめ', mapId, x: 22, y: 12,
+      lines: [
+        'なんでも屋は 素材と あおぞらパワーで そうびを つくってくれるよ。',
+        'いらない素材は ひきとって パワーに かえてくれるんだ。',
+      ],
+    },
+    {
+      // 入口 (南の通り) のそば。降り立ってすぐ会う。
+      id: 'futaba-kid', name: 'こども', mapId, x: 17, y: 29,
+      lines: [
+        '村の はしまで あるくと そとに 出られるよ。',
+        'たたかいに まけても さいごに たちよった 街に もどってくるだけだって。',
+      ],
+    },
+    {
+      // 西の家の前。
+      id: 'futaba-oldman', name: 'おじいさん', mapId, x: 5, y: 18,
+      lines: [
+        '街に つくと「ちずのかけら」が 手に はいって、ちずが ひろがるそうじゃ。',
+        '🗺 ちずボタンで いつでも たしかめられるぞい。',
+      ],
+    },
   ];
 }

--- a/packages/core/src/interior-samples.ts
+++ b/packages/core/src/interior-samples.ts
@@ -217,7 +217,8 @@ export function starterTownNpcs(): NpcDef[] {
       id: 'futaba-kid', name: 'こども', mapId, x: 17, y: 29,
       lines: [
         '村の はしまで あるくと そとに 出られるよ。',
-        'たたかいに まけても さいごに たちよった 街に もどってくるだけだって。',
+        // 敗北時は素材を少し失う (`rollDefeatLoss`)。「戻されるだけ」と言うと嘘になる。
+        'まけると さいごに たちよった 街まで もどされるんだって。もちものも すこし おとすらしい。',
       ],
     },
     {
@@ -229,4 +230,19 @@ export function starterTownNpcs(): NpcDef[] {
       ],
     },
   ];
+}
+
+/**
+ * **村人を入れられる村か** (#656)。入れられなければ理由 (エディタがそのまま出す)。
+ *
+ * 村人の位置は同梱の 32×32 の地形に合わせてあるので、旧版 (64×64) の村レコードが
+ * 残っている環境に入れると、おかみが壁の中に立つ (保存は通ってしまう — 施設と
+ * 範囲しか見ない)。大きさが違う村には入れさせず、先に村を入れ直させる。
+ */
+export function starterTownNpcsPlacementError(village: Pick<InteriorMap, 'size'> | undefined): string | null {
+  if (!village) return '「ふたばの村」がまだ無い。先に内部マップで「はじまりの村を入れる」→ 保存';
+  if (village.size !== STARTER_TOWN_SIZE) {
+    return `「ふたばの村」が旧版 (${village.size}×${village.size})。先に内部マップで「はじまりの村を入れる」で入れ直して 保存してから`;
+  }
+  return null;
 }


### PR DESCRIPTION
Closes #656

## なぜ

#648 で内部マップに NPC を置けるようになったが、NPC には同梱の既定が無く (管理レコードが無ければ 0 人)、はじまりの村 (ふたばの村, 32×32) は宿屋となんでも屋だけで人がいなかった。話しかけられる村人を同梱し、`/admin/npcs` から置けるようにする。

## 変更

### core (`packages/core/src/interior-samples.ts`)

`starterTownNpcs(): NpcDef[]` を追加 (5 人、`mapId = STARTER_TOWN_ID`)。宿代は `STARTER_TOWN_INN.price` から文字列を作る (数値を二重に持たない)。用語はチュートリアル (`world.tsx`) / なんでも屋 (`shop-modal.tsx`) に合わせた。

**id は固定クエスト (`GameQuestDef.npcId`) の発注元として後続 PR で参照するので固定** (同梱シナリオ `scenario-samples.ts` は NPC id を参照していないので衝突なし)。

| id | 役割 | 名前 | 位置 (x, y) | セリフ |
|---|---|---|---|---|
| `futaba-elder` | 村長 (広場の井戸のそば) | むらおさ | (14, 21) | ようこそ ふたばの村へ。わしが この村の むらおさじゃ。 / 村の そとには スライムが 出る。むりは するなよ。 |
| `futaba-innkeeper-wife` | 宿屋の前 (扉 (8,10) の右下) | やどやの おかみ | (9, 12) | やどやは ひとばん パワー 3 で とまれるよ。HP も MP も ぜんかいさ。 / つかれたら いつでも おいで。 |
| `futaba-shopfront` | なんでも屋の前 (扉 (23,10) の左下) | なんでも屋の むすめ | (22, 12) | なんでも屋は 素材と あおぞらパワーで そうびを つくってくれるよ。 / いらない素材は ひきとって パワーに かえてくれるんだ。 |
| `futaba-kid` | 入口 (15,28) のそば | こども | (17, 29) | 村の はしまで あるくと そとに 出られるよ。 / まけると さいごに たちよった 街まで もどされるんだって。もちものも すこし おとすらしい。 |
| `futaba-oldman` | 西の家の前 | おじいさん | (5, 18) | 街に つくと「ちずのかけら」が 手に はいって、ちずが ひろがるそうじゃ。 / 🗺 ちずボタンで いつでも たしかめられるぞい。 |

`starterTownNpcsPlacementError(village)` — 村が無い / 大きさが `STARTER_TOWN_SIZE` と違う (旧 64×64 のレコードが残っている) なら理由を返す。村人の位置は 32×32 の地形に合わせてあるので、旧版に入れると保存は通るのに壁の中に立つ。契約は core のこの 1 か所。

位置の条件 (テスト `packages/core/src/__tests__/interior.test.ts` 「同梱の村人 (#656)」で固定):
- 歩けるマス (`interiorWalkableAt`)、施設 (`facilityAt`: 宿屋 / なんでも屋 / ゲート) の無いマス
- 村の端 (外周 1 マス = 歩けば外へ出る) でない、入口 `STARTER_TOWN_ENTRANCE` でない
- 互いに重ならない、id 一意、セリフ 1〜2 窓で `MAX_NPC_LINE` 以内
- `setNpcs(starterTownNpcs())` が throw しない
- 村を入れた上で各村人のマスが `walkableIn` で false (ぶつかれる) かつ隣接 4 方向のどれかが歩ける (話しかけに行ける)
- 村人を入れた状態でも入口から宿屋・店へ到達できる (幅 1 の道 y=11 / y=17 を塞がない)
- 村が無い / size 64 の村では `starterTownNpcsPlacementError` が止め、32×32 なら null

### web (`apps/web/src/routes/admin-npcs.tsx`)

「ふたばの村の村人を入れる」ボタン (`AuthoredWorldGate` の中 = 読み込み前は押せない)。
- id が同じ村人は置き換え、他の NPC は残す
- 既に村人がいれば `window.confirm` で上書き確認 (admin-interiors の「はじまりの村を入れる」と同じ流儀)
- dirty にして「保存」で反映 (自動保存しない)
- 「ふたばの村」が無い / 旧版なら `starterTownNpcsPlacementError` の文言を note に出して何もしない (先に内部マップで村を入れ直させる)

### 絵

NPC の絵は既定の代替 (`world.tsx`: 頭 + 体の簡素な人形) で描かれるので、ドット絵が無くても村人は見える。ドット絵を付けたければ `/admin/npcs` の「絵をかく」で `npc:<id>` を描く (任意)。

## オーナーが dev で行う操作

1. `/admin/interiors` で「はじまりの村を入れる」→ 保存 (旧 64×64 の村が残っていれば入れ直す。村人の位置は 32×32 に合わせてある)
2. `/admin/npcs` → 「ふたばの村の村人を入れる」→ 「保存」
3. ワールドでふたばの村に入り、村人にぶつかって会話が出ること・幅 1 の道が通れることを確認

## テスト

- `pnpm --filter @aozoraquest/core typecheck` → exit 0
- `pnpm --filter @aozoraquest/core test` → exit 0 (39 files / 818 tests、うち新規 7 件)
- `pnpm --filter @aozoraquest/web typecheck` → exit 0
- `pnpm --filter @aozoraquest/web test` → exit 0 (44 files / 401 tests)

## Review

1 観点 (実装)。★★ 2 件、どちらも PR 内で対応 (commit 941a15d)。

- ★★-1 こども (`futaba-kid`) の 2 窓目「もどってくるだけ」が実装と違う — 敗北時は素材を必ず 1〜3 個失う (`battle.ts` `rollDefeatLoss`、edge `battle-reward.ts` で適用)。→ 「まけると さいごに たちよった 街まで もどされるんだって。もちものも すこし おとすらしい。」に変更 (`MAX_NPC_LINE` 内、テストで長さを固定)。
- ★★-2 旧 64×64 の村レコードが残る環境で「村人を入れる」→ 保存が通り、おかみが壁の中に立つ (`insertVillagers` のガードが村の存在しか見ていなかった)。→ core に `starterTownNpcsPlacementError(village)` を追加し、村が無い / `size !== STARTER_TOWN_SIZE` なら理由を返す (契約は 1 か所)。エディタはそれを note に出して止める。size 違いで止まるテストを追加。「オーナーが dev で行う操作」1 を「入れ直して保存」に修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXHZbULKCqUhgx1NCi6kZ7
