### PR TITLE
feat: メンテナンスモードと BAN リストを配線する (#561)

### DIFF
--- a/apps/edge/src/index.ts
+++ b/apps/edge/src/index.ts
@@ -18,7 +18,8 @@ export default {
     // promise が **reject もせず settle しない**。.catch() も走らないので警告すら出ず、
     // 読み込み中フラグがラッチされたままで **その isolate は二度と地図を読まない**
     // (workerd で実測)。結果、web は地図あり・edge は地図なしで地形の認識がずれる。
-    ctx.waitUntil(ensureAuthoredWorld(env, nsidRoot(req), Math.floor(Date.now() / 1000)));
+    // 管理系レコードの NSID の根は env で分けない (world-authoring の ADMIN_NSID_ROOT)。
+    ctx.waitUntil(ensureAuthoredWorld(env, Math.floor(Date.now() / 1000)));
     return handleRequest(req, env);
   },
 
@@ -30,10 +31,3 @@ export default {
     }
   },
 };
-
-/** NSID の根 (world.map / world.tileArt の collection を組む)。web の ADMIN_COL と揃える。 */
-function nsidRoot(req: Request): string {
-  // 管理系レコードは env で分けない (全環境が同じ 1 か所を見る)。web の collections.ts と同じ規則。
-  void req;
-  return 'app.aozoraquest';
-}

--- a/apps/edge/src/router.ts
+++ b/apps/edge/src/router.ts
@@ -18,11 +18,11 @@ import { shopCraft, shopSell, shopForge, shopDiscard, ShopError } from './shop';
 import { handleMove, handleTurn, handleTeleport, handleItem, handleGear, handleSearch, handleReset, migrateInitState, playerLuk, ResolverError } from './battle-resolver';
 import { signPosition, verifyPosition } from './world-token';
 import { handleQuestAccept, handleQuestComplete, GameQuestError } from './game-quest';
-import { ensureAuthoredWorld } from './world-authoring';
+import { ensureAuthoredWorld, bannedDidList } from './world-authoring';
 import { ServerWriteError } from './server-pds';
 import { isEdgeAdmin } from './oauth-config';
 import { readPdsUsage, opsRemaining, PUT_RECORD_POINTS } from './pds-usage';
