### PR TITLE
fix(world): NPC・店の空配列レコードを適用する (#660)

### DIFF
--- a/apps/edge/src/world-authoring.ts
+++ b/apps/edge/src/world-authoring.ts
@@ -114,12 +114,16 @@ export function ensureAuthoredWorld(env: WorldAuthoringEnv, nsid: string, now: n
     // 店のラインナップ (#422)。**アイテムの後に読む** (検証が EQUIPMENT_BY_ID を引くため)。
     await step('shops', async () => {
       const shops = await getRecord<{ shops?: ShopOverride[] }>(pds, did, `${nsid}.world.shops`, RKEY);
-      if (shops?.value?.shops?.length) setShopOverrides(shops.value.shops);
+      // **空配列も適用する** (クエストと同じ流儀。#660)。全店の上書きを外した保存は {shops: []}
+      // なので、length で弾くと warm isolate に外したはずの品揃えが残る。
+      if (shops?.value?.shops) setShopOverrides(shops.value.shops);
     });
     // NPC (#425)。**移動判定に効く** (立っているマスは塞ぐ) ので edge も必須。
     await step('npcs', async () => {
       const npcs = await getRecord<{ npcs?: NpcDef[] }>(pds, did, `${nsid}.world.npcs`, RKEY);
-      if (npcs?.value?.npcs?.length) setNpcs(npcs.value.npcs);
+      // **空配列も適用する** (クエストと同じ流儀。#660)。全 NPC 削除の保存は {npcs: []} なので、
+      // length で弾くと warm isolate に削除済みの NPC が立ち続け、マスを塞ぎ会話もできてしまう。
+      if (npcs?.value?.npcs) setNpcs(npcs.value.npcs);
     });
     // ジョブ (#544)。**戦闘計算は edge が権威**なので、web だけが編集後の値を見ていると
     // 画面の強さとサーバーの強さが食い違う。

--- a/apps/edge/test/world-authoring.test.ts
+++ b/apps/edge/test/world-authoring.test.ts
@@ -1,0 +1,80 @@
+/**
+ * 手編集ワールドの読み込み (edge 側) — レコードの**有無**で適用を決める (#660)。
+ *
+ * 守るべき不変条件:
+ *   - レコードが**存在すれば空配列でも適用する** (全削除の保存は {npcs: []} になる。
+ *     length で弾くと warm isolate に削除済みのものが残り続ける)
+ *   - レコードが**無ければ触らない** (読めない日にメモリの定義を消さない)
+ */
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { allNpcs, setNpcs, setShopOverrides, shopOverrides, type NpcDef, type ShopOverride } from '@aozoraquest/core';
+import { ensureAuthoredWorld, resetAuthoredWorldCache } from '../src/world-authoring';
+
+const DID = 'did:plc:admin';
+const PDS = 'https://pds.test';
+const NSID = 'app.aozoraquest';
+const NOW = 1_700_000_000;
+
+const NPC: NpcDef = { id: 'elder', name: '長老', x: 3, y: 4, lines: ['やあ'] };
+const SHOP: ShopOverride = { x: 10, y: 20, consumables: [] };
+
+const json = (status: number, body: unknown) =>
+  new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+
+/** 管理者 PDS のふり。`records` に無いコレクションは RecordNotFound。 */
+function fakePds(records: Record<string, unknown>): typeof fetch {
+  return (async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+    if (url.startsWith('https://plc.directory/')) {
+      return json(200, { id: DID, service: [{ id: '#atproto_pds', type: 'AtprotoPersonalDataServer', serviceEndpoint: PDS }] });
+    }
+    if (url.startsWith(`${PDS}/xrpc/com.atproto.repo.getRecord?`)) {
+      const col = new URL(url).searchParams.get('collection') ?? '';
+      const key = col.slice(`${NSID}.world.`.length);
+      if (key in records) return json(200, { uri: `at://${DID}/${col}/self`, cid: 'cid1', value: records[key] });
+      return json(400, { error: 'RecordNotFound', message: 'Could not locate record' });
+    }
+    return json(404, { error: 'not_found' });
+  }) as unknown as typeof fetch;
+}
+
+describe('ensureAuthoredWorld: 空配列のレコードを適用する (#660)', () => {
+  const orig = globalThis.fetch;
+  const env = { ADMIN_DIDS: DID };
+
+  beforeEach(() => {
+    resetAuthoredWorldCache();
+    setNpcs([NPC]);
+    setShopOverrides([SHOP]);
+  });
+  afterEach(() => {
+    globalThis.fetch = orig;
+    resetAuthoredWorldCache();
+    setNpcs(null);
+    setShopOverrides(null);
+  });
+
+  it('NPC: {npcs: []} で全 NPC が消える', async () => {
+    globalThis.fetch = fakePds({ npcs: { npcs: [] } });
+    await ensureAuthoredWorld(env, NSID, NOW);
+    expect(allNpcs()).toEqual([]);
+  });
+
+  it('NPC: レコードが無ければメモリの NPC を保持する', async () => {
+    globalThis.fetch = fakePds({});
+    await ensureAuthoredWorld(env, NSID, NOW);
+    expect(allNpcs().map((n) => n.id)).toEqual(['elder']);
+  });
+
+  it('店: {shops: []} で全上書きが外れる', async () => {
+    globalThis.fetch = fakePds({ shops: { shops: [] } });
+    await ensureAuthoredWorld(env, NSID, NOW);
+    expect(shopOverrides()).toEqual([]);
+  });
+
+  it('店: レコードが無ければメモリの上書きを保持する', async () => {
+    globalThis.fetch = fakePds({});
+    await ensureAuthoredWorld(env, NSID, NOW);
+    expect(shopOverrides().map((s) => [s.x, s.y])).toEqual([[10, 20]]);
+  });
+});

--- a/apps/web/src/lib/world-authoring.test.ts
+++ b/apps/web/src/lib/world-authoring.test.ts
@@ -1,0 +1,59 @@
+/**
+ * 手編集ワールドの読み込み (web 側) — レコードの**有無**で適用を決める (#660)。
+ * edge (`apps/edge/test/world-authoring.test.ts`) と同じ不変条件:
+ *   - レコードが存在すれば**空配列でも適用する** (全削除の保存は {npcs: []})
+ *   - レコードが無ければ触らない
+ */
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import type { Agent } from '@atproto/api';
+import { allNpcs, setNpcs, setShopOverrides, shopOverrides, type NpcDef, type ShopOverride } from '@aozoraquest/core';
+import { loadAuthoredWorld } from './world-authoring';
+
+const DID = 'did:plc:admin';
+const NPC: NpcDef = { id: 'elder', name: '長老', x: 3, y: 4, lines: ['やあ'] };
+const SHOP: ShopOverride = { x: 10, y: 20, consumables: [] };
+
+/** 管理者 repo のふり。`records` に無いコレクションは RecordNotFound を投げる。 */
+function fakeAgent(records: Record<string, unknown>): Agent {
+  const getRecord = async ({ collection }: { collection: string }) => {
+    const key = collection.slice(collection.lastIndexOf('.') + 1);
+    if (key in records) return { data: { uri: `at://${DID}/${collection}/self`, cid: 'cid1', value: records[key] } };
+    const err = new Error('Could not locate record');
+    err.name = 'RecordNotFoundError';
+    throw err;
+  };
+  return { com: { atproto: { repo: { getRecord } } } } as unknown as Agent;
+}
+
+describe('loadAuthoredWorld: 空配列のレコードを適用する (#660)', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_ADMIN_DIDS', DID);
+    setNpcs([NPC]);
+    setShopOverrides([SHOP]);
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    setNpcs(null);
+    setShopOverrides(null);
+  });
+
+  it('NPC: {npcs: []} で全 NPC が消える', async () => {
+    await loadAuthoredWorld(fakeAgent({ npcs: { npcs: [] } }));
+    expect(allNpcs()).toEqual([]);
+  });
+
+  it('NPC: レコードが無ければメモリの NPC を保持する', async () => {
+    await loadAuthoredWorld(fakeAgent({}));
+    expect(allNpcs().map((n) => n.id)).toEqual(['elder']);
+  });
+
+  it('店: {shops: []} で全上書きが外れる', async () => {
+    await loadAuthoredWorld(fakeAgent({ shops: { shops: [] } }));
+    expect(shopOverrides()).toEqual([]);
+  });
+
+  it('店: レコードが無ければメモリの上書きを保持する', async () => {
+    await loadAuthoredWorld(fakeAgent({}));
+    expect(shopOverrides().map((s) => [s.x, s.y])).toEqual([[10, 20]]);
+  });
+});