-import type { Command } from '@aozoraquest/core';
+import { isBanned, type Command } from '@aozoraquest/core';
 
 /** WORKER_DID / SERVER_DID / OAUTH_* / ADMIN_DIDS / OAUTH_TOKENS は OAuthRoutesEnv から継承。 */
 export interface Env extends OAuthRoutesEnv {
@@ -108,31 +108,17 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
 
   // service auth JWT を検証して呼び出し元 DID を返す (M1 認証基盤の疎通確認)。
   if (req.method === 'POST' && url.pathname === '/api/whoami') {
-    const token = bearer(req);
-    if (!token) return cors(json({ error: 'missing_token' }, 401), allowedOrigin);
-    const audience = env.WORKER_DID ?? 'did:web:edge.aozoraquest.app';
-    try {
-      const { iss } = await verifyServiceAuth(token, { audience, lxm: LXM_WHOAMI });
-      return cors(json({ did: iss }), allowedOrigin);
-    } catch (e) {
-      // fail-closed: 検証失敗は 401 (詳細は漏らしすぎない)
-      const msg = e instanceof ServiceAuthError ? e.message : 'verify_failed';
-      return cors(json({ error: 'unauthorized', reason: msg }, 401), allowedOrigin);
-    }
+    const auth = await authenticate(req, env, LXM_WHOAMI, 'none');
+    if (auth instanceof Response) return cors(auth, allowedOrigin);
+    return cors(json({ did: auth.did }), allowedOrigin);
   }
 
   // 権威 state (ゲーム経済) の読み取り。自分の DID の分だけ返す (JWT で本人確認)。
   // 読みは public getRecord なので session 不要。書き込みは M3 の battle 系で行う。
   if (req.method === 'GET' && url.pathname === '/api/me/state') {
-    const token = bearer(req);
-    if (!token) return cors(json({ error: 'missing_token' }, 401), allowedOrigin);
-    const audience = env.WORKER_DID ?? 'did:web:edge.aozoraquest.app';
-    let did: string;
-    try {
-      ({ iss: did } = await verifyServiceAuth(token, { audience, lxm: LXM_ME_STATE }));
-    } catch (e) {
-      return cors(json({ error: 'unauthorized', reason: e instanceof ServiceAuthError ? e.message : 'verify_failed' }, 401), allowedOrigin);
-    }
+    const auth = await authenticate(req, env, LXM_ME_STATE, 'none');
+    if (auth instanceof Response) return cors(auth, allowedOrigin);
+    const { did } = auth;
     // 読み書きとも repo はトークン由来 (readState)。未 bootstrap は 503 fail-closed。
     // 未初期化 (レコード無し) は §6-4 移行値を read-only で返す (power=0/Lv1 で表示が割れないように。
     // PDS へは書かない = 初回 move で確定)。initialized はレコード実在を表す。
@@ -152,15 +138,9 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
   // ── サーバー権威 ワールド/戦闘 (docs/21 §5) ── 移動も攻撃も毎回 Worker が処理 = チート不可 ──
   if (req.method === 'POST' && (url.pathname === '/api/world/move' || url.pathname === '/api/battle/turn')) {
     const isTurn = url.pathname === '/api/battle/turn';
-    const token = bearer(req);
-    if (!token) return cors(json({ error: 'missing_token' }, 401), allowedOrigin);
-    const audience = env.WORKER_DID ?? 'did:web:edge.aozoraquest.app';
-    let did: string;
-    try {
-      ({ iss: did } = await verifyServiceAuth(token, { audience, lxm: isTurn ? LXM_BATTLE_TURN : LXM_WORLD_MOVE }));
-    } catch (e) {
-      return cors(json({ error: 'unauthorized', reason: e instanceof ServiceAuthError ? e.message : 'verify_failed' }, 401), allowedOrigin);
-    }
+    const auth = await authenticate(req, env, isTurn ? LXM_BATTLE_TURN : LXM_WORLD_MOVE, 'world');
+    if (auth instanceof Response) return cors(auth, allowedOrigin);
+    const { did } = auth;
     const body = (await req.json().catch(() => ({}))) as { dx?: number; dy?: number; token?: string; battleId?: string; turn?: number; command?: string; skillIndex?: number };
     try {
       if (isTurn) {
@@ -168,18 +148,9 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
           return cors(json({ error: 'bad_request' }, 400), allowedOrigin);
         }
         const skillIndex = typeof body.skillIndex === 'number' ? body.skillIndex : 0; // とくぎ選択 (#436)。既定 0=署名
-        // クエスト定義 (#423) の討伐カウントは勝利決着のこの経路で数える。コールド isolate だと
-        // index.ts の waitUntil ロードが間に合わず「倒したのに数えられない」が無言で起きるので待つ
-        // (ロード済みならキャッシュ即返し。設計レビュー ★★)。
-        await ensureAuthoredWorld(env, nsFromOrigin(req), nowSec());
         return cors(json(await handleTurn(env, did, body.battleId, body.turn, body.command as Command, nowSec(), nsFromOrigin(req), skillIndex)), allowedOrigin);
       }
       if (typeof body.dx !== 'number' || typeof body.dy !== 'number') return cors(json({ error: 'bad_request' }, 400), allowedOrigin);
-      // **移動もワールドの読み込みを待つ。** ゲート (#424)・NPC (#425)・地図はここで効くので、
-      // コールド isolate で index.ts の waitUntil が間に合っていないと「街に入れない」
-      // 「人がいない」が無言で起きる (実際に踏んだ)。ロード済みならキャッシュ即返しで
-      // コストは乗らない。
-      await ensureAuthoredWorld(env, nsFromOrigin(req), nowSec());
       return cors(json(await handleMove(env, did, body.dx, body.dy, typeof body.token === 'string' ? body.token : undefined, nowSec(), nsFromOrigin(req))), allowedOrigin);
     } catch (e) {
       return cors(battleError(e), allowedOrigin);
@@ -188,15 +159,9 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
 
   // そらのはねワープ: 街タイルへテレポート (位置トークンを更新して 1 歩で戻されないようにする)。
   if (req.method === 'POST' && url.pathname === '/api/world/teleport') {
-    const token = bearer(req);
-    if (!token) return cors(json({ error: 'missing_token' }, 401), allowedOrigin);
-    const audience = env.WORKER_DID ?? 'did:web:edge.aozoraquest.app';
-    let did: string;
-    try {
-      ({ iss: did } = await verifyServiceAuth(token, { audience, lxm: LXM_WORLD_TELEPORT }));
-    } catch (e) {
-      return cors(json({ error: 'unauthorized', reason: e instanceof ServiceAuthError ? e.message : 'verify_failed' }, 401), allowedOrigin);
-    }
+    const auth = await authenticate(req, env, LXM_WORLD_TELEPORT, 'world');
+    if (auth instanceof Response) return cors(auth, allowedOrigin);
+    const { did } = auth;
     const body = (await req.json().catch(() => ({}))) as { x?: number; y?: number };
     if (typeof body.x !== 'number' || typeof body.y !== 'number') return cors(json({ error: 'bad_request' }, 400), allowedOrigin);
     try {
@@ -208,15 +173,9 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
 
   // フィールドの道具使用 (やくそう/そらのしずく)。サーバー在庫を消費して HP/MP を回復。
   if (req.method === 'POST' && url.pathname === '/api/world/item') {
-    const token = bearer(req);
-    if (!token) return cors(json({ error: 'missing_token' }, 401), allowedOrigin);
-    const audience = env.WORKER_DID ?? 'did:web:edge.aozoraquest.app';
-    let did: string;
-    try {
-      ({ iss: did } = await verifyServiceAuth(token, { audience, lxm: LXM_WORLD_ITEM }));
-    } catch (e) {
-      return cors(json({ error: 'unauthorized', reason: e instanceof ServiceAuthError ? e.message : 'verify_failed' }, 401), allowedOrigin);
-    }
+    const auth = await authenticate(req, env, LXM_WORLD_ITEM, 'world');
+    if (auth instanceof Response) return cors(auth, allowedOrigin);
+    const { did } = auth;
     const body = (await req.json().catch(() => ({}))) as { item?: string };
     if (body.item !== 'herb' && body.item !== 'tonic') return cors(json({ error: 'bad_request' }, 400), allowedOrigin);
     try {
@@ -228,15 +187,9 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
 
   // 装備ミラー: client が解決した GearSelection (強化値つき) を gameState に保存 (戦闘に反映)。
   if (req.method === 'POST' && url.pathname === '/api/world/gear') {
-    const token = bearer(req);
-    if (!token) return cors(json({ error: 'missing_token' }, 401), allowedOrigin);
-    const audience = env.WORKER_DID ?? 'did:web:edge.aozoraquest.app';
-    let did: string;
-    try {
-      ({ iss: did } = await verifyServiceAuth(token, { audience, lxm: LXM_WORLD_GEAR }));
-    } catch (e) {
-      return cors(json({ error: 'unauthorized', reason: e instanceof ServiceAuthError ? e.message : 'verify_failed' }, 401), allowedOrigin);
-    }
+    const auth = await authenticate(req, env, LXM_WORLD_GEAR, 'world');
+    if (auth instanceof Response) return cors(auth, allowedOrigin);
+    const { did } = auth;
     const body = (await req.json().catch(() => ({}))) as { gear?: unknown };
     if (typeof body.gear !== 'object' || body.gear === null) return cors(json({ error: 'bad_request' }, 400), allowedOrigin);
     try {
@@ -248,15 +201,9 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
 
   // しらべる: サーバーがアイテムを判定して gameState 在庫に付与 (client のみの幻を解消)。
   if (req.method === 'POST' && url.pathname === '/api/world/search') {
-    const token = bearer(req);
-    if (!token) return cors(json({ error: 'missing_token' }, 401), allowedOrigin);
-    const audience = env.WORKER_DID ?? 'did:web:edge.aozoraquest.app';
-    let did: string;
-    try {
-      ({ iss: did } = await verifyServiceAuth(token, { audience, lxm: LXM_WORLD_SEARCH }));
-    } catch (e) {
-      return cors(json({ error: 'unauthorized', reason: e instanceof ServiceAuthError ? e.message : 'verify_failed' }, 401), allowedOrigin);
-    }
+    const auth = await authenticate(req, env, LXM_WORLD_SEARCH, 'world');
+    if (auth instanceof Response) return cors(auth, allowedOrigin);
+    const { did } = auth;
     const body = (await req.json().catch(() => ({}))) as { token?: string; key?: unknown };
     try {
       return cors(json(await handleSearch(env, did, typeof body.token === 'string' ? body.token : undefined, nowSec(), nsFromOrigin(req), undefined,
@@ -269,15 +216,9 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
   // XP 申告: 投稿・クエストの XP を権威 state の jobXp に積む (#534)。
   // 種類ごとの上限クランプ + 冪等キーで、client 由来でも青天井にならないようにする。
   if (req.method === 'POST' && url.pathname === '/api/xp/claim') {
-    const token = bearer(req);
-    if (!token) return cors(json({ error: 'missing_token' }, 401), allowedOrigin);
-    const audience = env.WORKER_DID ?? 'did:web:edge.aozoraquest.app';
-    let did: string;
-    try {
-      ({ iss: did } = await verifyServiceAuth(token, { audience, lxm: LXM_XP_CLAIM }));
-    } catch (e) {
-      return cors(json({ error: 'unauthorized', reason: e instanceof ServiceAuthError ? e.message : 'verify_failed' }, 401), allowedOrigin);
-    }
+    const auth = await authenticate(req, env, LXM_XP_CLAIM, 'world');
+    if (auth instanceof Response) return cors(auth, allowedOrigin);
+    const { did } = auth;
     // **額は client が送らない** — サーバーが決める (2026-07-27)。送るのは投稿の URI だけ。
     const body = (await req.json().catch(() => ({}))) as { archetype?: unknown; postUri?: unknown };
     if (typeof body.archetype !== 'string' || typeof body.postUri !== 'string') {
@@ -302,15 +243,9 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
   // analysis を書き換える従来の管理ツールではレベルが動かせない。Lv30 パッシブ等の
   // 実プレイ確認に必要なので、**ADMIN_DIDS ゲート付き**で権威側に用意する。
   if (req.method === 'POST' && url.pathname === '/api/xp/admin-set') {
-    const token = bearer(req);
-    if (!token) return cors(json({ error: 'missing_token' }, 401), allowedOrigin);
-    const audience = env.WORKER_DID ?? 'did:web:edge.aozoraquest.app';
-    let did: string;
-    try {
-      ({ iss: did } = await verifyServiceAuth(token, { audience, lxm: LXM_XP_ADMIN_SET }));
-    } catch (e) {
-      return cors(json({ error: 'unauthorized', reason: e instanceof ServiceAuthError ? e.message : 'verify_failed' }, 401), allowedOrigin);
-    }
+    const auth = await authenticate(req, env, LXM_XP_ADMIN_SET, 'none');
+    if (auth instanceof Response) return cors(auth, allowedOrigin);
+    const { did } = auth;
     if (!isEdgeAdmin(env, did)) return cors(json({ error: 'forbidden' }, 403), allowedOrigin);
     const body = (await req.json().catch(() => ({}))) as { archetype?: unknown; level?: unknown };
     if (typeof body.archetype !== 'string' || typeof body.level !== 'number') {
@@ -332,15 +267,9 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
   // Bluesky の上限は DID ごと 5,000 points/時・35,000 points/日、putRecord は 2 points。
   // = 全ユーザー合計で 1 時間 2,500 操作 / 1 日 17,500 操作が天井。
   if (req.method === 'GET' && url.pathname === '/api/admin/pds-usage') {
-    const token = bearer(req);
-    if (!token) return cors(json({ error: 'missing_token' }, 401), allowedOrigin);
-    const audience = env.WORKER_DID ?? 'did:web:edge.aozoraquest.app';
-    let did: string;
-    try {
-      ({ iss: did } = await verifyServiceAuth(token, { audience, lxm: LXM_ADMIN_PDS_USAGE }));
-    } catch (e) {
-      return cors(json({ error: 'unauthorized', reason: e instanceof ServiceAuthError ? e.message : 'verify_failed' }, 401), allowedOrigin);
-    }
+    const auth = await authenticate(req, env, LXM_ADMIN_PDS_USAGE, 'none');
+    if (auth instanceof Response) return cors(auth, allowedOrigin);
+    const { did } = auth;
     if (!isEdgeAdmin(env, did)) return cors(json({ error: 'forbidden' }, 403), allowedOrigin);
     const usage = await readPdsUsage(env.OAUTH_TOKENS);
     return cors(json({ usage, opsRemaining: opsRemaining(usage), pointsPerOp: PUT_RECORD_POINTS }), allowedOrigin);
@@ -348,15 +277,9 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
 
   // パワーの消費 (カードの引き直しなど)。**値段はサーバーが決める** — client が金額を送らない。
   if (req.method === 'POST' && url.pathname === '/api/power/spend') {
-    const token = bearer(req);
-    if (!token) return cors(json({ error: 'missing_token' }, 401), allowedOrigin);
-    const audience = env.WORKER_DID ?? 'did:web:edge.aozoraquest.app';
-    let did: string;
-    try {
-      ({ iss: did } = await verifyServiceAuth(token, { audience, lxm: LXM_POWER_SPEND }));
-    } catch (e) {
-      return cors(json({ error: 'unauthorized', reason: e instanceof ServiceAuthError ? e.message : 'verify_failed' }, 401), allowedOrigin);
-    }
+    const auth = await authenticate(req, env, LXM_POWER_SPEND, 'world');
+    if (auth instanceof Response) return cors(auth, allowedOrigin);
+    const { did } = auth;
     const body = (await req.json().catch(() => ({}))) as { reason?: unknown; key?: unknown };
     if (body.reason !== 'card-draw' || typeof body.key !== 'string') return cors(json({ error: 'bad_request' }, 400), allowedOrigin);
     try {
@@ -372,15 +295,9 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
   // PDS レコードしか書いておらず、報酬の可否を決める GameState.power は 0 のままだった
   // (= 画面にはパワーがあるのに勝っても報酬が出ない)。
   if (req.method === 'POST' && url.pathname === '/api/power/admin-grant') {
-    const token = bearer(req);
-    if (!token) return cors(json({ error: 'missing_token' }, 401), allowedOrigin);
-    const audience = env.WORKER_DID ?? 'did:web:edge.aozoraquest.app';
-    let did: string;
-    try {
-      ({ iss: did } = await verifyServiceAuth(token, { audience, lxm: LXM_POWER_ADMIN_GRANT }));
-    } catch (e) {
-      return cors(json({ error: 'unauthorized', reason: e instanceof ServiceAuthError ? e.message : 'verify_failed' }, 401), allowedOrigin);
-    }
+    const auth = await authenticate(req, env, LXM_POWER_ADMIN_GRANT, 'none');
+    if (auth instanceof Response) return cors(auth, allowedOrigin);
+    const { did } = auth;
     if (!isEdgeAdmin(env, did)) return cors(json({ error: 'forbidden' }, 403), allowedOrigin);
     const body = (await req.json().catch(() => ({}))) as { amount?: unknown };
     if (typeof body.amount !== 'number') return cors(json({ error: 'bad_request' }, 400), allowedOrigin);
@@ -396,15 +313,9 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
   // なんでも屋: 装備を作ってもらう。**費用 (パワー + 素材) を権威側から引く** (#551)。
   // 品揃えも値段も強化値もサーバーが決める — client が送ってきた値段を信じない。
   if (req.method === 'POST' && url.pathname === '/api/shop/craft') {
-    const token = bearer(req);
-    if (!token) return cors(json({ error: 'missing_token' }, 401), allowedOrigin);
-    const audience = env.WORKER_DID ?? 'did:web:edge.aozoraquest.app';
-    let did: string;
-    try {
-      ({ iss: did } = await verifyServiceAuth(token, { audience, lxm: LXM_SHOP_CRAFT }));
-    } catch (e) {
-      return cors(json({ error: 'unauthorized', reason: e instanceof ServiceAuthError ? e.message : 'verify_failed' }, 401), allowedOrigin);
-    }
+    const auth = await authenticate(req, env, LXM_SHOP_CRAFT, 'world');
+    if (auth instanceof Response) return cors(auth, allowedOrigin);
+    const { did } = auth;
     const body = (await req.json().catch(() => ({}))) as { itemId?: unknown; rkey?: unknown; token?: unknown };
     if (typeof body.itemId !== 'string' || typeof body.rkey !== 'string') return cors(json({ error: 'bad_request' }, 400), allowedOrigin);
     try {
@@ -421,15 +332,9 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
 
   // なんでも屋: きたえる (同じ品・同じ強化値の 2 個体 → +1)。消費する個体は権威側から探す。
   if (req.method === 'POST' && url.pathname === '/api/shop/forge') {
-    const token = bearer(req);
-    if (!token) return cors(json({ error: 'missing_token' }, 401), allowedOrigin);
-    const audience = env.WORKER_DID ?? 'did:web:edge.aozoraquest.app';
-    let did: string;
-    try {
-      ({ iss: did } = await verifyServiceAuth(token, { audience, lxm: LXM_SHOP_FORGE }));
-    } catch (e) {
-      return cors(json({ error: 'unauthorized', reason: e instanceof ServiceAuthError ? e.message : 'verify_failed' }, 401), allowedOrigin);
-    }
+    const auth = await authenticate(req, env, LXM_SHOP_FORGE, 'world');
+    if (auth instanceof Response) return cors(auth, allowedOrigin);
+    const { did } = auth;
     const body = (await req.json().catch(() => ({}))) as { rkeys?: unknown; rkey?: unknown; token?: unknown };
     const pair = Array.isArray(body.rkeys) && body.rkeys.length === 2 && body.rkeys.every((v) => typeof v === 'string')
       ? (body.rkeys as [string, string]) : null;
@@ -447,15 +352,9 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
   // もちもの: 装備を すてる (#575)。**街の外でもできる** — 上限に達すると制作も購入も
   // 断られるので、街に着くまで整理できないと詰む。パワーは返さない。
   if (req.method === 'POST' && url.pathname === '/api/shop/discard') {
-    const token = bearer(req);
-    if (!token) return cors(json({ error: 'missing_token' }, 401), allowedOrigin);
-    const audience = env.WORKER_DID ?? 'did:web:edge.aozoraquest.app';
-    let did: string;
-    try {
-      ({ iss: did } = await verifyServiceAuth(token, { audience, lxm: LXM_SHOP_DISCARD }));
-    } catch (e) {
-      return cors(json({ error: 'unauthorized', reason: e instanceof ServiceAuthError ? e.message : 'verify_failed' }, 401), allowedOrigin);
-    }
+    const auth = await authenticate(req, env, LXM_SHOP_DISCARD, 'world');
+    if (auth instanceof Response) return cors(auth, allowedOrigin);
+    const { did } = auth;
     const body = (await req.json().catch(() => ({}))) as { rkeys?: unknown; rkey?: unknown };
     const rkeys = Array.isArray(body.rkeys) && body.rkeys.length > 0 && body.rkeys.every((v) => typeof v === 'string')
       ? (body.rkeys as string[]) : null;
@@ -473,22 +372,13 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
   // battle-reward が数え、素材は権威在庫を見て引き取り、パワーは定義の値だけ足す。
   if (req.method === 'POST' && (url.pathname === '/api/quest/accept' || url.pathname === '/api/quest/complete')) {
     const accept = url.pathname === '/api/quest/accept';
-    const token = bearer(req);
-    if (!token) return cors(json({ error: 'missing_token' }, 401), allowedOrigin);
-    const audience = env.WORKER_DID ?? 'did:web:edge.aozoraquest.app';
-    let did: string;
-    try {
-      ({ iss: did } = await verifyServiceAuth(token, { audience, lxm: accept ? LXM_QUEST_ACCEPT : LXM_QUEST_COMPLETE }));
-    } catch (e) {
-      return cors(json({ error: 'unauthorized', reason: e instanceof ServiceAuthError ? e.message : 'verify_failed' }, 401), allowedOrigin);
-    }
+    const auth = await authenticate(req, env, accept ? LXM_QUEST_ACCEPT : LXM_QUEST_COMPLETE, 'world');
+    if (auth instanceof Response) return cors(auth, allowedOrigin);
+    const { did } = auth;
     const body = (await req.json().catch(() => ({}))) as { questId?: unknown };
     if (typeof body.questId !== 'string') return cors(json({ error: 'bad_request' }, 400), allowedOrigin);
     try {
       const ns = nsFromOrigin(req);
-      // コールドスタート直後だと定義が未ロードで「そのクエストは無い」に落ちるので、ここは待つ
-      // (TTL 内はキャッシュ即返しでコスト無し)。
-      await ensureAuthoredWorld(env, ns, nowSec());
       const handler = accept ? handleQuestAccept : handleQuestComplete;
       return cors(json(await handler(env, did, body.questId, nowSec(), (d, iso) => migrateInitState(d, iso, ns))), allowedOrigin);
     } catch (e) {
@@ -499,15 +389,9 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
 
   // なんでも屋: 素材のひきとり (素材 → パワー)。権威側の在庫と残高を動かす。
   if (req.method === 'POST' && url.pathname === '/api/shop/sell') {
-    const token = bearer(req);
-    if (!token) return cors(json({ error: 'missing_token' }, 401), allowedOrigin);
-    const audience = env.WORKER_DID ?? 'did:web:edge.aozoraquest.app';
-    let did: string;
-    try {
-      ({ iss: did } = await verifyServiceAuth(token, { audience, lxm: LXM_SHOP_SELL }));
-    } catch (e) {
-      return cors(json({ error: 'unauthorized', reason: e instanceof ServiceAuthError ? e.message : 'verify_failed' }, 401), allowedOrigin);
-    }
+    const auth = await authenticate(req, env, LXM_SHOP_SELL, 'world');
+    if (auth instanceof Response) return cors(auth, allowedOrigin);
+    const { did } = auth;
     const body = (await req.json().catch(() => ({}))) as { materialId?: unknown; count?: unknown; rkey?: unknown; token?: unknown };
     if (typeof body.materialId !== 'string' || typeof body.count !== 'number' || typeof body.rkey !== 'string') {
       return cors(json({ error: 'bad_request' }, 400), allowedOrigin);
@@ -525,15 +409,9 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
   // オンボード用リセット: 認証済み本人の権威 gameState + 戦闘ガードを削除する (他人は消せない)。
   // client 側 PDS レコードの初期化は client が本人トークンで行う。UI は dev + 管理者に限定。
   if (req.method === 'POST' && url.pathname === '/api/world/reset') {
-    const token = bearer(req);
-    if (!token) return cors(json({ error: 'missing_token' }, 401), allowedOrigin);
-    const audience = env.WORKER_DID ?? 'did:web:edge.aozoraquest.app';
-    let did: string;
-    try {
-      ({ iss: did } = await verifyServiceAuth(token, { audience, lxm: LXM_WORLD_RESET }));
-    } catch (e) {
-      return cors(json({ error: 'unauthorized', reason: e instanceof ServiceAuthError ? e.message : 'verify_failed' }, 401), allowedOrigin);
-    }
+    const auth = await authenticate(req, env, LXM_WORLD_RESET, 'world');
+    if (auth instanceof Response) return cors(auth, allowedOrigin);
+    const { did } = auth;
     try {
       return cors(json(await handleReset(env, did, nowSec())), allowedOrigin);
     } catch (e) {
@@ -582,6 +460,38 @@ function battleError(e: unknown): Response {
   // 失効/無効トークンで PDS が 401/403 を返した場合も **fail-closed 503** (報酬なし。500 で誤魔化さない)。
   if (e instanceof PdsError && (e.status === 401 || e.status === 403)) return json({ error: 'server_write_unavailable', reason: 'auth' }, 503);
   return json({ error: 'internal' }, 500);
+}
+
+/**
+ * 権威 API の呼び出し元を確かめる。service auth JWT を検証し、`gate === 'world'` なら
+ * BAN 済み DID を 403 で拒む (#561)。失敗時は返した Response をそのまま `cors()` に載せる。
+ *
+ * **BAN が効くのはあおぞらワールドの権威 API だけ** — 権威 state (パワー・XP・在庫・位置) を
+ * 書き換える経路 (移動・戦闘・店・クエスト・XP 申告・パワー消費・リセット)。
+ * `GET /api/me/state` は表示用の読み取りで、ホーム/自分/カードも見るので止めない。
+ * 管理者専用の経路は `isEdgeAdmin` が門で、BAN 判定は掛けない。
+ *
+ * BAN リストは手編集の世界と同じ便 (`ensureAuthoredWorld`) で管理者 PDS から読む。
+ * コールド isolate では未読 (空) なので**判定の前に読み込みを待つ** — 地図・NPC・ゲート・
+ * クエスト定義も同じ待ちで揃うので、「街に入れない」「倒したのに数えられない」も同時に防ぐ
+ * (TTL 内はキャッシュ即返しでコストは乗らない)。
+ */
+async function authenticate(req: Request, env: Env, lxm: string, gate: 'world' | 'none'): Promise<{ did: string } | Response> {
+  const token = bearer(req);
+  if (!token) return json({ error: 'missing_token' }, 401);
+  const audience = env.WORKER_DID ?? 'did:web:edge.aozoraquest.app';
+  let did: string;
+  try {
+    ({ iss: did } = await verifyServiceAuth(token, { audience, lxm }));
+  } catch (e) {
+    // fail-closed: 検証失敗は 401 (詳細は漏らしすぎない)
+    return json({ error: 'unauthorized', reason: e instanceof ServiceAuthError ? e.message : 'verify_failed' }, 401);
+  }
+  if (gate === 'world') {
+    await ensureAuthoredWorld(env, nowSec());
+    if (isBanned(bannedDidList(), did)) return json({ error: 'forbidden', reason: 'banned' }, 403);
+  }
+  return { did };
 }
 
 /** Authorization: Bearer <jwt> を取り出す。 */

--- a/apps/edge/src/world-authoring.ts
+++ b/apps/edge/src/world-authoring.ts
@@ -1,4 +1,4 @@
-import { decodeWorldMap, loadStaticWorldMap, loadTileArts, setGameQuests, setInteriors, setScenario, setItemOverrides, setJobOverrides, setMonsterOverrides, setNpcs, setShopOverrides, setTownOverrides, setWorldMap, WORLD_SIZE, type EquipmentDef, type Gate, type GameQuestDef, type ScenarioEvent, type InteriorMap, type ItemDefData, type JobOverride, type MonsterDef, type NpcDef, type ShopOverride, type TownOverride, type WorldPart } from '@aozoraquest/core';
+import { BANS_RKEY, bansCollection, decodeWorldMap, loadStaticWorldMap, loadTileArts, setGameQuests, setInteriors, setScenario, setItemOverrides, setJobOverrides, setMonsterOverrides, setNpcs, setShopOverrides, setTownOverrides, setWorldMap, WORLD_SIZE, type BansRecord, type EquipmentDef, type Gate, type GameQuestDef, type ScenarioEvent, type InteriorMap, type ItemDefData, type JobOverride, type MonsterDef, type NpcDef, type ShopOverride, type TownOverride, type WorldPart } from '@aozoraquest/core';
 import { getRecord } from './pds';
 import { resolveDidDocument } from './service-auth';
 import { pdsEndpointFromDoc } from './oauth-metadata';
@@ -10,12 +10,33 @@ import { pdsEndpointFromDoc } from './oauth-metadata';
  * 地図を見ていると「画面では歩けるのにサーバーが弾く」= **プレイヤーがその場から
  * 動けなくなる**。同じ管理者 repo の同じ rkey を読んで揃える。
  *
+ * **BAN リスト (#561) も同じ便に乗せる。** ワールドの権威 API は BAN 済み DID を 403 で
+ * 拒むが、判定に使うリストは web が読むのと同じ管理者レコード (`config.bans`) で、
+ * collection・rkey・判定は `@aozoraquest/core` の `ban.ts` が 1 か所で持つ。
+ *
  * **リクエストごとに読まない。** isolate ごとにキャッシュし、TTL で寝かせる。
  * PDS の読み取りは書き込み点数を消費しないが、毎リクエストの往復はレイテンシに乗る。
  */
 
+/** 管理系レコードの NSID の根。**env で分けない** (dev も本番も同じ 1 か所を見る) —
+ *  web の `collections.ts` の `ADMIN_COL` と同じ規則。ユーザー記録の `nsFromOrigin` とは別物。 */
+export const ADMIN_NSID_ROOT = 'app.aozoraquest';
+
 const RKEY = 'self';
 const CACHE_TTL_SEC = 300;
+
+/** 読み込んだ BAN リスト。読めなかった回は前の値を保つ (空に戻して全員を通さない)。 */
+let bannedDids: readonly string[] = [];
+
+/** ルーターの BAN 判定に渡すリスト。`ensureAuthoredWorld` を待ってから読むこと (コールド isolate では空)。 */
+export function bannedDidList(): readonly string[] {
+  return bannedDids;
+}
+
+/** テスト用: リストを直接置く。本番では loader だけが呼ぶ。 */
+export function setBannedDids(dids: readonly string[]): void {
+  bannedDids = dids;
+}
 
 export interface WorldAuthoringEnv {
   /** カンマ区切り。先頭を主管理者として扱う (web の getPrimaryAdminDid と同じ規則)。 */
@@ -62,7 +83,8 @@ function fromBase64(b64: string): Uint8Array {
  * リクエスト自体は待たせない — 読み込むまでは同梱の地図かノイズ生成に倒れるだけで、
  * 結果は「編集前の世界」として一貫している。
  */
-export function ensureAuthoredWorld(env: WorldAuthoringEnv, nsid: string, now: number): Promise<void> {
+export function ensureAuthoredWorld(env: WorldAuthoringEnv, now: number): Promise<void> {
+  const nsid = ADMIN_NSID_ROOT;
   if (inflight) return inflight;
   if (loadedAt && now - loadedAt < CACHE_TTL_SEC) return Promise.resolve();
   /** レコード 1 つぶんの適用。**1 つが壊れても後続を止めない** — 1 本の try に
@@ -84,6 +106,12 @@ export function ensureAuthoredWorld(env: WorldAuthoringEnv, nsid: string, now: n
     const doc = await resolveDidDocument(did);
     const pds = pdsEndpointFromDoc(doc as Parameters<typeof pdsEndpointFromDoc>[0], did);
     if (!pds) return;
+    // BAN リスト (#561)。**レコードが無い = 誰も BAN していない** (空にする)。読めなかった回は
+    // step が握って前の値のまま (一時的な PDS 障害で BAN が外れないように)。
+    await step('bans', async () => {
+      const bans = await getRecord<BansRecord>(pds, did, bansCollection(nsid), BANS_RKEY);
+      setBannedDids(bans?.value?.dids ?? []);
+    });
     const map = await getRecord<WorldMapRecord>(pds, did, `${nsid}.world.map`, RKEY);
     if (map?.value?.gz) {
       const tiles = await decodeWorldMap(fromBase64(map.value.gz));
@@ -169,4 +197,5 @@ export function ensureAuthoredWorld(env: WorldAuthoringEnv, nsid: string, now: n
 export function resetAuthoredWorldCache(): void {
   loadedAt = 0;
   inflight = null;
+  bannedDids = [];
 }

--- a/apps/edge/test/ban-gate.test.ts
+++ b/apps/edge/test/ban-gate.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * **BAN 済み DID はワールドの権威 API を 403 で弾く** (#561)。
+ *
+ * BAN リストは管理者 PDS の `config.bans` (rkey=self) を、手編集の世界と同じ loader
+ * (`ensureAuthoredWorld`) で読む。ここでは JWT 検証と PDS 読み取りだけ差し替え、
+ * ルーター → authenticate → loader → core の isBanned という本番の経路をそのまま通す。
+ */
+
+const BANNED = 'did:plc:banned';
+const ADMIN = 'did:plc:admin';
+const BANS_COLLECTION = 'app.aozoraquest.config.bans';
+
+// vi.mock はファイル先頭へ巻き上げられるので、factory が触る値は vi.hoisted で先に作る。
+const h = vi.hoisted(() => {
+  const state = {
+    /** 呼び出し元 DID (JWT の iss)。テストごとに差し替える。 */
+    caller: 'did:plc:banned',
+    /** 管理者 PDS にある BAN レコードの中身。null = レコード無し。 */
+    bansRecord: null as { dids: string[]; updatedAt: string } | null,
+  };
+  const getRecordMock = vi.fn(async (_pds: string, _repo: string, collection: string, rkey: string) => {
+    if (collection === 'app.aozoraquest.config.bans' && rkey === 'self' && state.bansRecord) {
+      return { uri: 'at://x', cid: 'c', value: state.bansRecord };
+    }
+    return null;
+  });
+  return { state, getRecordMock };
+});
+
+vi.mock('../src/service-auth', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../src/service-auth')>();
+  return {
+    ...mod,
+    verifyServiceAuth: vi.fn(async () => ({ iss: h.state.caller })),
+    resolveDidDocument: vi.fn(async (did: string) => ({
+      id: did,
+      service: [{ id: '#atproto_pds', type: 'AtprotoPersonalDataServer', serviceEndpoint: 'https://pds.example' }],
+    })),
+  };
+});
+vi.mock('../src/pds', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../src/pds')>();
+  return { ...mod, getRecord: h.getRecordMock };
+});
+
+import { handleRequest, type Env } from '../src/router';
+import { resetAuthoredWorldCache } from '../src/world-authoring';
+
+const env: Env = { ENVIRONMENT: 'test', ADMIN_DIDS: ADMIN };
+
+function post(path: string, body: unknown = {}): Request {
+  return new Request(`https://x${path}`, {
+    method: 'POST',
+    headers: { authorization: 'Bearer test.jwt', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+function get(path: string): Request {
+  return new Request(`https://x${path}`, { headers: { authorization: 'Bearer test.jwt' } });
+}
+
+beforeEach(() => {
+  resetAuthoredWorldCache();
+  h.getRecordMock.mockClear();
+  h.state.caller = BANNED;
+  h.state.bansRecord = { dids: [BANNED], updatedAt: new Date(0).toISOString() };
+});
+
+describe('BAN ゲート (ワールドの権威 API)', () => {
+  it('BAN 済み DID の移動は 403 forbidden/banned', async () => {
+    const res = await handleRequest(post('/api/world/move', { dx: 1, dy: 0 }), env);
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({ error: 'forbidden', reason: 'banned' });
+  });
+
+  it('BAN リストは管理者 PDS の config.bans (rkey=self) から読む', async () => {
+    await handleRequest(post('/api/world/move', { dx: 1, dy: 0 }), env);
+    expect(h.getRecordMock).toHaveBeenCalledWith('https://pds.example', ADMIN, BANS_COLLECTION, 'self');
+  });
+
+  it.each([
+    ['/api/battle/turn', { battleId: 'b', turn: 1, command: 'attack' }],
+    ['/api/world/teleport', { x: 1, y: 1 }],
+    ['/api/world/item', { item: 'herb' }],
+    ['/api/world/gear', { gear: {} }],
+    ['/api/world/search', {}],
+    ['/api/world/reset', {}],
+    ['/api/xp/claim', { archetype: 'a', postUri: 'at://x' }],
+    ['/api/power/spend', { reason: 'card-draw', key: 'k' }],
+    ['/api/shop/craft', { itemId: 'i', rkey: 'r' }],
+    ['/api/shop/sell', { materialId: 'm', count: 1, rkey: 'r' }],
+    ['/api/shop/forge', { rkeys: ['a', 'b'], rkey: 'r' }],
+    ['/api/shop/discard', { rkeys: ['a'], rkey: 'r' }],
+    ['/api/quest/accept', { questId: 'q' }],
+    ['/api/quest/complete', { questId: 'q' }],
+  ])('BAN 済み DID の %s は 403', async (path, body) => {
+    const res = await handleRequest(post(path, body), env);
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({ error: 'forbidden', reason: 'banned' });
+  });
+
+  it('BAN リストが空なら通る (403 にならない)', async () => {
+    h.state.bansRecord = { dids: [], updatedAt: new Date(0).toISOString() };
+    const res = await handleRequest(post('/api/world/move', { dx: 1, dy: 0 }), env);
+    expect(res.status).not.toBe(403);
+    expect(res.status).not.toBe(401);
+  });
+
+  it('BAN レコードが無ければ誰も BAN されない', async () => {
+    h.state.bansRecord = null;
+    const res = await handleRequest(post('/api/world/move', { dx: 1, dy: 0 }), env);
+    expect(res.status).not.toBe(403);
+  });
+
+  it('リストに無い DID は通る', async () => {
+    h.state.caller = 'did:plc:someone';
+    const res = await handleRequest(post('/api/world/move', { dx: 1, dy: 0 }), env);
+    expect(res.status).not.toBe(403);
+  });
+
+  it('BAN はワールドだけ: whoami と me/state (表示用の読み取り) は止めない', async () => {
+    const who = await handleRequest(post('/api/whoami'), env);
+    expect(who.status).toBe(200);
+    expect(await who.json()).toEqual({ did: BANNED });
+    const state = await handleRequest(get('/api/me/state'), env);
+    expect(state.status).not.toBe(403);
+  });
+
+  it('同じ isolate では 2 回目以降も読み直さない (TTL キャッシュに乗る)', async () => {
+    await handleRequest(post('/api/world/move', { dx: 1, dy: 0 }), env);
+    const calls = h.getRecordMock.mock.calls.length;
+    const res = await handleRequest(post('/api/world/move', { dx: 1, dy: 0 }), env);
+    expect(res.status).toBe(403);
+    expect(h.getRecordMock.mock.calls.length).toBe(calls);
+  });
+});

--- a/apps/web/src/components/admin/config-admin.tsx
+++ b/apps/web/src/components/admin/config-admin.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import type { Agent } from '@atproto/api';
+import type { BansRecord } from '@aozoraquest/core';
 import { ADMIN_COL } from '@/lib/collections';
 import { useAdminConfig } from '@/lib/use-admin-config';
 
@@ -41,16 +42,6 @@ function SaveBar({ loaded, loadFailed, saving, savedMark, err, canWrite, onSave,
   );
 }
 
-/** **保存しても効かない**画面の印。判定関数はあるが production の呼び出し元が無い (#561)。
- *  「メンテを開始した」と信じて破壊的作業に入られるのが一番まずいので、見出しに出す。 */
-function NotWired() {
-  return (
-    <span style={{ fontSize: '0.75em', color: 'var(--color-danger, #e8566a)', marginLeft: '0.4em', fontWeight: 400 }}>
-      未配線 (保存しても効かない)
-    </span>
-  );
-}
-
 /** 主管理者以外でログインしているときの注意。保存しても web が読む先に反映されない。 */
 function WriteGuard({ canWrite }: { canWrite: boolean }) {
   if (canWrite) return null;
@@ -59,6 +50,16 @@ function WriteGuard({ canWrite }: { canWrite: boolean }) {
       主管理者のアカウントでないため保存できない (書き込み先が主管理者の repo のため)。閲覧のみ。
     </p>
   );
+}
+
+/** 改行区切りの DID 入力を配列にする (空行・`did:` で始まらない行・重複は捨てる)。 */
+export function parseDidLines(text: string): string[] {
+  const out: string[] = [];
+  for (const line of text.split('\n')) {
+    const d = line.trim();
+    if (d.startsWith('did:') && !out.includes(d)) out.push(d);
+  }
+  return out;
 }
 
 // ─────────────────────────────────────────── 参加者ディレクトリ
@@ -250,6 +251,8 @@ export function MaintenanceAdmin() {
   const [enabled, setEnabled] = useState(false);
   const [message, setMessage] = useState('メンテナンス中です。しばらくお待ちください。');
   const [until, setUntil] = useState('');
+  /** メンテ中でも通す DID (改行区切りで編集)。管理者 (VITE_ADMIN_DIDS) は書かなくても通る。 */
+  const [allowedText, setAllowedText] = useState('');
   const [confirm, setConfirm] = useState('');
 
   useEffect(() => {
@@ -257,20 +260,20 @@ export function MaintenanceAdmin() {
     setEnabled(value.enabled ?? false);
     if (value.message !== undefined) setMessage(value.message);
     if (value.until !== undefined) setUntil(value.until);
+    setAllowedText((value.allowedDids ?? []).join('\n'));
   }, [value]);
+
+  const allowedDids = parseDidLines(allowedText);
 
   // **有効化は全ユーザーを止める**ので、合言葉を打たせる (誤操作の抑止)。解除は自由。
   const armed = !enabled || confirm === 'MAINTENANCE';
 
   return (
     <section style={{ marginTop: '2em' }}>
-      <h3 style={{ fontSize: '0.95em' }}>メンテナンスモード <NotWired /></h3>
+      <h3 style={{ fontSize: '0.95em' }}>メンテナンスモード</h3>
       <p style={{ fontSize: '0.8em', color: 'var(--color-muted)' }}>
-        「メンテ中」の印を残すだけで、<strong>いまは誰も止まらない</strong>。
-        `isUnderMaintenance` を実際に見ている画面がまだ無い (#561)。
-        <br />
-        配線するときは注意: 現在の判定は <code>allowedDids</code> しか通さないので、
-        そのまま繋ぐと<strong>主管理者自身も締め出されて解除できなくなる</strong>。
+        <strong>アプリ全体</strong>をメンテナンス画面に差し替える。管理者と下の DID は通る。
+        締め出されても <code>/admin</code> とログインだけは入れる (解除の導線)。
       </p>
       <WriteGuard canWrite={canWrite} />
       {!loaded && <p style={{ fontSize: '0.85em', color: 'var(--color-muted)' }}>読み込み中…</p>}
@@ -282,6 +285,10 @@ export function MaintenanceAdmin() {
       <input value={message} onChange={(e) => setMessage(e.target.value)} placeholder="表示するメッセージ"
         style={{ width: '100%', marginTop: '0.4em', fontSize: '0.85em' }} />
       <input value={until} onChange={(e) => setUntil(e.target.value)} placeholder="終了予定 (任意。例 2026-07-28T10:00)"
+        style={{ width: '100%', marginTop: '0.4em', fontSize: '0.85em' }} />
+      <textarea value={allowedText} onChange={(e) => setAllowedText(e.target.value)} rows={3}
+        aria-label="メンテ中でも通す DID (1 行 1 つ)"
+        placeholder={'メンテ中でも通す DID (1 行 1 つ。管理者は書かなくても通る)\ndid:plc:...'}
         style={{ width: '100%', marginTop: '0.4em', fontSize: '0.85em' }} />
       {enabled && (
         <div style={{ marginTop: '0.4em' }}>
@@ -296,9 +303,7 @@ export function MaintenanceAdmin() {
           enabled,
           ...(message ? { message } : {}),
           ...(until ? { until } : {}),
-          // **この画面で編集しない項目を落とさない。** allowedDids (メンテ中でも通す DID) を
-          // 省くと、保存のたびに既存の設定が消える。
-          ...(value?.allowedDids ? { allowedDids: value.allowedDids } : {}),
+          ...(allowedDids.length ? { allowedDids } : {}),
           updatedAt: new Date().toISOString(),
         } satisfies MaintRecord)} />
     </section>
@@ -306,8 +311,6 @@ export function MaintenanceAdmin() {
 }
 
 // ─────────────────────────────────────────── BAN リスト
-
-interface BansRecord { dids: string[]; updatedAt: string }
 
 export function BansAdmin() {
   const { loaded, loadFailed, value, save, saving, err, savedMark, canWrite } = useAdminConfig<BansRecord>(ADMIN_COL.configBans, 'self');
@@ -325,10 +328,10 @@ export function BansAdmin() {
 
   return (
     <section style={{ marginTop: '2em' }}>
-      <h3 style={{ fontSize: '0.95em' }}>BAN リスト ({dids.length}) <NotWired /></h3>
+      <h3 style={{ fontSize: '0.95em' }}>BAN リスト ({dids.length})</h3>
       <p style={{ fontSize: '0.8em', color: 'var(--color-muted)' }}>
-        名簿を残すだけで、<strong>いまは何も除外されない</strong>。
-        `isBanned` を実際に見ている画面がまだ無い (#561)。
+        効くのは<strong>あおぞらワールドだけ</strong> (画面を出さない + サーバーが権威 API を拒む)。
+        投稿・タイムライン・依頼クエスト板には効かない。反映はサーバー側で最長 5 分。
         <br />
         <strong>このレコードは公開される</strong> (主管理者 PDS の公開レコード) ことに注意。
       </p>

--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -11,6 +11,7 @@ import { removeSplash } from '@/lib/splash';
 import { useQuestActionableCount, computeQuestActionableCount, setQuestActionableCount } from '@/lib/quest-actionable';
 import { subscribeNotificationsSeen } from '@/lib/notification-seen';
 import { useRuntimeConfig } from '@/components/config-provider';
+import { MaintenanceGate } from '@/components/maintenance-gate';
 import type { AppColumnKind } from '@/lib/app-columns';
 
 /** footer-nav の各タブと workspace カラム kind の対応。
@@ -207,7 +208,10 @@ export function AppShell() {
       <main className="content">
         {/* ルートは lazy 分割 (main.tsx)。チャンク取得中の簡素なフォールバック。 */}
         <Suspense fallback={<div style={{ padding: '1em', fontSize: '0.85em', color: 'var(--color-muted)' }}>読み込み中…</div>}>
-          <Outlet />
+          {/* メンテナンス中は全ルートを差し替える (#561)。誰を通すかは isUnderMaintenance が決める。 */}
+          <MaintenanceGate>
+            <Outlet />
+          </MaintenanceGate>
         </Suspense>
       </main>
       {showComposeFab && (

--- a/apps/web/src/components/config-provider.tsx
+++ b/apps/web/src/components/config-provider.tsx
@@ -2,15 +2,22 @@ import { createContext, useContext, useEffect, useState, type ReactNode } from '
 import { DEFAULT_RUNTIME_CONFIG, type RuntimeConfig } from '@aozoraquest/types';
 import { loadRuntimeConfig } from '@/lib/runtime-config';
 
-interface ConfigState {
+export interface ConfigState {
   config: RuntimeConfig;
+  /** 読み終えた (失敗して既定値に倒した場合も true)。 */
   loaded: boolean;
 }
 
-const ConfigContext = createContext<ConfigState>({ config: DEFAULT_RUNTIME_CONFIG, loaded: false });
+/** テストから状態を差し込むために公開する。本番は ConfigProvider 経由。 */
+export const ConfigContext = createContext<ConfigState>({ config: DEFAULT_RUNTIME_CONFIG, loaded: false });
 
 export function useRuntimeConfig(): RuntimeConfig {
   return useContext(ConfigContext).config;
+}
+
+/** 読み込み完了を待ちたい画面用 (ワールドの BAN 判定など、既定値で先に描くと困るところ)。 */
+export function useRuntimeConfigState(): ConfigState {
+  return useContext(ConfigContext);
 }
 
 export function ConfigProvider({ children }: { children: ReactNode }) {

--- a/apps/web/src/components/maintenance-gate.test.tsx
+++ b/apps/web/src/components/maintenance-gate.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { DEFAULT_RUNTIME_CONFIG, type RuntimeConfig } from '@aozoraquest/types';
+import { SessionContext, type SessionState } from '@/lib/session';
+import { ConfigContext } from '@/components/config-provider';
+import { MaintenanceGate, maintenanceExemptPath } from './maintenance-gate';
+
+/**
+ * **メンテナンス中は全ルートがメンテ画面に差し替わる** (#561)。
+ * 誰を通すか (管理者 / allowedDids) は isUnderMaintenance が決め、ここは
+ * 「画面が差し替わる / /admin だけは入れる」を固定する。
+ */
+
+const MAINT: RuntimeConfig = {
+  ...DEFAULT_RUNTIME_CONFIG,
+  maintenance: { enabled: true, message: 'いま直しています', until: '2026-09-02T10:00:00+09:00', updatedAt: 'x' },
+};
+
+function renderAt(path: string, session: SessionState, config: RuntimeConfig = MAINT) {
+  return render(
+    <ConfigContext.Provider value={{ config, loaded: true }}>
+      <SessionContext.Provider value={session}>
+        <MemoryRouter initialEntries={[path]}>
+          <MaintenanceGate>
+            <div data-testid="content">本体</div>
+          </MaintenanceGate>
+        </MemoryRouter>
+      </SessionContext.Provider>
+    </ConfigContext.Provider>,
+  );
+}
+
+const user: SessionState = { status: 'signed-in', did: 'did:plc:user' };
+
+describe('MaintenanceGate', () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('メンテ中の一般ユーザーはメンテ画面 (message と until が出て、本体は描かない)', () => {
+    renderAt('/', user);
+    expect(screen.queryByTestId('content')).toBeNull();
+    expect(screen.getByRole('status').textContent).toContain('いま直しています');
+    expect(screen.getByText(/終了予定/)).toBeTruthy();
+  });
+
+  it('未ログインもメンテ画面', () => {
+    renderAt('/', { status: 'signed-out' });
+    expect(screen.queryByTestId('content')).toBeNull();
+    expect(screen.getByRole('status')).toBeTruthy();
+  });
+
+  it('管理者 (VITE_ADMIN_DIDS) は通る', () => {
+    vi.stubEnv('VITE_ADMIN_DIDS', 'did:plc:admin');
+    renderAt('/', { status: 'signed-in', did: 'did:plc:admin' });
+    expect(screen.getByTestId('content')).toBeTruthy();
+  });
+
+  it('allowedDids の DID は通る', () => {
+    const cfg: RuntimeConfig = { ...MAINT, maintenance: { ...MAINT.maintenance, allowedDids: ['did:plc:vip'] } };
+    renderAt('/', { status: 'signed-in', did: 'did:plc:vip' }, cfg);
+    expect(screen.getByTestId('content')).toBeTruthy();
+  });
+
+  it('/admin 配下はメンテ中でも到達できる (解除の導線)', () => {
+    renderAt('/admin', user);
+    expect(screen.getByTestId('content')).toBeTruthy();
+  });
+
+  it('ログイン経路 (/onboarding) は未ログインでも到達できる (管理者がログインして解除するため)', () => {
+    renderAt('/onboarding', { status: 'signed-out' });
+    expect(screen.getByTestId('content')).toBeTruthy();
+  });
+
+  it('メンテ中でなければ本体をそのまま描く', () => {
+    renderAt('/', user, DEFAULT_RUNTIME_CONFIG);
+    expect(screen.getByTestId('content')).toBeTruthy();
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+
+  it('message が空なら既定文を出す', () => {
+    renderAt('/', user, { ...MAINT, maintenance: { enabled: true, updatedAt: 'x' } });
+    expect(screen.getByRole('status').textContent).toContain('メンテナンス中です');
+  });
+});
+
+describe('maintenanceExemptPath', () => {
+  it('/admin と配下、ログイン経路だけ', () => {
+    expect(maintenanceExemptPath('/admin')).toBe(true);
+    expect(maintenanceExemptPath('/admin/map')).toBe(true);
+    expect(maintenanceExemptPath('/onboarding')).toBe(true);
+    expect(maintenanceExemptPath('/oauth/callback')).toBe(true);
+    expect(maintenanceExemptPath('/')).toBe(false);
+    expect(maintenanceExemptPath('/world')).toBe(false);
+    expect(maintenanceExemptPath('/administrator')).toBe(false);
+  });
+});

--- a/apps/web/src/components/maintenance-gate.tsx
+++ b/apps/web/src/components/maintenance-gate.tsx
@@ -1,0 +1,54 @@
+import type { ReactNode } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useSession } from '@/lib/session';
+import { useRuntimeConfig } from '@/components/config-provider';
+import { isUnderMaintenance } from '@/lib/runtime-config';
+
+/**
+ * **メンテナンスモードはアプリ全体を止める** (#561)。app-shell が全ルートをこれで包む。
+ *
+ * 誰を通すかは `isUnderMaintenance` (runtime-config) が 1 か所で決める — 管理者と
+ * `allowedDids` は通る、未ログイン (セッション復元中を含む) は止まる。ここでは
+ * **どのパスを通すか**だけを持つ:
+ *
+ * - `/admin` 配下: 解除の導線。締め出されたときにここだけは入れる保証。
+ *   (中身は各画面の `isAdminDid` 表示ゲートに任せる — 一般ユーザーが来ても管理画面は開かない)
+ * - `/onboarding` と `/oauth/callback`: ログアウト中の管理者がログインして解除するための経路。
+ *   ログインしても管理者でなければ、戻った先でこの画面に止まる。
+ */
+export function maintenanceExemptPath(pathname: string): boolean {
+  return pathname === '/admin' || pathname.startsWith('/admin/')
+    || pathname === '/onboarding' || pathname === '/oauth/callback';
+}
+
+export function MaintenanceGate({ children }: { children: ReactNode }) {
+  const session = useSession();
+  const config = useRuntimeConfig();
+  const { pathname } = useLocation();
+  if (isUnderMaintenance(config, session.did) && !maintenanceExemptPath(pathname)) {
+    return <MaintenanceScreen {...config.maintenance} />;
+  }
+  return <>{children}</>;
+}
+
+const DEFAULT_MESSAGE = 'メンテナンス中です。しばらくお待ちください。';
+
+/** 管理画面で入れた `until` は自由書式なので、日時として読めたときだけ整形する。 */
+function formatUntil(until: string): string {
+  const t = new Date(until);
+  return Number.isNaN(t.getTime()) ? until : t.toLocaleString('ja-JP', { dateStyle: 'medium', timeStyle: 'short' });
+}
+
+function MaintenanceScreen({ message, until }: { message?: string | undefined; until?: string | undefined }) {
+  return (
+    <div role="status" className="dq-window" style={{ margin: '2em auto', maxWidth: '28em', padding: '1.2em 1.4em' }}>
+      <h2 style={{ fontSize: '1em', marginTop: 0 }}>メンテナンス中</h2>
+      <p style={{ whiteSpace: 'pre-wrap' }}>{message || DEFAULT_MESSAGE}</p>
+      {until && (
+        <p style={{ fontSize: '0.85em', color: 'var(--color-muted)' }}>
+          終了予定: <time dateTime={until}>{formatUntil(until)}</time>
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/collections.ts
+++ b/apps/web/src/lib/collections.ts
@@ -22,6 +22,8 @@
  * - 実 Bluesky 投稿 (`app.bsky.feed.post`) は性質上分離不可、
  *   dev からの投稿も実投稿になる。
  */
+import { bansCollection } from '@aozoraquest/core';
+
 const ROOT = (import.meta.env.VITE_NSID_ROOT as string | undefined)?.trim();
 if (!ROOT) {
   throw new Error(
@@ -78,7 +80,8 @@ export const ROOT_COL = {
 export const ADMIN_COL = {
   configFlags: `${ROOT}.config.flags`,
   configMaintenance: `${ROOT}.config.maintenance`,
-  configBans: `${ROOT}.config.bans`,
+  /** BAN リスト。collection・rkey・判定は core の `ban.ts` が持つ (edge も同じものを読む)。#561 */
+  configBans: bansCollection(ROOT),
   configPrompts: `${ROOT}.config.prompts`,
   directory: `${ROOT}.directory`,
   /** 手編集したワールドの地形 (1 タイル 1 バイトを gzip → base64)。#421 */

--- a/apps/web/src/lib/runtime-config.test.ts
+++ b/apps/web/src/lib/runtime-config.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import { DEFAULT_RUNTIME_CONFIG, type RuntimeConfig } from '@aozoraquest/types';
-import { isAdminDid, isBanned, isFlagEnabled, isUnderMaintenance } from './runtime-config';
+import { isAdminDid, isFlagEnabled, isUnderMaintenance } from './runtime-config';
 
 function cfg(overrides: Partial<RuntimeConfig> = {}): RuntimeConfig {
   return { ...DEFAULT_RUNTIME_CONFIG, ...overrides };
@@ -86,6 +86,8 @@ describe('isFlagEnabled', () => {
 });
 
 describe('isUnderMaintenance', () => {
+  afterEach(() => vi.unstubAllEnvs());
+
   test('enabled=false なら false', () => {
     expect(isUnderMaintenance(cfg(), 'did:plc:a')).toBe(false);
   });
@@ -95,21 +97,22 @@ describe('isUnderMaintenance', () => {
     expect(isUnderMaintenance(c, 'did:plc:a')).toBe(true);
   });
 
+  test('未ログイン (did 無し) も止める', () => {
+    const c = cfg({ maintenance: { enabled: true, updatedAt: 'x' } });
+    expect(isUnderMaintenance(c, undefined)).toBe(true);
+  });
+
   test('allowedDids に入っていれば false', () => {
-    const c = cfg({ maintenance: { enabled: true, allowedDids: ['did:plc:admin'], updatedAt: 'x' } });
-    expect(isUnderMaintenance(c, 'did:plc:admin')).toBe(false);
+    const c = cfg({ maintenance: { enabled: true, allowedDids: ['did:plc:vip'], updatedAt: 'x' } });
+    expect(isUnderMaintenance(c, 'did:plc:vip')).toBe(false);
     expect(isUnderMaintenance(c, 'did:plc:other')).toBe(true);
   });
-});
 
-describe('isBanned', () => {
-  test('空配列では false', () => {
-    expect(isBanned(cfg(), 'did:plc:a')).toBe(false);
-  });
-
-  test('入っていれば true', () => {
-    const c = cfg({ bans: ['did:plc:bad'] });
-    expect(isBanned(c, 'did:plc:bad')).toBe(true);
-    expect(isBanned(c, 'did:plc:good')).toBe(false);
+  test('管理者 (VITE_ADMIN_DIDS) は allowedDids に無くても常に通す — 締め出されると解除できない', () => {
+    vi.stubEnv('VITE_ADMIN_DIDS', 'did:plc:primary, did:plc:second');
+    const c = cfg({ maintenance: { enabled: true, updatedAt: 'x' } });
+    expect(isUnderMaintenance(c, 'did:plc:primary')).toBe(false);
+    expect(isUnderMaintenance(c, 'did:plc:second')).toBe(false);
+    expect(isUnderMaintenance(c, 'did:plc:other')).toBe(true);
   });
 });

--- a/apps/web/src/lib/runtime-config.ts
+++ b/apps/web/src/lib/runtime-config.ts
@@ -13,6 +13,7 @@
 
 import { AtpAgent } from '@atproto/api';
 import { DEFAULT_RUNTIME_CONFIG, type RuntimeConfig } from '@aozoraquest/types';
+import type { BansRecord } from '@aozoraquest/core';
 import { ADMIN_COL } from './collections';
 
 const PLC_DIRECTORY = 'https://plc.directory';
@@ -112,7 +113,6 @@ interface MaintenanceRecord {
   allowedDids?: string[];
   updatedAt: string;
 }
-interface BansRecord { dids: string[]; updatedAt: string }
 interface PromptRecord { id: string; body: string; updatedAt: string; maxNewTokens?: number }
 interface DirectoryRecord { users: Array<{ did: string; addedAt: string; note?: string }>; updatedAt: string }
 
@@ -188,12 +188,20 @@ function hashStr(s: string): number {
   return h >>> 0;
 }
 
+/**
+ * メンテナンス中で、この DID を止めるべきか (#561)。**判定はここ 1 か所** — 呼び出し側
+ * (app-shell の `MaintenanceGate`) で管理者判定を別に書かない。
+ *
+ * - 管理者 (`isAdminDid`) は常に通す。ここを通さないと**主管理者自身が締め出されて
+ *   `/admin` で解除できなくなる**。
+ * - `allowedDids` (メンテ中でも通す DID) も通す。
+ * - 未ログイン (did 無し) は止める。
+ *
+ * BAN 判定 (`isBanned`) は core にある — web と edge が同じものを呼ぶため。
+ */
 export function isUnderMaintenance(config: RuntimeConfig, userDid: string | undefined): boolean {
   if (!config.maintenance.enabled) return false;
+  if (isAdminDid(userDid)) return false;
   if (userDid && config.maintenance.allowedDids?.includes(userDid)) return false;
   return true;
-}
-
-export function isBanned(config: RuntimeConfig, did: string): boolean {
-  return config.bans.includes(did);
 }

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -28,7 +28,8 @@ const AdminQuests = lazy(() => import('@/routes/admin-quests').then(m => ({ defa
 const AdminJobs = lazy(() => import('@/routes/admin-jobs').then(m => ({ default: m.AdminJobs })));
 const AdminInteriors = lazy(() => import('@/routes/admin-interiors').then(m => ({ default: m.AdminInteriors })));
 const AdminScenario = lazy(() => import('@/routes/admin-scenario').then(m => ({ default: m.AdminScenario })));
-const World = lazy(() => import('@/routes/world').then(m => ({ default: m.World })));
+// /world は BAN 表示ゲート (world-gate) を経由して World に入る (#561)。
+const World = lazy(() => import('@/routes/world-gate').then(m => ({ default: m.WorldGate })));
 const Onboarding = lazy(() => import('@/routes/onboarding').then(m => ({ default: m.Onboarding })));
 const OAuthCallback = lazy(() => import('@/routes/oauth-callback').then(m => ({ default: m.OAuthCallback })));
 const Tos = lazy(() => import('@/routes/tos').then(m => ({ default: m.Tos })));

--- a/apps/web/src/routes/world-gate.test.tsx
+++ b/apps/web/src/routes/world-gate.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { DEFAULT_RUNTIME_CONFIG, type RuntimeConfig } from '@aozoraquest/types';
+import { SessionContext, type SessionState } from '@/lib/session';
+import { ConfigContext } from '@/components/config-provider';
+
+// ゲーム本体は重い (権威 API を mount 時に叩く) ので、描かれたかどうかだけ分かる印に差し替える。
+vi.mock('./world', () => ({ World: () => <div data-testid="game">ゲーム</div> }));
+
+import { WorldGate } from './world-gate';
+
+/** **BAN 済み DID で /world を開いてもゲーム UI を描画しない** (#561)。 */
+
+function renderGate(session: SessionState, config: RuntimeConfig, loaded = true) {
+  return render(
+    <ConfigContext.Provider value={{ config, loaded }}>
+      <SessionContext.Provider value={session}>
+        <MemoryRouter initialEntries={['/world']}>
+          <WorldGate />
+        </MemoryRouter>
+      </SessionContext.Provider>
+    </ConfigContext.Provider>,
+  );
+}
+
+const BANNED: RuntimeConfig = { ...DEFAULT_RUNTIME_CONFIG, bans: ['did:plc:bad'] };
+
+describe('WorldGate', () => {
+  it('BAN 済み DID には「利用できません」を出し、ゲームを描かない', () => {
+    renderGate({ status: 'signed-in', did: 'did:plc:bad' }, BANNED);
+    expect(screen.queryByTestId('game')).toBeNull();
+    expect(screen.getByRole('status').textContent).toContain('利用できません');
+  });
+
+  it('BAN されていない DID はゲームに入る', () => {
+    renderGate({ status: 'signed-in', did: 'did:plc:good' }, BANNED);
+    expect(screen.getByTestId('game')).toBeTruthy();
+  });
+
+  it('BAN リストが空なら誰でも入る', () => {
+    renderGate({ status: 'signed-in', did: 'did:plc:bad' }, DEFAULT_RUNTIME_CONFIG);
+    expect(screen.getByTestId('game')).toBeTruthy();
+  });
+
+  it('設定を読み終えるまではゲームを mount しない (既定値 = BAN 無しで先に描かない)', () => {
+    renderGate({ status: 'signed-in', did: 'did:plc:bad' }, DEFAULT_RUNTIME_CONFIG, false);
+    expect(screen.queryByTestId('game')).toBeNull();
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+
+  it('未ログインは BAN 判定せずゲーム側 (ログイン導線) に任せる', () => {
+    renderGate({ status: 'signed-out' }, BANNED);
+    expect(screen.getByTestId('game')).toBeTruthy();
+  });
+});

--- a/apps/web/src/routes/world-gate.tsx
+++ b/apps/web/src/routes/world-gate.tsx
@@ -1,0 +1,33 @@
+import { Link } from 'react-router-dom';
+import { isBanned } from '@aozoraquest/core';
+import { useSession } from '@/lib/session';
+import { useRuntimeConfigState } from '@/components/config-provider';
+import { World } from './world';
+
+/**
+ * **BAN 済み DID にはワールドを描かない** (#561)。`/world` はこれを経由して `World` に入る。
+ *
+ * BAN が効くのは**あおぞらワールドだけ** — 投稿・タイムライン・バッジ・依頼クエスト板には
+ * 効かせない (Bluesky の公開データで、こちらで除外しても他のクライアントからは見えるので
+ * 意味が薄い)。ワールドは権威 state をこちらが持っているので止める意味がある。本当の門は
+ * edge の 403 で、ここは「入れないのに歩けそうに見える」画面を出さないための表示ゲート。
+ *
+ * `World` は mount した瞬間から権威 API を叩くので、**設定を読み終えるまで mount しない**
+ * (既定値 = BAN 無しで先に描くと、BAN 済みの人にも一瞬ゲームが見えて 403 が並ぶ)。
+ * 判定関数 (`isBanned`) は core のもの — edge と同じ。
+ */
+export function WorldGate() {
+  const session = useSession();
+  const { config, loaded } = useRuntimeConfigState();
+  if (!loaded) return <p>読み込み中…</p>;
+  if (session.status === 'signed-in' && isBanned(config.bans, session.did)) {
+    return (
+      <div>
+        <h2>あおぞらワールド</h2>
+        <p role="status">このアカウントではワールドは利用できません。</p>
+        <Link to="/">← ホームへ</Link>
+      </div>
+    );
+  }
+  return <World />;
+}

--- a/docs/14-admin.md
+++ b/docs/14-admin.md
@@ -175,7 +175,15 @@ function isEnabled(flag: string, userDid: string, flags: FlagConfig): boolean {
 
 #### クライアントでの挙動
 
-boot 時に `enabled=true` かつ自分の DID が `allowedDids` に含まれないなら、全画面メンテナンス UI を表示してアプリ機能を停止。管理者 DID は常に許可 (ADMIN_DIDS をクライアント側で参照)。
+`enabled=true` なら app-shell が**全ルート**をメンテナンス画面 (`message` と `until` を表示) に差し替える (`MaintenanceGate`)。誰を通すかは `isUnderMaintenance` (web の `runtime-config.ts`) が 1 か所で決める:
+
+- 管理者 DID (`VITE_ADMIN_DIDS`) は常に通す — ここを通さないと主管理者自身が締め出されて解除できない
+- `allowedDids` の DID も通す (管理画面で改行区切りで編集)
+- 未ログイン (セッション復元中を含む) は止める
+
+パスの例外: `/admin` 配下 (解除の導線) と `/onboarding` `/oauth/callback` (ログアウト中の管理者がログインするため) はメンテ中でも到達できる。
+
+メンテナンスは web の表示だけで、edge の権威 API は止めない (管理者の動作確認ができるように)。
 
 ### (c) システムプロンプト編集
 
@@ -219,9 +227,15 @@ const result = await generateWithLocalLLM({ systemPrompt: prompt, history: messa
 }
 ```
 
-#### クライアントでの挙動
+#### 挙動 (効くのはあおぞらワールドだけ)
 
-クライアントは boot 時に BAN リストを取得し、該当 DID の投稿をタイムラインから除外 / バッジ非表示。
+投稿・タイムライン・バッジ・依頼クエスト板には**効かせない** — それらは Bluesky の公開データで、
+こちらで除外しても他のクライアントからは見えるので意味が薄い。ワールドは権威 state
+(パワー・XP・在庫・位置) をこちらが持っているので、そこへの書き込みを止めることに意味がある。
+
+- **web**: `/world` は `WorldGate` を経由し、BAN 済み DID には「ワールドは利用できません」を出してゲーム UI を描かない (設定を読み終えるまで mount しない)
+- **edge**: ワールドの権威 API (移動・戦闘・店・クエスト・XP 申告・パワー消費・リセット) は BAN 済み DID を `403 {error:'forbidden', reason:'banned'}` で拒む。`GET /api/me/state` (表示用の読み取り。ホーム/自分/カードも見る) と管理者専用の経路は止めない
+- **読み方は 1 か所**: collection (`config.bans`)・rkey (`self`)・レコードの形・判定 (`isBanned`) は `packages/core/src/ban.ts`。web は `ADMIN_COL.configBans`、edge は手編集の世界と同じ loader (`world-authoring.ts` の `ensureAuthoredWorld`) から読み、同じ TTL (5 分) で更新される。edge は読めなかった回は前の値を保つ (一時的な PDS 障害で BAN が外れない)
 
 **プライバシー注記**: このレコードは主管理者 PDS 上で公開されるため、BAN 対象 DID は誰でも見える。Bluesky のラベリングサービスと同じく「公開されるモデレーション情報」として扱う。
 

--- a/packages/core/src/__tests__/ban.test.ts
+++ b/packages/core/src/__tests__/ban.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { BANS_RKEY, bansCollection, isBanned } from '../ban.js';
+
+describe('bansCollection', () => {
+  it('NSID の根に config.bans を続ける (web の ADMIN_COL と edge の loader が同じ値を組む)', () => {
+    expect(bansCollection('app.aozoraquest')).toBe('app.aozoraquest.config.bans');
+    expect(BANS_RKEY).toBe('self');
+  });
+});
+
+describe('isBanned', () => {
+  it('空のリストでは誰も BAN されない', () => {
+    expect(isBanned([], 'did:plc:a')).toBe(false);
+  });
+
+  it('リストに入っている DID だけ true', () => {
+    const bans = ['did:plc:bad'];
+    expect(isBanned(bans, 'did:plc:bad')).toBe(true);
+    expect(isBanned(bans, 'did:plc:good')).toBe(false);
+  });
+
+  it('未ログイン (did 無し) は false', () => {
+    expect(isBanned(['did:plc:bad'], undefined)).toBe(false);
+    expect(isBanned(['did:plc:bad'], null)).toBe(false);
+    expect(isBanned(['did:plc:bad'], '')).toBe(false);
+  });
+});

--- a/packages/core/src/ban.ts
+++ b/packages/core/src/ban.ts
@@ -1,0 +1,33 @@
+/**
+ * **BAN リスト** (docs/14-admin §(d))。主管理者 PDS の公開レコード 1 本に DID を並べる。
+ *
+ * **効くのはあおぞらワールドだけ。** 投稿・タイムライン・バッジ・依頼クエスト板には
+ * 効かせない — それらは Bluesky の公開データで、こちらで除外しても他のクライアントからは
+ * 見えるので意味が薄い。ワールドは権威 state (パワー・XP・在庫) をこちらが持っているので、
+ * そこへの書き込みを止めることに意味がある。
+ *
+ * web (画面を出さない) と edge (権威 API を 403 で拒む) の両方がこのレコードを読むので、
+ * **collection・rkey・形・判定はここ 1 か所**に置く。別々に書くと片方だけ効く/効かないが起きる。
+ */
+
+/** NSID の根に続く collection 名。web の `ADMIN_COL.configBans` と edge の loader が同じ値を組む。 */
+export const BANS_COLLECTION_SUFFIX = 'config.bans';
+/** シングルトンなので rkey は固定。 */
+export const BANS_RKEY = 'self';
+
+/** `bansCollection('app.aozoraquest')` → `app.aozoraquest.config.bans`。 */
+export function bansCollection(nsidRoot: string): string {
+  return `${nsidRoot}.${BANS_COLLECTION_SUFFIX}`;
+}
+
+/** レコードの形。`@aozoraquest/types` の `ConfigBansSchema` が検証側の定義 (こちらは読み書きの最小形)。 */
+export interface BansRecord {
+  dids: string[];
+  updatedAt: string;
+}
+
+/** BAN 済みか。`bans` は読み込んだリスト、`did` は認証済みの本人 DID。未ログイン (did 無し) は false。 */
+export function isBanned(bans: readonly string[], did: string | null | undefined): boolean {
+  if (!did) return false;
+  return bans.includes(did);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,3 +32,4 @@ export * from './interior-samples.js';
 export * from './scenario.js';
 export * from './scenario-samples.js';
 export * from './equipment.js';
+export * from './ban.js';


### PR DESCRIPTION
Closes #561

管理画面で保存しても何も起きなかったメンテナンスモードと BAN リストを配線する。

## A. メンテナンスモード = アプリ全体

- `app-shell` が全ルートを `MaintenanceGate` (`apps/web/src/components/maintenance-gate.tsx`) で包み、メンテ中は `message` と `until` を出すメンテ画面に差し替える (本体は描かない)。
- **誰を通すかは `isUnderMaintenance` (`apps/web/src/lib/runtime-config.ts`) の 1 か所**: 管理者 (`isAdminDid`) は常に通す / `allowedDids` も通す / 未ログイン (復元中を含む) は止める。app-shell 側で管理者判定を別に書いていない。
- パスの例外は `maintenanceExemptPath`: `/admin` 配下 (解除の導線) と `/onboarding` `/oauth/callback` (ログアウト中の管理者がログインするため)。
- 管理画面 (`config-admin.tsx`) に `allowedDids` の改行区切り textarea を追加。保存時に持ち越すだけのコードを置き換えた。「未配線」の注記と `NotWired` を削除。

## B. BAN = あおぞらワールドだけ

- **契約を core に一本化**: `packages/core/src/ban.ts` に collection (`config.bans`)・rkey (`self`)・レコードの形 (`BansRecord`)・判定 (`isBanned`) を置き、web (`ADMIN_COL.configBans = bansCollection(ROOT)`, `runtime-config.ts`, `config-admin.tsx`) と edge (`world-authoring.ts`, `router.ts`) の両方が同じものを使う。web にあった `isBanned` と各所の `BansRecord` 定義は削除。
- **web**: `/world` は `WorldGate` (`apps/web/src/routes/world-gate.tsx`) を経由し、BAN 済み DID には「このアカウントではワールドは利用できません」を出してゲーム UI を描かない。`World` は mount 時に権威 API を叩くので、設定を読み終えるまで mount しない (`useRuntimeConfigState().loaded`)。`world.tsx` (1802 行) は触っていない。
- **edge**: BAN リストの読み方は**手編集の世界と同じ loader** (`ensureAuthoredWorld`) に `bans` step として載せた。同じ管理者 PDS・同じ 5 分 TTL・同じ inflight 共有。レコード無し = 空、読めなかった回は前の値を保つ (一時的な PDS 障害で BAN が外れない)。
- **edge の 403**: `router.ts` の 17 か所に繰り返されていた JWT 検証ブロックを `authenticate(req, env, lxm, gate)` に寄せ、`gate === 'world'` のとき `ensureAuthoredWorld` を待ってから `isBanned(bannedDidList(), did)` で `403 {error:'forbidden', reason:'banned'}`。対象は権威 state を書き換える経路 (move / battle.turn / teleport / item / gear / search / reset / xp.claim / power.spend / shop.craft / sell / forge / discard / quest.accept / complete)。`GET /api/me/state` は表示用の読み取りでホーム/自分/カードも見るため止めない。管理者専用の経路 (`isEdgeAdmin`) と whoami も対象外。router は 617 → 527 行。
- 管理系レコードの NSID の根は `world-authoring.ts` の `ADMIN_NSID_ROOT` に寄せ、`ensureAuthoredWorld` の `nsid` 引数を外した (index.ts の `nsidRoot()` と router の `nsFromOrigin(req)` 渡しで**根が 2 か所**にあり、router 側は env 付き NSID を渡していた)。
- 管理画面の BAN 側の注記を「効くのはあおぞらワールドだけ」に差し替え。

## C. テスト

- core: `packages/core/src/__tests__/ban.test.ts` (collection 名 / 判定 / 未ログイン)
- edge: `apps/edge/test/ban-gate.test.ts` — JWT 検証と PDS 読み取りだけ差し替え、router → authenticate → loader → core の経路をそのまま通す。BAN 済み DID の 15 エンドポイントが 403 / 空リスト・レコード無し・別 DID は通る / whoami と me/state は止めない / `config.bans` `self` を管理者 PDS から読む / TTL 内は読み直さない
- web: `maintenance-gate.test.tsx` (一般ユーザーと未ログインはメンテ画面 / 管理者と allowedDids は通る / `/admin` `/onboarding` は到達できる / 既定文) と `world-gate.test.tsx` (BAN 済みはゲームを描かない / 読み込み前は mount しない / 未ログインはゲーム側に任せる)。`runtime-config.test.ts` に管理者・未ログインのケースを追加、`isBanned` のテストは core へ移動。
- 既存テストはそのまま (弱めていない)。

## 検証 (exit code)

- `pnpm --filter @aozoraquest/core typecheck` 0 / `test` 0 (802 passed)
- `pnpm --filter @aozoraquest/edge typecheck` 0 / `test` 0 (282 passed)
- `pnpm --filter @aozoraquest/web typecheck` 0 / `lint` 0 (警告は既存分のみ) / `test` 0 (411 passed) / `build` 0 (VITE_APP_URL / VITE_NSID_ROOT 指定)

## docs

- `docs/14-admin.md` §(b) §(d) を実装に合わせて更新 (BAN は投稿除外ではなくワールド限定)。

## Review

(レビュー後に記入)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXHZbULKCqUhgx1NCi6kZ7