--- a/apps/web/src/lib/world-authoring.ts
+++ b/apps/web/src/lib/world-authoring.ts
@@ -172,13 +172,15 @@ export async function loadAuthoredWorld(agent: Agent | null): Promise<void> {
       // **アイテムの後に読む** — 上書きの検証が EQUIPMENT_BY_ID / ITEMS を引くので、
       // 先に読むと「編集した装備を並べた店」が未知 id 扱いで落ちる。
       const rec = await getRecord<{ shops?: ShopOverride[] }>(agent, adminDid, ADMIN_COL.shops, RKEY);
-      if (rec?.shops?.length) setShopOverrides(rec.shops);
+      // 空配列も適用する (全上書き解除の反映。クエストと同じ流儀。#660)。
+      if (rec?.shops) setShopOverrides(rec.shops);
     } catch (e) {
       console.warn('[world] shops load failed', e);
     }
     try {
       const rec = await getRecord<{ npcs?: NpcDef[] }>(agent, adminDid, ADMIN_COL.npcs, RKEY);
-      if (rec?.npcs?.length) setNpcs(rec.npcs);
+      // 空配列も適用する (全 NPC 削除の反映。クエストと同じ流儀。#660)。
+      if (rec?.npcs) setNpcs(rec.npcs);
     } catch (e) {
       console.warn('[world] npcs load failed', e);
     }


### PR DESCRIPTION
Closes #660

## なぜ

管理レコードの読み込みが `rec?.npcs?.length` で弾くため、全 NPC 削除の保存 (`{npcs: []}`) が `setNpcs([])` に届かず、edge の warm isolate / web のメモリに削除済み NPC が残り続けていた (マスを塞ぎ、会話もできる)。クエスト (`world.quests`) は「レコードが存在すれば空でも適用、無ければ触らない」流儀なので、それにそろえる。

## 直した箇所

同じ `?.length` 弾きは **店 (shops)** にもあり、`setShopOverrides([])` = 全上書き解除が同じ理由で反映されないため issue の対象に含めた。

| レコード | edge (`apps/edge/src/world-authoring.ts`) | web (`apps/web/src/lib/world-authoring.ts`) |
|---|---|---|
| `world.npcs` | `if (npcs?.value?.npcs?.length)` → `if (npcs?.value?.npcs)` | `if (rec?.npcs?.length)` → `if (rec?.npcs)` |
| `world.shops` | `if (shops?.value?.shops?.length)` → `if (shops?.value?.shops)` | `if (rec?.shops?.length)` → `if (rec?.shops)` |

### 対象外にしたもの (理由)

- **monsters / items** の `?.length`: core の検証が 0 件を弾く (`モンスターが 0 体` / `装備が 0 品`) ため、空配列は保存経路 (`saveMonsters` / `saveItems` は先に setter を通す) に乗らず、「空 = 全解除」の意味を持たない。触っても挙動は変わらない (throw して step が warn するだけ) ので据え置き。
- **interiors / jobs / quests / scenario / towns / tileArts**: もともと length で弾いていない。

## テスト

- 追加: `apps/edge/test/world-authoring.test.ts` (fetch を管理者 PDS のふりに差し替えて `ensureAuthoredWorld` を通す)
- 追加: `apps/web/src/lib/world-authoring.test.ts` (fake Agent + `vi.stubEnv('VITE_ADMIN_DIDS')` で `loadAuthoredWorld` を通す)
- 各 4 ケース: NPC / 店 × (空配列レコードで消える / レコード無しで保持)
- 修正を外すと edge の「空配列で消える」2 ケースが落ちることを確認済み (mutation check)

| コマンド | 結果 |
|---|---|
| `pnpm --filter @aozoraquest/edge typecheck` | exit 0 |
| `pnpm --filter @aozoraquest/edge test` | exit 0 (23 files / 265 tests) |
| `pnpm --filter @aozoraquest/web typecheck` | exit 0 |
| `pnpm --filter @aozoraquest/web test` | exit 0 (45 files / 405 tests) |

## Review

(レビュー後に記載)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXHZbULKCqUhgx1NCi6kZ7
